### PR TITLE
Avoid mixed content error when loading fonts

### DIFF
--- a/src/bb-modules/Orderbutton/assets/css/huraga-blue.css
+++ b/src/bb-modules/Orderbutton/assets/css/huraga-blue.css
@@ -5,7 +5,6 @@
  * Blue color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-modules/Orderbutton/assets/css/huraga-dark.css
+++ b/src/bb-modules/Orderbutton/assets/css/huraga-dark.css
@@ -5,7 +5,6 @@
  * Dark color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-modules/Orderbutton/assets/css/huraga-green.css
+++ b/src/bb-modules/Orderbutton/assets/css/huraga-green.css
@@ -5,7 +5,6 @@
  * Green color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-modules/Orderbutton/assets/css/huraga-red.css
+++ b/src/bb-modules/Orderbutton/assets/css/huraga-red.css
@@ -5,7 +5,6 @@
  * Red color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-themes/huraga/assets/css/huraga-blue.css
+++ b/src/bb-themes/huraga/assets/css/huraga-blue.css
@@ -5,7 +5,6 @@
  * Blue color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-themes/huraga/assets/css/huraga-dark.css
+++ b/src/bb-themes/huraga/assets/css/huraga-dark.css
@@ -5,7 +5,6 @@
  * Dark color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-themes/huraga/assets/css/huraga-green.css
+++ b/src/bb-themes/huraga/assets/css/huraga-green.css
@@ -5,7 +5,6 @@
  * Green color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-themes/huraga/assets/css/huraga-red.css
+++ b/src/bb-themes/huraga/assets/css/huraga-red.css
@@ -5,7 +5,6 @@
  * Red color
  * 
  */
-@import url("http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold");
 article,
 aside,
 details,

--- a/src/bb-themes/huraga/html/layout_default.html.twig
+++ b/src/bb-themes/huraga/html/layout_default.html.twig
@@ -14,7 +14,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block opengraph %}{% endblock %}
-
+    {% if 'https://' in app.request.uri %}
+        <link rel='stylesheet' type='text/css' href="https://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
+    {% else %}
+        <link rel='stylesheet' type='text/css' href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
+    {% endif %}
     <link rel='stylesheet' type='text/css' href="{{ ('css/huraga-' ~ settings.color_scheme ~ '.css') | asset_url }}">
     <link rel='stylesheet' type='text/css' href="{{ 'css/plugins/jquery.jgrowl.css' | asset_url }}">
     <link rel='stylesheet' type='text/css' href="{{ 'css/logos.css' | asset_url }}">

--- a/src/bb-themes/huraga/html/layout_default.html.twig
+++ b/src/bb-themes/huraga/html/layout_default.html.twig
@@ -15,9 +15,9 @@
 
     {% block opengraph %}{% endblock %}
     {% if 'https://' in app.request.uri %}
-        <link rel='stylesheet' type='text/css' href="https://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
+        <link rel='stylesheet' href="https://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
     {% else %}
-        <link rel='stylesheet' type='text/css' href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
+        <link rel='stylesheet' href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold">
     {% endif %}
     <link rel='stylesheet' type='text/css' href="{{ ('css/huraga-' ~ settings.color_scheme ~ '.css') | asset_url }}">
     <link rel='stylesheet' type='text/css' href="{{ 'css/plugins/jquery.jgrowl.css' | asset_url }}">


### PR DESCRIPTION
Huraga theme has google fonts hardcoded to HTTP in all of the CSS files.
This PR removes the import from the CSS files and instead loads the fonts through the main twig file, with the correct protocol (HTTP VS HTTPs)