### PR TITLE
Fix SQL creation failure on new news/announcement post

### DIFF
--- a/src/bb-modules/News/Api/Admin.php
+++ b/src/bb-modules/News/Api/Admin.php
@@ -160,7 +160,6 @@ class Admin extends \Api_Abstract
         $model = $this->di['db']->dispense('Post');
         $model->admin_id = $this->getIdentity()->id;
         $model->title = $data['title'];
-        $model->description = null;
         $model->slug = $this->di['tools']->slug($data['title']);
         $model->status = $this->di['array_get']($data, 'status', null);
         $model->content = $this->di['array_get']($data, 'content', null);


### PR DESCRIPTION
Fixes the following exception when creating a new post/announcement:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'description' in 'field list'