### PR TITLE
array_get : return null instead of an empty string

### DIFF
--- a/src/bb-di.php
+++ b/src/bb-di.php
@@ -423,7 +423,8 @@ $di['translate'] = $di->protect(function ($textDomain = '') use ($di) {
 });
 
 $di['array_get'] = $di->protect(function (array $array, $key, $default = null) {
-    return array_key_exists($key, $array) ? $array[$key] : $default;
+    $result = array_key_exists($key, $array) ? $array[$key] : $default;
+    return ($result === '') ? null : $result;
 });
 
 return $di;


### PR DESCRIPTION
Fixes #42
Issue was that the client update function was passing an empty string, which was invalid for DB rows that were specified to be an int. 

That issue is not the only example of this cropping up as a problem.

