### PR TITLE
Fix exception spam

### DIFF
--- a/src/bb-library/Box/AppAdmin.php
+++ b/src/bb-library/Box/AppAdmin.php
@@ -19,7 +19,9 @@ class Box_AppAdmin extends Box_App
     {
         $m = $this->di['mod']($this->mod);
         $controller = $m->getAdminController();
-        $controller->register($this);
+        if(!is_null($controller)){
+            $controller->register($this);
+        }
     }
 
     public function render($fileName, $variableArray = [])

--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -165,7 +165,7 @@ class Box_Mod
     public function getAdminController()
     {
         if(!$this->hasAdminController()) {
-            throw new \Box_Exception('Module :mod Admin controller class was not found', array(':mod'=>$this->mod));
+            return null;
         }
         $class = 'Box\\Mod\\'.ucfirst($this->mod).'\\Controller\\Admin';
         $service = new $class();

--- a/src/bb-modules/Extension/Service.php
+++ b/src/bb-modules/Extension/Service.php
@@ -246,14 +246,10 @@ class Service implements InjectionAwareInterface
             if (!$staff_service->hasPermission($admin, $mod)) {
                 continue;
             }
+            $m = $this->di['mod']($mod);
+            $obj = $m->getAdminController();
 
-            try {
-                $m = $this->di['mod']($mod);
-                $obj = $m->getAdminController();
-            } catch (\Exception $e) {
-                continue;
-            }
-            if (method_exists($obj, 'fetchNavigation')) {
+            if (!is_null($obj) && method_exists($obj, 'fetchNavigation')) {
                 $n = $obj->fetchNavigation();
 
                 if (isset($n['group'])) {


### PR DESCRIPTION
With modules that don't have an Admin controller, the system would throw exceptions.
Normally, this isn't an issue, but when debug is enabled, it causes a ton of backtraces to be spammed into the log:
```
[31-Oct-2022 06:17:30 UTC] An exception has been thrown. Stacktrace:
[31-Oct-2022 06:17:30 UTC] /bb-library/Box/Mod.php:168 - __construct(Module :mod Admin controller class was not found, )
/bb-modules/Extension/Service.php:252 - getAdminController()
/bb-modules/Extension/Api/Admin.php:73 - getAdminNavigation(, /FOSSBilling/admin/index)
/bb-library/Api/Handler.php:116 - get_navigation()
/vendor/twig/twig/src/Extension/CoreExtension.php:1607 - __call(extension_get_navigation, )
/bb-data/cache/3a/3a64812c83708ad96ad07dfc67d45e473e0814de42261fa82d29cffb59e4de16.php:64 - twig_get_attribute(, , , extension_get_navigation, , method, , , , )
/vendor/twig/twig/src/Template.php:394 - doDisplay(, )
/vendor/twig/twig/src/Template.php:367 - displayWithErrorHandling(, )
/bb-data/cache/f8/f8ad09bfa4133607a1fe14635a0ad14d9af9b6139781736ed6c5a0ae6d41d679.php:555 - display()
/vendor/twig/twig/src/Template.php:171 - block_nav(, )
/bb-data/cache/f8/f8ad09bfa4133607a1fe14635a0ad14d9af9b6139781736ed6c5a0ae6d41d679.php:120 - displayBlock(nav, , )
/vendor/twig/twig/src/Template.php:394 - doDisplay(, )
/vendor/twig/twig/src/Template.php:367 - displayWithErrorHandling(, )
/bb-data/cache/85/855335c64d27d51e37ee04e759a6c978ab1e35961ef69d3f97911c3d3ae88d37.php:47 - display(, )
/vendor/twig/twig/src/Template.php:394 - doDisplay(, )
/vendor/twig/twig/src/Template.php:367 - displayWithErrorHandling(, )
/vendor/twig/twig/src/Template.php:379 - display()
/vendor/twig/twig/src/TemplateWrapper.php:40 - render(, )
/bb-library/Box/AppAdmin.php:29 - render()
/bb-modules/Index/Controller/Admin.php:50 - render(mod_index_dashboard)
NO_FILE:NO_LINE - get_index()
/bb-library/Box/App.php:217 - invokeArgs(, )
/bb-library/Box/App.php:370 - executeShared(Box\Mod\Index\Controller\Admin, get_index, )
/bb-library/Box/App.php:158 - processRequest()
/index.php:28 - run()
```