### PR TITLE
Apply workaround for SVG images on PDFs

### DIFF
--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -1300,7 +1300,12 @@ class Service implements InjectionAwareInterface
                     $options->set('isRemoteEnabled',true);
                 }
 			}
-            $html .= "<img src=\"$url\" height=\"50\" class=\"CompanyLogo\"></img>";
+            // Workaround to get SVG images to render. Please see https://github.com/dompdf/dompdf/issues/320
+            if ('.svg' === substr($url, -4)) {
+                $html .= '<img src="data:image/svg+xml;base64,' . base64_encode(file_get_contents($url)) .'" height="50" class="CompanyLogo"></img>';
+            } else {
+                $html .= '<img src="'. $url .'" height="50" class="CompanyLogo"></img>';
+            }
             $html .= '<hr class="Rounded">';
         }
         $invoiceDate = strftime($localeDateFormat, strtotime($this->di['array_get']($invoice, 'due_at', $invoice['created_at'])));


### PR DESCRIPTION
For reference, please see https://github.com/dompdf/dompdf/issues/320 and the "limitations" section on the dompdf readme.
This is the recommended way to load SVG images with dompdf, by base64 encoding them.
dompdf SVG support is still imperfect, however. 
PNG:
![image](https://user-images.githubusercontent.com/17304943/196270860-405234cf-bd5c-4c01-a880-70bdba77f7e3.png)
SVG (default):
![image](https://user-images.githubusercontent.com/17304943/196270939-4a638e69-fbc7-443b-80e9-cbb88f3d6eba.png)


Not sure if we need to make any modifications to the SVG we ship FOSSBilling with to make it properly display with dompdf. 
Looking at that issue, it does seem like there are some considerations that should be used when using an SVG
