### PR TITLE
Removed the extra "&" from URLs

### DIFF
--- a/src/bb-library/Box/Url.php
+++ b/src/bb-library/Box/Url.php
@@ -47,17 +47,17 @@ class Box_Url implements Box\InjectionAwareInterface
     public function link($uri = null, $params = array())
     {
         $uri = trim($uri, '/');
-        $link =$this->baseUri .'index.php?_url=/' . $uri;
+        $link = BB_SEF_URLS ? $this->baseUri . $uri : $this->baseUri .'index.php?_url=/' . $uri;
         if(BB_SEF_URLS) {
-            $link = $this->baseUri . $uri;
             if (!empty($params)){
-                $link .= '?';
+                $link .= '?' . http_build_query($params);
+            }
+        } else {
+            if (!empty($params)){
+                $link .= '&' . http_build_query($params);
             }
         }
 
-        if(!empty($params)) {
-            $link  .= '&' . http_build_query($params);
-        }
         return $link;
     }
 


### PR DESCRIPTION
The "link" function used to add extra "&" characters to the generated URLs. I've fixed that.

An example of what it used to generate:

```
http://localhost/api/admin/massmailer/copy?&id=3
```

It now generates the URL without the extra "&".

(ignore the commit message saying "question mark". I was sleepy.)