### PR TITLE
Changed downloads link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <div align="center">
 
-<a href="https://fossbilling.org/downloads/preview"><img src="https://fossbilling.org/img/gh-download-button.png" alt="Download button" width="400"/></a>
+<a href="https://fossbilling.org/downloads/"><img src="https://fossbilling.org/img/gh-download-button.png" alt="Download button" width="400"/></a>
 
 [![PHP Composer](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml/badge.svg)](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml)
 [![Download Latest](https://img.shields.io/github/downloads/fossbilling/fossbilling/total)](https://github.com/fossbilling/fossbilling/releases/latest)


### PR DESCRIPTION
I've quickly created a [page](https://fossbilling.org/downloads) that has both the preview and the release download links. I've changed the link to that page. I've also updated the button.

![image](https://user-images.githubusercontent.com/35808275/205359751-3366703a-f193-430b-83a8-8a9cf710dd1e.png)

We can adjust the details later, I just did this to quickly have the links updated after the release.