### PR TITLE
New events: onBeforeAdminClientCreate & onAfterAdminClientCreate

### DIFF
--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -158,7 +158,9 @@ class Admin extends \Api_Abstract
             throw new \Box_Exception('Email is already registered.');
         }
 
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientCreate', 'params' => $data]);
         return $service->adminCreateClient($data);
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminClientCreate', 'params' => $data]);
     }
 
     /**

--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -159,9 +159,9 @@ class Admin extends \Api_Abstract
         }
 
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientCreate', 'params' => $data]);
-        $result = $service->adminCreateClient($data);
+        $id = $service->adminCreateClient($data);
         $this->di['events_manager']->fire(['event' => 'onAfterAdminClientCreate', 'params' => $data]);
-        return $result;
+        return $id;
     }
 
     /**

--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -159,10 +159,9 @@ class Admin extends \Api_Abstract
         }
 
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientCreate', 'params' => $data]);
-        $service->adminCreateClient($data);
+        $result = $service->adminCreateClient($data);
         $this->di['events_manager']->fire(['event' => 'onAfterAdminClientCreate', 'params' => $data]);
-
-        return true;
+        return $result;
     }
 
     /**

--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -159,8 +159,10 @@ class Admin extends \Api_Abstract
         }
 
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientCreate', 'params' => $data]);
-        return $service->adminCreateClient($data);
+        $service->adminCreateClient($data);
         $this->di['events_manager']->fire(['event' => 'onAfterAdminClientCreate', 'params' => $data]);
+
+        return true;
     }
 
     /**

--- a/tests/bb-modules/Client/Api/AdminTest.php
+++ b/tests/bb-modules/Client/Api/AdminTest.php
@@ -151,12 +151,17 @@ class AdminTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())->
         method('adminCreateClient')->will($this->returnValue(1));
 
+        $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
+        $eventMock->expects($this->atLeastOnce())->
+        method('fire');
+
         $validatorMock = $this->getMockBuilder('\Box_Validate')->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isEmailValid');
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
         $di              = new \Box_Di();
         $di['validator'] = $validatorMock;
+        $di['events_manager'] = $eventMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);


### PR DESCRIPTION
Adds two new events, one that fires right before a new user is created through the admin panel, the other that fires right after.
One use case will be the https://github.com/FOSSBilling/demo extension.

Fixes #171.