### PR TITLE
Fix client PW reset

### DIFF
--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -335,7 +335,7 @@ class Admin extends \Api_Abstract
             throw new \Box_Exception('Passwords do not match');
         }
 
-        $this->di['validator']->isPasswordStrong($password);
+        $this->di['validator']->isPasswordStrong($data['password']);
 
         $client = $this->di['db']->getExistingModelById('Client', $data['id'], 'Client not found');
 


### PR DESCRIPTION
Fixes typo that caused the PW to not be passed to `isPasswordStrong`, thus giving an error that it's not long enough