### PR TITLE
Adjust workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,19 @@
 
 version: 2
 updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "composer"
     directory: "/src" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
   
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "daily"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,8 @@ categories:
     labels:
       - 'task'
       - 'tests/CI'
+  - title: '📦 Dependencies'
+    labels:
       - 'dependencies'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,18 +1,24 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
+  - title: '⚠️ Breaking changes'
+    labels:
+      - 'breaking change'
   - title: '🚀 Features'
     labels:
       - 'feature'
       - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
-      - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+    labels:
+      - 'task'
+      - 'tests/CI'
+      - 'dependencies'
+exclude-labels:
+  - 'skip-changelog'
+change-template: '- $TITLE (@$AUTHOR, #$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
@@ -29,5 +35,3 @@ template: |
   ## Changes
 
   $CHANGES
-exclude-labels:
-  - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,9 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
+  - title: '🛡️ Security'
+    labels:
+      - 'security'
   - title: '🧰 Maintenance'
     labels:
       - 'task'


### PR DESCRIPTION
## Dependabot
* Dependabot now also keeps the dependencies of our GitHub Actions updated. ([see here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot))
* The checks are now done every day. It used to be weekly for Composer and monthly for npm.

## Release drafter
It now lists breaking changes and security issues explicitly. Also catches a few more labels. Let me know if you want anything else to be changed.

Configuration file reference: https://github.com/release-drafter/release-drafter#configuration