### PR TITLE
Small bugfix to the PDF generator

### DIFF
--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -1226,8 +1226,15 @@ class Service implements InjectionAwareInterface
 
         if (isset($company['logo_url']) && !empty($company['logo_url'])) {
             $url = parse_url($company['logo_url'], PHP_URL_PATH);
+            if(!file_exists($url){
+                $url = $_SERVER['DOCUMENT_ROOT'] . $url;
+                if(!file_exists($url){
+                    // Assume the URL points to an image not hosted on this server
+                    $url = $company['logo_url'];
+                }
+			}
             if ('.png' === substr($url, -4)) {
-                $pdf->ImagePngWithAlpha($_SERVER['DOCUMENT_ROOT'] . $url, $left + 15, 15, 50);
+                $pdf->ImagePngWithAlpha($url, $left + 15, 15, 50);
             } else {
                 // Converting to .png
                 $img = imagecreatefromstring(file_get_contents($url));

--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -1226,9 +1226,9 @@ class Service implements InjectionAwareInterface
 
         if (isset($company['logo_url']) && !empty($company['logo_url'])) {
             $url = parse_url($company['logo_url'], PHP_URL_PATH);
-            if(!file_exists($url){
+            if(!file_exists($url)){
                 $url = $_SERVER['DOCUMENT_ROOT'] . $url;
-                if(!file_exists($url){
+                if(!file_exists($url)){
                     // Assume the URL points to an image not hosted on this server
                     $url = $company['logo_url'];
                 }
@@ -1245,7 +1245,7 @@ class Service implements InjectionAwareInterface
                         unlink($filename);
                     }
                 } else {
-                    throw new \Box_Exception('Error converting image to .png');
+                    throw new \Box_Exception('Error converting logo to PNG. Please ensure company logo is of the JPEG, PNG, GIF, BMP, WBMP, GD2, or WEBP type.');
                 }
             }
         }


### PR DESCRIPTION
A few fixes for PDF invoice generation.

Address two issues left after https://github.com/FOSSBilling/FOSSBilling/commit/669b7142028283a4acc16d464844717626b0af57

1. Properly add the document root to the URL when needed
2. If the URL is an actual URL and points to an image not on this server, use that URL instead of stripping it down to the path

Additionally,  we can only convert JPEG, PNG, GIF, BMP, WBMP, GD2, or WEBP images with `imagecreatefromstring` so specify that when giving an error.

On another note, by default we ship FOSSBilling with a SVG for the logo. This means PDFs cannot be generated unless that logo is replaced with a different format