### PR TITLE
Feature | Disable email when in Demo mode

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -315,7 +315,10 @@ class Service implements \Box\InjectionAwareInterface
     public function resend(\Model_ActivityClientEmail $email)
     {
         $di = $this->getDi();
-
+        $extensionService = $di['mod_service']('extension');
+        if ($extensionService->isExtensionActive('mod', 'demo')) {
+            throw new \Box_Exception('Disabled for security reasons (Demo mode enabled)');
+        }
         $mail = $di['mail'];
         $mail->setBodyHtml($email->content_html);
         $mail->setFrom($email->sender);
@@ -558,6 +561,10 @@ class Service implements \Box\InjectionAwareInterface
 
     private function _sendFromQueue(\Model_ModEmailQueue $queue)
     {
+        $extensionService = $this->di['mod_service']('extension');
+        if ($extensionService->isExtensionActive('mod', 'demo')) {
+            throw new \Box_Exception('Disabled for security reasons (Demo mode enabled)');
+        }
         $queue->status = 'sending';
         $this->di['db']->store($queue);
 

--- a/src/modules/Massmailer/Service.php
+++ b/src/modules/Massmailer/Service.php
@@ -160,6 +160,11 @@ class Service implements \Box\InjectionAwareInterface
             'client_id' => $client_id,
         ];
 
+        $extensionService = $di['mod_service']('extension');
+        if ($extensionService->isExtensionActive('mod', 'demo')) {
+            throw new \Box_Exception('Disabled for security reasons (Demo mode enabled)');
+        }
+
         $mail = $this->di['mail'];
         $mail->setSubject($data['subject']);
         $mail->setBodyHtml($data['content']);


### PR DESCRIPTION
Required if we want to go live with the demo. 

Add to Email/Service.php for resend() and _sendFromQueue
```
        $extensionService = $this->di['mod_service']('extension');
        if ($extensionService->isExtensionActive('mod', 'demo')) {
            throw new \Box_Exception('Disabled for security reasons (Demo mode enabled)');
        }
        $queue->status = 'sending';
 ``` 
So far I can see it is the only things that interact with mail?

Maybe I have missed some locations



