### PR TITLE
Hyphen notice

### DIFF
--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -12,10 +12,11 @@
         <div class="widget nomargin step step-2">
             <div class="head"><h5 class="iAlert">Database configuration</h5></div>
             <div class="body">
-                <p>FOSSBilling stores data in a SQL database. You should already have an existing database before this step. If you do not have database prepared, you should do that now.</p>
-                <p>Installer will create all required tables in your database after correct connection details are provided.</p>
+                <p>FOSSBilling stores data in a SQL database. You should already have an existing database before this step. If you do not have a database prepared, you should do that now.</p>
+                <p>The installer will create all the required tables in your database after correct connection details are provided.</p>
+                <p><strong>NOTE:</strong> Please make sure your database name does not include a hyphen '-' as this will create an error.</p>
                 <h4 class="pt10">How to create a database?</h4>
-                <p>Depending on your hosting provider database can be created in different ways.</p>
+                <p>Depending on your hosting provider a database can be created in different ways.</p>
                 <p>Best way is to check the documentation available with your webhosting account. You can contact their support if you really get stuck.</p>
             </div>
         </div>


### PR DESCRIPTION
Adds a notice about not using a hyphen in the database name - this can be removed once a fix is pushed. 

Plus a couple of wording fixes.