### PR TITLE
Add 4 new events

### DIFF
--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -101,8 +101,11 @@ class Admin extends \Api_Abstract
         }
 
         $new_version = $updater->getLatestVersion();
-        $updater->performUpdate();
 
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminUpdateCore']);
+        $updater->performUpdate();
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminUpdateCore']);
+        
         $this->di['logger']->info('Updated FOSSBilling from %s to %s', \Box_Version::VERSION, $new_version);
 
         return true;

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -127,7 +127,10 @@ class Admin extends \Api_Abstract
         $ext = $this->_getExtension($data);
         $service = $this->getService();
 
-        return $service->update($ext);
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminUpdateExtension', 'params' => $ext]);
+        $ext2 = $service->update($ext);
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminUpdateExtension', 'params' => $ext2]);
+        return $ext2;
     }
 
     /**

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -185,7 +185,15 @@ class AdminTest extends \BBTestCase {
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
             ->will($this->returnValue(null));
+
+        $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
+            $eventMock->expects($this->atLeastOnce())->
+            method('fire');
+        
+        $di = new \Box_Di();
         $di['validator'] = $validatorMock;
+        $di['events_manager'] = $eventMock;
+
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -132,11 +132,14 @@ class AdminTest extends \BBTestCase {
         $updaterMock->expects($this->atLeastOnce())
             ->method('performUpdate');
 
-
+        $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
+        $eventMock->expects($this->atLeastOnce())->
+        method('fire');
 
         $di = new \Box_Di();
         $di['updater'] = $updaterMock;
         $di['logger'] = new \Box_Log();
+        $di['events_manager'] = $eventMock;
 
         $this->api->setDi($di);
 
@@ -465,4 +468,3 @@ class AdminTest extends \BBTestCase {
 
 
 }
- 


### PR DESCRIPTION
Adds four new events, onBeforeAdminUpdateCore, onAfterAdminUpdateCore, onBeforeAdminUpdateExtension and onAfterAdminUpdateExtension

One use case will be the [FOSSBilling/demo](https://github.com/FOSSBilling/demo) extension.

Fixes https://github.com/FOSSBilling/FOSSBilling/issues/173.