### PR TITLE
Set the guest dashboard page title to the company name

### DIFF
--- a/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
+++ b/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
@@ -1,6 +1,14 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
-{% block meta_title %}{{ 'Client Area'|trans }}{% endblock %}
+{% block meta_title %}
+{% if client %}
+    {{ 'Client Area'|trans }}
+{% else %}
+    {% set company = guest.system_company %}
+    {{ company.name |trans }}
+{% endif %}
+{% endblock %}
+
 {% block page_header %}{{ 'Dashboard'|trans }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -1,6 +1,14 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
-{% block meta_title %}{{ 'Client Area'|trans }}{% endblock %}
+{% block meta_title %}
+{% if client %}
+    {{ 'Client Area'|trans }}
+{% else %}
+    {% set company = guest.system_company %}
+    {{ company.name |trans }}
+{% endif %}
+{% endblock %}
+
 {% block page_header %}{{ 'Dashboard'|trans }}{% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
Changed because it doesn't make sense for the page title for guests to be "Client Area"
Logged out:
![image](https://user-images.githubusercontent.com/17304943/207259797-1f90f182-f682-4534-a6ff-1809fad7654a.png)
Logged in:
![image](https://user-images.githubusercontent.com/17304943/207259845-25cfecc1-eb2b-41d6-9718-21769dbc21bc.png)
