### PR TITLE
Enabled the "intl" extension on our Docker installer

### DIFF
--- a/data/docker/php/Dockerfile
+++ b/data/docker/php/Dockerfile
@@ -2,4 +2,5 @@ FROM php:8.0-fpm
 
 RUN apt-get update \
     && docker-php-ext-install \
-        pdo_mysql
+        pdo_mysql \
+        intl

--- a/data/docker/php/Dockerfile
+++ b/data/docker/php/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.0-fpm
 
 RUN apt-get update \
-    && docker-php-ext-install \
-        pdo_mysql \
-        intl
+    && apt-get install -y libicu-dev \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl

--- a/data/docker/php/Dockerfile
+++ b/data/docker/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm
 
 RUN apt-get update \
-    && apt-get install -y libicu-dev \
+    && apt-get install -y --no-install-recommends libicu-dev \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl


### PR DESCRIPTION
Recently, we've added the "intl" extension as a required dependency. This PR now installs and enables the extension on our default Docker installer environment.

Fixes #388.