### PR TITLE
BugFix Issue #262 Prevent cron from paying deposit invoice with credits

### DIFF
--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -559,10 +559,6 @@ class Service implements InjectionAwareInterface
             return;
         }
 
-        if ($this->isInvoiceTypeDeposit($invoice)) {
-            $this->markAsPaid($invoice, false);
-        }
-
         $client = $this->di['db']->load('Client', $invoice->client_id);
         $cbrepo = $this->di['mod_service']('Client', 'Balance');
         $balance = $cbrepo->getClientBalance($client);
@@ -1359,7 +1355,7 @@ class Service implements InjectionAwareInterface
 
     /**
      * Return list of unpaid invoices which can be covered from client balance.
-     *
+     * Deposit invoices are excluded as they cannot be covered from client balance.
      * @param array $filter
      *
      * @return array
@@ -1373,8 +1369,9 @@ class Service implements InjectionAwareInterface
                     LEFT JOIN invoice_item as pi on pi.invoice_id = m.id
                 WHERE m.status = :status
                     AND m.approved = 1
-                    AND cb.amount >= pi.price';
-        $params = ['status' => \Model_Invoice::STATUS_UNPAID];
+                    AND cb.amount >= pi.price
+                    AND pi.type != :type';
+        $params = ['status' => \Model_Invoice::STATUS_UNPAID, 'type' => \Model_InvoiceItem::TYPE_DEPOSIT];
 
         $client_id = isset($filter['client_id']) ? (int) $filter['client_id'] : null;
 

--- a/src/bb-modules/Invoice/ServiceInvoiceItem.php
+++ b/src/bb-modules/Invoice/ServiceInvoiceItem.php
@@ -121,16 +121,8 @@ class ServiceInvoiceItem implements InjectionAwareInterface
         }
 
         if (\Model_InvoiceItem::TYPE_DEPOSIT == $item->type) {
-            $clientService = $this->di['mod_service']('Client');
-
-            $invoice = $this->di['db']->getExistingModelById('Invoice', $item->invoice_id);
-            $client = $this->di['db']->getExistingModelById('Client', $invoice->client_id);
-            $data = [
-                'type' => 'invoice',
-                'rel_id' => $item->invoice_id,
-            ];
-            $clientService->addFunds($client, $this->getTotal($item), $item->title, $data);
-
+            // do not request to add funds to client balance
+            // associated invoice will have already been marked with a valid transaction and funds added
             $this->markAsExecuted($item);
         }
 

--- a/tests/bb-modules/Invoice/ServiceInvoiceItemTest.php
+++ b/tests/bb-modules/Invoice/ServiceInvoiceItemTest.php
@@ -137,18 +137,10 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $clientModel->loadBean(new \RedBeanPHP\OODBBean());
 
         $di = new \Box_Di();
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')
-            ->withConsecutive(array('Invoice'), array('Client'))
-            ->willReturnOnConsecutiveCalls($invoiceModel, $clientModel);
         $di['db'] = $dbMock;
 
         $clientServiceMock = $this->getMockBuilder('\Box\Mod\Client\Service')->getMock();
-        $clientServiceMock->expects($this->atLeastOnce())
-            ->method('addFunds')
-            ->with($clientModel);
         $di['mod_service'] = $di->protect(function ($serviceName) use ($clientServiceMock){
             if ($serviceName == 'Client'){
                 return $clientServiceMock;
@@ -156,13 +148,10 @@ class ServiceInvoiceItemTest extends \BBTestCase
         });
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\ServiceInvoiceItem')
-            ->setMethods(array('markAsExecuted', 'getTotal'))
+            ->setMethods(array('markAsExecuted'))
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('markAsExecuted');
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getTotal')
-            ->willReturn('1.00');
         $serviceMock->setDi($di);
 
         $serviceMock->executeTask($invoiceItemModel);


### PR DESCRIPTION
Deposit invoices types are generated during client add funds and should only be payable via payment gateways with valid transactions.