### PR TITLE
Fix minor module glitches

### DIFF
--- a/src/bb-library/Server/Manager/Plesk.php
+++ b/src/bb-library/Server/Manager/Plesk.php
@@ -25,7 +25,7 @@ class Server_Manager_Plesk extends Server_Manager
 		if (!$this->_config['secure']) {
             $protocol = 'http://';
         }
-        return $protocol.$this->_config['host'] . ':8443/enterprise/control/agent.php';
+        return $protocol.$this->_config['host'] . ':8443';
 	}
 
     public function getResellerLoginUrl()

--- a/src/bb-modules/Servicesolusvm/html_admin/mod_servicesolusvm_config.html.twig
+++ b/src/bb-modules/Servicesolusvm/html_admin/mod_servicesolusvm_config.html.twig
@@ -1,3 +1,5 @@
+{% import "macro_functions.phtml" as mf %}
+
 <div class="help">
     <h5>{{ 'SolusVM configuration'|trans }}</h5>
     <p>More information what does each configuration parameter means at {{ 'http://wiki.solusvm.com/index.php/API:Admin'|autolink|raw }}</p>


### PR DESCRIPTION
Added template macros to the SolusVM page as was required with CentovaCast - this fixes at least the issue of config options not showing up. (potentially solves [#1293 on the old repository](https://github.com/boxbilling/boxbilling/issues/1293). I do not have a test environment to debug any further - but SolusVM's API has not changed substantially since 2013 (this seems to have been last updated in 2015) so should be fine after this patch?

Fixed the login URL given by the Plesk module as it was incorrect, Provides a fix for one of the comments on [#1188  on the old repository](https://github.com/boxbilling/boxbilling/issues/1188).  As an aside, Plesk module works fine on the latest version of BoxBilling and Plesk in my environment.