### PR TITLE
Use the cryptographically secure random_int()

### DIFF
--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -185,21 +185,21 @@ class Box_Tools
 			break;
 			//lowercase + numeric
 			case 2:
-				$lower = rand(1, $length - 1);
+				$lower = random_int(1, $length - 1);
 				$numeric = $length - $lower;
 			break;
 			//lowercase + uppsercase + numeric
 			case 3:
-				$lower = rand(1, $length - 2);
-				$upper = rand(1, $length - $lower - 1);
+				$lower = random_int(1, $length - 2);
+				$upper = random_int(1, $length - $lower - 1);
 				$numeric = $length - $lower - $upper;
 			break;
 			//lowercase + uppercase + numeric + symbols
             case 4:
 			default:
-				$lower = rand(1, $length - 3);
-				$upper = rand(1, $length - $lower - 2);
-				$numeric = rand(1, $length - $lower - $upper - 1);
+				$lower = random_int(1, $length - 3);
+				$upper = random_int(1, $length - $lower - 2);
+				$numeric = random_int(1, $length - $lower - $upper - 1);
 				$other = $length - $lower - $upper - $numeric;
 			break;
 		}
@@ -207,16 +207,16 @@ class Box_Tools
         $passOrder = array();
 
 		for ($i = 0; $i < $upper; $i++) {
-        	$passOrder[] = $upper_letters[rand() % strlen($upper_letters)];
+        	$passOrder[] = $upper_letters[random_int() % strlen($upper_letters)];
     	}
     	for ($i = 0; $i < $lower; $i++) {
-        	$passOrder[] = $lower_letters[rand() % strlen($lower_letters)];
+        	$passOrder[] = $lower_letters[random_int() % strlen($lower_letters)];
     	}
     	for ($i = 0; $i < $numeric; $i++) {
-        	$passOrder[] = $numbers[rand() % strlen($numbers)];
+        	$passOrder[] = $numbers[random_int() % strlen($numbers)];
     	}
     	for ($i = 0; $i < $other; $i++) {
-        	$passOrder[] = $symbols[rand() % strlen($symbols)];
+        	$passOrder[] = $symbols[random_int() % strlen($symbols)];
     	}
 
     	shuffle($passOrder);

--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -207,16 +207,16 @@ class Box_Tools
         $passOrder = array();
 
 		for ($i = 0; $i < $upper; $i++) {
-        	$passOrder[] = $upper_letters[random_int() % strlen($upper_letters)];
+        	$passOrder[] = $upper_letters[random_int(0,getrandmax()) % strlen($upper_letters)];
     	}
     	for ($i = 0; $i < $lower; $i++) {
-        	$passOrder[] = $lower_letters[random_int() % strlen($lower_letters)];
+        	$passOrder[] = $lower_letters[random_int(0,getrandmax()) % strlen($lower_letters)];
     	}
     	for ($i = 0; $i < $numeric; $i++) {
-        	$passOrder[] = $numbers[random_int() % strlen($numbers)];
+        	$passOrder[] = $numbers[random_int(0,getrandmax()) % strlen($numbers)];
     	}
     	for ($i = 0; $i < $other; $i++) {
-        	$passOrder[] = $symbols[random_int() % strlen($symbols)];
+        	$passOrder[] = $symbols[random_int(0,getrandmax()) % strlen($symbols)];
     	}
 
     	shuffle($passOrder);

--- a/src/bb-library/Model/ClientPasswordResetTable.php
+++ b/src/bb-library/Model/ClientPasswordResetTable.php
@@ -46,7 +46,7 @@ class Model_ClientPasswordResetTable implements \Box\InjectionAwareInterface
         }
         
         $r->ip          = $ip;
-        $r->hash        = sha1(rand(50, rand(10, 99)));
+        $r->hash        = sha1(random_int(50, random_int(10, 99)));
         $r->updated_at  = date('Y-m-d H:i:s');
         $this->di['db']->store($r);
         

