### PR TITLE
Fix typo & error with service domain manage page

### DIFF
--- a/src/bb-modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/bb-modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -194,7 +194,7 @@
                                 <input type="hidden" name="order_id" value="{{ order.id }}">
                                 <div class="control-group">
                                     <div class="controls">
-                                        <button class="btn btn-primary" type="submit" value="{{ 'Update' %}">{{ 'Update'|trans }}</button>
+                                        <button class="btn btn-primary" type="submit" value="{{ 'Update' }}">{{ 'Update'|trans }}</button>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
Fixes issue when trying to manage a domain service (unexpected "}")