### PR TITLE
Blocked direct access to Twig template files

### DIFF
--- a/data/docker-nginx.conf
+++ b/data/docker-nginx.conf
@@ -19,6 +19,11 @@ http {
 
         include /etc/nginx/mime.types;
 
+        # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
+        location ~ (\.htaccess$|\.htpasswd$|\.ini$|\.log$|\.sh$|\.inc$|\.bak$|\.twig$|\.sql$) {
+            return 404;
+        }
+
         location @rewrite {
             rewrite ^/page/(.*)$ /index.php?_url=/custompages/$1;
             rewrite ^/(.*)$ /index.php?_url=/$1;
@@ -53,6 +58,5 @@ http {
         location ~ /\.ht {
             deny all;
         }
-        
     }
 }

--- a/data/docker-nginx.conf
+++ b/data/docker-nginx.conf
@@ -3,9 +3,7 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-
     server {
-
         set $root_path '/var/www/html/src';
         listen 80;
 
@@ -29,6 +27,16 @@ http {
             return 404;
         }
 
+        # Disable PHP execution in /bb-uploads
+        location ~* /bb-uploads/.*\.php$ {
+            return 404;
+        }
+        
+        # Deny access to /bb-data
+        location ~* /bb-data/ {
+            return 404;
+        }
+
         location @rewrite {
             rewrite ^/page/(.*)$ /index.php?_url=/custompages/$1;
             rewrite ^/(.*)$ /index.php?_url=/$1;
@@ -45,12 +53,6 @@ http {
             fastcgi_intercept_errors on;
 
             include fastcgi_params;
-        }
-
-        # Disable PHP execution in bb-uploads and bb-data
-        location ^~ /bb-uploads/ { }
-        location ^~ /bb-data/ {
-            deny all;
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {

--- a/data/docker-nginx.conf
+++ b/data/docker-nginx.conf
@@ -20,7 +20,12 @@ http {
         include /etc/nginx/mime.types;
 
         # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
-        location ~ (\.htaccess$|\.htpasswd$|\.ini$|\.log$|\.sh$|\.inc$|\.bak$|\.twig$|\.sql$) {
+        location ~* .(ini|sh|inc|bak|twig|sql)$ {
+            return 404;
+        }
+
+        # Block access to hidden files except .well-known
+        location ~ /\.(?!well-known\/) {
             return 404;
         }
 
@@ -53,10 +58,6 @@ http {
             expires off;
             proxy_no_cache 1;
             proxy_cache_bypass 1;
-        }
-      
-        location ~ /\.ht {
-            deny all;
         }
     }
 }

--- a/data/lighttpd.conf
+++ b/data/lighttpd.conf
@@ -10,7 +10,7 @@ $HTTP["host"] == "demo.example.com" {
       url.access-deny = ("")
   }
   url.rewrite-if-not-file = ( "" => "/index.php?_url=${url.path}${qsa}")
-  url.access-deny = ( "~", "htaccess", "htpasswd", "ini", "log", "sh", "inc", "bak", "phtml", "sql" )
+  url.access-deny = ( "~", "htaccess", "htpasswd", "ini", "log", "sh", "inc", "bak", "twig", "sql" )
 
   server.document-root = vhosts_dir + "/demo.example.com/htdocs/"
   accesslog.filename          = log_root + "/" + server_name + "/access.log"

--- a/data/nginx.conf
+++ b/data/nginx.conf
@@ -1,59 +1,64 @@
 # We've moved the nginx configuration file to our new configuration generator tool. It now is easier to generate a configuraiton file for your web server:
 #
 # https://config.fossbilling.org/
- server {
-     listen 80;
+server {
+    listen 80;
 
-     set $root_path '/var/www/fossbilling/src';
-     server_name fossbilling.vm www.fossbilling.vm;
+    set $root_path '/var/www/fossbilling/src';
+    server_name fossbilling.vm www.fossbilling.vm;
 
-     index index.html index.htm index.php;
-     root $root_path;
-     try_files $uri $uri/ @rewrite;
-     sendfile off;
+    index index.html index.htm index.php;
+    root $root_path;
+    try_files $uri $uri/ @rewrite;
+    sendfile off;
      
-     include /etc/nginx/mime.types;
+    include /etc/nginx/mime.types;
 
-     # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
-     location ~ (\.htaccess$|\.htpasswd$|\.ini$|\.log$|\.sh$|\.inc$|\.bak$|\.twig$|\.sql$) {
-         return 404;
-     }
+    # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
+    location ~* .(ini|sh|inc|bak|twig|sql)$ {
+        return 404;
+    }
 
-     location @rewrite {
-         rewrite ^/page/(.*)$ /index.php?_url=/custompages/$1;
-         rewrite ^/(.*)$ /index.php?_url=/$1;
-     }
+    # Block access to hidden files except .well-known
+    location ~ /\.(?!well-known\/) {
+        return 404;
+    }
 
-     location ~ \.php {
-         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    # Disable PHP execution in /bb-uploads
+    location ~* /bb-uploads/.*\.php$ {
+        return 404;
+    }
+        
+    # Deny access to /bb-data
+    location ~* /bb-data/ {
+        return 404;
+    }
 
-         # fastcgi_pass need to be changed according your server setup:
-         # phpx.x is your server setup
-         # examples: /var/run/phpx.x-fpm.sock, /var/run/php/phpx.x-fpm.sock or /run/php/phpx.x-fpm.sock are all valid options 
-         # Or even localhost:port (Default 9000 will work fine) 
-         # Please check your server setup
+    location @rewrite {
+        rewrite ^/page/(.*)$ /index.php?_url=/custompages/$1;
+        rewrite ^/(.*)$ /index.php?_url=/$1;
+    }
+
+    location ~ \.php {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+
+        # fastcgi_pass need to be changed according your server setup:
+        # phpx.x is your server setup
+        # examples: /var/run/phpx.x-fpm.sock, /var/run/php/phpx.x-fpm.sock or /run/php/phpx.x-fpm.sock are all valid options 
+        # Or even localhost:port (Default 9000 will work fine) 
+        # Please check your server setup
 
         fastcgi_pass unix:/run/php/phpx.x-fpm.sock
 
-         fastcgi_param PATH_INFO       $fastcgi_path_info;
-         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-         fastcgi_intercept_errors on;
+        fastcgi_param PATH_INFO       $fastcgi_path_info;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors on;
 
-         include fastcgi_params;
-     }
+        include fastcgi_params;
+    }
 
-     # Disable PHP execution in bb-uploads and bb-data
-     location ^~ /bb-uploads/ { }
-     location ^~ /bb-data/ {
-       deny all;
-     }
-
-     location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-         root $root_path;
-         expires off;
-     }
-
-     location ~ /\.ht {
-         deny all;
-     }
- }
+    location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
+        root $root_path;
+        expires off;
+    }
+}

--- a/data/nginx.conf
+++ b/data/nginx.conf
@@ -14,6 +14,10 @@
      
      include /etc/nginx/mime.types;
 
+     # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
+     location ~ (\.htaccess$|\.htpasswd$|\.ini$|\.log$|\.sh$|\.inc$|\.bak$|\.twig$|\.sql$) {
+         return 404;
+     }
 
      location @rewrite {
          rewrite ^/page/(.*)$ /index.php?_url=/custompages/$1;

--- a/src/htaccess.txt
+++ b/src/htaccess.txt
@@ -33,17 +33,16 @@ RewriteRule .* index.php [F]
 # This line is for Windows Environment when API is giving authorization error
 RewriteRule .? - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+# Block access to sensitive files and return 404 to make it indistinguishable from a missing file
+RewriteCond %{THE_REQUEST} /.+\.(htaccess|htpasswd|ini|log|sh|inc|bak|twig|sql|_) [NC]
+RewriteRule ^ - [R=404,L]
+
 RewriteCond %{REQUEST_FILENAME} -s [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
 RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
 RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
-
-<FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak|twig|sql)$">
-    Order Allow,Deny
-    Deny from all
-</FilesMatch>
 
 <IfModule mod_headers.c>
     # MONTH

--- a/src/htaccess.txt
+++ b/src/htaccess.txt
@@ -40,7 +40,7 @@ RewriteRule ^.*$ - [NC,L]
 RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
 RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
 
-<FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak|phtml|sql)$">
+<FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak|twig|sql)$">
     Order Allow,Deny
     Deny from all
 </FilesMatch>

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -65,7 +65,7 @@ const BB_PATH_HTACCESS = BB_PATH_ROOT . '/.htaccess';
 const BB_PATH_HTACCESS_TEMPLATE = BB_PATH_ROOT . '/htaccess.txt';
 
 const BB_HURAGA_CONFIG = BB_PATH_THEMES . '/huraga/config/settings_data.json';
-const BB_HURAGA_CONFIG_TEMPLATE = BB_PATH_THEMES . '/huraga/config/settings_data.json.txt';
+const BB_HURAGA_CONFIG_TEMPLATE = BB_PATH_THEMES . '/huraga/config/settings_data.json.example';
 
 // Ensure library/ is on include_path
 set_include_path(implode(PATH_SEPARATOR, [


### PR DESCRIPTION
We've migrated from .phtml to .html.twig long ago. This PR updates the server configuration files to block direct access to Twig template files with the new extension.