### PR TITLE
Fixed staff modal tabs not rendering correctly

### DIFF
--- a/src/bb-modules/Staff/Api/Admin.php
+++ b/src/bb-modules/Staff/Api/Admin.php
@@ -385,7 +385,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Returns currently loggen in staff member information.
+     * Returns currently logged in staff member information.
      *
      * @return array
      *

--- a/src/bb-themes/admin_default/html/mod_staff_manage.html.twig
+++ b/src/bb-themes/admin_default/html/mod_staff_manage.html.twig
@@ -100,13 +100,12 @@
 
         <div class="tab-pane fade" id="tab-permissions" role="tabpanel">
             <div class="card-body">
-                {% set member_name = staff.name %}
-                <h3>{{ '{{ member_name }} permissions'|trans }}</h3>
+                <h3>{{ staff.name }} {{ 'permissions'|trans }}</h3>
 
                 {% if staff.role == 'admin' %}
-                <p>{{ 'Administrator account is allowed to do everything'|trans }}</p>
+                <p>{{ 'This administrator is allowed to do everything'|trans }}</p>
+                </div>
                 {% else %}
-            </div>
 
             {% set prms = admin.staff_permissions_get({ 'id': staff.id }) %}
             <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
@@ -140,6 +139,7 @@
                     <input type="submit" value="{{ 'Save'|trans }}" class="btn btn-primary w-100">
                 </div>
             </form>
+            </div>
             {% endif %}
         </div>
 
@@ -170,7 +170,7 @@
         <div class="tab-pane fade" id="tab-api" role="tabpanel">
             <div class="card-body">
                 <h3>{{ 'API key'|trans }}</h3>
-                <p class="text-muted">{{ 'Api key is used to manage system via other interfaces.'|trans }}</p>
+                <p class="text-muted">{{ 'API keys are used to manage the system via other interfaces.'|trans }}</p>
 
                 <form method="post" action="admin/profile/generate_api_key" class="api-form" data-api-reload="1">
                     <div class="mb-3 row">


### PR DESCRIPTION
Fixed some tabs not rendering correctly when managing your own staff account.

![image](https://user-images.githubusercontent.com/35808275/193650154-1f1370cd-25d3-4b8d-a35f-b25e3335f067.png)

Closes #282.