### PR TITLE
Fix Invoice PDF Render with relative path logo

### DIFF
--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -1225,7 +1225,7 @@ class Service implements InjectionAwareInterface
         $fontSize = 12;
 
         if (isset($company['logo_url']) && !empty($company['logo_url'])) {
-            $url = $company['logo_url'];
+            $url = parse_url($company['logo_url'], PHP_URL_PATH);
             if ('.png' === substr($url, -4)) {
                 $pdf->ImagePngWithAlpha($_SERVER['DOCUMENT_ROOT'] . $url, $left + 15, 15, 50);
             } else {


### PR DESCRIPTION
Bugfix from bb-1282. The system module prepends baseUrl when rendering the company[logo_url] value which is used in all html templates. This built-in PHP function strips the base url for the purpose of rendering an on-disk path for the image transform library used in the PDF module.