### PR TITLE
Be descriptive if module folder doesn't match expected

### DIFF
--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -301,6 +301,11 @@ class Box_Mod
 
     private function _getModPath()
     {
-        return BB_PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($this->mod) . DIRECTORY_SEPARATOR;
+        $modPath = BB_PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($this->mod) . DIRECTORY_SEPARATOR;
+        if(is_dir($modPath)){
+            return $modPath;
+        }else{
+            throw new Box_Exception("Error: module $this->mod path appears to be invalid. Please ensure the module folder is named " . ucfirst($this->mod));
+        }
     }
 }


### PR DESCRIPTION
Expected folder name: `Examplemodule`
Invalid ones: `examplemodule`, `ExampleModule`.

This PR will throw an exception to provide a bit more info, useful for people who are developing a module and have the folder name mismatching,
Otherwise, they will get a cryptic error that just says "Module ExampleModule manifest file is missing or is not readable." & it won't be visible in the dashboard