### PR TITLE
Disable the API field for staff members

### DIFF
--- a/src/bb-themes/admin_default/html/mod_staff_manage.html.twig
+++ b/src/bb-themes/admin_default/html/mod_staff_manage.html.twig
@@ -171,7 +171,8 @@
             <div class="card-body">
                 <h3>{{ 'API key'|trans }}</h3>
                 <p class="text-muted">{{ 'API keys are used to manage the system via other interfaces.'|trans }}</p>
-
+                <p class="text-muted">{{ 'As of this time, staff members can only change their own API keys from within their'|trans }} <a href="{{ '/admin/staff/profile'|alink }}">profile</a></p>
+                <!--
                 <form method="post" action="admin/profile/generate_api_key" class="api-form" data-api-reload="1">
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API key'|trans }}</label>
@@ -183,6 +184,7 @@
                     <input type="hidden" name="id" value="{{ staff.id }}">
                     <input type="submit" value="{{ 'Generate new key'|trans }}" class="btn btn-primary w-100">
                 </form>
+                -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
On the backend, the API calls will only get / update the API key for the currently logged in staff member, so let's disable this field for staff members to prevent any confusion as seen in #320. Eventually, we will need to rewrite or create a new API call to get this functional
![image](https://user-images.githubusercontent.com/17304943/198848370-f6012125-d403-45d6-9208-8275d33aed1c.png)
