### PR TITLE
Rewritten the example module to reflect Tabler's styling

### DIFF
--- a/src/bb-modules/Cron/Service.php
+++ b/src/bb-modules/Cron/Service.php
@@ -66,7 +66,7 @@ class Service
     public function runCrons($interval = null)
     {
         $api = $this->di['api_system'];
-        $this->di['logger']->info('- Started executing cron');
+        $this->di['logger']->info('Started executing cron jobs');
 
         // @core tasks
         $this->_exec($api, 'hook_batch_connect');
@@ -91,7 +91,7 @@ class Service
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
 
-        $this->di['logger']->info('- Finished executing cron');
+        $this->di['logger']->info('Finished executing cron jobs');
 
         return true;
     }

--- a/src/bb-modules/Example/README.md
+++ b/src/bb-modules/Example/README.md
@@ -11,7 +11,7 @@ All modules can communicate with the other modules using their API endpoints.
 # Technical requirements about modules
 
 ## Required
-* API folder has to contain a **manifest.json** file to describe itself. The module engine will look for this file to find information about your extension.
+* Module folder has to contain a **manifest.json** file to describe itself. The module engine will look for this file to find information about your extension.
 
 ## Optional
 * **README.md** - file for installation and getting started instructions

--- a/src/bb-modules/Example/html_admin/mod_example_index.html.twig
+++ b/src/bb-modules/Example/html_admin/mod_example_index.html.twig
@@ -5,69 +5,66 @@
 {% set active_menu = 'example' %}
 
 {% block content %}
-
-<div class="widget">
-    <div class="head">
-        <h5>{{ 'Example module for developers'|trans }}</h5>
+<div class="card">
+	<div class="card-header">
+		<h5>{{ 'Example module for developers'|trans }}</h5>
     </div>
-
-    <div class="help">
-        <h3>{{ 'This is an example extension'|trans }}</h3>
+    <!-- First card -->
+    <div class="card-body">
+        <p>{{ 'This is an example module.'|trans }}</p>
+        <ul>
+            <li><a href="{{ 'example'|alink }}">Example module index</a></li>
+            <li><a href="{{ 'extension/settings/example'|alink }}">Example settings page</a></li>
+            <li><a href="{{ 'example'|alink }}/test">Test link with static URL</a></li>
+            <li><a href="{{ 'example'|alink }}/user/1">Test link location with parameter 1</a></li>
+            <li><a href="{{ 'example'|alink }}/user/2">Test link location with parameter 2</a></li>
+            <li><a href="{{ 'example'|alink }}/user/3">Test link location with parameter 3</a></li>
+            <li><a href="{{ 'example'|alink }}/api">API example</a></li>
+            <li><a href="{{ 'example'|link }}" target="_blank">Client area link example</a></li>
+        </ul>
     </div>
