### PR TITLE
Use DejaVu Sans for PDF generation

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1247,7 +1247,8 @@ class Service implements InjectionAwareInterface
 
         $html = '<!DOCTYPE html>
                   <html>
-                  <head>';
+                  <head>
+                  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>';
         $html .= '<title>' . $invoice['serie_nr'] . '</title>';
         $html .= '<style>
                      hr.Rounded {
@@ -1296,7 +1297,7 @@ class Service implements InjectionAwareInterface
                     div.Breakdown{
                         position: absolute;
                         width: 100%;
-                        top: 400px;
+                        top: 475px;
                     }
                     table {
                         border-collapse: collapse;
@@ -1310,6 +1311,7 @@ class Service implements InjectionAwareInterface
                     .right{
                         text-align:right;
                     }
+                    body { font-family: DejaVu Sans; }
                     </style>
                 </head>
                 <body>';


### PR DESCRIPTION
Closes https://github.com/FOSSBilling/FOSSBilling/issues/508 by switching to DejaVu Sans which has proper support for most Unicode characters and should give us good compatibility.
![image](https://user-images.githubusercontent.com/17304943/205459374-e0ffef86-9024-4bf6-885e-7c1581cde674.png)
