### PR TITLE
Replace usage of filter_var with htmlspecialchars

### DIFF
--- a/src/bb-library/Box/App.php
+++ b/src/bb-library/Box/App.php
@@ -62,7 +62,7 @@ class Box_App
                 [$mod] = explode('/', $requestUri);
             }
         }
-        $mod = filter_var($mod, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH);
+        $mod = htmlspecialchars($mod);
 
         $this->mod = $mod;
         $this->uri = $requestUri;


### PR DESCRIPTION
`8192 Constant FILTER_SANITIZE_STRING is deprecated public_html/FOSSBilling/bb-library/Box/App.php 65`

With PHP 8.1.0 `FILTER_SANITIZE_STRING` and `FILTER_SANITIZE_STRIPPED` is deprecated. Recommended to instead use `htmlspecialchars`

This is the only instance of filter_var being used like this in the code