### PR TITLE
Disable twig debug mode

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -449,7 +449,7 @@ final class Box_Installer
             ],
 
             'twig' => [
-                'debug' => true,
+                'debug' => false,
                 'auto_reload' => true,
                 'cache' => PATH_ROOT . '/data/cache',
             ],

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -515,7 +515,8 @@ class Box_Tools
                 'password' => $currentConfig['db']['password'],
             ],
             'twig' => [
-                'debug' => $currentConfig['twig']['debug'],
+                //'debug' => $currentConfig['twig']['debug'],
+                'debug' => false,
                 'auto_reload' => $currentConfig['twig']['auto_reload'],
                 'cache' => $currentConfig['twig']['cache'],
             ],


### PR DESCRIPTION
Based on my testing, disabling this fixes the "empty black box" while trying to make an order.
It also doesn't make sense to have it enabled by default.

For the next release, we will disable it during the update process, but once that release is pushed I'll enable the old behavior of copying the current setting