### PR TITLE
Fix for "Product ID not passed"

### DIFF
--- a/src/bb-themes/admin_default/html/mod_product_manage.html.twig
+++ b/src/bb-themes/admin_default/html/mod_product_manage.html.twig
@@ -158,6 +158,7 @@
                         </div>
                     </div>
 
+                    <input type="hidden" name="id" value="{{ product.id }}">
                     <button type="submit" class="btn btn-primary w-100">{{ 'Update'|trans }}</button>
                 </form>
             </div>


### PR DESCRIPTION
Pretty easy fix for #158 , the `product.id` was not being sent in the HTML form, so the request wouldn't have it at all. 