### PR TITLE
Only force HTTPs when installing on HTTPs

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -152,8 +152,9 @@ $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
     $mode = (isset($di['config']['security']['mode'])) ? $di['config']['security']['mode'] : 'strict';
     $lifespan =(isset($di['config']['security']['cookie_lifespan'])) ? $di['config']['security']['cookie_lifespan'] : 7200;
+    $secure = (isset($di['config']['security']['force_https'])) ? $di['config']['security']['force_https'] : true;
 
-    return new Box_Session($handler, $mode, $lifespan);
+    return new Box_Session($handler, $mode, $lifespan, $secure);
 };
 
 $di['cookie'] = function () use ($di) {

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -28,6 +28,23 @@ function isSSL(): bool
         || 443 === $_SERVER['SERVER_PORT'];
 }
 
+// If not connected via SSL, try and detect a valid SSL certificate on the server and then redirect to HTTPs.
+if(!isSSL()){
+    $context = stream_context_create(array(
+        'ssl' => array(
+            'verify_peer' => true,
+            'verify_peer_name' => true,
+        ),
+    ));
+    $result = file_get_contents($_SERVER['HTTP_HOST'], false, $context);
+    
+    if ($result === false) {
+        $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        header("Location: $url");
+        exit();
+    }
+}
+
 date_default_timezone_set('UTC');
 
 error_reporting(E_ALL);

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -36,10 +36,10 @@ if(!isSSL()){
             'verify_peer_name' => true,
         ),
     ));
-    $result = file_get_contents($_SERVER['HTTP_HOST'], false, $context);
+    $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    $result = file_get_contents($url, false, $context);
     
     if ($result !== false) {
-        $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         header("Location: $url");
         exit();
     }

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -38,7 +38,7 @@ if(!isSSL()){
     ));
     $result = file_get_contents($_SERVER['HTTP_HOST'], false, $context);
     
-    if ($result === false) {
+    if ($result !== false) {
         $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         header("Location: $url");
         exit();

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -439,7 +439,7 @@ final class Box_Installer
         $data = [
             'security' => [
                 'mode' => 'strict',
-                'force_https' => true,
+                'force_https' => isSSL() ? true : false,
                 'cookie_lifespan' => 7200,
             ],
             'debug' => false,

--- a/src/library/Box/Session.php
+++ b/src/library/Box/Session.php
@@ -22,7 +22,7 @@ class Box_Session
     }
 
 
-    public function __construct($handler, $securityMode = 'regular', $cookieLifespan = 7200)
+    public function __construct($handler, $securityMode = 'regular', $cookieLifespan = 7200, $secure = true)
     {
         session_set_save_handler(
             array($handler, 'open'),
@@ -36,13 +36,14 @@ class Box_Session
             $currentCookieParams = session_get_cookie_params();
             $currentCookieParams["httponly"] = true;
             $currentCookieParams["lifetime"] = $cookieLifespan;
+            $currentCookieParams["secure"] = $secure;
 
             if($securityMode == 'strict'){
                 session_set_cookie_params([
                     'lifetime' => $currentCookieParams["lifetime"],
                     'path' => $currentCookieParams["path"],
                     'domain' => $currentCookieParams["domain"],
-                    'secure' => true,
+                    'secure' => $currentCookieParams["secure"],
                     'httponly' => $currentCookieParams["httponly"],
                     'samesite' => 'Strict'
                 ]);


### PR DESCRIPTION
Changes:
 - Only force HTTPs if FOSSBilling is installed on HTTPs
 - Use the `force_https` config value to determine if we should enable the 'secure' option on cookies.