### PR TITLE
Fix issue #426

### DIFF
--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -591,7 +591,8 @@ class Service implements \Box\InjectionAwareInterface
             ++$queue->tries;
             $queue->updated_at = date('Y-m-d H:i:s');
             $this->di['db']->store($queue);
-            if ($settings['cancel_after'] && $queue->tries > $settings['cancel_after']) {
+            $maxTries = ( isset($settings['cancel_after']) ) ? $settings['cancel_after'] : 5;
+            if ($queue->tries > $maxTries) {
                 $this->di['db']->trash($queue);
             }
         }

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -583,7 +583,14 @@ class Service implements \Box\InjectionAwareInterface
                 error_log($e->getMessage());
             }
         } catch (\Exception $e) {
-            error_log($e->getMessage());
+            $message = $e->getMessage();
+            error_log($message);
+
+            // Prevent mass retries of emails if one of them is "invalid"
+            if(strpos($message, 'Invalid address:') !== false) {
+                return true;
+            }
+
             if ($queue->priority) {
                 --$queue->priority;
             }

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -588,6 +588,11 @@ class Service implements \Box\InjectionAwareInterface
 
             // Prevent mass retries of emails if one of them is "invalid"
             if(strpos($message, 'Invalid address:') !== false) {
+                try {
+                    $this->di['db']->trash($queue);
+                } catch (\Exception $e) {
+                    error_log($e->getMessage());
+                }
                 return true;
             }
 

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -599,7 +599,7 @@ class Service implements \Box\InjectionAwareInterface
             $queue->updated_at = date('Y-m-d H:i:s');
             $this->di['db']->store($queue);
             $maxTries = ( isset($settings['cancel_after']) ) ? $settings['cancel_after'] : 5;
-            if ($queue->tries > $maxTries) {
+            if ($queue->tries > $maxTries && $maxTries !== 0) {
                 $this->di['db']->trash($queue);
             }
         }

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -604,7 +604,7 @@ class Service implements \Box\InjectionAwareInterface
             $queue->updated_at = date('Y-m-d H:i:s');
             $this->di['db']->store($queue);
             $maxTries = ( isset($settings['cancel_after']) ) ? $settings['cancel_after'] : 5;
-            if ($queue->tries > $maxTries && $maxTries !== 0) {
+            if ($queue->tries > $maxTries) {
                 $this->di['db']->trash($queue);
             }
         }

--- a/src/bb-modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/bb-modules/Email/html_admin/mod_email_settings.html.twig
@@ -86,7 +86,7 @@
                     <div class="formBottom" id="mailer">
                         <label>{{ 'Send emails per cron run (0 = unlimited)'|trans }}</label><input type="text" name="queue_once" placeholder="0" value="{{ params.queue_once }}"/>
                         <label>{{ 'Max email sending time in minutes (0 = unlimited, default 5 min.)'|trans }}</label><input type="text" name="time_limit" placeholder="5" value="{% if params.time_limit %}{{ params.time_limit }}{% else %}5{% endif %}"/>
-                        <label>{{ 'Cancel sending email after unsuccessful tries (0 = do not cancel)'|trans }}</label><input type="text" name="cancel_after" placeholder="5" value="{{ params.cancel_after }}"/>
+                        <label>{{ 'Cancel sending email after unsuccessful tries'|trans }}</label><input type="text" name="cancel_after" placeholder="5" value="{{ params.cancel_after }}"/>
                     </div>
                     <div class="fix"></div>
                 </div>

--- a/src/bb-modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/bb-modules/Email/html_admin/mod_email_settings.html.twig
@@ -86,7 +86,7 @@
                     <div class="formBottom" id="mailer">
                         <label>{{ 'Send emails per cron run (0 = unlimited)'|trans }}</label><input type="text" name="queue_once" placeholder="0" value="{{ params.queue_once }}"/>
                         <label>{{ 'Max email sending time in minutes (0 = unlimited, default 5 min.)'|trans }}</label><input type="text" name="time_limit" placeholder="5" value="{% if params.time_limit %}{{ params.time_limit }}{% else %}5{% endif %}"/>
-                        <label>{{ 'Cancel sending email after unsuccessful tries (0 = do not cancel)'|trans }}</label><input type="text" name="cancel_after" placeholder="0" value="{{ params.cancel_after }}"/>
+                        <label>{{ 'Cancel sending email after unsuccessful tries (0 = do not cancel)'|trans }}</label><input type="text" name="cancel_after" placeholder="5" value="{{ params.cancel_after }}"/>
                     </div>
                     <div class="fix"></div>
                 </div>


### PR DESCRIPTION
If accepted, this PR should close issue #426 

Two major issues with the current implementation:
1) The default is to retry sending emails UNLIMITED TIMES. Changed this to 5
2) PHPMailer was complaining about an invalid email address and FOSSBilling then retried the entire mail queue. This changes it so if the exception is for an invalid address, it simply ignores the exception and performs the same behavior as if there was no exception

Having the reporter test this patch, do not merge yet