### PR TITLE
Updated references to bb-update.php

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -4,6 +4,6 @@ UPDATE_URL="https://www.fossbilling.org/version/latest_update.zip"
 
 wget -O update.zip -q $UPDATE_URL
 unzip -o update.zip
-php bb-update.php
+php foss-update.php
 rm -rf update.zip
 rm -rf bb-data/cache/*

--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
         <include name="bb-di.php"/>
         <include name="bb-ipn.php"/>
         <include name="bb-load.php"/>
-        <include name="bb-update.php"/>
+        <include name="foss-update.php"/>
         <include name="rb.php"/>
         <include name="index.php"/>
         <include name="robots.txt"/>


### PR DESCRIPTION
We've recently renamed bb-update.php to foss-update.php. This PR updates references to the old name.