### PR TITLE
Fixed wrong source for the staff login logo

### DIFF
--- a/src/themes/admin_default/html/partial_sidebar.html.twig
+++ b/src/themes/admin_default/html/partial_sidebar.html.twig
@@ -2,7 +2,7 @@
     <div class="container-fluid">
         <h1 class="navbar-brand">
             <a href="{{ 'index'|alink }}">
-                <img class="navbar-brand-image" src="{{ company.logo_url_dark }}" alt="{{ company.name }}">
+                <img class="navbar-brand-image" src="{{ company.logo_url }}" alt="{{ company.name }}">
             </a>
         </h1>
 


### PR DESCRIPTION
After #497, seems like I've used the white variant of the logo on a white background. This PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/35808275/205366011-5d62d340-d704-4c61-be5b-ea6f78361c3d.png)

After:
![image](https://user-images.githubusercontent.com/35808275/205366221-ab702007-555b-4de4-a450-ebe0eaef9081.png)