### PR TITLE
Added sponsor button to the admin panel

### DIFF
--- a/src/bb-themes/admin_default/assets/icons/heart.svg
+++ b/src/bb-themes/admin_default/assets/icons/heart.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-heart" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M19.5 12.572l-7.5 7.428l-7.5 -7.428m0 0a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572" />
+</svg>
+
+

--- a/src/bb-themes/admin_default/html/layout_default.html.twig
+++ b/src/bb-themes/admin_default/html/layout_default.html.twig
@@ -55,6 +55,12 @@
                                     </svg>
                                     {{ 'Source code'|trans }}
                                 </a>
+                                <a href="https://github.com/sponsors/FOSSBilling" class="btn" target="_blank" rel="noreferrer">
+                                    <svg class="icon icon-tabler icon-tabler-heart text-pink">
+                                        <use xlink:href="#heart" />
+                                    </svg>
+                                    {{ 'Sponsor'|trans }}
+                                </a>
                             </div>
                         </div>
                         <div class="d-none d-md-flex me-3">


### PR DESCRIPTION
Added a button that goes to our GitHub Sponsors page.

Icon from [tabler-icons](https://tabler-icons.io/i/heart).

Demonstration:
![image](https://user-images.githubusercontent.com/35808275/180183914-38265f89-14c5-47a1-95a1-f1bbbd2496ab.png)