### PR TITLE
Added an "about" tab

### DIFF
--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -12,7 +12,7 @@
             <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Extensions'|trans }}</a>
         </li>
         <li class="nav-item" role="presentation">
-            <a class="nav-link" href="#tab-store" data-bs-toggle="tab">{{ 'Extention Store'|trans }}</a>
+            <a class="nav-link" href="#tab-store" data-bs-toggle="tab">{{ 'Extension Store'|trans }}</a>
         </li>
         <li class="nav-item" role="presentation">
             <a class="nav-link" href="#tab-core" data-bs-toggle="tab">{{ 'Update FOSSBilling'|trans }}</a>
@@ -96,7 +96,7 @@
         <div class="tab-pane fade show active" id="tab-store" role="tabpanel">
             <div class="card-body">
                 <h5>Modules on the extension store</h5>
-                <p>These are all modules available for installation from the <a href="https://extensions.fossbilling.org/">extention store</a> at the click of a button.</p>
+                <p>These are all modules available for installation from the <a href="https://extensions.fossbilling.org/">extension store</a> at the click of a button.</p>
             </div>
             {% include 'partial_extensions.html.twig' %}
         </div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -38,6 +38,9 @@
         <li class="nav-item" role="presentation">
             <a class="nav-link" href="#tab-cache" data-bs-toggle="tab" role="tab">{{ 'Cache'|trans }}</a>
         </li>
+        <li class="nav-item" role="presentation">
+            <a class="nav-link" href="#tab-about" data-bs-toggle="tab" role="tab">{{ 'About'|trans }}</a>
+        </li>
     </ul>
 
 <div class="card">
@@ -450,6 +453,31 @@ ZW=Zimbabwe
                 </form>
             </div>
         </div>
+
+        <div class="tab-pane fade" id="tab-about" role="tabpanel">
+            <div class="card">
+              <div class="card-header">
+                <h3 class="card-title">{{ 'About FOSSBilling'|trans }}</h3>
+              </div>
+              <div class="card-body">
+                <div class="datagrid">
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">FOSSBilling version</div>
+                    <div class="datagrid-content">{{ guest.system_version }}</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">PHP version</div>
+                    <div class="datagrid-content">{{ constant('PHP_VERSION') }}</div>
+                  </div>
+                  <div class="datagrid-item">
+                    <div class="datagrid-title">License</div>
+                    <div class="datagrid-content"><a href="https://github.com/FOSSBilling/FOSSBilling/blob/main/LICENSE">Apache 2.0</a></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+        </div>
+        
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Added an "about" tab to the system settings. I think we can add more in the future, but this should be enough to start with.

![image](https://user-images.githubusercontent.com/35808275/205457384-18d243e6-4a50-479b-94c5-b22411f2e285.png)

Also fixed a typo.