### PR TITLE
Make the open collective badge function as a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
 [![CodeFactor](https://www.codefactor.io/repository/github/fossbilling/fossbilling/badge)](https://www.codefactor.io/repository/github/fossbilling/fossbilling)
-<img alt="open collective badge" src="https://opencollective.com/fossbilling/tiers/badge.svg?color=brightgreen" />
+[![Financial Contributors](https://opencollective.com/fossbilling/tiers/badge.svg?color=brightgreen)](https://opencollective.com/fossbilling)
 </div>
 
 


### PR DESCRIPTION
Realized it wasn't in the original PR