### PR TITLE
Cleanly handle a template not being provided

### DIFF
--- a/src/library/Payment/Adapter/Custom.php
+++ b/src/library/Payment/Adapter/Custom.php
@@ -70,7 +70,7 @@ class Payment_Adapter_Custom
         $vars = array(
             '_client_id'    => $invoice['client']['id'],
             'invoice'   =>  $invoice,
-            '_tpl'      =>  $subscription ? (isset($this->config['recurrent']) ? $this->config['recurrent'] : null) : (isset($this->config['single']) ? $this->config['single'] : null),
+            '_tpl'      =>  $subscription ? (isset($this->config['recurrent']) ? $this->config['recurrent'] : '"Custom" payment adapter is not fully configured.') : (isset($this->config['single']) ? $this->config['single'] : '"Custom" payment adapter is not fully configured.'),
         );
         $systemService = $this->di['mod_service']('System');
         return $systemService->renderString($vars['_tpl'], true, $vars);

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -343,7 +343,10 @@ class Service
                 // skip if admin is not logged in
             }
         }
-
+        if(is_null($tpl)){
+            $parsed = $this->createTemplateFromString("No template was provided, please contact the site administrator", $try_render, $vars);
+            return $parsed;
+        }        
         try {
             $template = $twig->load($tpl);
             $parsed = $template->render($vars);


### PR DESCRIPTION
So, it's taken me awhile to figure out where that pesky error that some people were reporting when trying to check out.
In my testing, the "custom" payment adapter calls `renderString` from the system module. By default, this module does not provide any text and it has to be manually set.

The `renderString` function did not do anything if the template passed to it is null, so this PR adds a check for that.
Additionally, I tweaked the custom payment adapter so that it will specifically set a message if it's not configured.
![image](https://user-images.githubusercontent.com/17304943/206826481-27b61d7a-3b3a-4284-9a4c-00070c40e80d.png)
