### PR TITLE
Detect an SLL cert after we set display_errors to 0

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -28,6 +28,14 @@ function isSSL(): bool
         || 443 === $_SERVER['SERVER_PORT'];
 }
 
+date_default_timezone_set('UTC');
+
+error_reporting(E_ALL);
+ini_set('display_errors', 0);
+ini_set('display_startup_errors', 1);
+ini_set('log_errors', '1');
+ini_set('error_log', __DIR__ . '/logs/php_error.log');
+
 // If not connected via SSL, try and detect a valid SSL certificate on the server and then redirect to HTTPs.
 if(!isSSL()){
     $context = stream_context_create(array(
@@ -44,14 +52,6 @@ if(!isSSL()){
         exit();
     }
 }
-
-date_default_timezone_set('UTC');
-
-error_reporting(E_ALL);
-ini_set('display_errors', 0);
-ini_set('display_startup_errors', 1);
-ini_set('log_errors', '1');
-ini_set('error_log', __DIR__ . '/logs/php_error.log');
 
 $protocol = isSSL() ? 'https' : 'http';
 $url = $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
That should hide the errors from the installer page and allow the user to continue without issue