### PR TITLE
Created new security mode option

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -12,11 +12,14 @@
 
 return [
     /* 
-     * This configuration option defines how strict the security in FOSSBilling is enforced.
-     * Acceptable values are 'regular' or 'strict'.
-     * The recommended value is 'strict', but this requires a valid SSL sertificate on your server
+     * These configuration options allow you to configure the security options inside of FOSSBilling.
+     * The default values are what we recommended running unless they are causing issues.
      */
-    'security_mode' => 'strict',
+    'security' => [
+        'mode' => 'strict',
+        'force_https' => true,
+        'cookie_lifespan' => 7200,
+    ],
 
     'salt' => '',
 

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -11,6 +11,13 @@
  */
 
 return [
+    /* 
+     * This configuration option defines how strict the security in FOSSBilling is enforced.
+     * Acceptable values are 'regular' or 'strict'.
+     * The recommended value is 'strict', but this requires a valid SSL sertificate on your server
+     */
+    'security_mode' => 'strict',
+
     'salt' => '',
 
     /*

--- a/src/di.php
+++ b/src/di.php
@@ -150,8 +150,9 @@ $di['events_manager'] = function () use ($di) {
 
 $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
+    $securityMode = (isset($di['config']['security_mode'])) ? $di['config']['security_mode'] : 'regular';
 
-    return new Box_Session($handler);
+    return new Box_Session($handler, $securityMode);
 };
 
 $di['cookie'] = function () use ($di) {

--- a/src/di.php
+++ b/src/di.php
@@ -150,9 +150,10 @@ $di['events_manager'] = function () use ($di) {
 
 $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
-    $config = $di['config']['security'];
+    $mode = (isset($di['config']['security']['mode'])) ? $di['config']['security']['mode'] : 'strict';
+    $lifespan =(isset($di['config']['security']['cookie_lifespan'])) ? $di['config']['security']['cookie_lifespan'] : 7200;
 
-    return new Box_Session($handler, $config['mode'], $config['cookie_lifespan']);
+    return new Box_Session($handler, $mode, $$lifespan);
 };
 
 $di['cookie'] = function () use ($di) {

--- a/src/di.php
+++ b/src/di.php
@@ -150,9 +150,9 @@ $di['events_manager'] = function () use ($di) {
 
 $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
-    $securityMode = (isset($di['config']['security_mode'])) ? $di['config']['security_mode'] : 'regular';
+    $config = $di['config']['security'];
 
-    return new Box_Session($handler, $securityMode);
+    return new Box_Session($handler, $config['mode'], $config['cookie_lifespan']);
 };
 
 $di['cookie'] = function () use ($di) {

--- a/src/di.php
+++ b/src/di.php
@@ -153,7 +153,7 @@ $di['session'] = function () use ($di) {
     $mode = (isset($di['config']['security']['mode'])) ? $di['config']['security']['mode'] : 'strict';
     $lifespan =(isset($di['config']['security']['cookie_lifespan'])) ? $di['config']['security']['cookie_lifespan'] : 7200;
 
-    return new Box_Session($handler, $mode, $$lifespan);
+    return new Box_Session($handler, $mode, $lifespan);
 };
 
 $di['cookie'] = function () use ($di) {

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -437,7 +437,11 @@ final class Box_Installer
 
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.
         $data = [
-            'security_mode' => 'strict',
+            'security' => [
+                'mode' => 'strict',
+                'force_https' => true,
+                'cookie_lifespan' => 7200,
+            ],
             'debug' => false,
             'update_branch' => $updateBranch,
             'log_stacktrace' => true,

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -437,6 +437,7 @@ final class Box_Installer
 
         // TODO: Why not just take the defaults from the bb.config.example.php file and modify accordingly? Also this method doesn't preserve the comments in the example config.
         $data = [
+            'security_mode' => 'strict',
             'debug' => false,
             'update_branch' => $updateBranch,
             'log_stacktrace' => true,

--- a/src/library/Box/Session.php
+++ b/src/library/Box/Session.php
@@ -22,7 +22,7 @@ class Box_Session
     }
 
 
-    public function __construct($handler, $securityMode = 'regular')
+    public function __construct($handler, $securityMode = 'regular', $cookieLifespan = 7200)
     {
         session_set_save_handler(
             array($handler, 'open'),
@@ -35,10 +35,11 @@ class Box_Session
         if(php_sapi_name() !== 'cli'){
             $currentCookieParams = session_get_cookie_params();
             $currentCookieParams["httponly"] = true;
+            $currentCookieParams["lifetime"] = $cookieLifespan;
 
             if($securityMode == 'strict'){
                 session_set_cookie_params([
-                    'lifetime' => '7200',
+                    'lifetime' => $currentCookieParams["lifetime"],
                     'path' => $currentCookieParams["path"],
                     'domain' => $currentCookieParams["domain"],
                     'secure' => true,
@@ -46,6 +47,7 @@ class Box_Session
                     'samesite' => 'Strict'
                 ]);
                 // TODO: Adjust the DB to support 64 character long session IDs
+                // Currently adjusting it causing issues within this file: https://github.com/FOSSBilling/FOSSBilling/blob/main/src/library/PdoSessionHandler.php
                 //$this->setRandomId();
             } else {
                 session_set_cookie_params(

--- a/src/library/Box/Session.php
+++ b/src/library/Box/Session.php
@@ -15,7 +15,14 @@
 
 class Box_Session
 {
-    public function __construct($handler)
+    public function setRandomId()
+    {
+        $id = random_bytes(64);
+        session_id($id);
+    }
+
+
+    public function __construct($handler, $securityMode = 'regular')
     {
         session_set_save_handler(
             array($handler, 'open'),
@@ -29,13 +36,27 @@ class Box_Session
             $currentCookieParams = session_get_cookie_params();
             $currentCookieParams["httponly"] = true;
 
-            session_set_cookie_params(
-                $currentCookieParams["lifetime"],
-                $currentCookieParams["path"],
-                $currentCookieParams["domain"],
-                $currentCookieParams["secure"],
-                $currentCookieParams["httponly"]
-            );
+            if($securityMode == 'strict'){
+                session_set_cookie_params([
+                    'lifetime' => '7200',
+                    'path' => $currentCookieParams["path"],
+                    'domain' => $currentCookieParams["domain"],
+                    'secure' => true,
+                    'httponly' => $currentCookieParams["httponly"],
+                    'samesite' => 'Strict'
+                ]);
+                // TODO: Adjust the DB to support 64 character long session IDs
+                //$this->setRandomId();
+            } else {
+                session_set_cookie_params(
+                    $currentCookieParams["lifetime"],
+                    $currentCookieParams["path"],
+                    $currentCookieParams["domain"],
+                    $currentCookieParams["secure"],
+                    $currentCookieParams["httponly"]
+                );
+            }
+
             session_start();
         }
     }

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -485,6 +485,7 @@ class Box_Tools
         }
 
         $newConfig = [
+            'security_mode' => (isset($currentConfig['security_mode'])) ? $currentConfig['security_mode'] : 'regular',
             'debug' => (isset($currentConfig['debug'])) ? $currentConfig['debug'] : false,
             'update_branch' => (isset($currentConfig['update_branch'])) ? $currentConfig['update_branch'] : 'release',
             'log_stacktrace' => (isset($currentConfig['log_stacktrace'])) ? $currentConfig['log_stacktrace'] : true,
@@ -515,8 +516,7 @@ class Box_Tools
                 'password' => $currentConfig['db']['password'],
             ],
             'twig' => [
-                //'debug' => $currentConfig['twig']['debug'],
-                'debug' => false,
+                'debug' => $currentConfig['twig']['debug'],
                 'auto_reload' => $currentConfig['twig']['auto_reload'],
                 'cache' => $currentConfig['twig']['cache'],
             ],

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -485,7 +485,11 @@ class Box_Tools
         }
 
         $newConfig = [
-            'security_mode' => (isset($currentConfig['security_mode'])) ? $currentConfig['security_mode'] : 'regular',
+            'security' => [
+                'mode' => (isset($currentConfig['security']['mode'])) ? $currentConfig['security']['mode'] : 'strict',
+                'force_https' => (isset($currentConfig['security']['force_https'])) ? $currentConfig['security']['force_https'] : true,
+                'cookie_lifespan' => (isset($currentConfig['security']['cookie_lifespan'])) ? $currentConfig['security']['cookie_lifespan'] : '7200',
+            ],
             'debug' => (isset($currentConfig['debug'])) ? $currentConfig['debug'] : false,
             'update_branch' => (isset($currentConfig['update_branch'])) ? $currentConfig['update_branch'] : 'release',
             'log_stacktrace' => (isset($currentConfig['log_stacktrace'])) ? $currentConfig['log_stacktrace'] : true,

--- a/src/load.php
+++ b/src/load.php
@@ -260,7 +260,7 @@ if ((isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST']) || ('cli' === PHP_SA
         $host = $_SERVER['HTTP_HOST'];
     }
 
-    $predictConfigPath = PATH_ROOT . '/bb-config-' . $host . '.php';
+    $predictConfigPath = PATH_ROOT . '/config-' . $host . '.php';
     if (file_exists($predictConfigPath)) {
         $configPath = $predictConfigPath;
     }
@@ -365,5 +365,26 @@ $serverSoftware = (isset($_SERVER['SERVER_SOFTWARE'])) ? $_SERVER['SERVER_SOFTWA
 if ($isApache or (false !== stripos($serverSoftware, 'apache'))) {
     if (!file_exists(PATH_ROOT . '/.htaccess')) {
         throw new Exception('Error: You appear to be running an Apache server without a valid <b><em>.htaccess</em></b> file. You may need to rename <b><em>htaccess.txt</em></b> to <b><em>.htaccess</em></b>');
+    }
+}
+
+// If the configured security mode is strict, redirect to HTTPS
+if (isset($config['security_mode']) && $config['security_mode'] == 'strict'){
+    $isHTTPS = false;
+    
+    if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+        $isHTTPS = true;
+    }
+    if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') {
+        $isHTTPS = true;
+    }
+    if (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on') {
+        $isHTTPS = true;
+    }
+
+    if(!$isHTTPS){
+        $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        header('Location: ' . $url);
+        exit;
     }
 }

--- a/src/load.php
+++ b/src/load.php
@@ -369,7 +369,7 @@ if ($isApache or (false !== stripos($serverSoftware, 'apache'))) {
 }
 
 // If the configured security mode is strict, redirect to HTTPS
-if (isset($config['security_mode']) && $config['security_mode'] == 'strict'){
+if (isset($config['security']['force_https']) && $config['security']['force_https']){
     $isHTTPS = false;
     
     if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {

--- a/src/load.php
+++ b/src/load.php
@@ -369,7 +369,7 @@ if ($isApache or (false !== stripos($serverSoftware, 'apache'))) {
 }
 
 // If the configured security mode is strict, redirect to HTTPS
-if (isset($config['security']['force_https']) && $config['security']['force_https']){
+if (isset($config['security']['force_https']) && $config['security']['force_https'] && 'cli' !== PHP_SAPI){
     $isHTTPS = false;
     
     if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {


### PR DESCRIPTION
This PR creates a new config option 'security_mode'.
Leaving it at 'normal' doesn't change anything in the FOSSBilling instance, Setting to 'strict' will do the following:
1. Redirect to the HTTPS version of the website 
2. Configure the session to be more secure
   1. ~~Increase the session ID to 64 characters so it's more difficult for it to be guessed. Default PHP session ID length is either 32 or 40 (depends on settings)~~
   2. Sets the max cookie length to 2 hours
   3. Enables the cookie 'secure' mode so they will only be sent on a secure connection
   4. Sets the cookies samesite mode to strict.

The default and recommended mode is strict, however for people updating the system will set it to recommended.
I am open to feedback on the settings I have chose and if we want to set the mode to strict when people install the next update

Oh, and proof the setting is working as intended:
![image](https://user-images.githubusercontent.com/17304943/206813745-03336002-992d-4c45-851d-e6607918305d.png)
