### PR TITLE
Fix ApexCharts tooltip colors when change to dark mode

### DIFF
--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -557,6 +557,9 @@
                         show: false,
                     },
                     colors: ["#206bc4"],
+                    tooltip: {
+                        theme: (localStorage.getItem('theme') === 'dark') ? 'dark' : 'light'
+                    }
                 }).render();
             }
         </script>


### PR DESCRIPTION
**Before:**
![before](https://user-images.githubusercontent.com/2430438/208415891-726e19b7-8e7b-4b30-bcd3-fc9ac9bd71f4.png)

**After:**
![after](https://user-images.githubusercontent.com/2430438/208415909-ad387426-77cb-43f9-a063-f8ce290f7ec4.png)

PS.: I'm still unable to change the tooltip color on-demand (when clicking the button to switch the theme, in other words, the change only happens after a page reload)