### PR TITLE
Move the extension store to a new tab

### DIFF
--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -12,6 +12,9 @@
             <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Extensions'|trans }}</a>
         </li>
         <li class="nav-item" role="presentation">
+            <a class="nav-link" href="#tab-store" data-bs-toggle="tab">{{ 'Extention Store'|trans }}</a>
+        </li>
+        <li class="nav-item" role="presentation">
             <a class="nav-link" href="#tab-core" data-bs-toggle="tab">{{ 'Update FOSSBilling'|trans }}</a>
         </li>
         <li class="nav-item" role="presentation">
@@ -88,9 +91,12 @@
                     {% endfor %}
                 </tbody>
             </table>
+        </div>
 
+        <div class="tab-pane fade show active" id="tab-store" role="tabpanel">
             <div class="card-body">
                 <h5>Modules on the extension store</h5>
+                <p>These are all modules available for installation from the <a href="https://extensions.fossbilling.org/">extention store</a> at the click of a button.</p>
             </div>
             {% include 'partial_extensions.html.twig' %}
         </div>


### PR DESCRIPTION
This PR just creates a new tab for modules that are on the extension store
![image](https://user-images.githubusercontent.com/17304943/205173052-9964b659-f9d4-4fd3-8f5d-406183b11af9.png)
