### PR TITLE
Reworked the settings page

### DIFF
--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -157,6 +157,38 @@ class Box_Mod
         return file_exists($this->_getModPath() . 'html_admin/mod_'.$this->mod.'_settings.html.twig');
     }
 
+    public function hasSettingsRoutes()
+    {
+        if($this->hasService()) {
+            $s = $this->getService();
+            if(method_exists($s, 'getSettingsRoutes')) {
+                return (count($s->getSettingsRoutes()) > 0);
+            }
+        }
+
+        return false;
+    }
+
+    public function getSettingsRoutes()
+    {
+        $result = array();
+        
+        if ($this->hasSettingsRoutes()) {
+            foreach ($this->getService()->getSettingsRoutes() as $route) {
+                // Check if it is a valid external link
+                $filtered = filter_var(idn_to_ascii($route["path"]), FILTER_VALIDATE_URL);
+                
+                // If it's an external link, return it directly. Otherwise, return the internal link with the /admin prefix.
+                $route['path'] = $filtered ? $filtered : $this->di['url']->adminLink($route["path"], []);
+                $result[] = $route;
+            }
+
+            return $result;
+        } else {
+            return array();
+        }
+    }
+
     public function hasAdminController()
     {
         return file_exists($this->_getModPath() . 'Controller/Admin.php');

--- a/src/bb-modules/Client/Service.php
+++ b/src/bb-modules/Client/Service.php
@@ -38,6 +38,28 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'active' => array(
+                'path' => '/client?status=active',
+                'label' => 'Active clients',
+            ),
+            'suspended' => array(
+                'path' => '/client?status=suspended',
+                'label' => 'Suspended clients',
+            ),
+            'canceled' => array(
+                'path' => '/client?status=canceled',
+                'label' => 'Canceled clients',
+            ),
+            'all' => array(
+                'path' => '/client',
+                'label' => 'All clients',
+            ),
+        );
+    }
+
     public function approveClientEmailByHash($hash)
     {
         $db = $this->di['db'];

--- a/src/bb-modules/Cron/Service.php
+++ b/src/bb-modules/Cron/Service.php
@@ -33,6 +33,16 @@ class Service
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'exec' => array(
+                'path' => BB_URL . 'bb-cron.php',
+                'label' => 'Execute now',
+            ),
+        );
+    }
+
     public function getCronInfo()
     {
         $service = $this->di['mod_service']('system');

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -30,6 +30,16 @@ class Service implements \Box\InjectionAwareInterface
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'history' => array(
+                'path' => 'email/history',
+                'label' => 'Email history',
+            ),
+        );
+    }
+
     public function getSearchQuery($data)
     {
         $query = 'SELECT * FROM activity_client_email';

--- a/src/bb-modules/Example/Service.php
+++ b/src/bb-modules/Example/Service.php
@@ -36,6 +36,25 @@ class Service
     }
 
     /**
+     * This method returns an array of custom links to be displayed in the settings page of the admin area.
+     * 
+     * @return array
+     */
+    public function getSettingsRoutes()
+    {
+        return array(
+            'source' => array(
+                'path' => 'https://github.com/FOSSBilling/example', // An example external link
+                'label' => 'View source code',
+            ),
+            'example' => array(
+                'path' => 'extension/settings/example', // An example internal link. Internal links are relative to the custom admin panel path.
+                'label' => 'This is an example!',
+            ),
+        );
+    }
+
+    /**
      * Method to install module. In most cases you will provide your own
      * database table or tables to store extension related data.
      *

--- a/src/bb-modules/Extension/Service.php
+++ b/src/bb-modules/Extension/Service.php
@@ -133,6 +133,8 @@ class Service implements InjectionAwareInterface
                 $manifest = $m->getManifest();
                 $manifest['status'] = 'core';
                 $manifest['has_settings'] = $m->hasSettingsPage();
+                $manifest['has_settings_routes'] = $m->hasSettingsRoutes();
+                $manifest['settings_routes'] = $m->hasSettingsRoutes() ? $m->getSettingsRoutes() : array();
                 $result[] = $manifest;
             }
         }
@@ -147,10 +149,10 @@ class Service implements InjectionAwareInterface
             $manifest['version'] = $im['version'];
 
             $manifest['status'] = $im['status'];
-            if ('mod' == $im['type'] && 'installed' == $im['status'] && $m->hasSettingsPage()) {
-                $manifest['has_settings'] = true;
-            } else {
-                $manifest['has_settings'] = false;
+            if ('mod' == $im['type'] && 'installed' == $im['status']) {
+                $manifest['has_settings'] = $m->hasSettingsPage();
+                $manifest['has_settings_routes'] = $m->hasSettingsRoutes();
+                $manifest['settings_routes'] = $m->hasSettingsRoutes() ? $m->getSettingsRoutes() : array();
             }
 
             $result[] = $manifest;
@@ -173,6 +175,8 @@ class Service implements InjectionAwareInterface
                 $manifest = $m->getManifest();
                 $manifest['status'] = null;
                 $manifest['has_settings'] = false;
+                $manifest['has_settings_routes'] = false;
+                $manifest['settings_routes'] = array();
 
                 $result[] = $manifest;
             }

--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -42,6 +42,28 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'unpaid' => array(
+                'path' => '/invoice?status=unpaid',
+                'label' => 'Unpaid invoices',
+            ),
+            'paid' => array(
+                'path' => '/invoice?status=paid',
+                'label' => 'Paid invoices',
+            ),
+            'refunded' => array(
+                'path' => '/invoice?status=refunded',
+                'label' => 'Refunded invoices',
+            ),
+            'all' => array(
+                'path' => '/invoice',
+                'label' => 'All invoices',
+            ),
+        );
+    }
+
     public function getSearchQuery($data)
     {
         $sql = 'SELECT p.*
@@ -1274,7 +1296,7 @@ class Service implements InjectionAwareInterface
                     div.Breakdown{
                         position: absolute;
                         width: 100%;
-                        top: 405px;
+                        top: 400px;
                     }
                     table {
                         border-collapse: collapse;
@@ -1337,13 +1359,8 @@ class Service implements InjectionAwareInterface
         $html .= '<p>Phone: ' . $invoice['buyer']['phone'] . '</p>';
         $html .= '</div>';
 
-        $html .= 
-        '<div class="Breakdown">';
-        if (!empty($invoice['text_1'])){
-            $html .= '<p>' . $invoice['text_1'] . '</p>';
-        }
-        $html .= 
-        '<table style="width:100%">
+        $html .= '<div class="Breakdown">
+        <table style="width:100%">
         <tr>
             <th>#</th>
             <th>Product</th>
@@ -1382,12 +1399,8 @@ class Service implements InjectionAwareInterface
         $html .= '<th class="right" colspan="3">Total:</th>';
         $html .= '<th>' . $invoice['total'] . $currencyCode . '</th>';
         $html .= '</tr>';
-        $html .= '</table>';
 
-        if (!empty($invoice['text_2'])){
-            $html .= '<p>' . $invoice['text_2'] . '</p>';
-        }
-        $html .= '</div>';
+        $html .= '</table>';
         $html .= '</body>
                   </html>';
 

--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -38,6 +38,28 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'pending_setup' => array(
+                'path' => '/order?status=pending_setup',
+                'label' => 'Orders pending setup',
+            ),
+            'active' => array(
+                'path' => '/order?status=active',
+                'label' => 'Active orders',
+            ),
+            'suspended' => array(
+                'path' => '/order?status=suspended',
+                'label' => 'Suspended orders',
+            ),
+            'all' => array(
+                'path' => '/order',
+                'label' => 'All orders',
+            ),
+        );
+    }
+
     public function counter()
     {
         $sql = '

--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -30,6 +30,28 @@ class Service implements \Box\InjectionAwareInterface
         return $this->di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'open' => array(
+                'path' => '/support?status=open',
+                'label' => 'Tickets waiting for staff reply',
+            ),
+            'on_hold' => array(
+                'path' => '/support?status=on_hold',
+                'label' => 'Tickets waiting for client reply',
+            ),
+            'closed' => array(
+                'path' => '/support?status=closed',
+                'label' => 'Resolved tickets',
+            ),
+            'all' => array(
+                'path' => '/support',
+                'label' => 'All tickets',
+            ),
+        );
+    }
+
     public static function onAfterClientOpenTicket(\Box_Event $event)
     {
         $di = $event->getDi();

--- a/src/bb-modules/System/Service.php
+++ b/src/bb-modules/System/Service.php
@@ -28,6 +28,24 @@ class Service
         $this->di = $di;
     }
 
+    public function getSettingsRoutes()
+    {
+        return array(
+            'report_bug' => array(
+                'path' => 'https://github.com/FOSSBilling/FOSSBilling/issues/',
+                'label' => 'Report a bug',
+            ),
+            'activity' => array(
+                'path' => 'activity',
+                'label' => 'Event history',
+            ),
+            'languages' => array(
+                'path' => 'extension/languages',
+                'label' => 'Languages',
+            ),
+        );
+    }
+
     /**
      * @param string $param
      * @param bool   $default

--- a/src/bb-themes/admin_default/html/mod_system_index.html.twig
+++ b/src/bb-themes/admin_default/html/mod_system_index.html.twig
@@ -9,32 +9,29 @@
 
 {% block content %}
     <div class="card">
-        <div class="tabs_container">
-            <div id="tab-index" class="tab_content nopadding">
-                {% include 'partial_search.html.twig' %}
-                <table class="table card-table table-vcenter table-striped text-nowrap">
-                    <tbody>
-                        {% for ext in admin.extension_get_list({ 'active': 1, 'has_settings': 1 }|merge(request)) %}
-                        <tr>
-                            <td class="w-5">
-                                <a href="{{ 'extension/settings'|alink }}/{{ ext.id }}">
-                                    <img src="{{ ext.icon_url }}" alt="{{ ext.name }}" style="width: 32px; height: 32px;">
-                                </a>
-                            </td>
-                            <td>
-                                <a href="{{ 'extension/settings'|alink }}/{{ ext.id }}">{{ ext.name }}</a>
-                            </td>
-                            <td class="w-1">
-                                <a class="btn btn-icon" href="{{ 'extension/settings'|alink }}/{{ ext.id }}">
-                                    <svg class="icon">
-                                        <use xlink:href="#play" />
-                                    </svg>
-                                </a>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+        <div class="card-header">
+            <h3 class="card-title">Settings</h3>
+        </div>
+        <div class="card-body">
+            <div class="datagrid">
+                {% for ext in admin.extension_get_list({ 'active': 1, 'has_settings': 1 }|merge(request)) %}
+                    <div class="datagrid-item">
+                        <div class="datagrid-title">
+                            <a href="{{ 'extension/settings'|alink }}/{{ ext.id }}" class="text-reset">
+                                <img src="{{ ext.icon_url }}" alt="{{ ext.name }}" style="width: 32px; height: 32px; margin-right: .5rem;"> {{ ext.name }}
+                            </a>
+                        </div>
+                        <div class="datagrid-content">
+                            <ul>
+                                {% for route in ext.settings_routes %}
+                                <li>
+                                    <a href="{{ route.path }}">{{route.label}}</a>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Rewritten the settings page to include quick actions. It now uses space more efficiently, and I think the quick actions will save some time (at least for me).

Here is the old layout:
![image](https://user-images.githubusercontent.com/35808275/201665576-5472a0aa-7064-47ea-97ef-c223dafe2387.png)

Versus the new layout:
![image](https://user-images.githubusercontent.com/35808275/201665734-898f50d7-8391-4472-a313-6d420b317f2e.png)

-----

This PR also introduces two new keys for the `admin/extension/get_list` endpoint: `has_settings_routes` and `settings_routes`.

`has_settings_routes` is a bool, `settings_routes` is an array.

![image](https://user-images.githubusercontent.com/35808275/201665071-22f8267c-65cf-4188-88c2-c2134610c9b7.png)

-----
## How can modules make use of this?
Modules' service classes can define a method named `getSettingsRoutes` like shown here in the example module:
https://github.com/FOSSBilling/FOSSBilling/blob/01e354d4f7dd2078e9173a38351c617238dad09a/src/bb-modules/Example/Service.php#L43-L55

This way, modules can dynamically define quick action links.