### PR TITLE
Fixed logo path for the installer

### DIFF
--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -10,7 +10,7 @@
 
 <body>
 <div id="header" class="wrapper">
-    <div class="logo"><a href="{{ constant('BB_URL_INSTALL') }}" title="FOSSBilling"><img src="../bb-themes/boxbilling/assets/images/logo.svg" alt="FOSSBilling logo" height="50px" width="238"/></a></div>
+    <div class="logo"><a href="{{ constant('BB_URL_INSTALL') }}" title="FOSSBilling"><img src="../bb-themes/huraga/assets/img/logo.svg" alt="FOSSBilling logo" height="50px" width="238"/></a></div>
     <div class="middleNav">
       <ul>
         <li class="iForum"><a href="https://github.com/FOSSBilling/FOSSBilling/issues" target="_blank" title="Report a bug on GitHub"><span>Report a bug</span></a></li>


### PR DESCRIPTION
Seems like the installer still depends on the removed "BoxBilling" theme. Fixed the path to have it depending on Huraga.