### PR TITLE
Changed the position of blocks

### DIFF
--- a/src/bb-themes/huraga/html/layout_default.html.twig
+++ b/src/bb-themes/huraga/html/layout_default.html.twig
@@ -177,7 +177,9 @@
             {% endif %}
         </div>
 
+        {% block content_before %}{% endblock %}
         <div class="content-block" role="main">
+            {% block content %}{% endblock %}
 
             {% if settings.show_breadcrumb %}
             {% block breadcrumbs %}
@@ -274,8 +276,6 @@
             </div>
             {% endif %}
 
-            {% block content_before %}{% endblock %}
-            {% block content %}{% endblock %}
             {% block content_after %}{% endblock %}
         </div>
     </section>


### PR DESCRIPTION
Changed the position of content blocks in Huraga to make sure the content is ordered as intended.

Before:
![image](https://user-images.githubusercontent.com/35808275/197414307-46d9bae1-6db8-426d-bfa1-1f6777e53d8f.png)

After:
![image](https://user-images.githubusercontent.com/35808275/197414286-2d1e238d-6fad-422f-99f8-d430774b999d.png)