### PR TITLE
Implement GetClass replacement

### DIFF
--- a/src/bb-modules/Hook/Service.php
+++ b/src/bb-modules/Hook/Service.php
@@ -112,8 +112,8 @@ class Service implements InjectionAwareInterface
                     $p = $method->getParameters();
                     if ($method->isPublic()
                         && isset($p[0])
-                        && $p[0]->getclass()
-                        && in_array($p[0]->getclass()->getName(), ['Box_Event', '\Box_Event'])) {
+                        && $p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null
+                        && in_array($p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null, ['Box_Event', '\Box_Event'])) {
                         $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
                     }
                 }


### PR DESCRIPTION
This was issue 1002 in BB.
GetClass is deprecated in PHP 8, causing a lot of spam in the log & at some point the function will be completely removed, thus breaking things.

Tested locally and the hooks still seem to activate correctly. See the screenshot where I activated two extensions after applying this PR:
![image](https://user-images.githubusercontent.com/17304943/195221755-14d37174-b0dd-4e0b-8741-435c0bb45790.png)
