### PR TITLE
Created a CSRF token system

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -185,6 +185,13 @@ return [
 
         // How many login requests allowed per time span
         'rate_limit_login' => 20,
+        
+        /*
+        * This enables the usage of a token to protect the system from CSRF attacks.
+        * Disabling this is highly discouraged and opens your instance to a known vulnerability.
+        * This option is only here for backwards compatibility.
+        */
+        'CSRFPrevention' => true,
     ],
 
     'guzzle' => [

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -47,6 +47,7 @@
 
 {% block content %}
         <form action="" class="mainForm" method="get" id="installer">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="widget nomargin">
                     <div class="wizard swMain">

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -47,7 +47,7 @@
 
 {% block content %}
         <form action="" class="mainForm" method="get" id="installer">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="widget nomargin">
                     <div class="wizard swMain">

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -47,7 +47,7 @@
 
 {% block content %}
         <form action="" class="mainForm" method="get" id="installer">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="widget nomargin">
                     <div class="wizard swMain">

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -47,7 +47,6 @@
 
 {% block content %}
         <form action="" class="mainForm" method="get" id="installer">
-            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="widget nomargin">
                     <div class="wizard swMain">

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -234,10 +234,6 @@ final class Box_Installer
         // $twig->addExtension(new Twig_Extension_Optimizer());
         $twig->addGlobal('request', $_REQUEST);
         $twig->addGlobal('version', Box_Version::VERSION);
-        
-        //CSRF token
-        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
-        $twig->addGlobal('CSRFToken', $token);
 
         return $twig->render($name, $vars);
     }

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -234,6 +234,10 @@ final class Box_Installer
         // $twig->addExtension(new Twig_Extension_Optimizer());
         $twig->addGlobal('request', $_REQUEST);
         $twig->addGlobal('version', Box_Version::VERSION);
+        
+        //CSRF token
+        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+        $twig->addGlobal('CSRFToken', $token);
 
         return $twig->render($name, $vars);
     }

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -462,6 +462,7 @@ final class Box_Installer
                 'throttle_delay' => 2,
                 'rate_span_login' => 60,
                 'rate_limit_login' => 20,
+                'CSRFPrevention' => true,
             ],
             'guzzle' => [
                 'user_agent' => 'Mozilla/5.0 (RedHatEnterpriseLinux; Linux x86_64; FOSSBilling; +http://fossbilling.org) Gecko/20100101 Firefox/93.0',

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -54,6 +54,10 @@ class Box_AppAdmin extends Box_App
         $twig->setLoader($loader);
 
         $twig->addGlobal('theme', $theme);
+        
+        //CSRF token
+        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+        $twig->addGlobal('CSRFToken', $token);
 
         if ($this->di['auth']->isAdminLoggedIn()) {
             $twig->addGlobal('admin', $this->di['api_admin']);

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -104,6 +104,10 @@ class Box_AppClient extends Box_App
         $twig->addGlobal('current_theme', $code);
         $twig->addGlobal('settings', $settings);
 
+        //CSRF token
+        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+        $twig->addGlobal('CSRFToken', $token);
+
         if ($this->di['auth']->isClientLoggedIn()) {
             $twig->addGlobal('client', $this->di['api_client']);
         }

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -527,6 +527,7 @@ class Box_Tools
                 'throttle_delay' => (isset($currentConfig['api']['rate_limit'])) ? $currentConfig['api']['rate_limit'] : 2,
                 'rate_span_login' => (isset($currentConfig['api']['rate_span_login'])) ? $currentConfig['api']['rate_span_login'] : 60,
                 'rate_limit_login' => (isset($currentConfig['api']['rate_limit_login'])) ? $currentConfig['api']['rate_limit_login'] : 20,
+                'CSRFPrevention' => (isset($currentConfig['api']['CSRFPrevention'])) ? $currentConfig['api']['CSRFPrevention'] : true,
             ],
             'guzzle' => [
                 'user_agent' => (isset($currentConfig['guzzle']['user_agent'])) ? $currentConfig['guzzle']['user_agent'] : 'Mozilla/5.0 (RedHatEnterpriseLinux; Linux x86_64; FOSSBilling; +http://fossbilling.org) Gecko/20100101 Firefox/93.0',

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -80,6 +80,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             'money_without_currency' => new TwigFilter('money_without_currency', 'twig_money_without_currency', ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert' => new TwigFilter('money_convert', 'twig_money_convert', ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert_without_currency' => new TwigFilter('money_convert_without_currency', ['needs_environment' => true, 'is_safe' => ['html']]),
+            'csrftoken_filter' => new TwigFilter('csrftoken_filter','twig_CSRFToken_filter', ['is_safe' => ['html']]),
         ];
     }
 
@@ -335,4 +336,12 @@ function twig_bbmd_filter(Twig\Environment $env, $value)
     $value = twig_markdown_filter($env, $value);
 
     return $value;
+}
+
+function twig_CSRFToken_filter()
+{
+    $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+    $name = 'CSRFToken';
+    $hiddenInput = '<input type="hidden" name="'. $name . '" value="'. $token . '"/>';
+    return $hiddenInput;
 }

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -337,14 +337,3 @@ function twig_bbmd_filter(Twig\Environment $env, $value)
 
     return $value;
 }
