### PR TITLE
Box_Exception: log a backtrace when debug enabled

### DIFF
--- a/src/bb-config-sample.php
+++ b/src/bb-config-sample.php
@@ -29,6 +29,15 @@ return [
      */
     'debug' => false,
 
+    /**
+     * Enable or disable stacktraces when an exception is thrown (also requires debug to be enabled).
+     */
+    'log_stacktrace' => true,
+    /**
+     * How long the stacktrace should be.
+     */
+    'stacktrace_length' => 25,
+
     'maintenance_mode' => [
         /**
          * Enable or disable the system maintenance mode.

--- a/src/bb-library/Box/Exception.php
+++ b/src/bb-library/Box/Exception.php
@@ -23,10 +23,13 @@ class Box_Exception extends Exception
 	public function __construct($message, array $variables = NULL, $code = 0)
 	{
 		$config = include BB_PATH_ROOT.'/bb-config.php';
+		$debug = (isset($config['debug'])) ? isset($config['debug']) : false;
+		$logStack = (isset($config['log_stacktrace'])) ? isset($config['log_stacktrace']) : true;
+		$stackLength = (isset($config['stacktrace_length'])) ? isset($config['stacktrace_length']) : 25;
 
-		if(isset($config['debug']) && $config['debug'] === true){
-			error_log('An exception has been called. Stacktrace:');
-			error_log( $this->stackTrace() );
+		if($debug && $logStack){
+			error_log('An exception has been thrown. Stacktrace:');
+			error_log( $this->stackTrace($stackLength) );
 		}
 
 		// Set the message

--- a/src/bb-library/Box/Exception.php
+++ b/src/bb-library/Box/Exception.php
@@ -64,7 +64,7 @@ class Box_Exception extends Exception
 	
 			$entry_file = 'NO_FILE';
 			if (array_key_exists('file', $entry)) {
-				$entry_file = $entry['file'];               
+				$entry_file = str_replace(BB_PATH_ROOT, '' , $entry['file']);               
 			}
 			$entry_line = 'NO_LINE';
 			if (array_key_exists('line', $entry)) {

--- a/src/bb-library/Box/Exception.php
+++ b/src/bb-library/Box/Exception.php
@@ -22,10 +22,56 @@ class Box_Exception extends Exception
 	 */
 	public function __construct($message, array $variables = NULL, $code = 0)
 	{
+		$config = include BB_PATH_ROOT.'/bb-config.php';
+
+		if(isset($config['debug']) && $config['debug'] === true){
+			error_log('An exception has been called. Stacktrace:');
+			error_log( $this->stackTrace() );
+		}
+
 		// Set the message
 		$message = __($message, $variables);
 
 		// Pass the message to the parent
 		parent::__construct($message, $code);
+	}
+
+	/**
+	 * Big thank you to jhurliman and jambroseclarke on Stack Overflow for this backtrace formatter.
+	 * We have slightly modified it for our purposes
+	 * https://stackoverflow.com/a/32365961
+	 */
+	private function stackTrace($Length = 25) {
+		$stack = debug_backtrace($Length);
+		$output = '';
+	
+		$stackLen = count($stack);
+		for ($i = 1; $i < $stackLen; $i++) {
+			$entry = $stack[$i];
+	
+			$func = $entry['function'] . '(';
+			if(isset($entry['args'])){
+				$argsLen = count($entry['args']);
+				for ($j = 0; $j < $argsLen; $j++) {
+					$my_entry = $entry['args'][$j];
+					if (is_string($my_entry)) {
+						$func .= $my_entry;
+					}
+					if ($j < $argsLen - 1) $func .= ', ';
+				}
+			}
+			$func .= ')';
+	
+			$entry_file = 'NO_FILE';
+			if (array_key_exists('file', $entry)) {
+				$entry_file = $entry['file'];               
+			}
+			$entry_line = 'NO_LINE';
+			if (array_key_exists('line', $entry)) {
+				$entry_line = $entry['line'];
+			}           
+			$output .= $entry_file . ':' . $entry_line . ' - ' . $func . PHP_EOL;
+		}
+		return $output;
 	}
 }

--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -490,6 +490,8 @@ class Box_Tools
 
         $newConfig = [
             'debug' => (isset($currentConfig['debug'])) ? $currentConfig['debug'] : false,
+            'log_stacktrace' => (isset($currentConfig['log_stacktrace'])) ? $currentConfig['log_stacktrace'] : true,
+            'stacktrace_length' => (isset($currentConfig['stacktrace_length'])) ? $currentConfig['stacktrace_length'] : 25,
             'maintenance_mode' => [
                 'enabled' => (isset($currentConfig['maintenance_mode']['enabled'])) ? $currentConfig['maintenance_mode']['enabled'] : false,
                 'allowed_urls' => (isset($currentConfig['maintenance_mode']['allowed_urls'])) ? $currentConfig['maintenance_mode']['allowed_urls'] : [],

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -411,6 +411,8 @@ final class Box_Installer
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.
         $data = [
             'debug' => false,
+            'log_stacktrace' => true,
+            'stacktrace_length' => 25,
 
             'maintenance_mode' => [
                 'enabled' => false,


### PR DESCRIPTION
Should be helpful for debugging.
Example stacktrace:
```
[29-Oct-2022 06:51:48 UTC] An exception has been called. Stacktrace:
[29-Oct-2022 06:51:48 UTC] /bb-library/Box/Update.php:171 - __construct(Error!)
/bb-modules/Extension/Api/Admin.php:125 - performConfigUpdate()
/bb-library/Api/Handler.php:116 - update_config()
/bb-modules/Api/Controller/Client.php:181 - __call(extension_update_config, )
/bb-modules/Api/Controller/Client.php:90 - _apiCall(admin, extension_update_config, )
/bb-modules/Api/Controller/Client.php:66 - tryCall(admin, extension_update_config, )
NO_FILE:NO_LINE - get_method(, admin, extension, update_config)
/bb-library/Box/App.php:217 - invokeArgs(, )
/bb-library/Box/App.php:370 - executeShared(Box\Mod\Api\Controller\Client, get_method, )
/bb-library/Box/App.php:158 - processRequest()
/index.php:28 - run()
```