### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,3 +29,5 @@ template: |
   ## Changes
 
   $CHANGES
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/.
+        with:
+            config-name: release-drafter.yml
+            disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release drafter will create a drafted changelog and update it with each PR.
It can distinguish the mission of the pull request by it's labels and place them accordingly.

Given a version number **vMAJOR.MINOR.PATCH**, release drafter will automatically

* Bump the MAJOR version when we make incompatible API changes and label the PR 'major',
* Bump the MINOR version when we add functionality in a backwards compatible manner and label the PR 'minor', and
* Bump the PATCH version when we make backwards compatible bug fixes.

It will check the latest release and bump it's PATCH version by default, if none of the PRs are labeled 'minor' or 'major'.

It will also ignore PRs labeled 'skip-changelog'.

-----

It will look like this:

![Release drafter](https://github.com/release-drafter/release-drafter/raw/master/design/screenshot-2.png)

-----

Check the action on GitHub Marketplace:
https://github.com/marketplace/actions/release-drafter