### PR TITLE
Zip the artifact instead of tar

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: tar cvf ./build/distribution/FOSSBilling-preview.tar -C ./build/source .
+        run: zip -r ./build/distribution/FOSSBilling-preview.zip ./build/source
 
       - name: Upload the final artifact to GitHub
         uses: actions/upload-artifact@v3

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,8 +70,11 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: zip -r ./build/distribution/FOSSBilling-preview.zip .
+        run: zip -r ./FOSSBilling-preview.zip .
         working-directory: ./build/source/
+
+      - name: Copy the archive to its final location
+        run: cp ./build/source/FOSSBilling-preview.zip ./build/distribution
 
       - name: Upload the final artifact to GitHub
         uses: actions/upload-artifact@v3

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,13 +70,14 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: zip -r ./build/distribution/FOSSBilling-preview.zip ./build/source/
+        run: zip -r ./build/distribution/FOSSBilling-preview.zip .
+        working-directory: ./build/source/
 
       - name: Upload the final artifact to GitHub
         uses: actions/upload-artifact@v3
         with:
           name: FOSSBilling Preview Archive
-          path: ./build/distribution/
+          path: ./build/distribution/FOSSBilling-preview.zip
           if-no-files-found: error
 
       - name: Upload the final artifact to our S3 bucket

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: zip -r ./build/distribution/FOSSBilling-preview.zip ./build/source
+        run: zip -r ./build/distribution/FOSSBilling-preview.zip ./build/source/
 
       - name: Upload the final artifact to GitHub
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This limitation should be fine, and once we are using zip files I can submit a PR to allow people to update to preview versions using the auto updater.
![image](https://user-images.githubusercontent.com/17304943/199537806-62bb5a81-d29f-4301-95cf-0784f4f51f43.png)
