### PR TITLE
Add download button to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 </h1>
 
 <div align="center">
-  
+
+<a href="https://fossbilling.org/downloads/preview"><img src="https://fossbilling.org/gh-download-button.png" alt="Download button" width="400"/></a>
+
 [![PHP Composer](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml/badge.svg)](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml)
 [![Download Latest](https://img.shields.io/github/downloads/fossbilling/fossbilling/total)](https://github.com/fossbilling/fossbilling/releases/latest)
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)


### PR DESCRIPTION
I've recently created a redirect that points to the latest artifact archive stored in our Amazon S3 storage. It gets built and deployed to S3 using GitHub Actions after every push.

It was hard for new users to find preview builds, so I created a pretty basic main page ([here](https://fossbilling.org)) with a button pointing to the latest one and added the same button to the README too.