### PR TITLE
Fix the way Hestia uses the credentials

### DIFF
--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -87,7 +87,9 @@ class Server_Manager_Hestia extends Server_Manager
         $host = 'https://'.$this->_config['host'].':'.$this->_getPort().'/api/';
 
         // Server credentials
-        if ('' != $this->_config['accesshash']) {
+        if ('' != $this->_config['accesshash'] && '' != $this->_config['username']) {
+            $params['hash'] = $this->_config['username'] . ":" . $this->_config['accesshash'];
+        } elseif ('' != $this->_config['accesshash']) {
             $params['hash'] = $this->_config['accesshash'];
         } else {
             $params['user'] = $this->_config['username'];


### PR DESCRIPTION
Configuring the Hestia adapter as intended in the new gui would cause authentication errors.
This PR corrects that so now it will correctly get the credentials for both the "new" and the "old" ways.
(picture for what I am referencing)
![image](https://user-images.githubusercontent.com/17304943/206620995-b059c8e3-45c5-478d-bcb2-a3ed38d0eeea.png)
