### PR TITLE
Use the standalone Composer image for Composer commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ exec-db: ## Enter DB container shell
 	$(DOCKER_DB_CONTAINER_EXEC) bash
 
 install: start ## Install app after start
-	docker run --rm --interactive --tty --volume $(PWD):/app composer install --working-dir=src --no-progress --prefer-dist --no-dev
+	$(DOCKER_PHP_CONTAINER_EXEC) composer install --working-dir=src --no-progress --prefer-dist --no-dev
 	rm -rf ./src/install
 
 reinstall: ## Reinstall app
@@ -56,7 +56,7 @@ test: start ## Run app tests
 	echo > ./src/bb-data/log/application.log
 	echo > ./src/bb-data/log/php_error.log
 	rm -rf src/install
-	docker run --rm --interactive --tty --volume $(PWD):/app composer install --working-dir=src --no-progress --no-suggest --prefer-dist
+	$(DOCKER_PHP_CONTAINER_EXEC) composer install --working-dir=src --no-progress --no-suggest --prefer-dist
 	$(DOCKER_PHP_CONTAINER_EXEC) ./src/vendor/bin/phpunit --dont-report-useless-tests ./tests/bb-modules/
 
 build: ## Build App with Docker CI image

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ exec-db: ## Enter DB container shell
 	$(DOCKER_DB_CONTAINER_EXEC) bash
 
 install: start ## Install app after start
-	$(DOCKER_PHP_CONTAINER_EXEC) composer install --working-dir=src --no-progress --prefer-dist --no-dev
+	docker run --rm --interactive --tty --volume $(PWD):/app composer install --working-dir=src --no-progress --prefer-dist --no-dev
 	rm -rf ./src/install
 
 reinstall: ## Reinstall app
@@ -56,7 +56,7 @@ test: start ## Run app tests
 	echo > ./src/bb-data/log/application.log
 	echo > ./src/bb-data/log/php_error.log
 	rm -rf src/install
-	$(DOCKER_PHP_CONTAINER_EXEC) composer install --working-dir=src --no-progress --no-suggest --prefer-dist
+	docker run --rm --interactive --tty --volume $(PWD):/app composer install --working-dir=src --no-progress --no-suggest --prefer-dist
 	$(DOCKER_PHP_CONTAINER_EXEC) ./src/vendor/bin/phpunit --dont-report-useless-tests ./tests/bb-modules/
 
 build: ## Build App with Docker CI image

--- a/data/docker/php/Dockerfile
+++ b/data/docker/php/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8.0-fpm
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
 RUN apt-get update \
     && docker-php-ext-install \
         pdo_mysql

--- a/data/docker/php/Dockerfile
+++ b/data/docker/php/Dockerfile
@@ -1,7 +1,5 @@
 FROM php:8.0-fpm
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-
 RUN apt-get update \
     && docker-php-ext-install \
         pdo_mysql


### PR DESCRIPTION
As per https://github.com/FOSSBilling/FOSSBilling/pull/281, Composer seems not to be preinstalled with the official PHP image. This PR will use the [official Composer image](https://hub.docker.com/_/composer) for Composer commands instead.