--- a/src/bb-library/Registrar/Adapter/Internetbs.php
+++ b/src/bb-library/Registrar/Adapter/Internetbs.php
@@ -220,7 +220,7 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 
         if ($domain->getTld() == '.fr' || $domain->getTld() == '.re')
         {
-            $tm = rand(100000000, 999999999);
+            $tm = random_int(100000000, 999999999);
             $params['registrant_dotFRContactEntityType'] = 'OTHER';
             $params['admin_dotFRContactEntityType'] = 'OTHER';
             $params['registrant_dotFRContactEntityName'] = $c->getName();

--- a/src/bb-library/Registrar/Adapter/srsx.php
+++ b/src/bb-library/Registrar/Adapter/srsx.php
@@ -593,7 +593,7 @@ class Registrar_Adapter_srsx extends Registrar_Adapter_Resellerclub
 		$randomResult = "";
 		mt_srand((double)microtime()*1000000);
 		while (strlen($randomResult)<$length) {
-			$randomResult .= $base[mt_rand(0,$max)];
+			$randomResult .= $base[random_int(0,$max)];
 		}
 		return $randomResult;
 	}

--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -200,7 +200,7 @@ class Service implements InjectionAwareInterface
         try {
             $productId = $this->di['db']->store($model);
         } catch (\Exception $e) {
-            $model->slug = $this->di['tools']->slug($title).'-'.rand(1, 9999);
+            $model->slug = $this->di['tools']->slug($title).'-'.random_int(1, 9999);
         }
         $productId = $this->di['db']->store($model);
 
@@ -415,7 +415,7 @@ class Service implements InjectionAwareInterface
         try {
             $productId = $this->di['db']->store($model);
         } catch (\Exception $e) {
-            $model->slug = $this->di['tools']->slug($title).'-'.rand(1, 9999);
+            $model->slug = $this->di['tools']->slug($title).'-'.random_int(1, 9999);
             $productId = $this->di['db']->store($model);
         }
 

--- a/src/bb-modules/Servicecentovacast/Service.php
+++ b/src/bb-modules/Servicecentovacast/Service.php
@@ -202,7 +202,7 @@ class Service implements \Box\InjectionAwareInterface
         $sql = 'SELECT id FROM service_centovacast WHERE username = :u';
         $exists = $this->di['db']->getCell($sql, ['u' => $u]);
         if ($exists) {
-            $u = $u . rand(1, 100);
+            $u = $u . random_int(1, 100);
         }
 
         return $u;

--- a/src/bb-modules/Servicecentovacast/class_HTTPRetriever.php
+++ b/src/bb-modules/Servicecentovacast/class_HTTPRetriever.php
@@ -1474,8 +1474,8 @@ class HTTPRetriever
         $output = [];
         foreach ($fields as $name => $field) {
             if ('image' == $field['type']) {
-                $output[$name.'.x'] = rand(2, 64);
-                $output[$name.'.y'] = rand(2, 16);
+                $output[$name.'.x'] = random_int(2, 64);
+                $output[$name.'.y'] = random_int(2, 16);
             } else {
                 $output[$name] = is_scalar($field['value']) ? $field['value'] : '';
             }

--- a/src/bb-modules/Servicehosting/Service.php
+++ b/src/bb-modules/Servicehosting/Service.php
@@ -396,7 +396,7 @@ class Service implements InjectionAwareInterface
     {
         $username = preg_replace('/[^A-Za-z0-9]/', '', $domain_name);
         $username = substr($username, 0, 7);
-        $randnum = rand(0, 9);
+        $randnum = random_int(0, 9);
         $username = $username.$randnum;
 
         return $username;

--- a/src/bb-modules/Servicelicense/Plugin/Simple.php
+++ b/src/bb-modules/Servicelicense/Plugin/Simple.php
@@ -51,7 +51,7 @@ class Simple
         $size = count($character_array) - 1;
         $string = '';
         for ($i = 1; $i < $length; ++$i) {
-            $string .= (0 == $i % 5) ? '-' : $character_array[rand(0, $size)];
+            $string .= (0 == $i % 5) ? '-' : $character_array[random_int(0, $size)];
         }
 
         return $prefix.$string;


### PR DESCRIPTION
Replaces instances of `rand()` and `mt_rand()` with `random_int()`, which is a drop in replacement, but is cryptographically secure
Edit:
It's mostly a drop in replacement, but does require both the min and max parameters to be used. This results in the same min/max as using `rand()`: `random_int(0,getrandmax()`