### PR TITLE
Labeler updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,3 +12,12 @@ github-config:
 
 javascript:
 - package.*
+
+localization:
+- lang/*
+
+databases:
+- database/*
+
+front-end:
+- resources/*


### PR DESCRIPTION
Made some changes to Labeler for the Laravel Codebase.
Most noteworthy in my opinion is now all PRs for the lara branch will automatically get the "Laravel" label added