### PR TITLE
Add config migrator to the update tab

### DIFF
--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -150,12 +150,22 @@ class Box_Update
         }
 
         //Migrate the configuration file
-        $this->di['tools']->updateConfig();
+        $this->performConfigUpdate();
         
         // clean up things
         $this->di['tools']->emptyFolder(BB_PATH_CACHE);
         $this->di['tools']->emptyFolder(BB_PATH_ROOT.'/install');
         rmdir(BB_PATH_ROOT.'/install');
         return true;
+    }
+
+    /**
+     * Perform config file update
+     *
+     * @throws Exception
+     */
+    public function performConfigUpdate()
+    {
+        return $this->di['tools']->updateConfig();
     }
 }

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -112,6 +112,24 @@ class Admin extends \Api_Abstract
     }
 
     /**
+     * Update FOSSBilling config.
+     *
+     * @return bool
+     *
+     * @throws Box_Exception
+     * @throws Exception
+     */
+    public function update_config($data)
+    {
+        $updater = $this->di['updater'];
+        $updater->performConfigUpdate();
+        
+        $this->di['logger']->info('Updated FOSSBilling config');
+
+        return true;
+    }
+
+    /**
      * Update existing extension.
      *
      * @param string $type - extensions type: mod, theme, gateway ...

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -119,7 +119,7 @@ class Admin extends \Api_Abstract
      * @throws Box_Exception
      * @throws Exception
      */
-    public function update_config($data)
+    public function update_config()
     {
         $updater = $this->di['updater'];
         $updater->performConfigUpdate();

--- a/src/bb-themes/admin_default/html/mod_extension_index.html.twig
+++ b/src/bb-themes/admin_default/html/mod_extension_index.html.twig
@@ -109,6 +109,17 @@
                 </a>
                 <hr>
 
+                <h3>{{ 'Migrate configuration file'|trans }}</h3>
+                <p class="text-muted">{{ 'Use this too to automatically migrate your configuration file to be compatible with the latest FOSSBilling changes. Note: this is only needed when performing manual updates'|trans }}</p>
+
+                <a href="{{ 'api/admin/extension/update_config'|link }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config with will be saved as bb-config.php.old." data-api-msg="Migration complete">
+                    <svg class="icon">
+                        <use xlink:href="#refresh" />
+                    </svg>
+                    {{ 'Migrate configuration'|trans }}
+                </a>
+                <hr>
+
                 <h3>{{ 'Manual update'|trans }}</h3>
                 <p>{{ 'Manual update is a solution when auto updater can not work on current installation environment'|trans }}</p>
 

--- a/src/bb-themes/admin_default/html/mod_extension_index.html.twig
+++ b/src/bb-themes/admin_default/html/mod_extension_index.html.twig
@@ -110,7 +110,7 @@
                 <hr>
 
                 <h3>{{ 'Migrate configuration file'|trans }}</h3>
-                <p class="text-muted">{{ 'Use this too to automatically migrate your configuration file to be compatible with the latest FOSSBilling changes. Note: this is only needed when performing manual updates'|trans }}</p>
+                <p class="text-muted">{{ 'Use this tool to automatically migrate your configuration file to be compatible with the latest FOSSBilling changes. Note: this is only needed when performing manual updates'|trans }}</p>
 
                 <a href="{{ 'api/admin/extension/update_config'|link }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config which will be saved as bb-config.php.old." data-api-msg="Migration complete">
                     <svg class="icon">

--- a/src/bb-themes/admin_default/html/mod_extension_index.html.twig
+++ b/src/bb-themes/admin_default/html/mod_extension_index.html.twig
@@ -112,7 +112,7 @@
                 <h3>{{ 'Migrate configuration file'|trans }}</h3>
                 <p class="text-muted">{{ 'Use this too to automatically migrate your configuration file to be compatible with the latest FOSSBilling changes. Note: this is only needed when performing manual updates'|trans }}</p>
 
-                <a href="{{ 'api/admin/extension/update_config'|link }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config with will be saved as bb-config.php.old." data-api-msg="Migration complete">
+                <a href="{{ 'api/admin/extension/update_config'|link }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config which will be saved as bb-config.php.old." data-api-msg="Migration complete">
                     <svg class="icon">
                         <use xlink:href="#refresh" />
                     </svg>

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -147,6 +147,31 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
+    public function testupdate_config()
+    {
+        $updaterMock = $this->getMockBuilder('\Box_Update')->getMock();
+        $updaterMock->expects($this->atLeastOnce())
+            ->method('performConfigUpdate')
+            ->will($this->returnValue(true));
+
+        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
+
+        $di = new \Box_Di();
+        $di['updater'] = $updaterMock;
+        $di['logger'] = new \Box_Log();
+        $di['tools'] = $toolsMock;
+
+        $this->api->setDi($di);
+
+        $currentConfig = count(include BB_PATH_ROOT.'/bb-config.php');
+
+        $result = $this->api->update_config();
+        $this->assertTrue($result);
+
+        $newConfig = count(include BB_PATH_ROOT.'/bb-config.php');
+        $this->assertEquals($currentConfig, $newConfig);
+    }
+
     public function testupdate_coreNewestVerInstalledException()
     {
         $updaterMock = $this->getMockBuilder('\Box_Update')->getMock();

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -163,12 +163,12 @@ class AdminTest extends \BBTestCase {
 
         $this->api->setDi($di);
 
-        $currentConfig = count(include BB_PATH_ROOT.'/bb-config.php');
+        $currentConfig = include BB_PATH_ROOT.'/bb-config.php';
 
         $result = $this->api->update_config();
         $this->assertTrue($result);
 
-        $newConfig = count(include BB_PATH_ROOT.'/bb-config.php');
+        $newConfig = include BB_PATH_ROOT.'/bb-config.php';
         $this->assertEquals($currentConfig, $newConfig);
     }
 


### PR DESCRIPTION
This can be used by FOSSBilling users when manually updating, or when they are migrating from BoxBilling.
![image](https://user-images.githubusercontent.com/17304943/198812345-d75d437b-6fdc-4a57-9738-21edf95ccbe4.png)