-    <ul>
-        <li><a href="{{ 'example'|alink }}">Example module index</a></li>
-        <li><a href="{{ 'extension/settings/example'|alink }}">Example settings page</a></li>
-        <li><a href="{{ 'example'|alink }}/test">Test link with static URL</a></li>
-        <li><a href="{{ 'example'|alink }}/user/1">Test link location with parameter 1</a></li>
-        <li><a href="{{ 'example'|alink }}/user/2">Test link location with parameter 2</a></li>
-        <li><a href="{{ 'example'|alink }}/user/3">Test link location with parameter 3</a></li>
-        <li><a href="{{ 'example'|alink }}/api">API example</a></li>
-        <li><a href="{{ 'example'|link }}" target="_blank">Client area link example</a></li>
-    </ul>
 
     {# Check if example parameters passed to template file #}
     {% if youparamname %}
-    <div class="help">
-        <h3>{{ 'Parameters from Controller'|trans }}</h3>
+    <div class="card-header">
+        <h5>{{ 'Parameters from Controller'|trans }}</h5>
     </div>
-    <div class="body">
+    <div class="card-body">
         <p>You have passed parameter youparamname: <strong>{{ youparamname }}</strong></p>
     </div>
     {% endif %}
 
     {# Check if example parameters passed to template file #}
     {% if userid %}
-    <div class="help">
-        <h3>{{ 'Parameters from URL'|trans }}</h3>
-    </div>
-    <div class="body">
-        <p>You have passed parameter userid: <strong>{{ userid }}</strong></p>
-    </div>
+        <div class="card-header">
+            <h5>{{ 'Parameters from URL'|trans }}</h5>
+        </div>
+        <div class="card-body">
+            <p>You have passed parameter userid: <strong>{{ userid }}</strong></p>
+        </div>
     {% endif %}
 
     {% if api_example %}
         {# API example #}
-        <div class="help">
-            <h3>{{ 'API example'|trans }}</h3>
+        <div class="card-header">
+            <h5>{{ 'API example'|trans }}</h5>
         </div>
-        <div class="body">
-        <h5 class="pt12">Data from API and passed to template from controller</h5>
-        <pre>{{ dump(list_from_controller) }}</pre>
+        <div class="card-body">
+            <h5 class="pt12">Data from API and passed to template from controller</h5>
+            <pre>{{ dump(list_from_controller) }}</pre>
 
-        <h5 class="pt12">Data from API accessed directly from template file</h5>
-        {% set list = admin.example_get_something({"microsoft":1}) %}
-        <pre>{{ dump(list) }}</pre>
+            <h5 class="pt12">Data from API accessed directly from template file</h5>
+            {% set list = admin.example_get_something({"microsoft":1}) %}
+            <pre>{{ dump(list) }}</pre>
         </div>
     {% endif %}
-</div>
 
-<div class="widget">
-    <div class="head">
-        <h5>{{ 'README'|trans }}</h5>
+    <!-- Second card -->
+	<div class="card-header">
+		<h5>{{ 'README'|trans }}</h5>
     </div>
-    
-    <div class="body list arrowBlue">
-        {{ guest.example_readme|bbmd }}
+    <div class="card-body markdown">
+        {{ guest.example_readme | bbmd }}
     </div>
 </div>
 {% endblock %}

--- a/src/bb-modules/Example/html_admin/mod_example_settings.html.twig
+++ b/src/bb-modules/Example/html_admin/mod_example_settings.html.twig
@@ -6,48 +6,34 @@
 
 {% set active_menu = 'system' %}
 
-{% block breadcrumbs %}
-<ul>
-    <li class="firstB"><a href="{{ '/'|alink }}">{{ 'Home'|trans }}</a></li>
-    <li><a href="{{ 'system'|alink }}">{{ 'Settings'|trans }}</a></li>
-    <li class="lastB">{{ 'Example module settings'|trans }}</li>
-</ul>
-{% endblock %}
-
 {% block content %}
-<div class="widget">
-    <div class="head">
-        <h5 class="iCog">{{ 'Example module settings'|trans }}</h5>
+<div class="card">
+	<div class="card-header">
+		<h5>{{ 'Example module settings'|trans }}</h5>
     </div>
 
-{% set params = admin.extension_config_get({ "ext": "mod_example" }) %}
-
-<form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-    <div class="help">
-        <h3>{{ 'Example extension settings'|trans }}</h3>
+    <div class="card-body">
         <p>{{ 'Every extension can have settings page. Only requirement is to have mod_example_settings.html.twig page in html_admin folder'|trans }}</p>
+
+        {% set params = admin.extension_config_get({ "ext": "mod_example" }) %}
+
+        <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Parameter title'|trans }}:</label>
+                <div class="col">
+                    <input class="form-control" type="text" name="custom_param" value="{{ params.custom_param }}" placeholder="{{ 'Example custom value'|trans }}">
+                </div>
+            </div>
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Public parameter title'|trans }}:</label>
+                <div class="col">
+                    <input class="form-control" type="text" name="public[param]" value="{{ params.public.param }}" placeholder="{{ 'This setting will be accessible by the Guest API'|trans }}">
+                </div>
+            </div>
+
+            <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary">
+            <input type="hidden" name="ext" value="mod_example" />
+        </form>
     </div>
-    
-    <fieldset>
-        <div class="rowElem noborder">
-            <label>{{ 'Parameter title'|trans }}</label>
-            <div class="formRight">
-                <input type="text" name="custom_param" value="{{ params.custom_param }}" placeholder="{{ 'Example custom value'|trans }}"/>
-            </div>
-            <div class="fix"></div>
-        </div>
-
-        <div class="rowElem">
-            <label>{{ 'Public parameter title'|trans }}</label>
-            <div class="formRight">
-                <input type="text" name="public[param]" value="{{ params.public.param }}" placeholder="{{ 'This setting will be accessible by the Guest API'|trans }}"/>
-            </div>
-            <div class="fix"></div>
-        </div>
-
-        <input type="submit" value="{{ 'Update'|trans }}" class="greyishBtn submitForm" />
-        <input type="hidden" name="ext" value="mod_example" />
-    </fieldset>
-</form>
 </div>
 {% endblock %}

--- a/src/bb-modules/Example/html_admin/mod_example_settings.html.twig
+++ b/src/bb-modules/Example/html_admin/mod_example_settings.html.twig
@@ -2,7 +2,7 @@
 
 {% import "macro_functions.html.twig" as mf %}
 
-{% block meta_title %}Example extension settings{% endblock %}
+{% block meta_title %}Example module settings{% endblock %}
 
 {% set active_menu = 'system' %}
 

--- a/src/bb-themes/admin_default/html/mod_invoice_transactions.html.twig
+++ b/src/bb-themes/admin_default/html/mod_invoice_transactions.html.twig
@@ -69,28 +69,66 @@
     </div>
 </section>
 {% else %}
-    {% set statuses = admin.invoice_transaction_get_statuses %}
-    <div class="stats">
-        <ul>
-            <li>
-                <a href="{{ 'invoice/transactions'|alink({ 'status': 'processed' }) }}" class="count green">{{ statuses.processed }}</a>
-                <span>{{ 'Processed'|trans }}</span>
-            </li>
-            <li>
-                <a href="{{ 'invoice/transactions'|alink({ 'status': 'approved' }) }}" class="count blue">{{ statuses.approved }}</a>
-                <span>{{ 'Approved'|trans }}</span>
-            </li>
-            <li>
-                <a href="{{ 'invoice/transactions'|alink({ 'status': 'error' }) }}" class="count red">{{ statuses.error }}</a>
-                <span>{{ 'Error'|trans }}</span>
-            </li>
-            <li class="last">
-                <a href="{{ 'invoice/transactions'|alink }}" class="count grey">{{ statuses.received + statuses.approved + statuses.processed + statuses.error }}</a>
-                <span>{{ 'Total'|trans }}</span>
-            </li>
-        </ul>
-        <div class="fix"></div>
-    </div>
+
+{% set statuses = admin.invoice_transaction_get_statuses %}
+    <section class="row row-cards mb-3">
+        <div class="col-sm-6 col-lg-3">
+            <a class="card card-sm card-link" href="{{ 'invoice/transactions'|alink({ 'status': 'processed' }) }}">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="bg-success text-white avatar">{{ statuses.processed }}</span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">{{ 'Processed'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <a class="card card-sm card-link" href="{{ 'invoice/transactions'|alink({ 'status': 'approved' }) }}">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="bg-info text-white avatar">{{ statuses.approved }}</span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">{{ 'Approved'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <a class="card card-sm card-link" href="{{ 'invoice/transactions'|alink({ 'status': 'error' }) }}">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="bg-danger text-white avatar">{{ statuses.error }}</span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">{{ 'Error'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <a class="card card-sm card-link" href="{{ 'invoice/transactions'|alink }}">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="bg-blue text-white avatar">{{ statuses.received + statuses.approved + statuses.processed + statuses.error }}</span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">{{ 'Total'|trans }}</div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </section>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
It looked broken and was written for the old admin panel theme.

New:
![image](https://user-images.githubusercontent.com/35808275/201734566-d0e52c54-5b04-4a8d-aeec-4e5b60a52ad2.png)

![image](https://user-images.githubusercontent.com/35808275/201734419-85b119ac-d7a3-4c06-b03c-5b41ffc0c473.png)

-----

While I was at it, I've also changed this part of `/invoice/transactions` accordingly:

Before:
![image](https://user-images.githubusercontent.com/35808275/201738380-5eb5a7fd-f4b6-4605-9349-036d19d0974b.png)

After:
![image](https://user-images.githubusercontent.com/35808275/201738448-6e0adbbb-eff2-4bb3-9049-df86bb33aa95.png)