### PR TITLE
Renamed "Blog" to "News"

### DIFF
--- a/src/bb-modules/News/html_client/mod_news_index.html.twig
+++ b/src/bb-modules/News/html_client/mod_news_index.html.twig
@@ -1,7 +1,7 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
-{% block meta_title %}{{ 'Blog'|trans }}{% endblock %}
-{% block breadcrumb %}{{ 'Blog'|trans }}{% endblock %}
+{% block meta_title %}{{ 'News'|trans }}{% endblock %}
+{% block breadcrumb %}{{ 'News'|trans }}{% endblock %}
 
 {% block content %}
 <div class="row">

--- a/src/bb-modules/News/html_client/mod_news_post.html.twig
+++ b/src/bb-modules/News/html_client/mod_news_post.html.twig
@@ -4,7 +4,7 @@
 {% block meta_description %}{{ post.description }}{% endblock %}
 
 {% block breadcrumb %}
-<li><a href="{{ 'news' | link}}">{{ 'Blog'|trans }}</a><span class="divider">/</span></li>
+<li><a href="{{ 'news' | link}}">{{ 'News'|trans }}</a><span class="divider">/</span></li>
 <li class="active">{{post.title}}</li>
 {% endblock %}
 

--- a/src/bb-themes/huraga/html/partial_menu.html.twig
+++ b/src/bb-themes/huraga/html/partial_menu.html.twig
@@ -44,7 +44,7 @@
 
     {% if (guest.extension_is_on({"mod":"news"}) and settings.side_menu_news) %}
     <li class="main-menu">
-        <a href="{{ '/news'|link }}"><span class="awe-edit"></span>{{ 'Blog'|trans }}</a>
+        <a href="{{ '/news'|link }}"><span class="awe-edit"></span>{{ 'News'|trans }}</a>
     </li>
     {% endif %}
 


### PR DESCRIPTION
There seemed to be some confusion with the naming of the Blog/News/Announcements module. It was mostly referred to as "News", but some places like Huraga's sidebar still mentioned it as "Blog".

It seemed like a better fit, and the URL paths already are "/news", so I've renamed it from "Blog" to "News".