### PR TITLE
Fix server selection bug in CentovaCast module

### DIFF
--- a/src/bb-modules/Servicecentovacast/Service.php
+++ b/src/bb-modules/Servicecentovacast/Service.php
@@ -400,7 +400,7 @@ class Service implements \Box\InjectionAwareInterface
             $account_password = 'admin|'.$server['secret'];
         }
 
-        require_once dirname(__FILE__).'/ccapiclient/ccapiclient.php';
+        require_once dirname(__FILE__).'/ccapiclient.php';
         $server = new CCServerAPIClient($centovacast_url);
         $server->cc_initialize($centovacast_url);
         $server->call($method, $account_username, $account_password, $arguments);

--- a/src/bb-modules/Servicecentovacast/html_admin/mod_servicecentovacast_config.html.twig
+++ b/src/bb-modules/Servicecentovacast/html_admin/mod_servicecentovacast_config.html.twig
@@ -1,3 +1,5 @@
+{% import "macro_functions.phtml" as mf %}
+
 <div class="help">
     <h5>{{ 'Centova Cast product settings'|trans }}</h5>
 </div>


### PR DESCRIPTION
Resolves [#904 from BoxBilling repo](https://github.com/boxbilling/boxbilling/issues/904) as far as I can tell.

Weird issue, seems the extension actually works perfectly fine (at least for me on PHP 8.0.19), the macros weren't included in the template and caused an issue as a result when configuring the product. (issue mentioned something about it working on an older version of PHP, this might just be a compatibility patch?)

Also, location to the API client was wrong and caused an error in one instance, this has been fixed. Didn't seem to cause any catastrophic failures on my end, but enough to throw an error.