### PR TITLE
Connect hooks after the setup

### DIFF
--- a/src/bb-modules/Staff/Api/Guest.php
+++ b/src/bb-modules/Staff/Api/Guest.php
@@ -25,7 +25,7 @@ class Guest extends \Api_Abstract
      * the system.
      * Database structure must be installed before calling this action.
      * bb-config.php file must already be present and configured.
-     * Used by automated FOSSBilling installer.
+     * Used by the automated FOSSBilling installer.
      *
      * @param string $email    - admin email
      * @param string $password - admin password
@@ -51,6 +51,11 @@ class Guest extends \Api_Abstract
         if ($result) {
             $this->login($data);
         }
+
+        // Connect hooks right after the initial user is created
+        // Related: https://github.com/FOSSBilling/FOSSBilling/issues/170
+        $hookService = $this->di['mod_service']('hook');
+        $hookService->batchConnect();
 
         return true;
     }


### PR DESCRIPTION
Fixes #170.

We have a problem with the hooks and events. Hooks are connected once the cron jobs are ran. So, until they're ran for the first time, hooks and events will not work as they are unregistered.

A way to solve this is connecting the hooks right after the installation is complete. This way, necessary hooks will still work even before the cron jobs are ran for the first time.

-----

Automated installers like the Docker helper script (make all) install FOSSBilling with appropriate configuration and let the user create the first admin account through the admin panel. I made the function that creates the initial account call the other function that connects hooks right after creating the account. This PR fixes the problem for those who use the automated installer

-----

However, for those who use the regular installer (the one you see in /install), the issue is still unresolved. I'll find some ways to fix it for them too.