### PR TITLE
API: Set HTTP 400/401 when applicable

### DIFF
--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -280,6 +280,13 @@ class Client implements InjectionAwareInterface
             error_log($e->getMessage() . ' ' . $e->getCode());
             $code = $e->getCode() ? $e->getCode() : 9999;
             $result = ['result' => null, 'error' => ['message' => $e->getMessage(), 'code' => $code]];
+            $authFailed = array(201, 202, 206, 204, 205, 203, 403, 1004, 1002);
+
+            if(in_array($code, $authFailed)) {
+                header('HTTP/1.1 401 Unauthorized');
+            } elseif($code == 701 || $code == 879) {
+                header('HTTP/1.1 400 Bad Request');
+            }
         } else {
             $result = ['result' => $data, 'error' => null];
         }


### PR DESCRIPTION
For issue #589

Currently, the excretion code used in the API module doesn't make much sense so the new addition uses some error codes that seem meaningless. Refactoring this should probably be done as part of https://github.com/FOSSBilling/FOSSBilling/issues/195