-
-function twig_CSRFToken_filter($mode = "hiddenInput")
-{
-    $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
-    $name = 'CSRFToken';
-    if($mode == "token") {
-        return $token;
-    } else {
-        return '<input type="hidden" name="'. $name . '" value="'. $token . '"/>';
-    }
-}

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -80,7 +80,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             'money_without_currency' => new TwigFilter('money_without_currency', 'twig_money_without_currency', ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert' => new TwigFilter('money_convert', 'twig_money_convert', ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert_without_currency' => new TwigFilter('money_convert_without_currency', ['needs_environment' => true, 'is_safe' => ['html']]),
-            'csrftoken_filter' => new TwigFilter('csrftoken_filter','twig_CSRFToken_filter', ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -338,10 +338,13 @@ function twig_bbmd_filter(Twig\Environment $env, $value)
     return $value;
 }
 
-function twig_CSRFToken_filter()
+function twig_CSRFToken_filter($mode = "hiddenInput")
 {
     $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
     $name = 'CSRFToken';
-    $hiddenInput = '<input type="hidden" name="'. $name . '" value="'. $token . '"/>';
-    return $hiddenInput;
+    if($mode == "token") {
+        return $token;
+    } else {
+        return '<input type="hidden" name="'. $name . '" value="'. $token . '"/>';
+    }
 }

--- a/src/modules/Activity/html_admin/mod_activity_index.html.twig
+++ b/src/modules/Activity/html_admin/mod_activity_index.html.twig
@@ -63,7 +63,7 @@
             <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
             <td>
                 <a class="btn btn-icon api-link"
-                    href="{{ 'api/admin/activity/log_delete'|link({ 'id': event.id }) }}"
+                    href="{{ 'api/admin/activity/log_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'activity'|alink }}">
                     <svg class="icon">

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -175,6 +175,9 @@ class Client implements InjectionAwareInterface
 
         try {
             $this->isRoleLoggedIn($role);
+            if($role == 'client' || $role == 'admin'){
+                $this->_checkCSRFToken();
+            }
         } catch (\Exception $e) {
             $this->_tryTokenLogin();
         }
@@ -287,5 +290,19 @@ class Client implements InjectionAwareInterface
     private function _getIp()
     {
         return $this->di['request']->getClientAddress();
+    }
+    
+    /**
+     * Checks if the CSRF token provided is valid
+     *
+     * @throws \Box_Exception
+     */
+    public function _checkCSRFToken(){
+        $token= (!empty($_POST["CSRFToken"]) ? $_POST["CSRFToken"] : $_GET["CSRFToken"]);
+        $expectedToken = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+
+        if(!is_null($expectedToken) && $expectedToken !== $token && php_sapi_name() !== 'cli'){
+            throw new \Box_Exception('CSRF token invalid.', null, 403);
+        }
     }
 }

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -298,8 +298,13 @@ class Client implements InjectionAwareInterface
      * @throws \Box_Exception
      */
     public function _checkCSRFToken(){
+        $this->_loadConfig();
         $token= (!empty($_POST["CSRFToken"]) ? $_POST["CSRFToken"] : $_GET["CSRFToken"]);
         $expectedToken = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+
+        if(isset($this->_api_config['CSRFPrevention']) && $this->_api_config['CSRFPrevention'] === false){
+            return true;
+        }
 
         if(!is_null($expectedToken) && $expectedToken !== $token && php_sapi_name() !== 'cli'){
             throw new \Box_Exception('CSRF token invalid.', null, 403);

--- a/src/modules/Client/html_admin/mod_client_group.html.twig
+++ b/src/modules/Client/html_admin/mod_client_group.html.twig
@@ -26,7 +26,7 @@
         <h4>{{ 'Edit client group'|trans }} - {{ group.title }}</h4>
     </div>
     <form method="post" action="{{ 'api/admin/client/group_update'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>

--- a/src/modules/Client/html_admin/mod_client_group.html.twig
+++ b/src/modules/Client/html_admin/mod_client_group.html.twig
@@ -47,7 +47,7 @@
             </a>
             <button class="btn btn-primary w-100" type="submit">{{ 'Update'|trans }}</button>
             <a class="btn btn-danger w-25 api-link"
-                href="{{ 'api/admin/client/group_delete'|link({ 'id': group.id }) }}"
+                href="{{ 'api/admin/client/group_delete'|link({ 'id': group.id, 'CSRFToken': CSRFToken }) }}"
                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                 data-api-redirect="{{ 'client'|alink }}">
                 <svg class="icon">

--- a/src/modules/Client/html_admin/mod_client_group.html.twig
+++ b/src/modules/Client/html_admin/mod_client_group.html.twig
@@ -26,7 +26,7 @@
         <h4>{{ 'Edit client group'|trans }} - {{ group.title }}</h4>
     </div>
     <form method="post" action="{{ 'api/admin/client/group_update'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>

--- a/src/modules/Client/html_admin/mod_client_group.html.twig
+++ b/src/modules/Client/html_admin/mod_client_group.html.twig
@@ -26,6 +26,7 @@
         <h4>{{ 'Edit client group'|trans }} - {{ group.title }}</h4>
     </div>
     <form method="post" action="{{ 'api/admin/client/group_update'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -243,7 +243,7 @@
                                             <use xlink:href="#edit" />
                                         </svg>
                                     </a>
-                                    <a class="btn btn-icon api-link" href="{{ 'api/admin/client/delete'|link({ 'id': client.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                                    <a class="btn btn-icon api-link" href="{{ 'api/admin/client/delete'|link({ 'id': client.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                                         <svg class="icon">
                                             <use xlink:href="#delete" />
                                         </svg>
@@ -399,7 +399,7 @@
                                         <use xlink:href="#edit" />
                                     </svg>
                                 </a>
-                                <a class="btn btn-icon api-link" href="{{ 'api/admin/client/group_delete'|link({ 'id': id }) }}" data-api-reload="1" data-api-confirm="{{ 'Are you sure?'|trans }}">
+                                <a class="btn btn-icon api-link" href="{{ 'api/admin/client/group_delete'|link({ 'id': id, 'CSRFToken': CSRFToken }) }}" data-api-reload="1" data-api-confirm="{{ 'Are you sure?'|trans }}">
                                     <svg class="icon">
                                         <use xlink:href="#delete" />
                                     </svg>

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -13,6 +13,7 @@
             <h5>{{ 'Filter clients'|trans }}</h5>
 
             <form method="get">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -267,6 +268,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/create'|link }}" class="api-form save" data-api-redirect="{{ 'client'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                             <div class="col">
@@ -416,6 +418,7 @@
             <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/group_create'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -13,7 +13,7 @@
             <h5>{{ 'Filter clients'|trans }}</h5>
 
             <form method="get">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -268,7 +268,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/create'|link }}" class="api-form save" data-api-redirect="{{ 'client'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                             <div class="col">
@@ -418,7 +418,7 @@
             <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/group_create'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -13,7 +13,7 @@
             <h5>{{ 'Filter clients'|trans }}</h5>
 
             <form method="get">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -268,7 +268,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/create'|link }}" class="api-form save" data-api-redirect="{{ 'client'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                             <div class="col">
@@ -418,7 +418,7 @@
             <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/client/group_create'|link }}" class="api-form" data-api-redirect="{{ 'client'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Client/html_admin/mod_client_login_history.html.twig
+++ b/src/modules/Client/html_admin/mod_client_login_history.html.twig
@@ -48,7 +48,7 @@
             <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
             <td>
                 <a class="btn btn-icon api-link"
-                    href="{{ 'api/admin/client/login_history_delete'|link({ 'id': event.id }) }}"
+                    href="{{ 'api/admin/client/login_history_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'client/logins'|alink }}">
                     <svg class="icon">

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -144,7 +144,7 @@
                     <span class="d-block text-secondary">{{ 'Login to client area'|trans }}</span>
                 </a>
                 <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                    href="{{ 'api/admin/client/delete'|link({ 'id': client.id }) }}"
+                    href="{{ 'api/admin/client/delete'|link({ 'id': client.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'client'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
@@ -530,7 +530,7 @@
 
                 <div class="card-body">
                     <a class="btn btn-primary api-link"
-                        href="{{ 'api/admin/invoice/prepare'|link({ 'client_id': client.id }) }}"
+                        href="{{ 'api/admin/invoice/prepare'|link({ 'client_id': client.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-jsonp="onAfterInvoicePrepared">
                         <svg class="icon">
                             <use xlink:href="#plus" />
@@ -629,7 +629,7 @@
                             <td>{{ tx.created_at|date("Y-m-d H:i") }}</td>
                             <td>
                                 <a class="btn btn-icon api-link"
-                                    href="{{ 'api/admin/client/balance_delete'|link({ 'id': tx.id }) }}"
+                                    href="{{ 'api/admin/client/balance_delete'|link({ 'id': tx.id, 'CSRFToken': CSRFToken }) }}"
                                     data-api-confirm="{{ 'Are you sure?'|trans }}">
                                     <svg class="icon">
                                         <use xlink:href="#delete" />

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -159,7 +159,7 @@
             <div class="card-body">
                 <h5>{{ 'Client profile details'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -361,7 +361,7 @@
 
                 <h5>{{ 'Change password'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -384,7 +384,7 @@
                 <h5>{{ 'Custom fields'|trans }}</h5>
                 <p class="text-muted">{{ 'Use these fields to define custom client details'|trans }}</p>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile custom fields updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     {% for i in 1..10 %}
                     {% set fn = 'custom_' ~ i %}
                     <div class="form-group mb-3 row">
@@ -653,7 +653,7 @@
                     method="post"
                     action="{{ 'api/admin/client/balance_add_funds'|link }}"
                     data-api-msg="{{ 'Funds added'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputAmount">{{ 'Amount'|trans }}:</label>
                         <div class="col input-group">

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -159,6 +159,7 @@
             <div class="card-body">
                 <h5>{{ 'Client profile details'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -360,6 +361,7 @@
 
                 <h5>{{ 'Change password'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -382,6 +384,7 @@
                 <h5>{{ 'Custom fields'|trans }}</h5>
                 <p class="text-muted">{{ 'Use these fields to define custom client details'|trans }}</p>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile custom fields updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     {% for i in 1..10 %}
                     {% set fn = 'custom_' ~ i %}
                     <div class="form-group mb-3 row">
@@ -650,6 +653,7 @@
                     method="post"
                     action="{{ 'api/admin/client/balance_add_funds'|link }}"
                     data-api-msg="{{ 'Funds added'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputAmount">{{ 'Amount'|trans }}:</label>
                         <div class="col input-group">

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -159,7 +159,7 @@
             <div class="card-body">
                 <h5>{{ 'Client profile details'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -361,7 +361,7 @@
 
                 <h5>{{ 'Change password'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/client/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -384,7 +384,7 @@
                 <h5>{{ 'Custom fields'|trans }}</h5>
                 <p class="text-muted">{{ 'Use these fields to define custom client details'|trans }}</p>
                 <form method="post" action="{{ 'api/admin/client/update'|link }}" class="api-form save" data-api-msg="{{ 'Client Profile custom fields updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     {% for i in 1..10 %}
                     {% set fn = 'custom_' ~ i %}
                     <div class="form-group mb-3 row">
@@ -653,7 +653,7 @@
                     method="post"
                     action="{{ 'api/admin/client/balance_add_funds'|link }}"
                     data-api-msg="{{ 'Funds added'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputAmount">{{ 'Amount'|trans }}:</label>
                         <div class="col input-group">

--- a/src/modules/Client/html_admin/mod_client_settings.html.twig
+++ b/src/modules/Client/html_admin/mod_client_settings.html.twig
@@ -26,6 +26,7 @@
     {% set params = admin.extension_config_get({ 'ext': 'mod_client' }) %}
     <div class="card">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <ul class="nav nav-tabs" role="tablist">
                 <li class="nav-item" role="presentation">
                     <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'General'|trans }}</a>

--- a/src/modules/Client/html_admin/mod_client_settings.html.twig
+++ b/src/modules/Client/html_admin/mod_client_settings.html.twig
@@ -26,7 +26,7 @@
     {% set params = admin.extension_config_get({ 'ext': 'mod_client' }) %}
     <div class="card">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <ul class="nav nav-tabs" role="tablist">
                 <li class="nav-item" role="presentation">
                     <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'General'|trans }}</a>

--- a/src/modules/Client/html_admin/mod_client_settings.html.twig
+++ b/src/modules/Client/html_admin/mod_client_settings.html.twig
@@ -26,7 +26,7 @@
     {% set params = admin.extension_config_get({ 'ext': 'mod_client' }) %}
     <div class="card">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <ul class="nav nav-tabs" role="tablist">
                 <li class="nav-item" role="presentation">
                     <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'General'|trans }}</a>

--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -52,7 +52,7 @@
             <div class="row-fluid">
                 <div class="span3">
                     <form action="" method="post" class="form-inline api-form" data-api-url="{{ 'api/client/invoice/funds_invoice'|link }}" data-api-jsonp="onAfterInvoiceCreated">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <fieldset>
                             <div class="control-group">
                                 <div class="form-controls">

--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -52,7 +52,7 @@
             <div class="row-fluid">
                 <div class="span3">
                     <form action="" method="post" class="form-inline api-form" data-api-url="{{ 'api/client/invoice/funds_invoice'|link }}" data-api-jsonp="onAfterInvoiceCreated">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <fieldset>
                             <div class="control-group">
                                 <div class="form-controls">

--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -52,6 +52,7 @@
             <div class="row-fluid">
                 <div class="span3">
                     <form action="" method="post" class="form-inline api-form" data-api-url="{{ 'api/client/invoice/funds_invoice'|link }}" data-api-jsonp="onAfterInvoiceCreated">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <fieldset>
                             <div class="control-group">
                                 <div class="form-controls">

--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -31,7 +31,7 @@
                 <p>{{ 'Keep your personal data up to date.'|trans }}</p>
             </header>
             <form method="post" action="" id="profile-update" class="form-horizontal">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="alert alert-block alert-success">
                         <div class="row">
@@ -185,7 +185,7 @@
                 <p>{{ 'Please enter new password two times in order avoid mistypes'|trans }}</p>
             </header>
             <form method="post" action="" id="change-password" class="form-horizontal">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                         <div class="control-group">
                             <label class="control-label" for="input">{{ 'Password'|trans }}</label>
@@ -212,7 +212,7 @@
                 <p>{{ 'API key allows integration with external applications. You will need this key for authentication.'|trans }}</p>
             </header>
             <form method="post" action="" id="change-api-key" class="form-horizontal">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="alert alert-block">
                      <h4><p>{{ 'Warning! Resetting the key will break existing applications using it!'|trans }}</p></h4>

--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -31,6 +31,7 @@
                 <p>{{ 'Keep your personal data up to date.'|trans }}</p>
             </header>
             <form method="post" action="" id="profile-update" class="form-horizontal">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="alert alert-block alert-success">
                         <div class="row">
@@ -184,6 +185,7 @@
                 <p>{{ 'Please enter new password two times in order avoid mistypes'|trans }}</p>
             </header>
             <form method="post" action="" id="change-password" class="form-horizontal">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                         <div class="control-group">
                             <label class="control-label" for="input">{{ 'Password'|trans }}</label>
@@ -210,6 +212,7 @@
                 <p>{{ 'API key allows integration with external applications. You will need this key for authentication.'|trans }}</p>
             </header>
             <form method="post" action="" id="change-api-key" class="form-horizontal">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="alert alert-block">
                      <h4><p>{{ 'Warning! Resetting the key will break existing applications using it!'|trans }}</p></h4>

--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -31,7 +31,7 @@
                 <p>{{ 'Keep your personal data up to date.'|trans }}</p>
             </header>
             <form method="post" action="" id="profile-update" class="form-horizontal">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="alert alert-block alert-success">
                         <div class="row">
@@ -185,7 +185,7 @@
                 <p>{{ 'Please enter new password two times in order avoid mistypes'|trans }}</p>
             </header>
             <form method="post" action="" id="change-password" class="form-horizontal">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                         <div class="control-group">
                             <label class="control-label" for="input">{{ 'Password'|trans }}</label>
@@ -212,7 +212,7 @@
                 <p>{{ 'API key allows integration with external applications. You will need this key for authentication.'|trans }}</p>
             </header>
             <form method="post" action="" id="change-api-key" class="form-horizontal">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="alert alert-block">
                      <h4><p>{{ 'Warning! Resetting the key will break existing applications using it!'|trans }}</p></h4>

--- a/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
@@ -19,6 +19,7 @@
     {% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
     <div class="tab_content nopadding" id="tab-new">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="formBottom">

--- a/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
@@ -19,7 +19,7 @@
     {% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
     <div class="tab_content nopadding" id="tab-new">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="formBottom">

--- a/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/html_admin/mod_cookieconsent_index.html.twig
@@ -19,7 +19,7 @@
     {% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
     <div class="tab_content nopadding" id="tab-new">
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="formBottom">

--- a/src/modules/Currency/html_admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_manage.html.twig
@@ -31,7 +31,7 @@
         <h3>{{ 'Edit currency information'|trans }} {{ currency.code }}</h3>
 
         <form method="post" action="{{ 'api/admin/currency/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Currency updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Currency/html_admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_manage.html.twig
@@ -31,7 +31,7 @@
         <h3>{{ 'Edit currency information'|trans }} {{ currency.code }}</h3>
 
         <form method="post" action="{{ 'api/admin/currency/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Currency updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Currency/html_admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_manage.html.twig
@@ -31,6 +31,7 @@
         <h3>{{ 'Edit currency information'|trans }} {{ currency.code }}</h3>
 
         <form method="post" action="{{ 'api/admin/currency/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Currency updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -119,6 +119,7 @@
         <div class="tab-pane fade" id="tab-new-currency" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/currency/create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/currency'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}:</label>
                         <div class="col">
@@ -156,6 +157,7 @@
                 <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources, including European Central Bank and currencylayer.</b></p>
 
                 <form method="post" action="{{ 'api/admin/currency/update_rate_settings'|link }}" class="api-form" data-api-msg="{{ 'Successfully updated settings'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API key for currencylayer'|trans }}:</label>
                         <div class="col">
@@ -184,6 +186,7 @@
 
         <div class="tab-pane fade" id="tab-converter" role="tabpanel">
             <form method="post" action="">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="card-body">
                     <div class="input-group">
                             <span class="input-group-text">{{ guest.currency_get.code }}</span>

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -77,7 +77,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/currency/delete'|link({ 'code': currency.code }) }}"
+                                href="{{ 'api/admin/currency/delete'|link({ 'code': currency.code, 'CSRFToken': CSRFToken }) }}"
                                 data-api-redirect="{{ 'extension/settings/currency'|alink }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}">
                                 <svg class="icon">
@@ -87,7 +87,7 @@
                             {% if not currency.default %}
                             <a class="btn btn-icon api-link"
                                 data-api-redirect="{{ 'extension/settings/currency'|alink }}"
-                                href="{{'api/admin/currency/set_default'|link({ 'code': currency.code }) }}"
+                                href="{{'api/admin/currency/set_default'|link({ 'code': currency.code, 'CSRFToken': CSRFToken }) }}"
                                 title="{{ 'Set as default'|trans }}">
                                 <svg class="icon">
                                     <use xlink:href="#check" />

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -119,7 +119,7 @@
         <div class="tab-pane fade" id="tab-new-currency" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/currency/create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/currency'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}:</label>
                         <div class="col">
@@ -157,7 +157,7 @@
                 <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources, including European Central Bank and currencylayer.</b></p>
 
                 <form method="post" action="{{ 'api/admin/currency/update_rate_settings'|link }}" class="api-form" data-api-msg="{{ 'Successfully updated settings'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API key for currencylayer'|trans }}:</label>
                         <div class="col">
@@ -186,7 +186,7 @@
 
         <div class="tab-pane fade" id="tab-converter" role="tabpanel">
             <form method="post" action="">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="card-body">
                     <div class="input-group">
                             <span class="input-group-text">{{ guest.currency_get.code }}</span>

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -119,7 +119,7 @@
         <div class="tab-pane fade" id="tab-new-currency" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/currency/create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/currency'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}:</label>
                         <div class="col">
@@ -157,7 +157,7 @@
                 <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources, including European Central Bank and currencylayer.</b></p>
 
                 <form method="post" action="{{ 'api/admin/currency/update_rate_settings'|link }}" class="api-form" data-api-msg="{{ 'Successfully updated settings'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API key for currencylayer'|trans }}:</label>
                         <div class="col">
@@ -186,7 +186,7 @@
 
         <div class="tab-pane fade" id="tab-converter" role="tabpanel">
             <form method="post" action="">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="card-body">
                     <div class="input-group">
                             <span class="input-group-text">{{ guest.currency_get.code }}</span>

--- a/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
@@ -58,7 +58,7 @@
         <div class="tab_content nopadding" id="tab-new">
 
             <form method="post" action="{{ 'api/admin/custompages/create'|link }}" class="mainForm api-form save" data-api-redirect="{{ 'custompages'|alink }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Title'|trans }}:</label>

--- a/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
@@ -38,7 +38,7 @@
                         <td>
                             <a class="btn14" href="{{ 'page'|link }}/{{ page.slug }}" title="{{ 'View'|trans }}"><img src="images/icons/dark/view.png" alt=""></a>
                             <a class="btn14" href="{{ 'custompages'|alink }}/{{ page.id }}" title="{{ 'Edit'|trans }}"><img src="assets/icons/edit.svg" alt=""></a>
-                            <a class="btn14 bb-rm-tr api-link" href="{{ 'api/admin/custompages/delete'|link({ 'id': page.id }) }}" title="{{ 'Delete'|trans }}" data-api-confirm="Are you sure?" data-api-reload="1"><img src="assets/icons/delete.svg" alt=""></a>
+                            <a class="btn14 bb-rm-tr api-link" href="{{ 'api/admin/custompages/delete'|link({ 'id': page.id, 'CSRFToken': CSRFToken }) }}" title="{{ 'Delete'|trans }}" data-api-confirm="Are you sure?" data-api-reload="1"><img src="assets/icons/delete.svg" alt=""></a>
                         </td>
                     </tr>
                     {% else %}

--- a/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
@@ -58,7 +58,7 @@
         <div class="tab_content nopadding" id="tab-new">
 
             <form method="post" action="{{ 'api/admin/custompages/create'|link }}" class="mainForm api-form save" data-api-redirect="{{ 'custompages'|alink }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Title'|trans }}:</label>

--- a/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
@@ -58,6 +58,7 @@
         <div class="tab_content nopadding" id="tab-new">
 
             <form method="post" action="{{ 'api/admin/custompages/create'|link }}" class="mainForm api-form save" data-api-redirect="{{ 'custompages'|alink }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Title'|trans }}:</label>

--- a/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
@@ -26,7 +26,7 @@
     </div>
     
     <form method="post" action="{{ 'api/admin/custompages/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Custom page updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <input type="hidden" name="id" value="{{ page.id }}">
         <fieldset>
             <div class="rowElem noborder">

--- a/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
@@ -26,6 +26,7 @@
     </div>
     
     <form method="post" action="{{ 'api/admin/custompages/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Custom page updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <input type="hidden" name="id" value="{{ page.id }}">
         <fieldset>
             <div class="rowElem noborder">

--- a/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_page.html.twig
@@ -26,7 +26,7 @@
     </div>
     
     <form method="post" action="{{ 'api/admin/custompages/update'|link }}" class="mainForm save api-form" data-api-msg="{{ 'Custom page updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <input type="hidden" name="id" value="{{ page.id }}">
         <fieldset>
             <div class="rowElem noborder">

--- a/src/modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/modules/Email/html_admin/mod_email_settings.html.twig
@@ -116,7 +116,7 @@
                 <p class="text-muted">{{ 'Newly created email templates can be used in custom event hooks.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/email/template_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">
@@ -163,7 +163,7 @@
         {% set params = admin.extension_config_get({ 'ext': 'mod_email' }) %}
         <div class="tab-pane fade" id="tab-email" role="tabpanel">
             <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Email settings updated'|trans }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="card-body">
                     <h3>{{ 'Configure email options'|trans }}</h3>
                     <p class="text-muted">{{ 'FOSSBilling sends emails using <em>sendmail</em> by default or you can configure your own SMTP server'|trans|raw }}</p>

--- a/src/modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/modules/Email/html_admin/mod_email_settings.html.twig
@@ -116,6 +116,7 @@
                 <p class="text-muted">{{ 'Newly created email templates can be used in custom event hooks.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/email/template_create'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">
@@ -162,6 +163,7 @@
         {% set params = admin.extension_config_get({ 'ext': 'mod_email' }) %}
         <div class="tab-pane fade" id="tab-email" role="tabpanel">
             <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Email settings updated'|trans }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="card-body">
                     <h3>{{ 'Configure email options'|trans }}</h3>
                     <p class="text-muted">{{ 'FOSSBilling sends emails using <em>sendmail</em> by default or you can configure your own SMTP server'|trans|raw }}</p>

--- a/src/modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/modules/Email/html_admin/mod_email_settings.html.twig
@@ -77,7 +77,7 @@
                             </svg>
                         </a>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/email/template_delete'|link({ 'id': template.id }) }}"
+                            href="{{ 'api/admin/email/template_delete'|link({ 'id': template.id, 'CSRFToken': CSRFToken }) }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-reload="1">
                             <svg class="icon">
@@ -95,15 +95,15 @@
             </table>
 
             <div class="card-footer text-center">
-                <a href="{{ 'api/admin/email/batch_template_generate'|link }}" class="btn55 mr10 api-link" data-api-reload="1">
+                <a href="{{ 'api/admin/email/batch_template_generate'|link({ 'CSRFToken': CSRFToken }) }}" class="btn55 mr10 api-link" data-api-reload="1">
                     <img src="images/icons/middlenav/power.png" alt="">
                     <span>Generate templates</span>
                 </a>
-                <a href="{{ 'api/admin/email/batch_template_enable'|link }}" class="btn55 mr10 api-link" data-api-msg="All email templates enabled">
+                <a href="{{ 'api/admin/email/batch_template_enable'|link({ 'CSRFToken': CSRFToken }) }}" class="btn55 mr10 api-link" data-api-msg="All email templates enabled">
                     <img src="images/icons/middlenav/play2.png" alt="">
                     <span>Enable all</span>
                 </a>
-                <a href="{{ 'api/admin/email/batch_template_disable'|link }}" class="btn55 mr10 api-link" data-api-msg="All email templates disabled">
+                <a href="{{ 'api/admin/email/batch_template_disable'|link({ 'CSRFToken': CSRFToken }) }}" class="btn55 mr10 api-link" data-api-msg="All email templates disabled">
                     <img src="images/icons/middlenav/stop.png" alt="">
                     <span>Disable all</span>
                 </a>
@@ -115,7 +115,7 @@
                 <h3>{{ 'Where I can use new email template?'|trans }}</h3>
                 <p class="text-muted">{{ 'Newly created email templates can be used in custom event hooks.'|trans }}</p>
 
-                <form method="post" action="{{ 'api/admin/email/template_create'|link }}" class="api-form" data-api-reload="1">
+                <form method="post" action="{{ 'api/admin/email/template_create'|link({ 'CSRFToken': CSRFToken }) }}" class="api-form" data-api-reload="1">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>

--- a/src/modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/modules/Email/html_admin/mod_email_settings.html.twig
@@ -116,7 +116,7 @@
                 <p class="text-muted">{{ 'Newly created email templates can be used in custom event hooks.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/email/template_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">
@@ -163,7 +163,7 @@
         {% set params = admin.extension_config_get({ 'ext': 'mod_email' }) %}
         <div class="tab-pane fade" id="tab-email" role="tabpanel">
             <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Email settings updated'|trans }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="card-body">
                     <h3>{{ 'Configure email options'|trans }}</h3>
                     <p class="text-muted">{{ 'FOSSBilling sends emails using <em>sendmail</em> by default or you can configure your own SMTP server'|trans|raw }}</p>

--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -80,7 +80,7 @@
 
                         <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary w-100">
                         <a class="btn btn-danger w-25 api-link"
-                            href="{{ 'api/admin/email/template_reset'|link }}?code={{ template.action_code }}"
+                            href="{{ 'api/admin/email/template_reset'|link }}?code={{ template.action_code, 'CSRFToken': CSRFToken }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-reload="1">
                             {{ 'Reset'|trans }}

--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -48,6 +48,7 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-template" role="tabpanel">
             <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="card-body">
                     <h3>{{ 'Manage email template'|trans }}</h3>
                     <p class="text-muted">{{ 'Most email templates receives parameters from FOSSBilling. You can browse them on "Variables" tab. Copy variable name to email template and hit preview to see parsed content. Please note that values will be different when actual email is sent.'|trans }}</p>
@@ -100,6 +101,7 @@
                 <p>{{ 'Enable or disable this email template.'|trans }}</p>
 
                 <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -48,7 +48,7 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-template" role="tabpanel">
             <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="card-body">
                     <h3>{{ 'Manage email template'|trans }}</h3>
                     <p class="text-muted">{{ 'Most email templates receives parameters from FOSSBilling. You can browse them on "Variables" tab. Copy variable name to email template and hit preview to see parsed content. Please note that values will be different when actual email is sent.'|trans }}</p>
@@ -101,7 +101,7 @@
                 <p>{{ 'Enable or disable this email template.'|trans }}</p>
 
                 <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -48,7 +48,7 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-template" role="tabpanel">
             <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="card-body">
                     <h3>{{ 'Manage email template'|trans }}</h3>
                     <p class="text-muted">{{ 'Most email templates receives parameters from FOSSBilling. You can browse them on "Variables" tab. Copy variable name to email template and hit preview to see parsed content. Please note that values will be different when actual email is sent.'|trans }}</p>
@@ -101,7 +101,7 @@
                 <p>{{ 'Enable or disable this email template.'|trans }}</p>
 
                 <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enabled'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Embed/html_client/mod_embed_contact.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_contact.html.twig
@@ -36,6 +36,7 @@
 
 <body>
     <form method="post" action="" id="public-ticket-create">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <fieldset>
             <p>
                 <label>{{ 'Name'|trans }}: </label>

--- a/src/modules/Embed/html_client/mod_embed_contact.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_contact.html.twig
@@ -36,7 +36,7 @@
 
 <body>
     <form method="post" action="" id="public-ticket-create">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <fieldset>
             <p>
                 <label>{{ 'Name'|trans }}: </label>

--- a/src/modules/Embed/html_client/mod_embed_contact.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_contact.html.twig
@@ -36,7 +36,7 @@
 
 <body>
     <form method="post" action="" id="public-ticket-create">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <fieldset>
             <p>
                 <label>{{ 'Name'|trans }}: </label>

--- a/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
@@ -30,6 +30,7 @@
 
 <body>
 <form method="post" action="" class="domainsearch" id="domain-checker">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <fieldset>
         <p>
             <input type="text" id="dsearch" value="" name="sld" />

--- a/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
@@ -30,7 +30,7 @@
 
 <body>
 <form method="post" action="" class="domainsearch" id="domain-checker">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
     <fieldset>
         <p>
             <input type="text" id="dsearch" value="" name="sld" />

--- a/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
@@ -30,7 +30,7 @@
 
 <body>
 <form method="post" action="" class="domainsearch" id="domain-checker">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <fieldset>
         <p>
             <input type="text" id="dsearch" value="" name="sld" />

--- a/src/modules/Embed/html_client/mod_embed_loginform.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_loginform.html.twig
@@ -30,7 +30,7 @@
 
 <body>
 <form action="" method="post" id="client-login">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <fieldset>
         <legend>Login to client area</legend>
         <p>

--- a/src/modules/Embed/html_client/mod_embed_loginform.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_loginform.html.twig
@@ -30,7 +30,7 @@
 
 <body>
 <form action="" method="post" id="client-login">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
     <fieldset>
         <legend>Login to client area</legend>
         <p>

--- a/src/modules/Embed/html_client/mod_embed_loginform.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_loginform.html.twig
@@ -30,6 +30,7 @@
 
 <body>
 <form action="" method="post" id="client-login">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <fieldset>
         <legend>Login to client area</legend>
         <p>

--- a/src/modules/Example/html_admin/mod_example_settings.html.twig
+++ b/src/modules/Example/html_admin/mod_example_settings.html.twig
@@ -18,6 +18,7 @@
         {% set params = admin.extension_config_get({ "ext": "mod_example" }) %}
 
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Parameter title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Example/html_admin/mod_example_settings.html.twig
+++ b/src/modules/Example/html_admin/mod_example_settings.html.twig
@@ -18,7 +18,7 @@
         {% set params = admin.extension_config_get({ "ext": "mod_example" }) %}
 
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Parameter title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Example/html_admin/mod_example_settings.html.twig
+++ b/src/modules/Example/html_admin/mod_example_settings.html.twig
@@ -18,7 +18,7 @@
         {% set params = admin.extension_config_get({ "ext": "mod_example" }) %}
 
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Parameter title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -59,13 +59,13 @@
                         <td>
                             {% if ext.type == 'mod' %}
                                 {% if ext.status == 'installed' %}
-                                <a class="btn btn-icon api-link" href="{{ 'api/admin/extension/deactivate'|link({ 'type': ext.type, 'id': ext.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="Module was deactivated" title="{{ 'Deactivate'|trans }}">
+                                <a class="btn btn-icon api-link" href="{{ 'api/admin/extension/deactivate'|link({ 'type': ext.type, 'id': ext.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="Module was deactivated" title="{{ 'Deactivate'|trans }}">
                                     <svg class="icon">
                                         <use xlink:href="#close" />
                                     </svg>
                                 </a>
                                 {% else %}
-                                <a class="btn btn-icon api-link" href="{{ 'api/admin/extension/activate'|link({ 'type': ext.type, 'id': ext.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-jsonp="onAfterModuleActivated">
+                                <a class="btn btn-icon api-link" href="{{ 'api/admin/extension/activate'|link({ 'type': ext.type, 'id': ext.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-jsonp="onAfterModuleActivated">
                                     <svg class="icon">
                                         <use xlink:href="#play" />
                                     </svg>
@@ -107,7 +107,7 @@
                 <p class="text-muted">{{ 'Automatic updater is a tool to update FOSSBilling to latest version in one click. Works on these hosting environments where PHP has permissions to overwrite files uploaded via FTP.'|trans }}</p>
 
                 {{ admin.system_release_notes|bbmd }}
-                <a href="{{ 'api/admin/extension/update_core'|link }}" class="btn btn-primary api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. Click OK when you are ready to continue." data-api-msg="Update complete">
+                <a href="{{ 'api/admin/extension/update_core'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. Click OK when you are ready to continue." data-api-msg="Update complete">
                     <svg class="icon">
                         <use xlink:href="#refresh" />
                     </svg>
@@ -118,7 +118,7 @@
                 <h3>{{ 'Migrate configuration file'|trans }}</h3>
                 <p class="text-muted">{{ 'Use this tool to automatically migrate your configuration file to be compatible with the latest FOSSBilling changes. Note: this is only needed when performing manual updates'|trans }}</p>
 
-                <a href="{{ 'api/admin/extension/update_config'|link }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config which will be saved as config.php.old." data-api-msg="Migration complete">
+                <a href="{{ 'api/admin/extension/update_config'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config which will be saved as config.php.old." data-api-msg="Migration complete">
                     <svg class="icon">
                         <use xlink:href="#refresh" />
                     </svg>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
@@ -1,5 +1,5 @@
 <form method="post" action="" name="field_form{{ field.id }}" class="field-form update-field">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
 <div class="head">
     <h5><span class="awe-edit"></span> {{ 'Edit field'|trans }}</h5>
     <a href="#" class="floatright close-field-form"><span class="ui-icon ui-icon-closethick ui-icon" ></span></a>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
@@ -1,5 +1,5 @@
 <form method="post" action="" name="field_form{{ field.id }}" class="field-form update-field">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
 <div class="head">
     <h5><span class="awe-edit"></span> {{ 'Edit field'|trans }}</h5>
     <a href="#" class="floatright close-field-form"><span class="ui-icon ui-icon-closethick ui-icon" ></span></a>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
@@ -1,4 +1,5 @@
 <form method="post" action="" name="field_form{{ field.id }}" class="field-form update-field">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
 <div class="head">
     <h5><span class="awe-edit"></span> {{ 'Edit field'|trans }}</h5>
     <a href="#" class="floatright close-field-form"><span class="ui-icon ui-icon-closethick ui-icon" ></span></a>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
@@ -1,7 +1,7 @@
 {% set form = guest.formbuilder_get({ "id": order.form_id }) %}
 {% set config = order.config %}
 <form class="api-form"  action="{{ 'api/admin/order/update_config'|link }}" data-api-msg="Order was updated">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <input type="hidden" name="config[form_id]" value="{{ config.form_id }}" />
         <input type="hidden" name="config[id]" value="{{ config.id }}" />
         <input type="hidden" name="config[product_id]" value="{{ form.product_id }}" />

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
@@ -1,6 +1,7 @@
 {% set form = guest.formbuilder_get({ "id": order.form_id }) %}
 {% set config = order.config %}
 <form class="api-form"  action="{{ 'api/admin/order/update_config'|link }}" data-api-msg="Order was updated">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <input type="hidden" name="config[form_id]" value="{{ config.form_id }}" />
         <input type="hidden" name="config[id]" value="{{ config.id }}" />
         <input type="hidden" name="config[product_id]" value="{{ form.product_id }}" />

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_manage.html.twig
@@ -1,7 +1,7 @@
 {% set form = guest.formbuilder_get({ "id": order.form_id }) %}
 {% set config = order.config %}
 <form class="api-form"  action="{{ 'api/admin/order/update_config'|link }}" data-api-msg="Order was updated">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <input type="hidden" name="config[form_id]" value="{{ config.form_id }}" />
         <input type="hidden" name="config[id]" value="{{ config.id }}" />
         <input type="hidden" name="config[product_id]" value="{{ form.product_id }}" />

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -97,7 +97,7 @@
 
         <div class="tab_content" id="tab-import">
             <form method="post" action="{{ 'api/admin/formbuilder/import'|link }}" class="mainForm api-form save" data-api-reload="1">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="formBottom">
                         <textarea name="form" cols="5" rows="5" placeholder="Paste new form configuration text."></textarea>
@@ -120,7 +120,7 @@
 
     <div class="mainForm">
         <form  id="update-form-options">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="rowElem">
                 <label>
                     <strong>{{ 'New form name and options'|trans }}</strong>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -170,11 +170,11 @@
 <div class="mainForm">
 
 <div class="body" id="fields">
-    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'text'}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1" ><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Text'|trans }}</span></a>
-    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'select'}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Dropdown'|trans }}</span></a>
-    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'radio'}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Radio'|trans }}</span></a>
-    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'checkbox'}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Checkbox'|trans }}</span></a>
-    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'textarea'}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Textarea'|trans }}</span></a>
+    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'text', 'CSRFToken': CSRFToken}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1" ><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Text'|trans }}</span></a>
+    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'select', 'CSRFToken': CSRFToken}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Dropdown'|trans }}</span></a>
+    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'radio', 'CSRFToken': CSRFToken}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Radio'|trans }}</span></a>
+    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'checkbox', 'CSRFToken': CSRFToken}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Checkbox'|trans }}</span></a>
+    <a href="{{ 'api/admin/formbuilder/add_field'|link({'form_id': form.id, 'type': 'textarea', 'CSRFToken': CSRFToken}) }}" title="" class="btnIconLeft mr10 api-link" data-api-reload="1"><img src="images/icons/dark/add.png" alt="" class="icon"><span>{{ 'Textarea'|trans }}</span></a>
 </div>
 
 <fieldset>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -97,7 +97,7 @@
 
         <div class="tab_content" id="tab-import">
             <form method="post" action="{{ 'api/admin/formbuilder/import'|link }}" class="mainForm api-form save" data-api-reload="1">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="formBottom">
                         <textarea name="form" cols="5" rows="5" placeholder="Paste new form configuration text."></textarea>
@@ -120,7 +120,7 @@
 
     <div class="mainForm">
         <form  id="update-form-options">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="rowElem">
                 <label>
                     <strong>{{ 'New form name and options'|trans }}</strong>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -97,6 +97,7 @@
 
         <div class="tab_content" id="tab-import">
             <form method="post" action="{{ 'api/admin/formbuilder/import'|link }}" class="mainForm api-form save" data-api-reload="1">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="formBottom">
                         <textarea name="form" cols="5" rows="5" placeholder="Paste new form configuration text."></textarea>
@@ -119,6 +120,7 @@
 
     <div class="mainForm">
         <form  id="update-form-options">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="rowElem">
                 <label>
                     <strong>{{ 'New form name and options'|trans }}</strong>

--- a/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
@@ -30,7 +30,7 @@
         {{ gateway.description|raw }}
 
         <form method="post" action="{{ 'api/admin/invoice/gateway_update'|link }}" class="api-form" data-api-msg="{{ 'Gateway updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Payment gateway title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
@@ -30,6 +30,7 @@
         {{ gateway.description|raw }}
 
         <form method="post" action="{{ 'api/admin/invoice/gateway_update'|link }}" class="api-form" data-api-msg="{{ 'Gateway updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Payment gateway title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateway.html.twig
@@ -30,7 +30,7 @@
         {{ gateway.description|raw }}
 
         <form method="post" action="{{ 'api/admin/invoice/gateway_update'|link }}" class="api-form" data-api-msg="{{ 'Gateway updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Payment gateway title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
@@ -48,7 +48,7 @@
                     <td>{{ mf.q(gateway.allow_recurrent) }}</td>
                     <td>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/invoice/gateway_copy'|link({ 'id': gateway.id }) }}"
+                            href="{{ 'api/admin/invoice/gateway_copy'|link({ 'id': gateway.id, 'CSRFToken': CSRFToken }) }}"
                             title="{{ 'Copy'|trans }}"
                             data-api-redirect="{{ 'invoice/gateways'|alink }}">
                             <svg class="icon">
@@ -61,7 +61,7 @@
                             </svg>
                         </a>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/invoice/gateway_delete'|link({ 'id': gateway.id }) }}"
+                            href="{{ 'api/admin/invoice/gateway_delete'|link({ 'id': gateway.id, 'CSRFToken': CSRFToken }) }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-redirect="{{ 'invoice/gateways'|alink }}">
                             <svg class="icon">
@@ -111,7 +111,7 @@
                     <td>{{ gtw }}</td>
                     <td>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/invoice/gateway_install'|link({ 'code': gtw }) }}"
+                            href="{{ 'api/admin/invoice/gateway_install'|link({ 'code': gtw, 'CSRFToken': CSRFToken }) }}"
                              title="{{ 'Install'|trans }}"
                             data-api-redirect="{{ 'invoice/gateways'|alink }}">
                             <svg class="icon">

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -290,7 +290,8 @@
                     dataType: "json",
                     data: {
                         per_page: 10,
-                        search: request.term
+                        search: request.term,
+                        CSRFToken: {{ CSRFToken }}
                     },
                     success: function(data) {
                         response($.map(data.result, function(name, id) {

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -12,7 +12,7 @@
         <div class="card-body">
             <h5>{{ 'Filter invoices'|trans }}</h5>
             <form method="get">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -263,7 +263,7 @@
             <div class="tab-pane show" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/prepare'|link }}" class="api-form" data-api-jsonp="onAfterInvoicePrepared">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label" for="inputUser">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -12,6 +12,7 @@
         <div class="card-body">
             <h5>{{ 'Filter invoices'|trans }}</h5>
             <form method="get">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -262,6 +263,7 @@
             <div class="tab-pane show" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/prepare'|link }}" class="api-form" data-api-jsonp="onAfterInvoicePrepared">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label" for="inputUser">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -12,7 +12,7 @@
         <div class="card-body">
             <h5>{{ 'Filter invoices'|trans }}</h5>
             <form method="get">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                     <div class="col">
@@ -263,7 +263,7 @@
             <div class="tab-pane show" id="tab-new" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/prepare'|link }}" class="api-form" data-api-jsonp="onAfterInvoicePrepared">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label" for="inputUser">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -291,7 +291,7 @@
                     data: {
                         per_page: 10,
                         search: request.term,
-                        CSRFToken: {{ CSRFToken }}
+                        CSRFToken: "{{ CSRFToken }}"
                     },
                     success: function(data) {
                         response($.map(data.result, function(name, id) {

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -237,7 +237,7 @@
                                     </svg>
                                 </a>
                                 <a class="btn btn-icon api-link"
-                                    href="{{ 'api/admin/invoice/delete'|link({ 'id': invoice.id }) }}"
+                                    href="{{ 'api/admin/invoice/delete'|link({ 'id': invoice.id, 'CSRFToken': CSRFToken }) }}"
                                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                                     data-api-reload="1">
                                     <svg class="icon">

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -128,7 +128,7 @@
                     </svg>
                     <span class="d-block text-secondary">{{ 'View as client'|trans }}</span>
                 </a>
-                <a href="{{ 'api/admin/invoice/delete'|link({ 'id': invoice.id }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
+                <a href="{{ 'api/admin/invoice/delete'|link({ 'id': invoice.id, 'CSRFToken': CSRFToken }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
                         <use xlink:href="#delete" />
                     </svg>
@@ -169,7 +169,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="{{ 'Invoice updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -263,7 +263,7 @@
         <div class="tab-pane fade" id="tab-texts" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Text before invoice items table'|trans }}</label>
                         <div class="col">
@@ -289,7 +289,7 @@
 
                 {% set seller = invoice.seller %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Company'|trans }}:</label>
                         <div class="col">
@@ -339,7 +339,7 @@
 
                 {% set buyer = invoice.buyer %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'First name'|trans }}:</label>
                         <div class="col">
@@ -429,7 +429,7 @@
 
     {% if not invoice.approved %}
     <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="1">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <table class="table card-table table-vcenter table-striped text-nowrap">
             <thead>
                 <tr>

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -135,13 +135,13 @@
                     <span class="d-block text-secondary">{{ 'Delete'|trans }}</span>
                 </a>
                 {% if invoice.status == 'unpaid' %}
-                <a href="{{ 'api/admin/invoice/send_reminder'|link({ 'id': invoice.id}) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-msg="Payment reminder was sent">
+                <a href="{{ 'api/admin/invoice/send_reminder'|link({ 'id': invoice.id, 'CSRFToken': CSRFToken}) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-msg="Payment reminder was sent">
                     <svg class="mb-2 text-secondary" width="24" height="24">
                         <use xlink:href="#mail" />
                     </svg>
                     <span class="d-block text-secondary">{{ 'Send reminder'|trans }}</span>
                 </a>
-                <a href="{{ 'api/admin/invoice/mark_as_paid'|link({ 'id': invoice.id, 'execute': 1 }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-reload="Invoice marked as paid">
+                <a href="{{ 'api/admin/invoice/mark_as_paid'|link({ 'id': invoice.id, 'execute': 1, 'CSRFToken': CSRFToken }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-reload="Invoice marked as paid">
                     <svg class="mb-2 text-secondary" width="24" height="24">
                         <use xlink:href="#check" />
                     </svg>
@@ -150,7 +150,7 @@
                 {% endif %}
 
                 {% if invoice.status == 'paid' %}
-                <a href="{{ 'api/admin/invoice/refund'|link({ 'id': invoice.id }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
+                <a href="{{ 'api/admin/invoice/refund'|link({ 'id': invoice.id, 'CSRFToken': CSRFToken }) }}" class="d-inline-block mx-1 btn bg-light bg-gradient api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
                         <use xlink:href="#receipt-refund" />
                     </svg>
@@ -455,7 +455,7 @@
                     </td>
                     <td>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/invoice/item_delete'|link({ 'id': item.id }) }}"
+                            href="{{ 'api/admin/invoice/item_delete'|link({ 'id': item.id, 'CSRFToken': CSRFToken }) }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-reload="1">
                             <svg class="icon">
@@ -503,7 +503,7 @@
         <div class="card-footer d-flex gap-2">
             {% if not invoice.approved %}
             <a class="btn btn-success w-100 api-link"
-                href="{{ 'api/admin/invoice/approve'|link({ 'id': invoice.id }) }}"
+                href="{{ 'api/admin/invoice/approve'|link({ 'id': invoice.id, 'CSRFToken': CSRFToken }) }}"
                 data-api-reload="{{ 'invoices'|alink }}">
                 <svg class="icon">
                     <use xlink:href="#check" />
@@ -620,7 +620,7 @@
         <button class="bb-button" type="button" onclick="window.print()">
             <span class="dark-icon i-print"></span> {{ 'Print'|trans }}</button>
         {% if invoice.status == 'unpaid' %}
-        <a class="bb-button api-link" href="{{ 'api/client/invoice/delete'|link({ 'hash': invoice.hash }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
+        <a class="bb-button api-link" href="{{ 'api/client/invoice/delete'|link({ 'hash': invoice.hash, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice'|alink }}">
             <span class="dark-icon i-bin"></span> {{ 'Delete'|trans }}</a>
         {% endif %}
     </div>

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -169,7 +169,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="{{ 'Invoice updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -263,7 +263,7 @@
         <div class="tab-pane fade" id="tab-texts" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Text before invoice items table'|trans }}</label>
                         <div class="col">
@@ -289,7 +289,7 @@
 
                 {% set seller = invoice.seller %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Company'|trans }}:</label>
                         <div class="col">
@@ -339,7 +339,7 @@
 
                 {% set buyer = invoice.buyer %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'First name'|trans }}:</label>
                         <div class="col">
@@ -429,7 +429,7 @@
 
     {% if not invoice.approved %}
     <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="1">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <table class="table card-table table-vcenter table-striped text-nowrap">
             <thead>
                 <tr>

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -169,6 +169,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="{{ 'Invoice updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">
@@ -262,6 +263,7 @@
         <div class="tab-pane fade" id="tab-texts" role="tabpanel">
             <div class="card-body">
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Text before invoice items table'|trans }}</label>
                         <div class="col">
@@ -287,6 +289,7 @@
 
                 {% set seller = invoice.seller %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Company'|trans }}:</label>
                         <div class="col">
@@ -336,6 +339,7 @@
 
                 {% set buyer = invoice.buyer %}
                 <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'Invoice updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'First name'|trans }}:</label>
                         <div class="col">
@@ -425,6 +429,7 @@
 
     {% if not invoice.approved %}
     <form action="{{ 'api/admin/invoice/update'|link }}" method="post" class="api-form" data-api-reload="1">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <table class="table card-table table-vcenter table-striped text-nowrap">
             <thead>
                 <tr>

--- a/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
@@ -29,6 +29,7 @@
 
         {% set params = admin.system_get_params %}
         <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="Settings updated">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Number of days to generate new invoice before order expiration'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.system_get_params %}
         <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="Settings updated">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Number of days to generate new invoice before order expiration'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.system_get_params %}
         <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="Settings updated">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Number of days to generate new invoice before order expiration'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -100,7 +100,7 @@
             <div class="tab-pane fade" id="tab-manage" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/subscription_update'|link }}" class="api-form" data-api-reload="1">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Payment Gateway'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -86,7 +86,7 @@
 
                 <div class="body footer text-center">
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/invoice/subscription_delete'|link({ 'id': subscription.id }) }}"
+                        href="{{ 'api/admin/invoice/subscription_delete'|link({ 'id': subscription.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-redirect="{{ 'invoice/subscriptions'|alink }}">
                         <svg class="mb-2 text-secondary" width="24" height="24">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -100,6 +100,7 @@
             <div class="tab-pane fade" id="tab-manage" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/subscription_update'|link }}" class="api-form" data-api-reload="1">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Payment Gateway'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -100,7 +100,7 @@
             <div class="tab-pane fade" id="tab-manage" role="tabpanel">
                 <div class="card-body">
                     <form method="post" action="{{ 'api/admin/invoice/subscription_update'|link }}" class="api-form" data-api-reload="1">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Payment Gateway'|trans }}:</label>
                             <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -168,7 +168,7 @@
                     data: {
                         per_page: 10,
                         search: request.term,
-                        CSRFToken: {{ CSRFToken }}
+                        CSRFToken: "{{ CSRFToken }}"
                     },
                     success: function(data) {
                         response( $.map( data.result, function(name, id) {

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -73,7 +73,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/subscription_delete'|link({ 'id': subscription.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                            <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/subscription_delete'|link({ 'id': subscription.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -97,6 +97,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/subscription_create'|link }}" class="save api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -97,7 +97,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/subscription_create'|link }}" class="save api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -167,7 +167,8 @@
                     dataType: "json",
                     data: {
                         per_page: 10,
-                        search: request.term
+                        search: request.term,
+                        CSRFToken: {{ CSRFToken }}
                     },
                     success: function(data) {
                         response( $.map( data.result, function(name, id) {

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -97,7 +97,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/subscription_create'|link }}" class="save api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -101,7 +101,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/tax_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                         <div class="col">
@@ -139,7 +139,7 @@
         <div class="tab-pane fade" id="tab-settings" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Tax settings updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable tax support'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -101,7 +101,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/tax_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                         <div class="col">
@@ -139,7 +139,7 @@
         <div class="tab-pane fade" id="tab-settings" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Tax settings updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable tax support'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -101,6 +101,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/tax_create'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                         <div class="col">
@@ -138,6 +139,7 @@
         <div class="tab-pane fade" id="tab-settings" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Tax settings updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable tax support'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -74,7 +74,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/invoice/tax_delete'|link({ 'id': tax.id }) }}"
+                                href="{{ 'api/admin/invoice/tax_delete'|link({ 'id': tax.id, 'CSRFToken': CSRFToken }) }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                                 data-api-reload="1">
                                 <svg class="icon">
@@ -165,7 +165,7 @@
                 <p class="text-muted">{{ 'If you would like FOSSBilling to automatically setup the EU VAT tax rules for you for all EU Member States then simply enter your VAT Label & local VAT rate below and click the submit button. <strong>This action will delete any existing tax rules</strong> and configure the VAT rates for all EU countries.'|trans }}</p>
 
                 <div class="text-center">
-                    <a href="{{ 'api/admin/invoice/tax_setup_eu'|link}}" class="btn55 mr10 api-link" data-api-reload="1" data-api-confirm="{{ 'It will overwrite your existing VAT rules. Are you sure?'|trans }}">
+                    <a href="{{ 'api/admin/invoice/tax_setup_eu'|link({ 'CSRFToken': CSRFToken }) }}" class="btn55 mr10 api-link" data-api-reload="1" data-api-confirm="{{ 'It will overwrite your existing VAT rules. Are you sure?'|trans }}">
                         <img src="images/icons/middlenav/power.png" alt="">
                         <span>{{ 'Generate VAT rates'|trans }}</span>
                     </a>

--- a/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
@@ -12,6 +12,7 @@
             <h3>{{ 'Update tax rule'|trans }}</h3>
 
             <form method="post" action="{{ 'api/admin/invoice/tax_update'|link }}" data-api-redirect="{{ 'invoice/tax'|alink }}" class="api-form">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                     <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
@@ -12,7 +12,7 @@
             <h3>{{ 'Update tax rule'|trans }}</h3>
 
             <form method="post" action="{{ 'api/admin/invoice/tax_update'|link }}" data-api-redirect="{{ 'invoice/tax'|alink }}" class="api-form">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                     <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_taxupdate.html.twig
@@ -12,7 +12,7 @@
             <h3>{{ 'Update tax rule'|trans }}</h3>
 
             <form method="post" action="{{ 'api/admin/invoice/tax_update'|link }}" data-api-redirect="{{ 'invoice/tax'|alink }}" class="api-form">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Tax title'|trans }}:</label>
                     <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
@@ -125,7 +125,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-reload="{{ 'Transaction updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <h5>{{ 'Transaction payment information'|trans }}</h5>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Invoice ID'|trans }}:</label>
@@ -198,7 +198,7 @@
                 <h3>{{ 'Note about this transaction'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-msg="{{ 'Transaction note updated.'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Content'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
@@ -125,7 +125,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-reload="{{ 'Transaction updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <h5>{{ 'Transaction payment information'|trans }}</h5>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Invoice ID'|trans }}:</label>
@@ -198,7 +198,7 @@
                 <h3>{{ 'Note about this transaction'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-msg="{{ 'Transaction note updated.'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Content'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
@@ -111,11 +111,11 @@
             </div>
 
             <div class="card-footer text-center">
-                <a class="btn55 mr10 api-link" href="{{ 'api/admin/invoice/transaction_process'|link({ 'id': transaction.id }) }}" data-api-reload="1">
+                <a class="btn55 mr10 api-link" href="{{ 'api/admin/invoice/transaction_process'|link({ 'id': transaction.id, 'CSRFToken': CSRFToken }) }}" data-api-reload="1">
                     <img src="assets/icons/refresh.svg" alt="">
                     <span>{{ 'Process'|trans }}</span>
                 </a>
-                <a class="btn55 mr10 api-link" href="{{ 'api/admin/invoice/transaction_delete'|link({ 'id': transaction.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice/transactions'|alink }}">
+                <a class="btn55 mr10 api-link" href="{{ 'api/admin/invoice/transaction_delete'|link({ 'id': transaction.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'invoice/transactions'|alink }}">
                     <img src="images/icons/middlenav/trash.png" alt="">
                     <span>{{ 'Delete'|trans }}</span>
                 </a>

--- a/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
@@ -125,6 +125,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-reload="{{ 'Transaction updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <h5>{{ 'Transaction payment information'|trans }}</h5>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Invoice ID'|trans }}:</label>
@@ -197,6 +198,7 @@
                 <h3>{{ 'Note about this transaction'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/invoice/transaction_update'|link }}" class="api-form" data-api-msg="{{ 'Transaction note updated.'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Content'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -12,7 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter transactions'|trans }}</h5>
         <form method="get">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -187,12 +187,12 @@
                             <use xlink:href="#edit" />
                         </svg>
                     </a>
-                    <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/transaction_process'|link({ 'id': tx.id }) }}" data-api-msg="Processed" title="Process again">
+                    <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/transaction_process'|link({ 'id': tx.id, 'CSRFToken': CSRFToken }) }}" data-api-msg="Processed" title="Process again">
                         <svg class="icon">
                             <use xlink:href="#refresh" />
                         </svg>
                     </a>
-                    <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/transaction_delete'|link({ 'id': tx.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                    <a class="btn btn-icon api-link" href="{{ 'api/admin/invoice/transaction_delete'|link({ 'id': tx.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                         <svg class="icon">
                             <use xlink:href="#delete" />
                         </svg>

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -12,6 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter transactions'|trans }}</h5>
         <form method="get">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -12,7 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter transactions'|trans }}</h5>
         <form method="get">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">

--- a/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
@@ -22,7 +22,7 @@
                 {% if payment.type == 'form' %}
                 <h2>{{ 'Redirecting to payment gateway..'|trans }}</h2>
                 <form name="payment_form" action="{{ payment.service_url }}" method="post">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     {% for key, value in payment.result %}
                     <input type="hidden" name="{{ key }}" value="{{ value }}" />
                     {% endfor %}

--- a/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
@@ -22,7 +22,7 @@
                 {% if payment.type == 'form' %}
                 <h2>{{ 'Redirecting to payment gateway..'|trans }}</h2>
                 <form name="payment_form" action="{{ payment.service_url }}" method="post">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     {% for key, value in payment.result %}
                     <input type="hidden" name="{{ key }}" value="{{ value }}" />
                     {% endfor %}

--- a/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
@@ -22,6 +22,7 @@
                 {% if payment.type == 'form' %}
                 <h2>{{ 'Redirecting to payment gateway..'|trans }}</h2>
                 <form name="payment_form" action="{{ payment.service_url }}" method="post">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     {% for key, value in payment.result %}
                     <input type="hidden" name="{{ key }}" value="{{ value }}" />
                     {% endfor %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -25,6 +25,7 @@
                         <p>{{ 'Please choose payment type and pay for your chosen products.'|trans }}</p>
                     </header>
                     <form method="post" action="{{ 'api/guest/invoice/payment'|link }}" class="api-form" data-api-redirect="{{ ('invoice/'~invoice.hash)|link({ 'auto_redirect': 1 }) }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <input type="hidden" name="hash" value="{{ invoice.hash }}"/>
                         {% for gtw in guest.invoice_gateways %}
                         {% if invoice.currency in gtw.accepted_currencies %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -25,7 +25,7 @@
                         <p>{{ 'Please choose payment type and pay for your chosen products.'|trans }}</p>
                     </header>
                     <form method="post" action="{{ 'api/guest/invoice/payment'|link }}" class="api-form" data-api-redirect="{{ ('invoice/'~invoice.hash)|link({ 'auto_redirect': 1 }) }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <input type="hidden" name="hash" value="{{ invoice.hash }}"/>
                         {% for gtw in guest.invoice_gateways %}
                         {% if invoice.currency in gtw.accepted_currencies %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -25,7 +25,7 @@
                         <p>{{ 'Please choose payment type and pay for your chosen products.'|trans }}</p>
                     </header>
                     <form method="post" action="{{ 'api/guest/invoice/payment'|link }}" class="api-form" data-api-redirect="{{ ('invoice/'~invoice.hash)|link({ 'auto_redirect': 1 }) }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <input type="hidden" name="hash" value="{{ invoice.hash }}"/>
                         {% for gtw in guest.invoice_gateways %}
                         {% if invoice.currency in gtw.accepted_currencies %}

--- a/src/modules/Kb/html_admin/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_article.html.twig
@@ -25,6 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/article_update'|link }}" class="api-form" data-api-msg="{{ 'Article updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ post.title }}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_article.html.twig
@@ -25,7 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/article_update'|link }}" class="api-form" data-api-msg="{{ 'Article updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <h3>{{ post.title }}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_article.html.twig
@@ -25,7 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/article_update'|link }}" class="api-form" data-api-msg="{{ 'Article updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ post.title }}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_category.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_category.html.twig
@@ -26,7 +26,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ category.title}}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_category.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_category.html.twig
@@ -26,7 +26,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <h3>{{ category.title}}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_category.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_category.html.twig
@@ -26,6 +26,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/kb/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ category.title}}</h3>
 

--- a/src/modules/Kb/html_admin/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_index.html.twig
@@ -92,7 +92,7 @@
         <div class="tab-pane fade" id="tab-new-article" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/article_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -166,7 +166,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/category_create'|link }}" class="api-form" data-api-reload="{{ 'Category created'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Kb/html_admin/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_index.html.twig
@@ -92,6 +92,7 @@
         <div class="tab-pane fade" id="tab-new-article" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/article_create'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -165,6 +166,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/category_create'|link }}" class="api-form" data-api-reload="{{ 'Category created'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Kb/html_admin/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_index.html.twig
@@ -71,7 +71,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{'kb'|alink}}" href="{{ 'api/admin/kb/article_delete'|link({ 'id': post.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{'kb'|alink}}" href="{{ 'api/admin/kb/article_delete'|link({ 'id': post.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -145,7 +145,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/kb/category_delete'|link({ 'id': cat_id }) }}"
+                                href="{{ 'api/admin/kb/category_delete'|link({ 'id': cat_id, 'CSRFToken': CSRFToken }) }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                                 data-api-redirect="{{ 'kb/new'|alink }}">
                                 <svg class="icon">

--- a/src/modules/Kb/html_admin/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_index.html.twig
@@ -92,7 +92,7 @@
         <div class="tab-pane fade" id="tab-new-article" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/article_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -166,7 +166,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/kb/category_create'|link }}" class="api-form" data-api-reload="{{ 'Category created'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Kb/html_client/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_index.html.twig
@@ -18,7 +18,7 @@
                     <h1>{{ 'Knowledge base'|trans }}</h1><br/>
                     {{ 'Please try to read related topics in knowledge base before contacting support.'|trans }}
                     <form method="get" action="" class="form form-search pull-right" style="background: none; border: 0px">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <p>
                             <input class="" name="_url" type="hidden" value="/kb">
                             <input class="search-query text" name="q" type="text" value="{{ request.q }}" placeholder="{{ 'What are you looking for?'|trans }}">

--- a/src/modules/Kb/html_client/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_index.html.twig
@@ -18,6 +18,7 @@
                     <h1>{{ 'Knowledge base'|trans }}</h1><br/>
                     {{ 'Please try to read related topics in knowledge base before contacting support.'|trans }}
                     <form method="get" action="" class="form form-search pull-right" style="background: none; border: 0px">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <p>
                             <input class="" name="_url" type="hidden" value="/kb">
                             <input class="search-query text" name="q" type="text" value="{{ request.q }}" placeholder="{{ 'What are you looking for?'|trans }}">

--- a/src/modules/Kb/html_client/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_index.html.twig
@@ -18,7 +18,7 @@
                     <h1>{{ 'Knowledge base'|trans }}</h1><br/>
                     {{ 'Please try to read related topics in knowledge base before contacting support.'|trans }}
                     <form method="get" action="" class="form form-search pull-right" style="background: none; border: 0px">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <p>
                             <input class="" name="_url" type="hidden" value="/kb">
                             <input class="search-query text" name="q" type="text" value="{{ request.q }}" placeholder="{{ 'What are you looking for?'|trans }}">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
@@ -82,7 +82,7 @@
         </div>
         <div class="tab-pane" id="new" role="tabpanel">
           <form method="post" action="admin/massmailer/create" class="mainForm api-form" data-api-jsonp="onAfterCreateMM">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="rowElem noborder">
                     <label>{{ 'Subject'|trans }}:</label>
@@ -99,7 +99,7 @@
                     <h4>{{ 'Mass Mail Settings'|trans }}</h4>
                     {% set params = admin.extension_config_get({"ext":"mod_massmailer"}) %}
                     <form method="post" action="admin/extension/config_save" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="moreFields">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
@@ -82,7 +82,7 @@
         </div>
         <div class="tab-pane" id="new" role="tabpanel">
           <form method="post" action="admin/massmailer/create" class="mainForm api-form" data-api-jsonp="onAfterCreateMM">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <label>{{ 'Subject'|trans }}:</label>
@@ -99,7 +99,7 @@
                     <h4>{{ 'Mass Mail Settings'|trans }}</h4>
                     {% set params = admin.extension_config_get({"ext":"mod_massmailer"}) %}
                     <form method="post" action="admin/extension/config_save" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="moreFields">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
@@ -82,6 +82,7 @@
         </div>
         <div class="tab-pane" id="new" role="tabpanel">
           <form method="post" action="admin/massmailer/create" class="mainForm api-form" data-api-jsonp="onAfterCreateMM">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <label>{{ 'Subject'|trans }}:</label>
@@ -98,6 +99,7 @@
                     <h4>{{ 'Mass Mail Settings'|trans }}</h4>
                     {% set params = admin.extension_config_get({"ext":"mod_massmailer"}) %}
                     <form method="post" action="admin/extension/config_save" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="rowElem noborder">
                     <div class="moreFields">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
@@ -53,7 +53,7 @@
                         <td>{{ msg.from_name }} <br/>{{ msg.from_email }}</td>
                         <td>{{ mf.status_name(msg.status) }}</td>
                         <td>
-                            <a class="btn btn-icon api-link" href="{{ 'api/admin/massmailer/copy'|link({'id' : msg.id}) }}" data-api-redirect="{{ 'massmailer'|alink }}">
+                            <a class="btn btn-icon api-link" href="{{ 'api/admin/massmailer/copy'|link({'id' : msg.id, 'CSRFToken': CSRFToken}) }}" data-api-redirect="{{ 'massmailer'|alink }}">
                                 <svg class="icon">
                                     <use xlink:href="#copy" />
                                 </svg>
@@ -63,7 +63,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/massmailer/delete'|link({'id' : msg.id}) }}" data-api-redirect="{{ 'massmailer'|alink }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/massmailer/delete'|link({'id' : msg.id, 'CSRFToken': CSRFToken}) }}" data-api-redirect="{{ 'massmailer'|alink }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
@@ -11,7 +11,7 @@
     </div>
     
     <form method="post" action="admin/massmailer/update" class="mainForm save api-form" data-api-jsonp="onAfterMessageUpdate" id="msg-form">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <fieldset>
             
             <div class="rowElem noborder">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
@@ -11,7 +11,7 @@
     </div>
     
     <form method="post" action="admin/massmailer/update" class="mainForm save api-form" data-api-jsonp="onAfterMessageUpdate" id="msg-form">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <fieldset>
             
             <div class="rowElem noborder">

--- a/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
@@ -11,6 +11,7 @@
     </div>
     
     <form method="post" action="admin/massmailer/update" class="mainForm save api-form" data-api-jsonp="onAfterMessageUpdate" id="msg-form">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <fieldset>
             
             <div class="rowElem noborder">

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -92,7 +92,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/news/create'|link }}" class="api-form" data-api-redirect="{{ 'news'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -66,7 +66,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/news/delete'|link({ 'id': post.id }) }}"
+                                href="{{ 'api/admin/news/delete'|link({ 'id': post.id, 'CSRFToken': CSRFToken }) }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                                 data-api-redirect="{{ 'news'|alink }}">
                                 <svg class="icon">

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -92,7 +92,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/news/create'|link }}" class="api-form" data-api-redirect="{{ 'news'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -92,6 +92,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/news/create'|link }}" class="api-form" data-api-redirect="{{ 'news'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/News/html_admin/mod_news_post.html.twig
+++ b/src/modules/News/html_admin/mod_news_post.html.twig
@@ -25,6 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/news/update'|link }}" class="api-form" data-api-msg="{{ 'Post updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ 'Edit post'|trans }}</h3>
             <p class="text-muted">{{ post.title }}</p>

--- a/src/modules/News/html_admin/mod_news_post.html.twig
+++ b/src/modules/News/html_admin/mod_news_post.html.twig
@@ -25,7 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/news/update'|link }}" class="api-form" data-api-msg="{{ 'Post updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <h3>{{ 'Edit post'|trans }}</h3>
             <p class="text-muted">{{ post.title }}</p>

--- a/src/modules/News/html_admin/mod_news_post.html.twig
+++ b/src/modules/News/html_admin/mod_news_post.html.twig
@@ -25,7 +25,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/news/update'|link }}" class="api-form" data-api-msg="{{ 'Post updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ 'Edit post'|trans }}</h3>
             <p class="text-muted">{{ post.title }}</p>

--- a/src/modules/Notification/html_admin/mod_notification_index.html.twig
+++ b/src/modules/Notification/html_admin/mod_notification_index.html.twig
@@ -73,7 +73,7 @@
         <div class="tab-pane fade" id="tab-new-note" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/notification/add'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Note'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Notification/html_admin/mod_notification_index.html.twig
+++ b/src/modules/Notification/html_admin/mod_notification_index.html.twig
@@ -43,7 +43,7 @@
                             <td>{{ admin.system_string_render({ "_tpl": event.meta_value, "_try": true })|raw }}</td>
                             <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
                             <td>
-                                <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'notification'|alink }}" href="{{ 'api/admin/notification/delete'|link({ 'id': event.id }) }}">
+                                <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'notification'|alink }}" href="{{ 'api/admin/notification/delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}">
                                     <svg class="icon">
                                         <use xlink:href="#delete" />
                                     </svg>
@@ -60,7 +60,7 @@
                 {% include "partial_pagination.html.twig" with {'list': events, 'url':'notification'} %}
 
                 <div class="card-footer d-flex align-items-center justify-content-between">
-                    <a class="btn btn-danger api-link" href="{{ 'api/admin/notification/delete_all'|link }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                    <a class="btn btn-danger api-link" href="{{ 'api/admin/notification/delete_all'|link({ 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                         <svg class="icon">
                             <use xlink:href="#delete"></use>
                         </svg>

--- a/src/modules/Notification/html_admin/mod_notification_index.html.twig
+++ b/src/modules/Notification/html_admin/mod_notification_index.html.twig
@@ -73,7 +73,7 @@
         <div class="tab-pane fade" id="tab-new-note" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/notification/add'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Note'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Notification/html_admin/mod_notification_index.html.twig
+++ b/src/modules/Notification/html_admin/mod_notification_index.html.twig
@@ -73,6 +73,7 @@
         <div class="tab-pane fade" id="tab-new-note" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/notification/add'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Note'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -12,6 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter orders'|trans }}</h5>
         <form method="get">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">
@@ -239,6 +240,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
                 <div class="card-body">
                     <form method="post" action="{{ 'order/new'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -12,7 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter orders'|trans }}</h5>
         <form method="get">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">
@@ -240,7 +240,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
                 <div class="card-body">
                     <form method="post" action="{{ 'order/new'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -281,7 +281,8 @@
                         dataType: "json",
                         data: {
                             per_page: 10,
-                            search: request.term
+                            search: request.term,
+                            CSRFToken: {{ CSRFToken }}
                         },
                         success: function( data ) {
                             response($.map(data.result, function(name, id) {

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -12,7 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter orders'|trans }}</h5>
         <form method="get">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">
@@ -240,7 +240,7 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
                 <div class="card-body">
                     <form method="post" action="{{ 'order/new'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -282,7 +282,7 @@
                         data: {
                             per_page: 10,
                             search: request.term,
-                            CSRFToken: {{ CSRFToken }}
+                            CSRFToken: "{{ CSRFToken }}"
                         },
                         success: function( data ) {
                             response($.map(data.result, function(name, id) {

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -215,7 +215,7 @@
                                             <use xlink:href="#edit" />
                                         </svg>
                                     </a>
-                                    <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }} " href="{{ 'api/admin/order/delete'|link({ 'id': order.id }) }}" data-api-redirect="{{ 'order'|alink }}">
+                                    <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }} " href="{{ 'api/admin/order/delete'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}" data-api-redirect="{{ 'order'|alink }}">
                                         <svg class="icon">
                                             <use xlink:href="#delete" />
                                         </svg>

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -297,7 +297,7 @@
             <div class="card-body">
                 <h3>{{ 'Order management'|trans }}</h2>
                 <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>
                         <div class="col">
@@ -365,7 +365,7 @@
             </div>
 
             {# <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <legend>Order promotion code</legend>
 
@@ -389,7 +389,7 @@
             </div>
 
             <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-msg="Order config updated">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 {% for name, value in order.config %}
                 <div class="mb-3 row">
                     <label class="topLabel">{{ name }}:</label>
@@ -412,7 +412,7 @@
                 <p class="text-muted">{{ 'Please be cautious and make sure you know what you are doing when editing order config! FOSSBilling relies on these parameters and you might get unexpected results if you change some of them.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     {% for key, config in order.config %}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ key }}</label>

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -169,7 +169,7 @@
                 {% set order_actions %}
                     {% if order.status == 'pending_setup' or order.status == 'failed_setup' %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/activate'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/activate'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="{{ 'Order activated'|trans }}">
                         <svg class="mb-2 text-secondary" width="24" height="24">
@@ -182,7 +182,7 @@
                     {% if order.status == 'active' %}
                     {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/renew'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/renew'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="{{ 'Order renewed'|trans }}">
                         <svg class="mb-2 text-secondary" width="24" height="24">
@@ -193,7 +193,7 @@
 
                     {% if params.suspend_reason_list|trim == null %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/suspend'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/suspend'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-prompt-key="reason"
                         data-api-prompt="1"
                         data-api-prompt-text="{{ 'Reason of suspension'|trans }}"
@@ -234,7 +234,7 @@
                     </a>
                     {% endif %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/cancel'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/cancel'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-prompt-key="reason"
                         data-api-prompt="1"
                         data-api-prompt-text="{{ 'Reason of cancelation'|trans }}"
@@ -249,7 +249,7 @@
 
                     {% if order.status == 'suspended' %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/unsuspend'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/unsuspend'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="{{ 'Order activated'|trans }}">
                         <svg class="mb-2 text-secondary" width="24" height="24">
@@ -260,14 +260,14 @@
                     {% endif %}
 
                     {% if order.status == 'canceled' %}
-                    <a href="{{ 'api/admin/order/uncancel'|link({ 'id': order.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" class="btn55 mr10 api-link" data-api-reload="Order activated">
+                    <a href="{{ 'api/admin/order/uncancel'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" class="btn55 mr10 api-link" data-api-reload="Order activated">
                         <img src="images/icons/middlenav/play2.png" alt="">
                         <span>{{ 'Activate'|trans }}</span>
                     </a>
                     {% endif %}
 
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/order/delete'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/order/delete'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-redirect="{{ 'order'|alink }}">
                         <svg class="mb-2 text-secondary" width="24" height="24">
@@ -278,7 +278,7 @@
 
                     {% if not order.unpaid_invoice_id %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                        href="{{ 'api/admin/invoice/renewal_invoice'|link({ 'id': order.id }) }}"
+                        href="{{ 'api/admin/invoice/renewal_invoice'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="1">
                         <svg class="mb-2 text-secondary" width="24" height="24">
@@ -585,7 +585,7 @@
                         </td>
                         <td>{{ sh.notes }}</td>
                         <td>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'support'|alink }}" href="{{ 'api/admin/order/status_history_delete'|link({ 'id': sh.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'support'|alink }}" href="{{ 'api/admin/order/status_history_delete'|link({ 'id': sh.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -297,6 +297,7 @@
             <div class="card-body">
                 <h3>{{ 'Order management'|trans }}</h2>
                 <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>
                         <div class="col">
@@ -364,6 +365,7 @@
             </div>
 
             {# <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <legend>Order promotion code</legend>
 
@@ -387,6 +389,7 @@
             </div>
 
             <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-msg="Order config updated">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 {% for name, value in order.config %}
                 <div class="mb-3 row">
                     <label class="topLabel">{{ name }}:</label>
@@ -409,6 +412,7 @@
                 <p class="text-muted">{{ 'Please be cautious and make sure you know what you are doing when editing order config! FOSSBilling relies on these parameters and you might get unexpected results if you change some of them.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     {% for key, config in order.config %}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ key }}</label>

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -297,7 +297,7 @@
             <div class="card-body">
                 <h3>{{ 'Order management'|trans }}</h2>
                 <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>
                         <div class="col">
@@ -365,7 +365,7 @@
             </div>
 
             {# <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <legend>Order promotion code</legend>
 
@@ -389,7 +389,7 @@
             </div>
 
             <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-msg="Order config updated">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 {% for name, value in order.config %}
                 <div class="mb-3 row">
                     <label class="topLabel">{{ name }}:</label>
@@ -412,7 +412,7 @@
                 <p class="text-muted">{{ 'Please be cautious and make sure you know what you are doing when editing order config! FOSSBilling relies on these parameters and you might get unexpected results if you change some of them.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/order/update_config'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     {% for key, config in order.config %}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ key }}</label>

--- a/src/modules/Order/html_admin/mod_order_new.html.twig
+++ b/src/modules/Order/html_admin/mod_order_new.html.twig
@@ -29,6 +29,7 @@
         <p class="text-muted">{{ product.title }} {{ 'for'|trans }} {{ client.first_name }} {{ client.last_name }}</h2>
 
         <form method="get" action="{{ 'api/admin/order/create'|link }}" class="api-form" data-api-jsonp="onAfterOrderPlaced">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Invoice option'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_new.html.twig
+++ b/src/modules/Order/html_admin/mod_order_new.html.twig
@@ -29,7 +29,7 @@
         <p class="text-muted">{{ product.title }} {{ 'for'|trans }} {{ client.first_name }} {{ client.last_name }}</h2>
 
         <form method="get" action="{{ 'api/admin/order/create'|link }}" class="api-form" data-api-jsonp="onAfterOrderPlaced">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Invoice option'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_new.html.twig
+++ b/src/modules/Order/html_admin/mod_order_new.html.twig
@@ -29,7 +29,7 @@
         <p class="text-muted">{{ product.title }} {{ 'for'|trans }} {{ client.first_name }} {{ client.last_name }}</h2>
 
         <form method="get" action="{{ 'api/admin/order/create'|link }}" class="api-form" data-api-jsonp="onAfterOrderPlaced">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Invoice option'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_settings.html.twig
+++ b/src/modules/Order/html_admin/mod_order_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Settings updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Expiration date'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_settings.html.twig
+++ b/src/modules/Order/html_admin/mod_order_settings.html.twig
@@ -29,6 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Settings updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Expiration date'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_settings.html.twig
+++ b/src/modules/Order/html_admin/mod_order_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Settings updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Expiration date'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -172,6 +172,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" style="background: none" class="open-ticket">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
@@ -211,6 +212,7 @@
         </div>
         <div class="modal-body">
             <form action="" method="post" style="background:none" class="request-cancellation">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">
@@ -248,6 +250,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" class="request-upgrade" data-api-url="client/support/ticket_create" data-api-msg="Upgrade request received" style="background: none">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Subject'|trans }}: </label>

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -172,7 +172,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" style="background: none" class="open-ticket">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
@@ -212,7 +212,7 @@
         </div>
         <div class="modal-body">
             <form action="" method="post" style="background:none" class="request-cancellation">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">
@@ -250,7 +250,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" class="request-upgrade" data-api-url="client/support/ticket_create" data-api-msg="Upgrade request received" style="background: none">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Subject'|trans }}: </label>

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -172,7 +172,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" style="background: none" class="open-ticket">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
@@ -212,7 +212,7 @@
         </div>
         <div class="modal-body">
             <form action="" method="post" style="background:none" class="request-cancellation">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">
@@ -250,7 +250,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" class="request-upgrade" data-api-url="client/support/ticket_create" data-api-msg="Upgrade request received" style="background: none">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="control-group">
                     <label>{{ 'Subject'|trans }}: </label>

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -37,7 +37,7 @@
     </ul>
 
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-reload="Settings updated">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <div class="tabs_container">
         <div class="fix"></div>
 
@@ -167,7 +167,7 @@
     </div>
 
     <form class="mainForm">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <fieldset>
             <div class="rowElem">
                 <div class="formBottom moreFields">

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -37,6 +37,7 @@
     </ul>
 
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-reload="Settings updated">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <div class="tabs_container">
         <div class="fix"></div>
 
@@ -166,6 +167,7 @@
     </div>
 
     <form class="mainForm">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <fieldset>
             <div class="rowElem">
                 <div class="formBottom moreFields">

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -37,7 +37,7 @@
     </ul>
 
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-reload="Settings updated">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
     <div class="tabs_container">
         <div class="fix"></div>
 
@@ -167,7 +167,7 @@
     </div>
 
     <form class="mainForm">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <fieldset>
             <div class="rowElem">
                 <div class="formBottom moreFields">

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -111,7 +111,7 @@
                     {% endif %}
 
                     <form action="guest/cart/apply_promo" method="post" class="well" id="apply-promo" data-api-reload="1" {% if not cart.promocode %}style="display:none"{% endif %}>
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="control-group">
                             <div class="form-controls">
                                 <div class="input-append">
@@ -166,7 +166,7 @@
                     </table>
 
                     <form method="post" action="client/cart/checkout" class="form-horizontal" id="checkout-form" onsubmit="return false;">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <fieldset>
                             {% set enough_in_balance = client.client_balance_get_total >= cart.total %}
                             {% if cart.total and not enough_in_balance %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -117,7 +117,7 @@
                                 <div class="input-append">
                                     <input class="span8" type="text" name="promocode" id="promocode" value="{{ request.promocode|default(cart.promocode) }}" {% if promo.required %}required="required"{% endif %} placeholder="{{ 'Enter code'|trans }}">
                                     {% if cart.promocode %}
-                                    <button class="btn" id="remove-promo" href="{{ 'api/guest/cart/remove_promo'|link }}" type="button" data-api-reload="1">{{ 'Remove'|trans }}</button>
+                                    <button class="btn" id="remove-promo" href="{{ 'api/guest/cart/remove_promo'|link({ 'CSRFToken': CSRFToken }) }}" type="button" data-api-reload="1">{{ 'Remove'|trans }}</button>
                                     {% else %}
                                     <button class="btn" type="submit">{{ 'Apply'|trans }}</button>
                                     {% endif %}
@@ -127,7 +127,7 @@
                         {#
                         <input type="text" class="search-query" name="promocode" value="{{ request.promocode|default(cart.promocode) }}" {% if promo.required %}required="required"{% endif %} placeholder="{{ 'Enter code'|trans }}">
                         {% if cart.promocode %}
-                        <a href="{{ 'api/guest/cart/remove_promo'|link }}" class="btn btn-info api-link" data-api-reload="1" >{{ 'Remove '|trans }}(<strong>{{cart.promocode}}</strong>)</a>
+                        <a href="{{ 'api/guest/cart/remove_promo'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-info api-link" data-api-reload="1" >{{ 'Remove '|trans }}(<strong>{{cart.promocode}}</strong>)</a>
                         {% else %}
                         <button class="btn btn-info" type="submit"><span class="awe-gift"></span> {{ 'Apply'|trans }}</button>
                         {% endif %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -111,7 +111,7 @@
                     {% endif %}
 
                     <form action="guest/cart/apply_promo" method="post" class="well" id="apply-promo" data-api-reload="1" {% if not cart.promocode %}style="display:none"{% endif %}>
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="control-group">
                             <div class="form-controls">
                                 <div class="input-append">
@@ -166,7 +166,7 @@
                     </table>
 
                     <form method="post" action="client/cart/checkout" class="form-horizontal" id="checkout-form" onsubmit="return false;">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <fieldset>
                             {% set enough_in_balance = client.client_balance_get_total >= cart.total %}
                             {% if cart.total and not enough_in_balance %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -111,6 +111,7 @@
                     {% endif %}
 
                     <form action="guest/cart/apply_promo" method="post" class="well" id="apply-promo" data-api-reload="1" {% if not cart.promocode %}style="display:none"{% endif %}>
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="control-group">
                             <div class="form-controls">
                                 <div class="input-append">
@@ -165,6 +166,7 @@
                     </table>
 
                     <form method="post" action="client/cart/checkout" class="form-horizontal" id="checkout-form" onsubmit="return false;">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <fieldset>
                             {% set enough_in_balance = client.client_balance_get_total >= cart.total %}
                             {% if cart.total and not enough_in_balance %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -10,7 +10,7 @@
 <div class="tab-content">
     <div class="tab-pane active" id="login-tab">
         <form method="post" action="" id="client-login">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>
@@ -41,7 +41,7 @@
     </div>
     <div class="tab-pane" id="register-tab">
         <form action="" method="post" id="create-profile">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             {% set r = guest.client_required %}
             <fieldset>
                 <div class="control-group">

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -10,7 +10,7 @@
 <div class="tab-content">
     <div class="tab-pane active" id="login-tab">
         <form method="post" action="" id="client-login">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>
@@ -41,7 +41,7 @@
     </div>
     <div class="tab-pane" id="register-tab">
         <form action="" method="post" id="create-profile">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             {% set r = guest.client_required %}
             <fieldset>
                 <div class="control-group">

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -10,6 +10,7 @@
 <div class="tab-content">
     <div class="tab-pane active" id="login-tab">
         <form method="post" action="" id="client-login">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>
@@ -40,6 +41,7 @@
     </div>
     <div class="tab-pane" id="register-tab">
         <form action="" method="post" id="create-profile">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             {% set r = guest.client_required %}
             <fieldset>
                 <div class="control-group">

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -7,7 +7,7 @@
     <div id="order" class="accordion-body collapse {% if request.order%}in{%endif%}">
         <div class="accordion-inner">
             <form method="post" style="background:none;" class="form-{{ product.form_id ? guest.formbuilder_get( {"id":product.form_id}).style.type : 0 }}" action="{{ '/order'|link }}/{{ product.slug }}" id="add-to-cart" onsubmit="return false;">
-
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             {% set product_details %}
             <div class="well">
                 <strong>{{ product.title }}</strong>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -7,7 +7,7 @@
     <div id="order" class="accordion-body collapse {% if request.order%}in{%endif%}">
         <div class="accordion-inner">
             <form method="post" style="background:none;" class="form-{{ product.form_id ? guest.formbuilder_get( {"id":product.form_id}).style.type : 0 }}" action="{{ '/order'|link }}/{{ product.slug }}" id="add-to-cart" onsubmit="return false;">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             {% set product_details %}
             <div class="well">
                 <strong>{{ product.title }}</strong>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -7,7 +7,7 @@
     <div id="order" class="accordion-body collapse {% if request.order%}in{%endif%}">
         <div class="accordion-inner">
             <form method="post" style="background:none;" class="form-{{ product.form_id ? guest.formbuilder_get( {"id":product.form_id}).style.type : 0 }}" action="{{ '/order'|link }}/{{ product.slug }}" id="add-to-cart" onsubmit="return false;">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             {% set product_details %}
             <div class="well">
                 <strong>{{ product.title }}</strong>

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -20,7 +20,7 @@
     <div class="data-block">
         <div class="data-container">
             <form method="post" action="" id="client-login">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="control-group">
                         <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -20,7 +20,7 @@
     <div class="data-block">
         <div class="data-container">
             <form method="post" action="" id="client-login">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="control-group">
                         <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -20,6 +20,7 @@
     <div class="data-block">
         <div class="data-container">
             <form method="post" action="" id="client-login">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="control-group">
                         <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -12,6 +12,7 @@
     <div class="data-container">
 
         <form method="post" action="" id="password-reset">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -12,7 +12,7 @@
     <div class="data-container">
 
         <form method="post" action="" id="password-reset">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -12,7 +12,7 @@
     <div class="data-container">
 
         <form method="post" action="" id="password-reset">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -18,7 +18,7 @@
         <div class="data-container">
 
             <form method="post" action="" id="client-signup">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="alert alert-info" style="display: none" id="account-created-info-block">
                     <button class="close" data-dismiss="alert">×</button>
                     <strong>{{ 'Account has been created'|trans }}.</strong> {{ 'Please check your mailbox and confirm email address'|trans }}.

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -18,6 +18,7 @@
         <div class="data-container">
 
             <form method="post" action="" id="client-signup">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="alert alert-info" style="display: none" id="account-created-info-block">
                     <button class="close" data-dismiss="alert">×</button>
                     <strong>{{ 'Account has been created'|trans }}.</strong> {{ 'Please check your mailbox and confirm email address'|trans }}.

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -18,7 +18,7 @@
         <div class="data-container">
 
             <form method="post" action="" id="client-signup">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="alert alert-info" style="display: none" id="account-created-info-block">
                     <button class="close" data-dismiss="alert">×</button>
                     <strong>{{ 'Account has been created'|trans }}.</strong> {{ 'Please check your mailbox and confirm email address'|trans }}.

--- a/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
+++ b/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
@@ -30,7 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_paidsupport" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="Settings updated">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <fieldset>
         <div class="rowElem">
             <label>{{ 'Ticket price:'|trans }}</label>

--- a/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
+++ b/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
@@ -30,6 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_paidsupport" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="Settings updated">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <fieldset>
         <div class="rowElem">
             <label>{{ 'Ticket price:'|trans }}</label>

--- a/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
+++ b/src/modules/Paidsupport/html_admin/mod_paidsupport_settings.html.twig
@@ -30,7 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_paidsupport" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="Settings updated">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <fieldset>
         <div class="rowElem">
             <label>{{ 'Ticket price:'|trans }}</label>

--- a/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
@@ -28,7 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Edit product addon'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/addon_update'|link }}" class="api-form save" data-api-msg="{{ 'Addon updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
@@ -28,7 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Edit product addon'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/addon_update'|link }}" class="api-form save" data-api-msg="{{ 'Addon updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addon_manage.html.twig
@@ -28,6 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Edit product addon'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/addon_update'|link }}" class="api-form save" data-api-msg="{{ 'Addon updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_addons.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addons.html.twig
@@ -82,7 +82,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/addon_create'|link }}" class="api-form" data-api-jsonp="onAfterAddonCreate">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_addons.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addons.html.twig
@@ -82,7 +82,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/addon_create'|link }}" class="api-form" data-api-jsonp="onAfterAddonCreate">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_addons.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addons.html.twig
@@ -63,7 +63,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'product/addons'|alink }}" href="{{ 'api/admin/product/delete'|link({ 'id': addon_id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'product/addons'|alink }}" href="{{ 'api/admin/product/delete'|link({ 'id': addon_id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Product/html_admin/mod_product_addons.html.twig
+++ b/src/modules/Product/html_admin/mod_product_addons.html.twig
@@ -82,6 +82,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/addon_create'|link }}" class="api-form" data-api-jsonp="onAfterAddonCreate">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Status'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_category.html.twig
+++ b/src/modules/Product/html_admin/mod_product_category.html.twig
@@ -28,7 +28,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/product/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <h3>{{ category.title }}</h3>
 

--- a/src/modules/Product/html_admin/mod_product_category.html.twig
+++ b/src/modules/Product/html_admin/mod_product_category.html.twig
@@ -28,6 +28,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/product/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ category.title }}</h3>
 

--- a/src/modules/Product/html_admin/mod_product_category.html.twig
+++ b/src/modules/Product/html_admin/mod_product_category.html.twig
@@ -28,7 +28,7 @@
 {% block content %}
 <div class="card">
     <form method="post" action="{{ 'api/admin/product/category_update'|link }}" class="api-form" data-api-msg="{{ 'Category updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <h3>{{ category.title }}</h3>
 

--- a/src/modules/Product/html_admin/mod_product_index.html.twig
+++ b/src/modules/Product/html_admin/mod_product_index.html.twig
@@ -38,7 +38,7 @@
             {% include 'partial_search.html.twig' %}
             <div class="table-responsive">
                 <form method="post" action="{{ 'api/admin/product/update_priority'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <table class="table card-table table-vcenter table-striped text-nowrap">
                         <thead>
                             <tr>
@@ -108,7 +108,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/prepare'|link }}" class="mainForm" id="prepare-product">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Type'|trans }}:</label>
                         <div class="col">
@@ -174,7 +174,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel" aria-labelledby="new-category-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/category_create'|link }}" class="save api-form" data-api-redirect="{{ 'product'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_index.html.twig
+++ b/src/modules/Product/html_admin/mod_product_index.html.twig
@@ -38,7 +38,7 @@
             {% include 'partial_search.html.twig' %}
             <div class="table-responsive">
                 <form method="post" action="{{ 'api/admin/product/update_priority'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <table class="table card-table table-vcenter table-striped text-nowrap">
                         <thead>
                             <tr>
@@ -108,7 +108,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/prepare'|link }}" class="mainForm" id="prepare-product">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Type'|trans }}:</label>
                         <div class="col">
@@ -174,7 +174,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel" aria-labelledby="new-category-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/category_create'|link }}" class="save api-form" data-api-redirect="{{ 'product'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_index.html.twig
+++ b/src/modules/Product/html_admin/mod_product_index.html.twig
@@ -76,7 +76,7 @@
                                             <use xlink:href="#edit" />
                                         </svg>
                                     </a>
-                                    <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/delete'|link({'id' : product.id}) }}" data-api-redirect="{{ 'product'|alink }}">
+                                    <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/delete'|link({'id' : product.id, 'CSRFToken': CSRFToken}) }}" data-api-redirect="{{ 'product'|alink }}">
                                         <svg class="icon">
                                             <use xlink:href="#delete" />
                                         </svg>
@@ -155,7 +155,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/category_delete'|link({ 'id': cat_id }) }}" data-api-redirect="{{ 'product'|alink }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/category_delete'|link({ 'id': cat_id, 'CSRFToken': CSRFToken }) }}" data-api-redirect="{{ 'product'|alink }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Product/html_admin/mod_product_index.html.twig
+++ b/src/modules/Product/html_admin/mod_product_index.html.twig
@@ -38,6 +38,7 @@
             {% include 'partial_search.html.twig' %}
             <div class="table-responsive">
                 <form method="post" action="{{ 'api/admin/product/update_priority'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <table class="table card-table table-vcenter table-striped text-nowrap">
                         <thead>
                             <tr>
@@ -107,6 +108,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/prepare'|link }}" class="mainForm" id="prepare-product">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Type'|trans }}:</label>
                         <div class="col">
@@ -172,6 +174,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel" aria-labelledby="new-category-tab">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/product/category_create'|link }}" class="save api-form" data-api-redirect="{{ 'product'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -47,6 +47,7 @@
             <div class="card-body">
                 <h5>{{ product.type|title }} {{ 'General settings'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}" name="form">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -176,6 +177,7 @@
 
         <div class="tab-pane fade" id="tab-addons" role="tabpanel" aria-labelledby="addons-tab">
             <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="card-body">
                     <h5>{{ 'Choose which addons you would like to offer with'|trans }} {{ product.title }}</h5>
                 </div>
@@ -224,6 +226,7 @@
             <div class="card-body">
                 <h5>{{ 'Choose which products can client upgrade to'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -47,7 +47,7 @@
             <div class="card-body">
                 <h5>{{ product.type|title }} {{ 'General settings'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}" name="form">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -177,7 +177,7 @@
 
         <div class="tab-pane fade" id="tab-addons" role="tabpanel" aria-labelledby="addons-tab">
             <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="card-body">
                     <h5>{{ 'Choose which addons you would like to offer with'|trans }} {{ product.title }}</h5>
                 </div>
@@ -226,7 +226,7 @@
             <div class="card-body">
                 <h5>{{ 'Choose which products can client upgrade to'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -47,7 +47,7 @@
             <div class="card-body">
                 <h5>{{ product.type|title }} {{ 'General settings'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}" name="form">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -177,7 +177,7 @@
 
         <div class="tab-pane fade" id="tab-addons" role="tabpanel" aria-labelledby="addons-tab">
             <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="card-body">
                     <h5>{{ 'Choose which addons you would like to offer with'|trans }} {{ product.title }}</h5>
                 </div>
@@ -226,7 +226,7 @@
             <div class="card-body">
                 <h5>{{ 'Choose which products can client upgrade to'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promo.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promo.html.twig
@@ -28,6 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Manage coupon code'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/promo_update'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promo.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promo.html.twig
@@ -28,7 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Manage coupon code'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/promo_update'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promo.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promo.html.twig
@@ -28,7 +28,7 @@
     <div class="card-body">
         <h5>{{ 'Manage coupon code'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/product/promo_update'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                 <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -117,7 +117,7 @@
                     <h3>{{ 'Create new coupon code'|trans }}</h3>
                     <p class="text-muted">{{ 'Create special offers for your clients by creating coupon codes.'|trans }}</p>
                     <form method="post" action="{{ 'api/admin/product/promo_create'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                             <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -94,7 +94,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/promo_delete'|link({ 'id': promo.id }) }}" data-api-redirect="{{ 'product/promos'|alink }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/product/promo_delete'|link({ 'id': promo.id, 'CSRFToken': CSRFToken }) }}" data-api-redirect="{{ 'product/promos'|alink }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -117,6 +117,7 @@
                     <h3>{{ 'Create new coupon code'|trans }}</h3>
                     <p class="text-muted">{{ 'Create special offers for your clients by creating coupon codes.'|trans }}</p>
                     <form method="post" action="{{ 'api/admin/product/promo_create'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                             <div class="col">

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -117,7 +117,7 @@
                     <h3>{{ 'Create new coupon code'|trans }}</h3>
                     <p class="text-muted">{{ 'Create special offers for your clients by creating coupon codes.'|trans }}</p>
                     <form method="post" action="{{ 'api/admin/product/promo_create'|link }}" class="api-form" data-api-redirect="{{ 'product/promos'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Code'|trans }}</label>
                             <div class="col">

--- a/src/modules/Queue/html_admin/mod_queue_settings.html.twig
+++ b/src/modules/Queue/html_admin/mod_queue_settings.html.twig
@@ -53,7 +53,7 @@
                 <td>{{ queue.created_at|bb_date }}</td>
                 <td class="actions">
                     <a class="btn btn-icon api-link"
-                        href="{{ 'api/admin/queue/execute'|link({ 'queue': queue.name }) }}"
+                        href="{{ 'api/admin/queue/execute'|link({ 'queue': queue.name, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="1">
                         <svg class="icon">
@@ -61,7 +61,7 @@
                         </svg>
                     </a>
                     {# <a class="btn btn-icon api-link"
-                        href="{{ 'api/admin/queue/queue_delete'|link({ 'id': queue.name }) }}"
+                        href="{{ 'api/admin/queue/queue_delete'|link({ 'id': queue.name, 'CSRFToken': CSRFToken }) }}"
                         data-api-confirm="{{ 'Are you sure?'|trans }}"
                         data-api-reload="1">
                         <svg class="icon">

--- a/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
+++ b/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
@@ -31,7 +31,7 @@
             <h5>{{ 'Create new redirect'|trans }}</h5>
 
             <form method="post" action="{{ 'api/admin/redirect/create'|link }}" class="api-form" data-api-reload="1">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="input-group">
                     <span class="input-group-text">{{ ''|link }}</span>
                     <input class="form-control" type="text" name="path" required="required">

--- a/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
+++ b/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
@@ -75,7 +75,7 @@
                     </td>
                     <td>
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/redirect/delete'|link({ 'id': r.id }) }}"
+                            href="{{ 'api/admin/redirect/delete'|link({ 'id': r.id, 'CSRFToken': CSRFToken }) }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-reload="1">
                             <svg class="icon">

--- a/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
+++ b/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
@@ -31,7 +31,7 @@
             <h5>{{ 'Create new redirect'|trans }}</h5>
 
             <form method="post" action="{{ 'api/admin/redirect/create'|link }}" class="api-form" data-api-reload="1">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="input-group">
                     <span class="input-group-text">{{ ''|link }}</span>
                     <input class="form-control" type="text" name="path" required="required">

--- a/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
+++ b/src/modules/Redirect/html_admin/mod_redirect_settings.html.twig
@@ -31,6 +31,7 @@
             <h5>{{ 'Create new redirect'|trans }}</h5>
 
             <form method="post" action="{{ 'api/admin/redirect/create'|link }}" class="api-form" data-api-reload="1">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="input-group">
                     <span class="input-group-text">{{ ''|link }}</span>
                     <input class="form-control" type="text" name="path" required="required">

--- a/src/modules/Seo/html_admin/mod_seo_settings.html.twig
+++ b/src/modules/Seo/html_admin/mod_seo_settings.html.twig
@@ -30,7 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_seo" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <fieldset>
             <legend>Sitemap</legend>
             <div class="rowElem noborder">

--- a/src/modules/Seo/html_admin/mod_seo_settings.html.twig
+++ b/src/modules/Seo/html_admin/mod_seo_settings.html.twig
@@ -30,7 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_seo" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <fieldset>
             <legend>Sitemap</legend>
             <div class="rowElem noborder">

--- a/src/modules/Seo/html_admin/mod_seo_settings.html.twig
+++ b/src/modules/Seo/html_admin/mod_seo_settings.html.twig
@@ -30,6 +30,7 @@
 
     {% set params = admin.extension_config_get({ "ext": "mod_seo" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <fieldset>
             <legend>Sitemap</legend>
             <div class="rowElem noborder">

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
@@ -2,7 +2,7 @@
     <h5>{{ 'Stock control settings'|trans }}</h5>
 
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Enable stock control'|trans }}:</label>
             <div class="col">
@@ -42,7 +42,7 @@
 
     <h5>{{ 'Plugin'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Plugin name'|trans }}:</label>
             <div class="col">
@@ -55,7 +55,7 @@
     <hr>
 
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm save api-form" data-api-reload="1">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <h6>Custom parameters</h6>
         {% for k, v in product.config %}
         <div class="form-group mb-3 row">

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
@@ -2,6 +2,7 @@
     <h5>{{ 'Stock control settings'|trans }}</h5>
 
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Enable stock control'|trans }}:</label>
             <div class="col">
@@ -41,6 +42,7 @@
 
     <h5>{{ 'Plugin'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Plugin name'|trans }}:</label>
             <div class="col">
@@ -53,6 +55,7 @@
     <hr>
 
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm save api-form" data-api-reload="1">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <h6>Custom parameters</h6>
         {% for k, v in product.config %}
         <div class="form-group mb-3 row">

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
@@ -2,7 +2,7 @@
     <h5>{{ 'Stock control settings'|trans }}</h5>
 
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Enable stock control'|trans }}:</label>
             <div class="col">
@@ -42,7 +42,7 @@
 
     <h5>{{ 'Plugin'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="form-group mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Plugin name'|trans }}:</label>
             <div class="col">
@@ -55,7 +55,7 @@
     <hr>
 
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm save api-form" data-api-reload="1">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <h6>Custom parameters</h6>
         {% for k, v in product.config %}
         <div class="form-group mb-3 row">

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
@@ -10,7 +10,7 @@
 {# include plugin #}
 
 <form method="post" action="{{ 'api/admin/servicecustom/update'|link }}" class="mainForm save api-form" data-api-msg="Service updated">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <fieldset>
 
         {% for name, value in service %}

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
@@ -10,7 +10,7 @@
 {# include plugin #}
 
 <form method="post" action="{{ 'api/admin/servicecustom/update'|link }}" class="mainForm save api-form" data-api-msg="Service updated">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
     <fieldset>
 
         {% for name, value in service %}

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_manage.html.twig
@@ -10,6 +10,7 @@
 {# include plugin #}
 
 <form method="post" action="{{ 'api/admin/servicecustom/update'|link }}" class="mainForm save api-form" data-api-msg="Service updated">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <fieldset>
 
         {% for name, value in service %}

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -78,7 +78,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1" href="{{ 'api/admin/servicedomain/tld_delete'|link({ 'tld': tld.tld }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1" href="{{ 'api/admin/servicedomain/tld_delete'|link({ 'tld': tld.tld, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -202,7 +202,7 @@
                             <a href="{{ 'servicedomain/registrar/'|alink }}/{{ registrar.id }}">{{ registrar.title }}</a>
                         </td>
                         <td>
-                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_copy'|link({ 'id': registrar.id }) }}" data-api-reload="1" title="Install">
+                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_copy'|link({ 'id': registrar.id, 'CSRFToken': CSRFToken }) }}" data-api-reload="1" title="Install">
                                 <svg class="icon">
                                     <use xlink:href="#copy" />
                                 </svg>
@@ -212,7 +212,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_delete'|link({ 'id': registrar.id }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_delete'|link({ 'id': registrar.id, 'CSRFToken': CSRFToken }) }}" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -254,7 +254,7 @@
                 <tr>
                     <td>{{ code }}</td>
                     <td>
-                        <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_install'|link({ 'code': code }) }}" data-api-msg="{{ 'Domain registrar installed'|trans }}" title="Install">
+                        <a class="btn btn-icon api-link" href="{{ 'api/admin/servicedomain/registrar_install'|link({ 'code': code, 'CSRFToken': CSRFToken }) }}" data-api-msg="{{ 'Domain registrar installed'|trans }}" title="Install">
                             <svg  class="icon">
                                 <use xlink:href="#cog" />
                             </svg>

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -96,7 +96,7 @@
                 <p class="text-muted">{{ 'Setup new TLD prices and properties'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicedomain/tld_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tld'|trans }}:</label>
                         <div class="col">
@@ -279,7 +279,7 @@
                 <p class="text-muted">{{ 'Setup default nameservers that will be used for new domain registrations if client have not provided his own nameservers in order form'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -96,7 +96,7 @@
                 <p class="text-muted">{{ 'Setup new TLD prices and properties'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicedomain/tld_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tld'|trans }}:</label>
                         <div class="col">
@@ -279,7 +279,7 @@
                 <p class="text-muted">{{ 'Setup default nameservers that will be used for new domain registrations if client have not provided his own nameservers in order form'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -96,6 +96,7 @@
                 <p class="text-muted">{{ 'Setup new TLD prices and properties'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicedomain/tld_create'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Tld'|trans }}:</label>
                         <div class="col">
@@ -278,6 +279,7 @@
                 <p class="text-muted">{{ 'Setup default nameservers that will be used for new domain registrations if client have not provided his own nameservers in order form'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
@@ -109,7 +109,7 @@
 <div class="card-body">
     <h3>{{ 'Nameservers'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_nameservers'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
             <div class="col">
@@ -142,7 +142,7 @@
 
     <h3>{{ 'Domain data'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update'|link }}" class="api-form" data-api-msg="{{ 'Domain data updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Transfer code (EPP)'|trans }}: </label>
             <div class="col">
@@ -163,7 +163,7 @@
 
     <h3>{{ 'Update domain contact details'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_contacts'|link }}" class="api-form" data-api-msg="{{ 'Domain contact details updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'First Name'|trans }}: </label>
             <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
@@ -109,6 +109,7 @@
 <div class="card-body">
     <h3>{{ 'Nameservers'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_nameservers'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
             <div class="col">
@@ -141,6 +142,7 @@
 
     <h3>{{ 'Domain data'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update'|link }}" class="api-form" data-api-msg="{{ 'Domain data updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Transfer code (EPP)'|trans }}: </label>
             <div class="col">
@@ -161,6 +163,7 @@
 
     <h3>{{ 'Update domain contact details'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_contacts'|link }}" class="api-form" data-api-msg="{{ 'Domain contact details updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'First Name'|trans }}: </label>
             <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
@@ -109,7 +109,7 @@
 <div class="card-body">
     <h3>{{ 'Nameservers'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_nameservers'|link }}" class="api-form" data-api-msg="{{ 'Nameservers updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Nameserver 1'|trans }}:</label>
             <div class="col">
@@ -142,7 +142,7 @@
 
     <h3>{{ 'Domain data'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update'|link }}" class="api-form" data-api-msg="{{ 'Domain data updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Transfer code (EPP)'|trans }}: </label>
             <div class="col">
@@ -163,7 +163,7 @@
 
     <h3>{{ 'Update domain contact details'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicedomain/update_contacts'|link }}" class="api-form" data-api-msg="{{ 'Domain contact details updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'First Name'|trans }}: </label>
             <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
@@ -33,7 +33,7 @@
         <p class="text-muted">{{ registrar.label }}</p>
 
         <form method="post" action="{{ 'api/admin/servicedomain/registrar_update'|link }}" class="api-form" data-api-msg="{{ 'Registrar updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Enable test mode'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
@@ -33,7 +33,7 @@
         <p class="text-muted">{{ registrar.label }}</p>
 
         <form method="post" action="{{ 'api/admin/servicedomain/registrar_update'|link }}" class="api-form" data-api-msg="{{ 'Registrar updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Enable test mode'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_registrar.html.twig
@@ -33,6 +33,7 @@
         <p class="text-muted">{{ registrar.label }}</p>
 
         <form method="post" action="{{ 'api/admin/servicedomain/registrar_update'|link }}" class="api-form" data-api-msg="{{ 'Registrar updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Enable test mode'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
@@ -28,6 +28,7 @@
         <h3>{{ tld.tld }} {{ 'Top level domain management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicedomain/tld_update'|link }}" class="api-form" data-api-msg="{{ 'Top level domain settings updated.'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Registrar'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
@@ -28,7 +28,7 @@
         <h3>{{ tld.tld }} {{ 'Top level domain management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicedomain/tld_update'|link }}" class="api-form" data-api-msg="{{ 'Top level domain settings updated.'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Registrar'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_tld.html.twig
@@ -28,7 +28,7 @@
         <h3>{{ tld.tld }} {{ 'Top level domain management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicedomain/tld_update'|link }}" class="api-form" data-api-msg="{{ 'Top level domain settings updated.'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Registrar'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -65,7 +65,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'If you would like to host this domain with another company you can update nameservers.'|trans }}</p>
                         <form action="" method="post" id="update-nameservers" class="form-horizontal">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Nameserver 1'|trans }}: </label>
@@ -107,7 +107,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'Domain contact details will be displayed once someone will check WHOIS output (which is public) of your service. This will update Technical, Billing and Admin contacts for this service. You can enable domain privacy protection if you want to hide your public WHOIS information.'|trans }}</p>
                         <form method="post" action="" id="update-contact" class="form-horizontal">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'First Name'|trans }}: </label>

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -65,7 +65,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'If you would like to host this domain with another company you can update nameservers.'|trans }}</p>
                         <form action="" method="post" id="update-nameservers" class="form-horizontal">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Nameserver 1'|trans }}: </label>
@@ -107,7 +107,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'Domain contact details will be displayed once someone will check WHOIS output (which is public) of your service. This will update Technical, Billing and Admin contacts for this service. You can enable domain privacy protection if you want to hide your public WHOIS information.'|trans }}</p>
                         <form method="post" action="" id="update-contact" class="form-horizontal">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'First Name'|trans }}: </label>

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -65,6 +65,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'If you would like to host this domain with another company you can update nameservers.'|trans }}</p>
                         <form action="" method="post" id="update-nameservers" class="form-horizontal">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Nameserver 1'|trans }}: </label>
@@ -106,6 +107,7 @@
                     <div class="block">
                         <p class="alert alert-info">{{ 'Domain contact details will be displayed once someone will check WHOIS output (which is public) of your service. This will update Technical, Billing and Admin contacts for this service. You can enable domain privacy protection if you want to hide your public WHOIS information.'|trans }}</p>
                         <form method="post" action="" id="update-contact" class="form-horizontal">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'First Name'|trans }}: </label>

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
@@ -1,7 +1,7 @@
 <div class="card-nody">
     <h5>{{ 'File'|trans }}</h5>
     <form method="post" action="" class="" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         {% if product.config.filename  %}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
@@ -1,6 +1,7 @@
 <div class="card-nody">
     <h5>{{ 'File'|trans }}</h5>
     <form method="post" action="" class="" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         {% if product.config.filename  %}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
@@ -1,7 +1,7 @@
 <div class="card-nody">
     <h5>{{ 'File'|trans }}</h5>
     <form method="post" action="" class="" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         {% if product.config.filename  %}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
@@ -23,6 +23,7 @@
     <p class="text-muted">{{ 'Use this function to update existing order file. Client will be able to download new file from client area'|trans }}</p>
 
     <form method="post" action="" class="mainForm" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
@@ -23,7 +23,7 @@
     <p class="text-muted">{{ 'Use this function to update existing order file. Client will be able to download new file from client area'|trans }}</p>
 
     <form method="post" action="" class="mainForm" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
@@ -23,7 +23,7 @@
     <p class="text-muted">{{ 'Use this function to update existing order file. Client will be able to download new file from client area'|trans }}</p>
 
     <form method="post" action="" class="mainForm" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
@@ -3,7 +3,7 @@
 <div class="card-body">
     <h5>{{ 'Hosting settings'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'Hosting settings updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Server'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
@@ -3,7 +3,7 @@
 <div class="card-body">
     <h5>{{ 'Hosting settings'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'Hosting settings updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Server'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
@@ -3,6 +3,7 @@
 <div class="card-body">
     <h5>{{ 'Hosting settings'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'Hosting settings updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Server'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
@@ -25,7 +25,7 @@
     <div class="card-body">
         <h5>{{ 'Manage hosting plan'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-msg="{{ 'Hosting plan updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">
@@ -101,7 +101,7 @@
         <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters. List of parameters server managers requires you can find on extensions page.'|trans }}</p>
 
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-reload="1">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row g-2">
                 <div class="col">
                     <label class="form-label">{{ 'Parameter name'|trans }}:</label>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
@@ -25,7 +25,7 @@
     <div class="card-body">
         <h5>{{ 'Manage hosting plan'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-msg="{{ 'Hosting plan updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">
@@ -101,7 +101,7 @@
         <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters. List of parameters server managers requires you can find on extensions page.'|trans }}</p>
 
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-reload="1">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row g-2">
                 <div class="col">
                     <label class="form-label">{{ 'Parameter name'|trans }}:</label>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_hp.html.twig
@@ -25,6 +25,7 @@
     <div class="card-body">
         <h5>{{ 'Manage hosting plan'|trans }}</h5>
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-msg="{{ 'Hosting plan updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">
@@ -100,6 +101,7 @@
         <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters. List of parameters server managers requires you can find on extensions page.'|trans }}</p>
 
         <form method="post" action="{{ 'api/admin/servicehosting/hp_update'|link }}" class="api-form" data-api-reload="1">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row g-2">
                 <div class="col">
                     <label class="form-label">{{ 'Parameter name'|trans }}:</label>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -136,7 +136,7 @@
         <div class="tab-pane fade" id="tab-new-server" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="admin/servicehosting/server_create" class="api-form" data-api-redirect="{{ 'servicehosting'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">
@@ -254,7 +254,7 @@
                 <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters in next step. In this step provide basic hosting plan information.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicehosting/hp_create'|link}}" class="api-form" data-api-jsonp="onAfterHostingPlanCreate">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -136,7 +136,7 @@
         <div class="tab-pane fade" id="tab-new-server" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="admin/servicehosting/server_create" class="api-form" data-api-redirect="{{ 'servicehosting'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">
@@ -254,7 +254,7 @@
                 <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters in next step. In this step provide basic hosting plan information.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicehosting/hp_create'|link}}" class="api-form" data-api-jsonp="onAfterHostingPlanCreate">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -61,7 +61,7 @@
                                     <use xlink:href="#settings" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicehosting/server_test_connection'|link({ 'id': server.id }) }}" title="{{ 'Test connection'|trans }}" data-api-msg="{{ 'Server connected'|trans }}">
+                            <a class="btn btn-icon api-link" href="{{ 'api/admin/servicehosting/server_test_connection'|link({ 'id': server.id, 'CSRFToken': CSRFToken }) }}" title="{{ 'Test connection'|trans }}" data-api-msg="{{ 'Server connected'|trans }}">
                                 <svg class="icon">
                                     <use xlink:href="#wifi" />
                                 </svg>
@@ -71,7 +71,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'servicehosting'|alink }}" href="{{ 'api/admin/servicehosting/server_delete'|link({ 'id': server.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'servicehosting'|alink }}" href="{{ 'api/admin/servicehosting/server_delete'|link({ 'id': server.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -117,7 +117,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'servicehosting'|alink }}" href="{{ 'api/admin/servicehosting/hp_delete'|link({ 'id': hp.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'servicehosting'|alink }}" href="{{ 'api/admin/servicehosting/hp_delete'|link({ 'id': hp.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -136,6 +136,7 @@
         <div class="tab-pane fade" id="tab-new-server" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="admin/servicehosting/server_create" class="api-form" data-api-redirect="{{ 'servicehosting'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">
@@ -253,6 +254,7 @@
                 <p class="text-muted">{{ 'Depending on server manager used to setup hosting account you may require provide additional parameters in next step. In this step provide basic hosting plan information.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/servicehosting/hp_create'|link}}" class="api-form" data-api-jsonp="onAfterHostingPlanCreate">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
@@ -101,7 +101,7 @@
     <h3>{{ 'Change hosting plan'|trans }}</h3>
 
     <form action="{{ 'api/admin/servicehosting/change_plan'|link }}" method="post" class="api-form" data-api-msg="{{ 'Hosting plan changed'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'New hosting plan'|trans }}:</label>
             <div class="col">
@@ -116,7 +116,7 @@
 
     <h3>{{ 'Change account password'|trans }}</h3>
     <form action="{{ 'api/admin/servicehosting/change_password'|link }}" method="post" class="api-form" data-api-msg="{{ 'Account password changed'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}:</label>
             <div class="col">
@@ -137,7 +137,7 @@
 
     <h3>{{ 'Change IP'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_ip'|link }}" class="api-form" data-api-msg="{{ 'Account IP changed'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'IP'|trans }}:</label>
             <div class="col">
@@ -152,7 +152,7 @@
 
     <h3>{{ 'Change username'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_username'|link }}" class="api-form" data-api-msg="{{ 'Account username changed'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Username'|trans }}:</label>
             <div class="col">
@@ -167,7 +167,7 @@
 
     <h3>{{ 'Change domain'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_domain'|link }}" class="api-form" data-api-msg="{{ 'Account domain changed'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Domain'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
@@ -101,6 +101,7 @@
     <h3>{{ 'Change hosting plan'|trans }}</h3>
 
     <form action="{{ 'api/admin/servicehosting/change_plan'|link }}" method="post" class="api-form" data-api-msg="{{ 'Hosting plan changed'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'New hosting plan'|trans }}:</label>
             <div class="col">
@@ -115,6 +116,7 @@
 
     <h3>{{ 'Change account password'|trans }}</h3>
     <form action="{{ 'api/admin/servicehosting/change_password'|link }}" method="post" class="api-form" data-api-msg="{{ 'Account password changed'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}:</label>
             <div class="col">
@@ -135,6 +137,7 @@
 
     <h3>{{ 'Change IP'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_ip'|link }}" class="api-form" data-api-msg="{{ 'Account IP changed'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'IP'|trans }}:</label>
             <div class="col">
@@ -149,6 +152,7 @@
 
     <h3>{{ 'Change username'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_username'|link }}" class="api-form" data-api-msg="{{ 'Account username changed'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Username'|trans }}:</label>
             <div class="col">
@@ -163,6 +167,7 @@
 
     <h3>{{ 'Change domain'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_domain'|link }}" class="api-form" data-api-msg="{{ 'Account domain changed'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Domain'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
@@ -101,7 +101,7 @@
     <h3>{{ 'Change hosting plan'|trans }}</h3>
 
     <form action="{{ 'api/admin/servicehosting/change_plan'|link }}" method="post" class="api-form" data-api-msg="{{ 'Hosting plan changed'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'New hosting plan'|trans }}:</label>
             <div class="col">
@@ -116,7 +116,7 @@
 
     <h3>{{ 'Change account password'|trans }}</h3>
     <form action="{{ 'api/admin/servicehosting/change_password'|link }}" method="post" class="api-form" data-api-msg="{{ 'Account password changed'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}:</label>
             <div class="col">
@@ -137,7 +137,7 @@
 
     <h3>{{ 'Change IP'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_ip'|link }}" class="api-form" data-api-msg="{{ 'Account IP changed'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'IP'|trans }}:</label>
             <div class="col">
@@ -152,7 +152,7 @@
 
     <h3>{{ 'Change username'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_username'|link }}" class="api-form" data-api-msg="{{ 'Account username changed'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Username'|trans }}:</label>
             <div class="col">
@@ -167,7 +167,7 @@
 
     <h3>{{ 'Change domain'|trans }}</h3>
     <form method="post" action="{{ 'api/admin/servicehosting/change_domain'|link }}" class="api-form" data-api-msg="{{ 'Account domain changed'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Domain'|trans }}:</label>
             <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_manage.html.twig
@@ -87,7 +87,7 @@
     {% endif %}
 
     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-        href="{{ 'api/admin/servicehosting/sync'|link({ 'order_id': order.id }) }}"
+        href="{{ 'api/admin/servicehosting/sync'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure?'|trans }}"
         data-api-msg="{{ 'Account was synced'|trans }}">
         <svg class="mb-2 text-secondary" width="24" height="24">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -26,6 +26,7 @@
         <h3>{{ 'Server management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicehosting/server_update'|link }}" id="server-update" class="api-form" data-api-msg="{{ 'Server updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -26,7 +26,7 @@
         <h3>{{ 'Server management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicehosting/server_update'|link }}" id="server-update" class="api-form" data-api-msg="{{ 'Server updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -26,7 +26,7 @@
         <h3>{{ 'Server management'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/servicehosting/server_update'|link }}" id="server-update" class="api-form" data-api-msg="{{ 'Server updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -76,7 +76,7 @@
                 <div class="tab-pane" id="tab-change-pass">
                     <h3>{{ 'Change your FTP/cPanel/SSH password.'|trans }}</h3>
                         <form action="" method="post" id="change-password" class="form-horizontal">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'Password'|trans }}: </label>
@@ -104,7 +104,7 @@
                 <div class="tab-pane" id="tab-change-domain">
                     <h3>{{ 'Change domain'|trans }}</h3>
                         <form action="" method="post" id="change-domain" class="form-horizontal">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'New domain'|trans }}: </label>
@@ -126,7 +126,7 @@
                 <div class="tab-pane" id="tab-change-username">
                     <h3>{{ 'Change username'|trans }}</h3>
                         <form action="" method="post" id="change-username" class="form-horizontal">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Username'|trans }}: </label>

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -76,7 +76,7 @@
                 <div class="tab-pane" id="tab-change-pass">
                     <h3>{{ 'Change your FTP/cPanel/SSH password.'|trans }}</h3>
                         <form action="" method="post" id="change-password" class="form-horizontal">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'Password'|trans }}: </label>
@@ -104,7 +104,7 @@
                 <div class="tab-pane" id="tab-change-domain">
                     <h3>{{ 'Change domain'|trans }}</h3>
                         <form action="" method="post" id="change-domain" class="form-horizontal">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'New domain'|trans }}: </label>
@@ -126,7 +126,7 @@
                 <div class="tab-pane" id="tab-change-username">
                     <h3>{{ 'Change username'|trans }}</h3>
                         <form action="" method="post" id="change-username" class="form-horizontal">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Username'|trans }}: </label>

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -76,6 +76,7 @@
                 <div class="tab-pane" id="tab-change-pass">
                     <h3>{{ 'Change your FTP/cPanel/SSH password.'|trans }}</h3>
                         <form action="" method="post" id="change-password" class="form-horizontal">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'Password'|trans }}: </label>
@@ -103,6 +104,7 @@
                 <div class="tab-pane" id="tab-change-domain">
                     <h3>{{ 'Change domain'|trans }}</h3>
                         <form action="" method="post" id="change-domain" class="form-horizontal">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                                 <div class="control-group">
                                     <label class="control-label" >{{ 'New domain'|trans }}: </label>
@@ -124,6 +126,7 @@
                 <div class="tab-pane" id="tab-change-username">
                     <h3>{{ 'Change username'|trans }}</h3>
                         <form action="" method="post" id="change-username" class="form-horizontal">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                             <div class="control-group">
                                 <label class="control-label" >{{ 'Username'|trans }}: </label>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
@@ -5,6 +5,7 @@
 </div>
 
 <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm api-form save" data-api-msg="License settings updated">
+{{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
 <fieldset>
     <div class="rowElem noborder">
         <label>{{ 'Prefix'|trans }}:</label>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
@@ -5,7 +5,7 @@
 </div>
 
 <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm api-form save" data-api-msg="License settings updated">
-{{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+{{ 'hiddenInput' |csrftoken_filter }}
 <fieldset>
     <div class="rowElem noborder">
         <label>{{ 'Prefix'|trans }}:</label>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
@@ -5,7 +5,7 @@
 </div>
 
 <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="mainForm api-form save" data-api-msg="License settings updated">
-{{ 'hiddenInput' |csrftoken_filter }}
+<input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
 <fieldset>
     <div class="rowElem noborder">
         <label>{{ 'Prefix'|trans }}:</label>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
@@ -41,7 +41,7 @@
 </table>
 
 <form method="post" action="{{ 'api/admin/servicelicense/update'|link }}" class="mainForm api-form" data-api-msg="License updated">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <fieldset>
         <legend>{{ 'License data'|trans }}</legend>
         <div class="rowElem">

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
@@ -41,7 +41,7 @@
 </table>
 
 <form method="post" action="{{ 'api/admin/servicelicense/update'|link }}" class="mainForm api-form" data-api-msg="License updated">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
     <fieldset>
         <legend>{{ 'License data'|trans }}</legend>
         <div class="rowElem">

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
@@ -41,6 +41,7 @@
 </table>
 
 <form method="post" action="{{ 'api/admin/servicelicense/update'|link }}" class="mainForm api-form" data-api-msg="License updated">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <fieldset>
         <legend>{{ 'License data'|trans }}</legend>
         <div class="rowElem">

--- a/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
+++ b/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
@@ -33,7 +33,7 @@
 {% set params = admin.extension_config_get({ "ext": "mod_spamchecker" }) %}
 
 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+    {{ 'hiddenInput' |csrftoken_filter }}
     <fieldset>
         <div class="rowElem noborder">
             <label>{{ 'Enable IP blocking'|trans }}</label>

--- a/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
+++ b/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
@@ -33,6 +33,7 @@
 {% set params = admin.extension_config_get({ "ext": "mod_spamchecker" }) %}
 
 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
     <fieldset>
         <div class="rowElem noborder">
             <label>{{ 'Enable IP blocking'|trans }}</label>

--- a/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
+++ b/src/modules/Spamchecker/html_admin/mod_spamchecker_settings.html.twig
@@ -33,7 +33,7 @@
 {% set params = admin.extension_config_get({ "ext": "mod_spamchecker" }) %}
 
 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="mainForm api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-    {{ 'hiddenInput' |csrftoken_filter }}
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
     <fieldset>
         <div class="rowElem noborder">
             <label>{{ 'Enable IP blocking'|trans }}</label>

--- a/src/modules/Staff/html_admin/mod_staff_group.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_group.html.twig
@@ -32,7 +32,7 @@
         <h5>{{ 'Manage staff member details'|trans }}</h5>
 
         <form method="post" action="{{ 'api/admin/staff/group_update'|link }}" class="api-form" data-api-msg="{{ 'Staff group updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label" for="inputName">{{ 'Name'|trans }}</label>
                 <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_group.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_group.html.twig
@@ -32,7 +32,7 @@
         <h5>{{ 'Manage staff member details'|trans }}</h5>
 
         <form method="post" action="{{ 'api/admin/staff/group_update'|link }}" class="api-form" data-api-msg="{{ 'Staff group updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label" for="inputName">{{ 'Name'|trans }}</label>
                 <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_group.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_group.html.twig
@@ -32,6 +32,7 @@
         <h5>{{ 'Manage staff member details'|trans }}</h5>
 
         <form method="post" action="{{ 'api/admin/staff/group_update'|link }}" class="api-form" data-api-msg="{{ 'Staff group updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label" for="inputName">{{ 'Name'|trans }}</label>
                 <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_index.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_index.html.twig
@@ -54,7 +54,7 @@
                         <a class="bb-button btn14" href="{{ '/staff/manage'|alink }}/{{ member.id }}">
                             <img src="assets/icons/edit.svg" alt="">
                         </a>
-                        <a class="bb-button btn14 bb-rm-tr api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'staff'|alink }}" href="{{ 'api/admin/staff/delete'|link({ 'id': member.id }) }}">
+                        <a class="bb-button btn14 bb-rm-tr api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'staff'|alink }}" href="{{ 'api/admin/staff/delete'|link({ 'id': member.id, 'CSRFToken': CSRFToken }) }}">
                             <img src="assets/icons/delete.svg" alt="">
                         </a>
                     </td>
@@ -147,7 +147,7 @@
                         <a class="bb-button btn14" href="{{ '/staff/group'|alink }}/{{ group.id }}">
                             <img src="assets/icons/edit.svg" alt="">
                         </a>
-                        <a class="bb-button btn14 bb-rm-tr api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'staff'|alink }}" href="{{ 'api/admin/staff/group_delete'|link({'id' : group.id}) }}"><img src="assets/icons/delete.svg" alt=""></a>
+                        <a class="bb-button btn14 bb-rm-tr api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'staff'|alink }}" href="{{ 'api/admin/staff/group_delete'|link({'id' : group.id, 'CSRFToken': CSRFToken}) }}"><img src="assets/icons/delete.svg" alt=""></a>
                     </td>
                 </tr>
                 </tbody>

--- a/src/modules/Staff/html_admin/mod_staff_index.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_index.html.twig
@@ -74,7 +74,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new">
             <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterStaffCreate">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Group'|trans }}</label>
@@ -164,7 +164,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new-group">
             <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'staff'|alink }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="rowElem noborder">
                     <label>{{ 'Name'|trans }}</label>
                     <div class="formRight">

--- a/src/modules/Staff/html_admin/mod_staff_index.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_index.html.twig
@@ -74,7 +74,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new">
             <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterStaffCreate">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Group'|trans }}</label>
@@ -164,7 +164,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new-group">
             <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'staff'|alink }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="rowElem noborder">
                     <label>{{ 'Name'|trans }}</label>
                     <div class="formRight">

--- a/src/modules/Staff/html_admin/mod_staff_index.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_index.html.twig
@@ -74,6 +74,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new">
             <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterStaffCreate">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <fieldset>
                     <div class="rowElem noborder">
                         <label>{{ 'Group'|trans }}</label>
@@ -163,6 +164,7 @@
         <div class="fix"></div>
         <div class="tab_content nopadding" id="tab-new-group">
             <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'staff'|alink }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="rowElem noborder">
                     <label>{{ 'Name'|trans }}</label>
                     <div class="formRight">

--- a/src/modules/Staff/html_admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login.html.twig
@@ -16,6 +16,7 @@
                 {% if create_admin %}
                     <h2 class="card-title text-center mb-4">{{ 'Create main administrator account'|trans }}</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/create'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <div class="col">
@@ -35,6 +36,7 @@
                 {% else %}
                     <h2 class="h2 text-center mb-4">Log into your account</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <input class="form-control"

--- a/src/modules/Staff/html_admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login.html.twig
@@ -16,7 +16,7 @@
                 {% if create_admin %}
                     <h2 class="card-title text-center mb-4">{{ 'Create main administrator account'|trans }}</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/create'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <div class="col">
@@ -36,7 +36,7 @@
                 {% else %}
                     <h2 class="h2 text-center mb-4">Log into your account</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <input class="form-control"

--- a/src/modules/Staff/html_admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login.html.twig
@@ -16,7 +16,7 @@
                 {% if create_admin %}
                     <h2 class="card-title text-center mb-4">{{ 'Create main administrator account'|trans }}</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/create'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <div class="col">
@@ -36,7 +36,7 @@
                 {% else %}
                     <h2 class="h2 text-center mb-4">Log into your account</h2>
                     <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email'|trans }}</label>
                             <input class="form-control"

--- a/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
@@ -50,7 +50,7 @@
             <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
             <td>
                 <a class="btn btn-icon api-link"
-                    href="{{ 'api/admin/staff/login_history_delete'|link({ 'id': event.id }) }}"
+                    href="{{ 'api/admin/staff/login_history_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{'staff/logins'|alink }}">
                     <svg class="icon">

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -51,7 +51,7 @@
                 <h3>{{ 'Manage staff member details'|trans }}</h3>
 
                 <form method="post" action="admin/staff/update" class="api-form" data-api-msg="{{ 'This staff member updated.'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -107,7 +107,7 @@
 
             {% set prms = admin.staff_permissions_get({ 'id': staff.id }) %}
             <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <table class="table card-table table-vcenter table-striped text-nowrap">
                     <thead>
                         <tr>
@@ -147,7 +147,7 @@
                 <h3>{{ 'Change staff member password'|trans }}</h3>
 
                 <form method="post" action="admin/staff/change_password" class="api-form" data-api-msg="{{ 'Staff member password changed'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputPassword">{{ 'Password'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -51,6 +51,7 @@
                 <h3>{{ 'Manage staff member details'|trans }}</h3>
 
                 <form method="post" action="admin/staff/update" class="api-form" data-api-msg="{{ 'This staff member updated.'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -106,6 +107,7 @@
 
             {% set prms = admin.staff_permissions_get({ 'id': staff.id }) %}
             <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <table class="table card-table table-vcenter table-striped text-nowrap">
                     <thead>
                         <tr>
@@ -145,6 +147,7 @@
                 <h3>{{ 'Change staff member password'|trans }}</h3>
 
                 <form method="post" action="admin/staff/change_password" class="api-form" data-api-msg="{{ 'Staff member password changed'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputPassword">{{ 'Password'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -51,7 +51,7 @@
                 <h3>{{ 'Manage staff member details'|trans }}</h3>
 
                 <form method="post" action="admin/staff/update" class="api-form" data-api-msg="{{ 'This staff member updated.'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -107,7 +107,7 @@
 
             {% set prms = admin.staff_permissions_get({ 'id': staff.id }) %}
             <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <table class="table card-table table-vcenter table-striped text-nowrap">
                     <thead>
                         <tr>
@@ -147,7 +147,7 @@
                 <h3>{{ 'Change staff member password'|trans }}</h3>
 
                 <form method="post" action="admin/staff/change_password" class="api-form" data-api-msg="{{ 'Staff member password changed'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="inputPassword">{{ 'Password'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_profile.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_profile.html.twig
@@ -29,7 +29,7 @@
         <div class="tab-pane fade show active" id="tab-profile" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/update'|link }}" class="api-form" data-api-msg="{{ 'Profile updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -58,7 +58,7 @@
         <div class="tab-pane fade" id="tab-password" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -84,8 +84,8 @@
                 <p class="text-muted">{{ 'External application can control every aspect of FOSSBilling using this API key.'|trans }}</p>
                 <p class="text-muted">{{ 'Warning! Resetting the key will break existing applications using it.'|trans }}</p>
 
-                <form method="post" action="{{ 'api/admin/profile/generate_api_key'|link }}" class="api-form" data-api-jsonp="onAfterKeyUpdate">+
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                <form method="post" action="{{ 'api/admin/profile/generate_api_key'|link }}" class="api-form" data-api-jsonp="onAfterKeyUpdate">
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API Key'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_profile.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_profile.html.twig
@@ -29,6 +29,7 @@
         <div class="tab-pane fade show active" id="tab-profile" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/update'|link }}" class="api-form" data-api-msg="{{ 'Profile updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -57,6 +58,7 @@
         <div class="tab-pane fade" id="tab-password" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -82,7 +84,8 @@
                 <p class="text-muted">{{ 'External application can control every aspect of FOSSBilling using this API key.'|trans }}</p>
                 <p class="text-muted">{{ 'Warning! Resetting the key will break existing applications using it.'|trans }}</p>
 
-                <form method="post" action="{{ 'api/admin/profile/generate_api_key'|link }}" class="api-form" data-api-jsonp="onAfterKeyUpdate">
+                <form method="post" action="{{ 'api/admin/profile/generate_api_key'|link }}" class="api-form" data-api-jsonp="onAfterKeyUpdate">+
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API Key'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_profile.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_profile.html.twig
@@ -29,7 +29,7 @@
         <div class="tab-pane fade show active" id="tab-profile" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/update'|link }}" class="api-form" data-api-msg="{{ 'Profile updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -58,7 +58,7 @@
         <div class="tab-pane fade" id="tab-password" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/profile/change_password'|link }}" class="api-form" data-api-msg="{{ 'Password changed'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password'|trans }}</label>
                         <div class="col">
@@ -85,7 +85,7 @@
                 <p class="text-muted">{{ 'Warning! Resetting the key will break existing applications using it.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/profile/generate_api_key'|link }}" class="api-form" data-api-jsonp="onAfterKeyUpdate">+
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'API Key'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -116,7 +116,7 @@
             <div class="card-body">
                 {% set params = admin.extension_config_get({ 'ext': 'mod_staff' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Check login IP'|trans }}</label>
                             <div class="col">
@@ -146,7 +146,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="api-form" data-api-jsonp="onAfterStaffCreate">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -236,7 +236,7 @@
         <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/staff'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -96,7 +96,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'extension/settings/staff'|alink }}" href="{{ 'api/admin/staff/delete'|link({ 'id': member.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'extension/settings/staff'|alink }}" href="{{ 'api/admin/staff/delete'|link({ 'id': member.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -217,7 +217,7 @@
                                     <use xlink:href="#edit" />
                                 </svg>
                             </a>
-                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'extension/settings/staff'|alink }}" href="{{ 'api/admin/staff/group_delete'|link({ 'id': group.id }) }}">
+                            <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-redirect="{{ 'extension/settings/staff'|alink }}" href="{{ 'api/admin/staff/group_delete'|link({ 'id': group.id, 'CSRFToken': CSRFToken }) }}">
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -116,7 +116,7 @@
             <div class="card-body">
                 {% set params = admin.extension_config_get({ 'ext': 'mod_staff' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Check login IP'|trans }}</label>
                             <div class="col">
@@ -146,7 +146,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="api-form" data-api-jsonp="onAfterStaffCreate">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -236,7 +236,7 @@
         <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/staff'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -116,6 +116,7 @@
             <div class="card-body">
                 {% set params = admin.extension_config_get({ 'ext': 'mod_staff' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Check login IP'|trans }}</label>
                             <div class="col">
@@ -145,6 +146,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/create'|link }}" class="api-form" data-api-jsonp="onAfterStaffCreate">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Group'|trans }}</label>
                         <div class="col">
@@ -234,6 +236,7 @@
         <div class="tab-pane fade" id="tab-new-group" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/staff/group_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/staff'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_category.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_category.html.twig
@@ -34,6 +34,7 @@
         <h3>{{ 'Canned category'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/support/canned_category_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_category.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_category.html.twig
@@ -34,7 +34,7 @@
         <h3>{{ 'Canned category'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/support/canned_category_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_category.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_category.html.twig
@@ -34,7 +34,7 @@
         <h3>{{ 'Canned category'|trans }}</h3>
 
         <form method="post" action="{{ 'api/admin/support/canned_category_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_response.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_response.html.twig
@@ -32,7 +32,7 @@
         <p class="text-muted">{{ response.title }}</p>
 
         <form method="post" action="{{ 'api/admin/support/canned_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_response.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_response.html.twig
@@ -32,7 +32,7 @@
         <p class="text-muted">{{ response.title }}</p>
 
         <form method="post" action="{{ 'api/admin/support/canned_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_response.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_response.html.twig
@@ -32,6 +32,7 @@
         <p class="text-muted">{{ response.title }}</p>
 
         <form method="post" action="{{ 'api/admin/support/canned_update'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                 <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
@@ -95,7 +95,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -163,7 +163,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_category_create'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
@@ -95,6 +95,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -162,6 +163,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_category_create'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
@@ -75,7 +75,7 @@
                                 <use xlink:href="#edit" />
                             </svg>
                         </a>
-                        <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/support/canned_delete'|link({ 'id': response.id }) }}" data-api-redirect="{{ 'support/canned-responses'|alink }}">
+                        <a class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" href="{{ 'api/admin/support/canned_delete'|link({ 'id': response.id, 'CSRFToken': CSRFToken }) }}" data-api-redirect="{{ 'support/canned-responses'|alink }}">
                             <svg class="icon">
                                 <use xlink:href="#delete" />
                             </svg>

--- a/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
@@ -95,7 +95,7 @@
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_create'|link }}" class="mainForm save api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
                         <div class="col">
@@ -163,7 +163,7 @@
         <div class="tab-pane fade" id="tab-new-category" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/canned_category_create'|link }}" class="api-form" data-api-redirect="{{ 'support/canned-responses'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_canned_selector.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_selector.html.twig
@@ -21,7 +21,7 @@
         $('select.canned').on("change", function () {
             var id = $(this).val();
 
-            if (id) bb.get('admin/support/canned_get', { id: id }, function (result) {
+            if (id) bb.get('admin/support/canned_get', { id: id, CSRFToken: "{{CSRFToken}}" }, function (result) {
                 bb.insertToTextarea('rt', result.content)
             });
 

--- a/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
@@ -33,7 +33,7 @@
 
 <div class="card">
     <form method="post" action="{{ 'api/admin/support/helpdesk_update'|link }}" class="api-form" data-api-msg="{{ 'Help desk updated'|trans }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>

--- a/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
@@ -33,7 +33,7 @@
 
 <div class="card">
     <form method="post" action="{{ 'api/admin/support/helpdesk_update'|link }}" class="api-form" data-api-msg="{{ 'Help desk updated'|trans }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>

--- a/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
@@ -85,7 +85,7 @@
             </a>
             <button class="btn btn-primary w-100" type="submit">{{ 'Update'|trans }}</button>
             <a class="btn btn-danger w-25 api-link"
-                href="{{ 'api/admin/support/helpdesk_delete'|link({ 'id': helpdesk.id }) }}"
+                href="{{ 'api/admin/support/helpdesk_delete'|link({ 'id': helpdesk.id, 'CSRFToken': CSRFToken }) }}"
                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                 data-api-redirect="{{ 'extension/settings/support'|alink }}">
                 <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/mod_support_helpdesk.html.twig
@@ -33,6 +33,7 @@
 
 <div class="card">
     <form method="post" action="{{ 'api/admin/support/helpdesk_update'|link }}" class="api-form" data-api-msg="{{ 'Help desk updated'|trans }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Title'|trans }}</label>

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -115,6 +115,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/public_ticket_update'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -164,6 +165,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/public_ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support/public-tickets'|alink({ 'status': 'open' }) }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -84,7 +84,7 @@
             <div class="card-footer text-center">
                 {% if ticket.status != 'closed' %}
                 <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                    href="{{ 'api/admin/support/public_ticket_close'|link({ 'id': ticket.id }) }}"
+                    href="{{ 'api/admin/support/public_ticket_close'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-redirect="{{ 'support/public-tickets'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
                         <use xlink:href="#close" />
@@ -93,7 +93,7 @@
                 </a>
                 {% endif %}
                 <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                    href="{{ 'api/admin/support/public_ticket_delete'|link({ 'id' : ticket.id }) }}"
+                    href="{{ 'api/admin/support/public_ticket_delete'|link({ 'id' : ticket.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'support/public-tickets'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
@@ -192,7 +192,7 @@
 
             {% if ticket.messages|length > 2 and ticket.status != 'closed' %}
             <a class="btn btn-danger w-25 api-link"
-                href="{{ 'api/admin/support/public_ticket_close'|link({ 'id': ticket.id }) }}"
+                href="{{ 'api/admin/support/public_ticket_close'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                 data-api-redirect="{{ 'support/public-tickets'|alink({ 'status': 'open' }) }}">
                 <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -115,7 +115,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/public_ticket_update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -165,7 +165,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/public_ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support/public-tickets'|alink({ 'status': 'open' }) }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -115,7 +115,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/public_ticket_update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -165,7 +165,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/public_ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support/public-tickets'|alink({ 'status': 'open' }) }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_settings.html.twig
+++ b/src/modules/Support/html_admin/mod_support_settings.html.twig
@@ -40,6 +40,7 @@
 
                 {% set params = admin.extension_config_get({ 'ext': 'mod_support' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable auto responder'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_settings.html.twig
+++ b/src/modules/Support/html_admin/mod_support_settings.html.twig
@@ -40,7 +40,7 @@
 
                 {% set params = admin.extension_config_get({ 'ext': 'mod_support' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable auto responder'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_settings.html.twig
+++ b/src/modules/Support/html_admin/mod_support_settings.html.twig
@@ -40,7 +40,7 @@
 
                 {% set params = admin.extension_config_get({ 'ext': 'mod_support' }) %}
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Enable auto responder'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_settings.html.twig
+++ b/src/modules/Support/html_admin/mod_support_settings.html.twig
@@ -153,7 +153,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/support/helpdesk_delete'|link({ 'id': helpdesk.id }) }}"
+                                href="{{ 'api/admin/support/helpdesk_delete'|link({ 'id': helpdesk.id, 'CSRFToken': CSRFToken }) }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                                 data-api-redirect="{{ 'extension/settings/support'|alink }}">
                                 <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -137,7 +137,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/ticket_update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -194,7 +194,7 @@
 
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/note_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="textareaNote">{{ 'Note'|trans }}</label>
                         <div class="col">
@@ -295,7 +295,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
-        {{ 'hiddenInput' |csrftoken_filter }}
+        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -106,7 +106,7 @@
             <div class="card-footer text-center">
                 {% if ticket.status != 'closed' %}
                 <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                    href="{{ 'api/admin/support/ticket_close'|link({ 'id': ticket.id }) }}"
+                    href="{{ 'api/admin/support/ticket_close'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
@@ -116,7 +116,7 @@
                 </a>
                 {% endif %}
                 <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-                    href="{{ 'api/admin/support/ticket_delete'|link({ 'id': ticket.id }) }}"
+                    href="{{ 'api/admin/support/ticket_delete'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                     data-api-confirm="{{ 'Are you sure?'|trans }}"
                     data-api-redirect="{{ 'support'|alink }}">
                     <svg class="mb-2 text-secondary" width="24" height="24">
@@ -126,7 +126,7 @@
                 </a>
 
                 {% if task.status == 'pending' %}
-                <a href="{{ 'api/admin/support/task_complete'|link({ 'id': ticket.id }) }}" class="btn55 mr10 api-link" data-api-reload="1">
+                <a href="{{ 'api/admin/support/task_complete'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}" class="btn55 mr10 api-link" data-api-reload="1">
                     <img src="images/icons/middlenav/check.png" alt="" data-api-reload="1">
                     <span>{{ 'Set Task complete'|trans }}</span>
                 </a>
@@ -179,7 +179,7 @@
                     <td>{{ note.note }}</td>
                     <td class="w-1">
                         <a class="btn btn-icon api-link"
-                            href="{{ 'api/admin/support/note_delete'|link({ 'id': note.id }) }}"
+                            href="{{ 'api/admin/support/note_delete'|link({ 'id': note.id, 'CSRFToken': CSRFToken }) }}"
                             data-api-confirm="{{ 'Are you sure?'|trans }}"
                             data-api-reload="1">
                             <svg class="icon">
@@ -321,7 +321,7 @@
 
             {% if ticket.messages|length > 2 and ticket.status != 'closed' %}
             <a class="btn btn-danger w-25 api-link"
-                href="{{ 'api/admin/support/ticket_close'|link({ 'id': ticket.id }) }}"
+                href="{{ 'api/admin/support/ticket_close'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                 data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
                 <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -362,14 +362,16 @@
         $('.shd select').change(function(){
             bb.get('admin/support/ticket_update', {
                 id: {{ ticket.id }},
-                support_helpdesk_id: $(this).val()
+                support_helpdesk_id: $(this).val(),
+                CSRFToken: "{{CSRFToken}}"
             });
         });
 
         $('input.tst').click(function(){
             bb.get('admin/support/ticket_update', {
                 id: {{ ticket.id }},
-                status: $(this).val()
+                status: $(this).val(),
+                CSRFToken: "{{CSRFToken}}"
             });
         });
 

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -137,6 +137,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/ticket_update'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -193,6 +194,7 @@
 
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/note_create'|link }}" class="api-form" data-api-reload="1">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="textareaNote">{{ 'Note'|trans }}</label>
                         <div class="col">
@@ -293,6 +295,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
+        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -137,7 +137,7 @@
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/ticket_update'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Subject'|trans }}</label>
                         <div class="col">
@@ -194,7 +194,7 @@
 
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/support/note_create'|link }}" class="api-form" data-api-reload="1">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label" for="textareaNote">{{ 'Note'|trans }}</label>
                         <div class="col">
@@ -295,7 +295,7 @@
 
 <div class="card" id="reply-box">
     <form method="post" action="{{ 'api/admin/support/ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
-        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+        {{ 'hiddenInput' |csrftoken_filter }}
         <div class="card-body">
             <div class="d-flex">
                 <h5>{{ 'Reply as'|trans }} {{ profile.name }}</h5>

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -13,7 +13,7 @@
         <div class="card-body">
             <h5>{{ 'Filter support tickets'|trans }}</h5>
             <form method="get">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Client ID'|trans }}</label>
                     <div class="col">
@@ -256,7 +256,7 @@
             <div class="card-body">
                 <h5>{{ 'Open ticket for existing client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/ticket_create'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     {% if not request.client_id %}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
@@ -294,7 +294,7 @@
             <div class="card-body">
                 <h5>{{ 'Open public ticket for non client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/public_ticket_create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterPublicTicketCreate">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Receivers name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -13,6 +13,7 @@
         <div class="card-body">
             <h5>{{ 'Filter support tickets'|trans }}</h5>
             <form method="get">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Client ID'|trans }}</label>
                     <div class="col">
@@ -255,6 +256,7 @@
             <div class="card-body">
                 <h5>{{ 'Open ticket for existing client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/ticket_create'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     {% if not request.client_id %}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
@@ -292,6 +294,7 @@
             <div class="card-body">
                 <h5>{{ 'Open public ticket for non client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/public_ticket_create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterPublicTicketCreate">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Receivers name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -229,7 +229,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon api-link"
-                                href="{{ 'api/admin/support/ticket_delete'|link({ 'id': ticket.id }) }}"
+                                href="{{ 'api/admin/support/ticket_delete'|link({ 'id': ticket.id, 'CSRFToken': CSRFToken }) }}"
                                 data-api-confirm="{{ 'Are you sure?'|trans }}"
                                 data-api-redirect="{{ 'support'|alink }}">
                                 <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -339,7 +339,8 @@ $(function() {
                 dataType: "json",
                 data: {
                     per_page: 10,
-                    search: request.term
+                    search: request.term,
+                    CSRFToken: {{ CSRFToken }}
                 },
                 success: function( data ) {
                     response( $.map( data.result, function( name, id) {

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -13,7 +13,7 @@
         <div class="card-body">
             <h5>{{ 'Filter support tickets'|trans }}</h5>
             <form method="get">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Client ID'|trans }}</label>
                     <div class="col">
@@ -256,7 +256,7 @@
             <div class="card-body">
                 <h5>{{ 'Open ticket for existing client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/ticket_create'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     {% if not request.client_id %}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Client'|trans }}</label>
@@ -294,7 +294,7 @@
             <div class="card-body">
                 <h5>{{ 'Open public ticket for non client'|trans }}</h5>
                 <form method="post" action="{{ 'api/admin/support/public_ticket_create'|link }}" class="mainForm api-form" data-api-jsonp="onAfterPublicTicketCreate">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Receivers name'|trans }}</label>
                         <div class="col">

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -340,7 +340,7 @@ $(function() {
                 data: {
                     per_page: 10,
                     search: request.term,
-                    CSRFToken: {{ CSRFToken }}
+                    CSRFToken: "{{ CSRFToken }}"
                 },
                 success: function( data ) {
                     response( $.map( data.result, function( name, id) {

--- a/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <form method="post" action="{{ 'api/admin/support/helpdesk_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/support'|alink }}">
-                {{ 'hiddenInput' |csrftoken_filter }}
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'Create new helpdesk'|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <form method="post" action="{{ 'api/admin/support/helpdesk_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/support'|alink }}">
-                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'Create new helpdesk'|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
+++ b/src/modules/Support/html_admin/modal/mod_support_new_helpdesk.html.twig
@@ -2,6 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <form method="post" action="{{ 'api/admin/support/helpdesk_create'|link }}" class="api-form" data-api-redirect="{{ 'extension/settings/support'|alink }}">
+                {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'Create new helpdesk'|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -17,7 +17,7 @@
                 </header>
                 <section>
                     <form method="post" action="" id="public-ticket-create" class="form form-horizontal span6">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <fieldset>
                             <div class="control-group">
                                 <label for="name">{{ 'Name'|trans }}: </label>

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -17,6 +17,7 @@
                 </header>
                 <section>
                     <form method="post" action="" id="public-ticket-create" class="form form-horizontal span6">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <fieldset>
                             <div class="control-group">
                                 <label for="name">{{ 'Name'|trans }}: </label>

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -17,7 +17,7 @@
                 </header>
                 <section>
                     <form method="post" action="" id="public-ticket-create" class="form form-horizontal span6">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <fieldset>
                             <div class="control-group">
                                 <label for="name">{{ 'Name'|trans }}: </label>

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -18,7 +18,7 @@
                 <h2>{{ 'Ticket information'|trans }}</h2>
                 <div class="pull-right">
                     {% if ticket.status != 'closed' %}
-                        <button class="btn btn-small" href="{{ 'api/guest/support/ticket_close'|link({ 'hash': ticket.hash })}}" id="new-ticket-button" data-api-reload="1"> {{ 'Close ticket'|trans }}</button>
+                        <button class="btn btn-small" href="{{ 'api/guest/support/ticket_close'|link({ 'hash': ticket.hash, 'CSRFToken': CSRFToken })}}" id="new-ticket-button" data-api-reload="1"> {{ 'Close ticket'|trans }}</button>
                     {% endif %}
                 </div>
             </header>

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -99,7 +99,7 @@
                     <div class="span9">
                         {% if ticket.status != 'closed' %}
                         <form method="post" action="" class="api_form" data-api-url="guest/support/ticket_reply" data-api-reload="1">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                                 <textarea name="message" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" value="{{ 'Post'|trans }}" onclick="$('.wait').show()">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -99,7 +99,7 @@
                     <div class="span9">
                         {% if ticket.status != 'closed' %}
                         <form method="post" action="" class="api_form" data-api-url="guest/support/ticket_reply" data-api-reload="1">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                                 <textarea name="message" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" value="{{ 'Post'|trans }}" onclick="$('.wait').show()">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -99,6 +99,7 @@
                     <div class="span9">
                         {% if ticket.status != 'closed' %}
                         <form method="post" action="" class="api_form" data-api-url="guest/support/ticket_reply" data-api-reload="1">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                                 <textarea name="message" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" value="{{ 'Post'|trans }}" onclick="$('.wait').show()">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -145,6 +145,7 @@
                     <div class="span3"></div>
                     <div class="span9">
                         <form method="post" action="" class="api_form" data-api-url="{{ 'api/client/support/ticket_reply'|link }}" data-api-reload="1">
+                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                             <fieldset>
                                 <textarea name="content" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" id="submit-support-message" value="{{ 'Post'|trans }}" onclick="">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -145,7 +145,7 @@
                     <div class="span3"></div>
                     <div class="span9">
                         <form method="post" action="" class="api_form" data-api-url="{{ 'api/client/support/ticket_reply'|link }}" data-api-reload="1">
-                            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                            {{ 'hiddenInput' |csrftoken_filter }}
                             <fieldset>
                                 <textarea name="content" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" id="submit-support-message" value="{{ 'Post'|trans }}" onclick="">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -145,7 +145,7 @@
                     <div class="span3"></div>
                     <div class="span9">
                         <form method="post" action="" class="api_form" data-api-url="{{ 'api/client/support/ticket_reply'|link }}" data-api-reload="1">
-                            {{ 'hiddenInput' |csrftoken_filter }}
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <fieldset>
                                 <textarea name="content" cols="5" rows="10" class="span12" required="required" id="ticket-reply-text"></textarea>
                                 <button class="btn btn-primary btn-large" type="submit" id="submit-support-message" value="{{ 'Post'|trans }}" onclick="">{{ 'Post'|trans }}</button>

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -86,7 +86,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" id="ticket-submit" class="form" style="background: none">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -86,6 +86,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" id="ticket-submit" class="form" style="background: none">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -86,7 +86,7 @@
     </div>
     <div class="modal-body">
         <form action="" method="post" id="ticket-submit" class="form" style="background: none">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
                 <div class="control-group">
                     <label>{{ 'Help desk'|trans }}: </label>
                     <div class="controls">

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -48,7 +48,7 @@
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -117,7 +117,7 @@
                 <hr>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="mb-3">
                         <h3>{{ 'Company terms of service, legal regulation'|trans }}</h3>
                         <textarea class="form-control bb-textarea" name="company_tos" rows="5">{{ params.company_tos }}</textarea>
@@ -139,7 +139,7 @@
         <div class="tab-pane fade" id="tab-countries" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Countries updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
 {% set default_countries %}
 AF=Afghanistan
 AX=Aland Islands
@@ -406,7 +406,7 @@ ZW=Zimbabwe
                 <p class="text-muted">{{ 'FTP is used to manage FOSSBilling modules and updates.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'FTP settings updated'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'FTP hostname'|trans }}:</label>
                         <div class="col">
@@ -453,7 +453,7 @@ ZW=Zimbabwe
                 <h3>{{ 'Cache control'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/system/clear_cache'|link }}" class="api-form" data-api-msg="{{ 'Cache folder cleared'|trans }}">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <button class="btn btn-danger w-100" type="submit">{{ 'Invalidate cache'|trans }}</button>
                 </form>
             </div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -48,6 +48,7 @@
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -116,6 +117,7 @@
                 <hr>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="mb-3">
                         <h3>{{ 'Company terms of service, legal regulation'|trans }}</h3>
                         <textarea class="form-control bb-textarea" name="company_tos" rows="5">{{ params.company_tos }}</textarea>
@@ -137,6 +139,7 @@
         <div class="tab-pane fade" id="tab-countries" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Countries updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
 {% set default_countries %}
 AF=Afghanistan
 AX=Aland Islands
@@ -403,6 +406,7 @@ ZW=Zimbabwe
                 <p class="text-muted">{{ 'FTP is used to manage FOSSBilling modules and updates.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'FTP settings updated'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'FTP hostname'|trans }}:</label>
                         <div class="col">
@@ -449,6 +453,7 @@ ZW=Zimbabwe
                 <h3>{{ 'Cache control'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/system/clear_cache'|link }}" class="api-form" data-api-msg="{{ 'Cache folder cleared'|trans }}">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <button class="btn btn-danger w-100" type="submit">{{ 'Invalidate cache'|trans }}</button>
                 </form>
             </div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -48,7 +48,7 @@
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Name'|trans }}</label>
                         <div class="col">
@@ -117,7 +117,7 @@
                 <hr>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'Company updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3">
                         <h3>{{ 'Company terms of service, legal regulation'|trans }}</h3>
                         <textarea class="form-control bb-textarea" name="company_tos" rows="5">{{ params.company_tos }}</textarea>
@@ -139,7 +139,7 @@
         <div class="tab-pane fade" id="tab-countries" role="tabpanel">
             <div class="card-body">
                 <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Countries updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
 {% set default_countries %}
 AF=Afghanistan
 AX=Aland Islands
@@ -406,7 +406,7 @@ ZW=Zimbabwe
                 <p class="text-muted">{{ 'FTP is used to manage FOSSBilling modules and updates.'|trans }}</p>
 
                 <form method="post" action="{{ 'api/admin/system/update_params'|link }}" class="api-form" data-api-msg="{{ 'FTP settings updated'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'FTP hostname'|trans }}:</label>
                         <div class="col">
@@ -453,7 +453,7 @@ ZW=Zimbabwe
                 <h3>{{ 'Cache control'|trans }}</h3>
 
                 <form method="post" action="{{ 'api/admin/system/clear_cache'|link }}" class="api-form" data-api-msg="{{ 'Cache folder cleared'|trans }}">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <button class="btn btn-danger w-100" type="submit">{{ 'Invalidate cache'|trans }}</button>
                 </form>
             </div>

--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -49,7 +49,7 @@
                                 {% endfor %}
                             </select>
                             {% if presets|length > 1 and current_preset != 'Default' %}
-                                <a href="{{ 'api/admin/theme/preset_delete'|link({ 'code': theme_code, 'preset': current_preset}) }}" class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
+                                <a href="{{ 'api/admin/theme/preset_delete'|link({ 'code': theme_code, 'preset': current_preset, 'CSRFToken': CSRFToken}) }}" class="btn btn-icon api-link" data-api-confirm="{{ 'Are you sure?'|trans }}" data-api-reload="1">
                                     <svg class="icon">
                                         <use xlink:href="#delete" />
                                     </svg>

--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -61,7 +61,7 @@
 
                 <div id="theme-settings">
                     <form method="post" action="" enctype="multipart/form-data">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         {{ settings_html|raw }}
                         <div class="mt-3">
                             <div class="form-check">

--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -61,7 +61,7 @@
 
                 <div id="theme-settings">
                     <form method="post" action="" enctype="multipart/form-data">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         {{ settings_html|raw }}
                         <div class="mt-3">
                             <div class="form-check">

--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -61,6 +61,7 @@
 
                 <div id="theme-settings">
                     <form method="post" action="" enctype="multipart/form-data">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         {{ settings_html|raw }}
                         <div class="mt-3">
                             <div class="form-check">

--- a/src/modules/Theme/html_admin/mod_theme_settings.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_settings.html.twig
@@ -45,7 +45,7 @@
                         {{ 'Settings'|trans }}
                     </a>
                     {% if guest.extension_theme(true).code != theme.code %}
-                    <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({ 'code': theme.code }) }}">
+                    <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({ 'code': theme.code, 'CSRFToken': CSRFToken }) }}">
                         <svg class="icon">
                             <use xlink:href="#check" />
                         </svg>
@@ -93,7 +93,7 @@
                         {{ 'Settings'|trans }}
                     </a>
                     {% if guest.extension_theme(false).code != theme.code %}
-                    <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({'code' : theme.code}) }}">
+                    <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({'code' : theme.code, 'CSRFToken': CSRFToken}) }}">
                         <svg class="icon">
                             <use xlink:href="#check" />
                         </svg>

--- a/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
+++ b/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_wysiwyg' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Default editor'|trans }}</label>
                 <div class="col">

--- a/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
+++ b/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
@@ -29,7 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_wysiwyg' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Default editor'|trans }}</label>
                 <div class="col">

--- a/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
+++ b/src/modules/Wysiwyg/html_admin/mod_wysiwyg_settings.html.twig
@@ -29,6 +29,7 @@
 
         {% set params = admin.extension_config_get({ 'ext': 'mod_wysiwyg' }) %}
         <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Default editor'|trans }}</label>
                 <div class="col">

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -109,7 +109,7 @@
                               href="{{ 'system'|alink }}">{{ 'Settings'|trans }}</a>
                            <div class="dropdown-divider"></div>
                            <a class="dropdown-item api-link"
-                              href="{{ 'api/admin/profile/logout'|link }}"
+                              href="{{ 'api/admin/profile/logout'|link({ 'CSRFToken': CSRFToken }) }}"
                               data-api-redirect="{{ 'staff/login'|alink }}">{{ 'Logout'|trans }}</a>
                         </div>
                      </div>

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -126,7 +126,7 @@
 <div style="position: relative;">
     <div class="dataTables_filter">
         <form method="get" action="">
-            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+            {{ 'hiddenInput' |csrftoken_filter }}
             <input type="hidden" name="_url" value="{{request._url}}"/>
             <label>{% trans %}Search:{% endtrans %} <input type="text" name="search" placeholder="{% trans %}Enter search text..{% endtrans %}" value="{{request.search}}"><div class="srch"></div></label>
         </form>

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -126,7 +126,7 @@
 <div style="position: relative;">
     <div class="dataTables_filter">
         <form method="get" action="">
-            {{ 'hiddenInput' |csrftoken_filter }}
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <input type="hidden" name="_url" value="{{request._url}}"/>
             <label>{% trans %}Search:{% endtrans %} <input type="text" name="search" placeholder="{% trans %}Enter search text..{% endtrans %}" value="{{request.search}}"><div class="srch"></div></label>
         </form>

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -126,6 +126,7 @@
 <div style="position: relative;">
     <div class="dataTables_filter">
         <form method="get" action="">
+            {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
             <input type="hidden" name="_url" value="{{request._url}}"/>
             <label>{% trans %}Search:{% endtrans %} <input type="text" name="search" placeholder="{% trans %}Enter search text..{% endtrans %}" value="{{request.search}}"><div class="srch"></div></label>
         </form>

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -360,7 +360,7 @@
             <div class="card-body">
                 <h5>{{ 'Define date interval for graphs'|trans }}</h5>
                 <form method="get" action="">
-                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                    {{ 'hiddenInput' |csrftoken_filter }}
                     <input type="hidden" name="_url" value="{{ request._url }}">
                     <div class="input-group">
                         <input class="form-control" type="date" name="date_from" value="{% if request.date_from %}{{ request.date_from|date('Y-m-d') }}{% endif %}" placeholder="{{ now|date('Y-m-d') }}">

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -360,6 +360,7 @@
             <div class="card-body">
                 <h5>{{ 'Define date interval for graphs'|trans }}</h5>
                 <form method="get" action="">
+                    {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                     <input type="hidden" name="_url" value="{{ request._url }}">
                     <div class="input-group">
                         <input class="form-control" type="date" name="date_from" value="{% if request.date_from %}{{ request.date_from|date('Y-m-d') }}{% endif %}" placeholder="{{ now|date('Y-m-d') }}">

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -360,7 +360,7 @@
             <div class="card-body">
                 <h5>{{ 'Define date interval for graphs'|trans }}</h5>
                 <form method="get" action="">
-                    {{ 'hiddenInput' |csrftoken_filter }}
+                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <input type="hidden" name="_url" value="{{ request._url }}">
                     <div class="input-group">
                         <input class="form-control" type="date" name="date_from" value="{% if request.date_from %}{{ request.date_from|date('Y-m-d') }}{% endif %}" placeholder="{{ now|date('Y-m-d') }}">

--- a/src/themes/admin_default/html/partial_extensions.html.twig
+++ b/src/themes/admin_default/html/partial_extensions.html.twig
@@ -29,7 +29,7 @@
                 <a href="https://extensions.fossbilling.org/extension/{{ extension.id }}" target="_blank" title="Project details">{{ 'Learn more'|trans }}</a>
             </td>
             <td>
-                <a class="btn btn-icon api-link" data-api-confirm="By installing '{{ extension.name }}', you agree with terms and conditions. Only install extensions you trust. You also might want to have a full backup ready in case something goes wrong. Continue?" data-api-reload="1" href="{{ 'api/admin/extension/install'|link ({ 'type': extension.type, 'id': extension.id }) }}" title="Install extension">
+                <a class="btn btn-icon api-link" data-api-confirm="By installing '{{ extension.name }}', you agree with terms and conditions. Only install extensions you trust. You also might want to have a full backup ready in case something goes wrong. Continue?" data-api-reload="1" href="{{ 'api/admin/extension/install'|link ({ 'type': extension.type, 'id': extension.id, 'CSRFToken': CSRFToken }) }}" title="Install extension">
                     <svg class="icon">
                         <use xlink:href="#download" />
                     </svg>

--- a/src/themes/admin_default/html/partial_search.html.twig
+++ b/src/themes/admin_default/html/partial_search.html.twig
@@ -4,6 +4,7 @@
             <div class="ms-2 d-inline-block">
                 <div class="d-flex">
                     <form method="get">
+                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
                         <input type="hidden" name="_url" value="{{ request._url }}">
                         <div class="input-group input-group-flat">
                             <input class="form-control"

--- a/src/themes/admin_default/html/partial_search.html.twig
+++ b/src/themes/admin_default/html/partial_search.html.twig
@@ -4,7 +4,7 @@
             <div class="ms-2 d-inline-block">
                 <div class="d-flex">
                     <form method="get">
-                        {{ 'FOSSBilling_CSRFToken' |csrftoken_filter }}
+                        {{ 'hiddenInput' |csrftoken_filter }}
                         <input type="hidden" name="_url" value="{{ request._url }}">
                         <div class="input-group input-group-flat">
                             <input class="form-control"

--- a/src/themes/admin_default/html/partial_search.html.twig
+++ b/src/themes/admin_default/html/partial_search.html.twig
@@ -4,7 +4,7 @@
             <div class="ms-2 d-inline-block">
                 <div class="d-flex">
                     <form method="get">
-                        {{ 'hiddenInput' |csrftoken_filter }}
+                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <input type="hidden" name="_url" value="{{ request._url }}">
                         <div class="input-group input-group-flat">
                             <input class="form-control"


### PR DESCRIPTION
This PR protects the API through a CSRF token. The only times the token isn't needed is if there isn't a valid PHP session, for guest accounts, if the API is being calling through CLI, or if an API key is being used.
This is a majorly breaking change, but it's needed to protect FOSSBilling from CSRF vulnerabilities.

I'm not sure if there's a better way to do it, but I created a new twig extension to add a hidden input element with the token.

Please review and test, we will also need to make a note of this on our docs for developers. 