### PR TITLE
Fix misbehaving isPreviewVersion()

### DIFF
--- a/src/library/Box/Update.php
+++ b/src/library/Box/Update.php
@@ -49,7 +49,7 @@ class Box_Update
      */
     public function isPreviewVersion(){
         $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
-        if(preg_match($reg, $this->getLatestVersion) === '0'){
+        if(preg_match($reg, $this->getLatestVersion())){
             return false;
         } else {
             return true;


### PR DESCRIPTION
Previously it was always returning that the system is running a preview version, and therefore the dashboard would always show that there is an update available. This fixes it