### PR TITLE
Add / Fix strikethrough support

### DIFF
--- a/src/bb-library/Box/TwigExtensions.php
+++ b/src/bb-library/Box/TwigExtensions.php
@@ -306,6 +306,7 @@ function twig_markdown_filter(Twig\Environment $env, $value)
         return $match[0];
     }, $result);
 
+    $result = preg_replace('/(?:~~)([^~~]*)(?:~~)/', '<s>$1</s>', $result);
     return $result;
 }
 

--- a/src/bb-modules/Wysiwyg/assets/markitup/sets/default/set.js
+++ b/src/bb-modules/Wysiwyg/assets/markitup/sets/default/set.js
@@ -27,7 +27,7 @@ function returnSettings(assetPath){
 		markupSet:  [ 	
 			{name:'Bold', key:'B', openWith:'**', closeWith:'**'},
 			{name:'Italic', key:'I', openWith:'_', closeWith:'_'},
-			{name:'Stroke through', key:'S', openWith:'~~~', closeWith:'~~~' },
+			{name:'Strike Through', key:'S', openWith:'~~', closeWith:'~~' },
 			{separator:'---------------' },
 			{name:'Bulleted List', openWith:'- '},
 			{name:'Numeric List', openWith:function(markItUp) {


### PR DESCRIPTION
It seems like the markdown extension doesn't support the strikethrough option https://github.com/michelf/php-markdown/issues/268
This PR corrects the markitup settings to fix a typo & use the standard ``~~strike~~`` format and then uses a `preg_replace` to get them working. We could also use the `del` tag instead of the `s` tag, but as far as I can tell they are virtually identical in function

![image](https://user-images.githubusercontent.com/17304943/202336548-199eaf27-9f30-4e98-ad4a-e44ebf29ab5c.png)
