### PR TITLE
Make sure the period is selected for domain orders

### DIFF
--- a/src/bb-modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/bb-modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -45,7 +45,7 @@
 
             <input type="hidden" name="multiple" value="1" />
             <input type="hidden" name="id" value="{{ product.id }}" />
-               <button type="submit" class="btn btn-primary">{{ 'Order'|trans }}</button>
+            <button type="submit" class="btn btn-primary" id="config-next">{{ 'Next'|trans }}</button>
         </div>
         </form>
     </div>

--- a/src/bb-modules/Servicedomain/html_client/mod_servicedomain_order_form.html.twig
+++ b/src/bb-modules/Servicedomain/html_client/mod_servicedomain_order_form.html.twig
@@ -74,7 +74,7 @@
                                 <div class="form-horizontal">
                                     <div id="domain-transfer-config" style="display:none;">
                                         <p>{{ 'Transfer price'|trans }}: <span id="transfer-price"></span></p>
-                                        <input type="text" name="transfer_code" value="{{ request.transfer_code }}" style="width: 200px" placeholder="{{ 'Enter domain transfer code'|trans }}">
+                                        <input type="text" name="transfer_code" value="{{ request.transfer_code }}" style="width: 200px" placeholder="{{ 'Enter domain transfer code'|trans }}" required>
                                     </div>
                                 </div>
                             </div>
@@ -96,6 +96,8 @@ $(function() {
     $('ul.nav.nav-tabs > li.domain-tab a').bind('click', function () {
         $('#domain-action').val($(this).attr('rel'));
     });
+
+    $('#config-next').hide();
 
     if ($(".addons").length) {
         $('.order-button').one('click', function() {
@@ -167,6 +169,7 @@ $(function() {
 
                     s.append(new Option(i + "{{ ' Year/s @ '|trans }}" + price, i));
                 }
+                $('#config-next').show();
             }
         );
     }
@@ -179,6 +182,7 @@ $(function() {
                 var price = bb.currency(result.price_transfer, {{ currency.conversion_rate }}, "{{ currency.code }}");
                 
                 $('#transfer-price').text(price);
+                $('#config-next').show();
             }
         );
     }


### PR DESCRIPTION
Fixes #468 and #469.

Previously, you could click the next button before selecting how long the domain should be registered for.
I've now made the page load with the button hidden, then made it show the button again once the period is selected.

Also made the "transfer code" a required field for domain transfer orders. Though we should make sure the code is provided as a server-side check before the order is put. That should be for another PR.