### PR TITLE
Use semver regex to check if running preview build

### DIFF
--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -45,6 +45,18 @@ class Box_Update
     }
 
     /**
+     * Checks if FOSSBilling is running a preview version or not
+     */
+    public function isPreviewVersion(){
+        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
+        if(preg_match($reg, $this->getLatestVersion) !== '1'){
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Returns latest information
      */
     private function _getLatestVersionInfo()
@@ -109,6 +121,7 @@ class Box_Update
     {
         $version = $this->getLatestVersion();
         $result = Box_Version::compareVersion($version);
+        $result = ($this->isPreviewVersion()) ? 1 : $result;
         return ($result > 0);
     }
 

--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -48,11 +48,11 @@ class Box_Update
      * Checks if FOSSBilling is running a preview version or not
      */
     public function isPreviewVersion(){
-        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
-        if(preg_match($reg, $this->getLatestVersion) !== '1'){
-            return true;
-        } else {
+        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
+        if(preg_match($reg, $this->getLatestVersion) === '0'){
             return false;
+        } else {
+            return true;
         }
     }
 

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -409,7 +409,8 @@ final class Box_Installer
     private function _getConfigOutput($ns): string
     {
         $version = new Box_Requirements();
-        $updateBranch = (preg_match('#^(\d+\.)?(\d+\.)?(\d+)(-[a-z0-9]+)?$#i', Box_Version::VERSION, $matches) !== 0) ? "release" : "preview"; 
+        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
+        $updateBranch = (preg_match($reg, Box_Version::VERSION, $matches) !== 0) ? "release" : "preview"; 
 
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.
         $data = [

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -409,7 +409,7 @@ final class Box_Installer
     private function _getConfigOutput($ns): string
     {
         $version = new Box_Requirements();
-        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
+        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
         $updateBranch = (preg_match($reg, Box_Version::VERSION, $matches) !== 0) ? "release" : "preview"; 
 
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.


### PR DESCRIPTION
Closes https://github.com/FOSSBilling/FOSSBilling/issues/221 as now the updater will always allow an update if the current version number is not a valid semver version.
Uses the official regex https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string