### PR TITLE
Delete extra bracket in the email registrar

### DIFF
--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -713,5 +713,5 @@ class Whois2 {
             return preg_match("/".$not_found_string."/i",$whois_string);
         }
         }
-    }
 }
+


### PR DESCRIPTION
Closes #513
Can now be enabled and used without breaking the registrar settings page
![image](https://user-images.githubusercontent.com/17304943/205458521-66984936-b106-4ef2-ba15-f260a84a285f.png)
