### PR TITLE
Auto Updater: Destroy the current session

### DIFF
--- a/src/library/Box/Update.php
+++ b/src/library/Box/Update.php
@@ -189,6 +189,11 @@ class Box_Update
         $this->di['tools']->emptyFolder(PATH_CACHE);
         $this->di['tools']->emptyFolder(PATH_ROOT.'/install');
         rmdir(PATH_ROOT.'/install');
+
+        // Log off the current user and destroy the session.
+        $this->di['cookie']->delete('BOXADMR');
+        $this->di['session']->delete('admin');
+        session_destroy();
         return true;
     }
 

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -107,7 +107,7 @@
                 <p class="text-muted">{{ 'Automatic updater is a tool to update FOSSBilling to latest version in one click. Works on these hosting environments where PHP has permissions to overwrite files uploaded via FTP.'|trans }}</p>
 
                 {{ admin.system_release_notes|bbmd }}
-                <a href="{{ 'api/admin/extension/update_core'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. Click OK when you are ready to continue." data-api-msg="Update complete">
+                <a href="{{ 'api/admin/extension/update_core'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. You will need to log back into your account. Click OK when you are ready to continue." data-api-msg="Update complete. Please refresh your page to login back in.">
                     <svg class="icon">
                         <use xlink:href="#refresh" />
                     </svg>


### PR DESCRIPTION
As the title says, this helps ensure that all cache is cleared out and that a new session is started. 
I suspect this will help a bit for people who have issues with the CSRF protection directly after updating, but either way destroying the existing session after an update makes sense