### PR TITLE
Fix port selection in Virtualmin manager

### DIFF
--- a/src/bb-library/Server/Manager/Virtualmin.php
+++ b/src/bb-library/Server/Manager/Virtualmin.php
@@ -22,8 +22,10 @@ class Server_Manager_Virtualmin extends Server_Manager
 	    if (!extension_loaded('curl')) {
             throw new Server_Exception('cURL extension is not enabled');
         }
-        
-        $this->_config['port'] = 20000;
+
+		if(empty($this->_config['port'])){
+			$this->_config['port'] = 10000;
+		}
 	}
 
 	public static function getForm()


### PR DESCRIPTION
Should close issue #35.
As far as I can tell, that's the only real issue with the manager.
Default port for virtualmin is 10000, and the URLs are correct in the manager.

I will be honest, though, I was having a hard time reading the original post to understand what they were reporting