### PR TITLE
Introduce the ability to update preview releases

### DIFF
--- a/src/bb-config-sample.php
+++ b/src/bb-config-sample.php
@@ -28,6 +28,12 @@ return [
      * You should keep this disabled unless you're making tests as it can reveal some information about your server.
      */
     'debug' => false,
+	
+    /**
+     * Configure the update branch for the automatic updater.
+     * Currently acceptable options are "release" or "preview".
+     */
+    'update_branch' => 'release',
 
     /**
      * Enable or disable stacktraces when an exception is thrown (also requires debug to be enabled).

--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -490,6 +490,7 @@ class Box_Tools
 
         $newConfig = [
             'debug' => (isset($currentConfig['debug'])) ? $currentConfig['debug'] : false,
+            'update_branch' => (isset($currentConfig['update_branch'])) ? $currentConfig['update_branch'] : 'release',
             'log_stacktrace' => (isset($currentConfig['log_stacktrace'])) ? $currentConfig['log_stacktrace'] : true,
             'stacktrace_length' => (isset($currentConfig['stacktrace_length'])) ? $currentConfig['stacktrace_length'] : 25,
             'maintenance_mode' => [

--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -143,7 +143,7 @@ class Box_Update
      */
     public function performUpdate()
     {
-        if($this->getUpdateBranch() === 'release' && !$this->getCanUpdate()) {
+        if($this->getUpdateBranch() !== 'preview' && !$this->getCanUpdate()) {
             throw new LogicException('You have latest version of FOSSBilling. You do not need to update.');
         }
 

--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -35,7 +35,14 @@ class Box_Update
         return $this->di;
     }
     private $_url = 'https://api.github.com/repos/FOSSBilling/FOSSBilling/releases/latest';
+    private $_preview_url = 'https://fossbilling.org/downloads/preview/';
 
+    /**
+     * Determines which branch FOSSBilling is configured to update from.
+     */
+    public function getUpdateBranch(){
+        return ( isset($this->di['config']['update_branch']) ) ? $this->di['config']['update_branch'] : "release";
+    }
 
     /**
      * Returns latest information
@@ -51,6 +58,10 @@ class Box_Update
      */
     public function getLatestReleaseNotes()
     {
+        if($this->getUpdateBranch() === "preview"){
+            return "Release notes are not available for preview builds. You can check the latest changes on our [Github](https://github.com/FOSSBilling/FOSSBilling/commits/main)";
+        }
+
         $response = $this->_getLatestVersionInfo();
         if(!isset($response['body'])){
             return "**Error: Release info unavailable**";
@@ -64,6 +75,10 @@ class Box_Update
      */
     public function getLatestVersion()
     {
+        if($this->getUpdateBranch() === "preview"){
+            return Box_Version::VERSION;
+        }
+
         $response = $this->_getLatestVersionInfo();
         if(!isset($response['tag_name'])){
             return Box_Version::VERSION;
@@ -77,6 +92,10 @@ class Box_Update
      */
     public function getLatestVersionDownloadLink()
     {
+        if($this->getUpdateBranch() === "preview"){
+            return $this->_preview_url;
+        }
+
         $response = $this->_getLatestVersionInfo();
         return $response['assets'][0]['browser_download_url'];
     }
@@ -124,7 +143,7 @@ class Box_Update
      */
     public function performUpdate()
     {
-        if(!$this->getCanUpdate()) {
+        if($this->getUpdateBranch() === 'release' && !$this->getCanUpdate()) {
             throw new LogicException('You have latest version of FOSSBilling. You do not need to update.');
         }
 

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -96,7 +96,7 @@ class Admin extends \Api_Abstract
     public function update_core($data)
     {
         $updater = $this->di['updater'];
-        if (!$updater->getCanUpdate()) {
+        if($updater->getUpdateBranch() === 'release' && !$updater->getCanUpdate()) {
             throw new \Box_Exception('You have latest version of FOSSBilling. You do not need to update.', null, 930);
         }
 

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -96,7 +96,7 @@ class Admin extends \Api_Abstract
     public function update_core($data)
     {
         $updater = $this->di['updater'];
-        if($updater->getUpdateBranch() === 'release' && !$updater->getCanUpdate()) {
+        if($updater->getUpdateBranch() !== 'preview' && !$updater->getCanUpdate()) {
             throw new \Box_Exception('You have latest version of FOSSBilling. You do not need to update.', null, 930);
         }
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -32,7 +32,8 @@
         "symfony/translation": "^6.0",
         "symfony/twig-bridge": "^6.0",
         "dompdf/dompdf": "^2.0.1",
-        "symfony/polyfill-intl-idn" : "*"
+        "symfony/polyfill-intl-idn" : "*",
+        "nelexa/zip": "^4.0.2"
      
     },
     "require-dev": {

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bb1f83c4e6fa85ac60d5a96c7cf9b1a",
+    "content-hash": "a4fe4a125c81cf77e7b0cc94a812edda",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -892,6 +892,79 @@
             "time": "2019-09-10T13:16:29+00:00"
         },
         {
+            "name": "nelexa/zip",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ne-Lexa/php-zip.git",
+                "reference": "88a1b6549be813278ff2dd3b6b2ac188827634a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ne-Lexa/php-zip/zipball/88a1b6549be813278ff2dd3b6b2ac188827634a7",
+                "reference": "88a1b6549be813278ff2dd3b6b2ac188827634a7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^7.4 || ^8.0",
+                "psr/http-message": "*",
+                "symfony/finder": "*"
+            },
+            "require-dev": {
+                "ext-bz2": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-iconv": "*",
+                "ext-openssl": "*",
+                "ext-xml": "*",
+                "friendsofphp/php-cs-fixer": "^3.4.0",
+                "guzzlehttp/psr7": "^1.6",
+                "phpunit/phpunit": "^9",
+                "symfony/http-foundation": "*",
+                "symfony/var-dumper": "*",
+                "vimeo/psalm": "^4.6"
+            },
+            "suggest": {
+                "ext-bz2": "Needed to support BZIP2 compression",
+                "ext-fileinfo": "Needed to get mime-type file",
+                "ext-iconv": "Needed to support convert zip entry name to requested character encoding",
+                "ext-openssl": "Needed to support encrypt zip entries or use ext-mcrypt"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpZip\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ne-Lexa",
+                    "email": "alexey@nelexa.ru",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PhpZip is a php-library for extended work with ZIP-archives. Open, create, update, delete, extract and get info tool. Supports appending to existing ZIP files, WinZip AES encryption, Traditional PKWARE Encryption, BZIP2 compression, external file attributes and ZIP64 extensions. Alternative ZipArchive. It does not require php-zip extension.",
+            "homepage": "https://github.com/Ne-Lexa/php-zip",
+            "keywords": [
+                "archive",
+                "extract",
+                "unzip",
+                "winzip",
+                "zip",
+                "ziparchive"
+            ],
+            "support": {
+                "issues": "https://github.com/Ne-Lexa/php-zip/issues",
+                "source": "https://github.com/Ne-Lexa/php-zip/tree/4.0.2"
+            },
+            "time": "2022-06-17T11:17:46+00:00"
+        },
+        {
             "name": "phenx/php-font-lib",
             "version": "0.5.4",
             "source": {
@@ -1598,6 +1671,67 @@
                 }
             ],
             "time": "2022-01-02T09:55:41+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v6.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/09cb683ba5720385ea6966e5e06be2a34f2568b1",
+                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v6.0.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-29T07:39:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4936,67 +5070,6 @@
                 }
             ],
             "time": "2022-09-21T20:25:27+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v6.0.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/09cb683ba5720385ea6966e5e06be2a34f2568b1",
-                "reference": "09cb683ba5720385ea6966e5e06be2a34f2568b1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-07-29T07:39:48+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -75,6 +75,9 @@ set_include_path(implode(PATH_SEPARATOR, [
 
 require BB_PATH_VENDOR . '/autoload.php';
 
+$FOSSBillingVersion = Box_Version::VERSION
+$updateBranch = (preg_match('#^(\d+\.)?(\d+\.)?(\d+)(-[a-z0-9]+)?$#i', $FOSSBillingVersion, $matches) !== 0) ? "release" : "preview"; 
+
 final class Box_Installer
 {
     private Session $session;
@@ -184,7 +187,7 @@ final class Box_Installer
                     'files' => $se->files(),
                     'os' => PHP_OS,
                     'os_ok' => true,
-                    'box_ver' => Box_Version::VERSION,
+                    'box_ver' => $FOSSBillingVersion,
                     'box_ver_ok' => $se->isBoxVersionOk(),
                     'php_ver' => $options['php']['version'],
                     'php_ver_req' => $options['php']['min_version'],
@@ -411,6 +414,7 @@ final class Box_Installer
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.
         $data = [
             'debug' => false,
+            'update_branch' => $updateBranch,
             'log_stacktrace' => true,
             'stacktrace_length' => 25,
 

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -121,9 +121,6 @@ class AdminTest extends \BBTestCase {
     public function testupdate_core()
     {
         $updaterMock = $this->getMockBuilder('\Box_Update')->getMock();
-        $updaterMock->expects($this->atLeastOnce())
-            ->method('getCanUpdate')
-            ->will($this->returnValue(true));
 
         $updaterMock->expects($this->atLeastOnce())
             ->method('getLatestVersion')

--- a/tests/bb-modules/Extension/Api/AdminTest.php
+++ b/tests/bb-modules/Extension/Api/AdminTest.php
@@ -121,6 +121,9 @@ class AdminTest extends \BBTestCase {
     public function testupdate_core()
     {
         $updaterMock = $this->getMockBuilder('\Box_Update')->getMock();
+        $updaterMock->expects($this->atLeastOnce())
+            ->method('getCanUpdate')
+            ->will($this->returnValue(true));
 
         $updaterMock->expects($this->atLeastOnce())
             ->method('getLatestVersion')


### PR DESCRIPTION
Now that our preview builds are zip files, we can use them for as an auto update source.
This PR adds that functionality. Tested and verified it works correctly 

Also re-added the zip dependency that was wrongly removed here: https://github.com/FOSSBilling/FOSSBilling/commit/ec2fe7e9f56120bdaafed0ef96fe965022addd1e