### PR TITLE
Hide "Settings" button for themes without settings

### DIFF
--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -386,6 +386,11 @@ class Service implements InjectionAwareInterface
 
         $config['code'] = $theme;
         $config['paths'] = $paths;
+        $config['hasSettings'] = false;
+
+        if (is_dir($theme_path . '/config')) {
+            $config['hasSettings'] = true;
+        }
 
         return $config;
     }

--- a/src/modules/Theme/html_admin/mod_theme_settings.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_settings.html.twig
@@ -38,12 +38,16 @@
             <tr>
                 <td>{% if guest.extension_theme(true).code == theme.code %}<strong>{{ theme.code }}</strong>{% else %}{{ theme.code }}{% endif %}</td>
                 <td>
+                    {% if theme.hasSettings %}
                     <a class="btn btn-primary" href="{{ 'theme'|alink }}/{{theme.code}}">
                         <svg class="icon">
                             <use xlink:href="#settings" />
                         </svg>
                         {{ 'Settings'|trans }}
                     </a>
+                    {% else %}
+                    <p>Theme does not have settings</p>
+                    {% endif %}
                     {% if guest.extension_theme(true).code != theme.code %}
                     <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({ 'code': theme.code, 'CSRFToken': CSRFToken }) }}">
                         <svg class="icon">
@@ -86,12 +90,16 @@
                     {% endif %}
                 </td>
                 <td>
+                    {% if theme.hasSettings %}
                     <a class="btn btn-primary" href="{{ 'theme'|alink }}/{{theme.code}}">
                         <svg class="icon">
                             <use xlink:href="#settings" />
                         </svg>
                         {{ 'Settings'|trans }}
                     </a>
+                    {% else %}
+                    <p>Theme does not have settings</p>
+                    {% endif %}
                     {% if guest.extension_theme(false).code != theme.code %}
                     <a class="btn btn-primary api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({'code' : theme.code, 'CSRFToken': CSRFToken}) }}">
                         <svg class="icon">


### PR DESCRIPTION
Closes https://github.com/FOSSBilling/FOSSBilling/issues/548
Looks like this: 
![image](https://user-images.githubusercontent.com/17304943/206388879-b7141912-51ce-4d95-85a1-dcec996f53be.png)
