### PR TITLE
Revert "Be descriptive if module folder doesn't match expected"

### DIFF
--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -301,11 +301,6 @@ class Box_Mod
 
     private function _getModPath()
     {
-        $modPath = BB_PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($this->mod) . DIRECTORY_SEPARATOR;
-        if(is_dir($modPath)){
-            return $modPath;
-        }else{
-            throw new Box_Exception("Error: module $this->mod path appears to be invalid. Please ensure the module folder is named " . ucfirst($this->mod));
-        }
+        return BB_PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($this->mod) . DIRECTORY_SEPARATOR;
     }
 }


### PR DESCRIPTION
This reverts commit 4acee5089cae5c3fe6d622ffca9f74fd40b5c8f7 as it seems to have some unintended consequences.
I'll have to find a better way to do this
![image](https://user-images.githubusercontent.com/17304943/202369246-265bb75a-e72a-4972-b7fd-9c7196397a48.png)
