### PR TITLE
Automatically rename the config from the old name

### DIFF
--- a/src/load.php
+++ b/src/load.php
@@ -266,6 +266,11 @@ if ((isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST']) || ('cli' === PHP_SA
     }
 }
 
+// Rename the old "bb-config" file to the new name if it exists
+if(!file_exists($configPath) && file_exists(PATH_ROOT . '/bb-config.php')){
+    rename(PATH_ROOT . '/bb-config.php', $configPath);
+}
+
 // Try to check if configuration is available
 if (!file_exists($configPath) || 0 === filesize($configPath)) {
     // Try to create an empty configuration file


### PR DESCRIPTION
This will prevent people from seeing this message when they update a older preview build of FOSSBilling to the new file structure
![image](https://user-images.githubusercontent.com/17304943/204408084-0f2c1399-fc80-4e52-9820-7cda63253cba.png)
