### PR TITLE
Use action secrets instead

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: 'releases'
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -88,5 +88,5 @@ jobs:
           AWS_S3_BUCKET: 'releases'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_S3_ENDPOINT: 'https://s4-ams-fossbilling.nl-ams1.upcloudobjects.com/'
+          AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
           SOURCE_DIR: './build/distribution'


### PR DESCRIPTION
This PR uses action secrets for the S3 endpoint so we don't have to create a PR each time we want to point to another instance.