### PR TITLE
Starting to move away from jQuery in the installer

### DIFF
--- a/src/install/assets/css/install.css
+++ b/src/install/assets/css/install.css
@@ -1,0 +1,18 @@
+/**
+ * FOSSBilling
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+.show {
+    transition: opacity 400ms;
+}
+
+.hide {
+    opacity: 0;
+}
+  

--- a/src/install/assets/css/main.css
+++ b/src/install/assets/css/main.css
@@ -405,7 +405,7 @@ ul.sub li ul li { padding-left: 10px; }
 /* ===== Right side content ===== */
 
 .widget { /*width: 342px;*/ /*width: 100%;*/ margin-top: 40px; border: 1px solid #d5d5d5; display: block; background: #fafafa; clear: both; border-top: none; }
-.head { background: #efefef url(../images/leftNavBg.png) repeat-x; height: 38px; border-top: 1px solid #d5d5d5; border-bottom: 1px solid #d5d5d5; position: relative; }
+.head { background: #efefef url(../images/leftNavBg.png) repeat-x; height: 38px; border-top: 1px solid #d5d5d5; border-bottom: 1px solid #d5d5d5; position: relative; -webkit-transition:400ms linear; -moz-transition:400ms linear; -o-transition:400ms linear; -ms-transition:400ms linear; transition:400ms linear; }
 .widget .head h5, .table h5 { font-weight: normal; padding: 9px 12px 9px 35px; float: left; } 
 .widget .body { padding: 12px 14px; }
 .widget .normal h5, .accordion-close h5 { background: url(../images/aNormal.png) no-repeat 15px 15px; padding: 9px 12px 9px 32px!important }

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -1,7 +1,7 @@
 {% extends "./assets/layout.html.twig" %}
 
 {% block left %}
-        <div class="widget nomargin step step-1">
+        <div class="widget nomargin step step-1 hide">
             <div class="head"><h5 class="iAlert">FOSSBilling installation</h5></div>
             <div class="body">
                 <p>This setup will guide you through installation process of FOSSBilling.</p>
@@ -238,120 +238,10 @@
 
 {% block js %}
 <div id="overlay" style="position: absolute; display: none; z-index: 1000; background-color: whitesmoke; width: 725px; height: 50px; opacity:0.5;"></div>
+<script type="text/javascript">
+const installURL = '{{constant("BB_URL_INSTALL")}}';
+</script>
 <script src="./assets/js/jquery.min.js" type="text/javascript"></script>
 <script src="./assets/js/jquery.smartWizard.js" type="text/javascript"></script>
-<script type="text/javascript">
-$(function() {
-	$('.wizard').smartWizard({
-		selected: 0,  // Selected Step, 0 = first step
-		keyNavigation: true, // Enable/Disable key navigation (left and right keys are used if enabled)
-		enableAllSteps: false,  // Enable/Disable all steps on first load
-		transitionEffect: 'fade', // Effect on navigation, none/fade/slide/slideleft
-		contentURL:null, // specifying content url enables ajax content loading
-		contentCache:false, // cache step contents, if false content is fetched always from ajax url
-		cycleSteps: false, // cycle step navigation
-		enableFinishButton: false, // makes finish button enabled always
-		errorSteps:[],    // array of step numbers to highlighting as error steps
-		labelNext:'Next', // label for Next button
-		labelPrevious:'Previous', // label for Previous button
-		labelFinish:'Finish',  // label for Finish button
-	  // Events
-		onLeaveStep: function(o, c){ if(c.fromStep < c.toStep) { return validateSteps(c.fromStep); } else { return true; } }, // triggers when leaving a step
-		onShowStep: function(o, c){ return showStep(c.toStep); },  // triggers when showing a step
-		onFinish: doFinish  // triggers when Finish button is clicked
-	 });
-
-    $("#overlay").ajaxStart(function(){
-        var o = $('.wizard').offset();
-        $(this).css('height', $('.wizard').height()-2).offset({top: o.top+1, left:o.left+1}).show();
-    }).ajaxStop(function(){
-        $(this).hide();
-    });
-});
-
-    function doFinish(){
-        $('#installer').hide();
-        $('.leftNav').animate({
-            width: '980px'
-        }, 400);
-        //$('.leftNav').css('width', '980px');
-        return false;
-    }
-
-    function showStep(stepnumber){
-        $('.step').hide();
-        $('.step.step-'+stepnumber).fadeIn();
-    }
-
-    function validateSteps(stepnumber){
-        var url = '{{constant("BB_URL_INSTALL")}}install.php?a=';
-        var data = $('#installer').serialize();
-        var ok = false;
-
-        if(stepnumber == 1){
-            if(!$('#agree').is(':checked')) {
-                alert('You must agree with terms of service');
-                return false;
-            }
-        }
-
-        if(stepnumber == 2){
-            if(isEmpty('db_host')) return false;
-            if(isEmpty('db_name')) return false;
-            if(isEmpty('db_user')) return false;
-
-            $.ajax({
-                async: false,
-                type: "POST",
-                url: url+'check-db',
-                data: data
-            }).done(function( msg ) {
-                if(msg != 'ok') {
-                    alert(msg);
-                } else {
-                    ok = true;
-                }
-            });
-            return ok;
-        }
-
-        if(stepnumber == 3){
-            if(isEmpty('admin_name')) return false;
-            if(isEmpty('admin_email')) return false;
-            if(isEmpty('admin_pass')) return false;
-            if(confirm('FOSSBilling installer will create database. It may take some time. Do not close this window. Continue?')) {
-                $.ajax({
-                    async: false,
-                    type: "POST",
-                    url: url+'install',
-                    data: data
-                }).done(function( msg ) {
-                    if(msg != 'ok') {
-                        alert(msg);
-                    } else {
-                        $('.buttonNext').text('Installed');
-                        $('.buttonPrevious').hide();
-                        ok = true;
-                    }
-                });
-                return ok;
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    function isEmpty(id)
-    {
-        if(!$('#'+id).val()) {
-            $('#'+id).addClass('error');
-            return true;
-        } else {
-            $('#'+id).removeClass('error');
-            return false;
-        }
-    }
-
-</script>
+<script src="./assets/js/install.js" type="text/javascript"></script>
 {% endblock %}

--- a/src/install/assets/js/install.js
+++ b/src/install/assets/js/install.js
@@ -1,0 +1,131 @@
+/**
+ * FOSSBilling
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+$(function() {
+	$('.wizard').smartWizard({
+		selected: 0,  // Selected Step, 0 = first step
+		keyNavigation: false, // Enable/Disable key navigation (left and right keys are used if enabled)
+		enableAllSteps: false,  // Enable/Disable all steps on first load
+		transitionEffect: 'fade', // Effect on navigation, none/fade/slide/slideleft
+		contentURL:null, // specifying content url enables ajax content loading
+		contentCache:false, // cache step contents, if false content is fetched always from ajax url
+		cycleSteps: false, // cycle step navigation
+		enableFinishButton: false, // makes finish button enabled always
+		errorSteps:[],    // array of step numbers to highlighting as error steps
+		labelNext:'Next', // label for Next button
+		labelPrevious:'Previous', // label for Previous button
+		labelFinish:'Finish',  // label for Finish button
+        // Events
+		onLeaveStep: function(o, c) { if (c.fromStep < c.toStep) { return validateSteps(c.fromStep); } else { return true; } }, // triggers when leaving a step
+        onShowStep: function(o, c) { return showStep(c.toStep); },  // triggers when showing a step
+		onFinish: doFinish  // triggers when Finish button is clicked
+	 });
+
+    $("#overlay").ajaxStart(function() {
+        var o = $('.wizard').offset();
+        $(this).css('height', $('.wizard').height()-2).offset({top: o.top+1, left:o.left+1}).show();
+    }).ajaxStop(function() {
+        $(this).hide();
+    });
+});
+
+    function doFinish() {
+        document.getElementById('installer').style.display = "none"; // Hide the form
+        document.getElementsByClassName('leftNav')[0].style.width = "980px" // Make the sidebar wider
+    }
+
+    function showStep(stepnumber) {
+        [...document.getElementsByClassName('step')].forEach(function(step) {
+            step.style.display = 'none'; // Hide every step
+        });
+
+        [...document.getElementsByClassName('step-'+stepnumber)].forEach(function(step) {
+            step.style.display = ''; // Make the current step and its sidebar visible
+            step.classList.replace('hide', 'show'); // Animate the sidebar
+        });
+
+    }
+
+    function validateSteps(stepnumber) {
+        var url = installURL+'install.php?a=';
+        var el = document.getElementById('installer');
+        var data = new URLSearchParams(new FormData(el)); // Docs: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+        var ok = false;
+
+        if (stepnumber == 1) {
+            var checkbox = document.getElementById("agree");
+            if (!checkbox.checked) {
+                alert('You must agree to the terms of service');
+                return false;
+            }
+        }
+
+        if (stepnumber == 2) {
+            if (isEmpty('db_host')) return false;
+            if (isEmpty('db_name')) return false;
+            if (isEmpty('db_user')) return false;
+
+            fetch(url+'check-db', {
+                method: 'POST',
+                body: data
+              }).then(function(response) {
+                return response.text();
+              }).then((data) => {
+                if (data != 'ok') {
+                    alert(data)
+                } else {
+                    ok = true;
+                }
+
+                return ok;
+            });
+        }
+
+        if (stepnumber == 3) {
+            if (isEmpty('admin_name')) return false;
+            if (isEmpty('admin_email')) return false;
+            if (isEmpty('admin_pass')) return false;
+            if (confirm('FOSSBilling installer will create database. It may take some time. Do not close this window. Continue?')) {
+
+                fetch(url+'install', {
+                    method: 'POST',
+                    body: data
+                  }).then(function(response) {
+                    return response.text();
+                  }).then((data) => {
+                    if (data != 'ok') {
+                        alert(data);
+                    } else {
+                        document.getElementsByClassName("buttonNext")[0].textContent = 'Installed';
+                        document.getElementsByClassName("buttonPrevious")[0].style.display = 'none';
+                        ok = true;
+                    }
+
+                    return ok;
+                    });
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    function isEmpty(id)
+    {
+        var el = document.getElementById(id);
+        if (el && !el.value) {
+            el.classList.add('error');
+            return true;
+        } else {
+            el.classList.remove('error');
+            return false;
+        }
+    }

--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -5,6 +5,7 @@
   <title>FOSSBilling setup</title>
   <base href="{{ constant('BB_URL_INSTALL') }}"/>
   <link href="./assets/css/main.css" rel="stylesheet" type="text/css" />
+  <link href="./assets/css/install.css" rel="stylesheet" type="text/css" />
   <link href="https://fonts.googleapis.com/css?family=Cuprum" rel="stylesheet" type="text/css" />
 </head>
 


### PR DESCRIPTION
This PR is the first step to removing jQuery dependance from the installer.

In this PR, I've rewritten the helper functions in regular vanilla JavaScript. It still depends on jQuery because of the "Smart Wizard" thing. I'm planning to find a replacement for that written in vanilla JS or maybe even start writing it. One step at a time.

We don't need to use jQuery. The "[You Might Not Need jQuery](https://youmightnotneedjquery.com/)" website was a great resource and I'm planning to continue replacing jQuery with vanilla JS wherever I can.

There should be no expected behavioral changes with this. However, please check if you can find any irregularities before merging it.