### PR TITLE
Change how we load locale names

### DIFF
--- a/src/modules/Extension/Api/Guest.php
+++ b/src/modules/Extension/Api/Guest.php
@@ -79,7 +79,7 @@ class Guest extends \Api_Abstract
      *
      * @return array
      */
-    public function languages($deep)
+    public function languages($deep = false)
     {
         $service = $this->di['mod_service']('system');
 

--- a/src/modules/Extension/Api/Guest.php
+++ b/src/modules/Extension/Api/Guest.php
@@ -79,10 +79,10 @@ class Guest extends \Api_Abstract
      *
      * @return array
      */
-    public function languages()
+    public function languages($deep)
     {
         $service = $this->di['mod_service']('system');
 
-        return $service->getLanguages();
+        return $service->getLanguages($deep);
     }
 }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -202,6 +202,9 @@ class Service
             closedir($handle);
         }
         sort($locales);
+        if(!$deep){
+            return $locales;
+        }
         $array = include PATH_ROOT . '/locale/locales.php';
         $details = [];
         foreach($locales as $locale){

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -202,29 +202,22 @@ class Service
             closedir($handle);
         }
         sort($locales);
-        if (!$deep) {
-            return $locales;
-        }
-
+        $array = include PATH_ROOT . '/locale/locales.php';
         $details = [];
-
-        foreach ($locales as $locale) {
-            $file = $path . '/' . $locale . '/LC_MESSAGES/messages.po';
-
-            if (file_exists($file)) {
-                $lNames = $this->getLocales();
-                if (isset($lNames[$locale]) && !empty($lNames[$locale])) {
-                    $title = $lNames[$locale];
-                } else {
-                    $title = null;
-                }
+        foreach($locales as $locale){
+            if (empty($array[$locale])){
+                //fall back on locale string
                 $details[] = [
                     'locale' => $locale,
-                    'title' => $title,
+                    'title' => $locale .' ('.$locale.')',
                 ];
+            }else{
+            $details[] = [
+                'locale' => $locale,
+                'title' => $array[$locale] .' ('.$locale.')',
+            ];
             }
         }
-
         return $details;
     }
 
@@ -346,7 +339,7 @@ class Service
         if(is_null($tpl)){
             $parsed = $this->createTemplateFromString("No template was provided, please contact the site administrator", $try_render, $vars);
             return $parsed;
-        }        
+        }
         try {
             $template = $twig->load($tpl);
             $parsed = $template->render($vars);

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -44,7 +44,7 @@
                   <span class="navbar-toggler-icon"></span>
                   </button>
                   <div class="navbar-nav flex-row order-md-last">
-                    {% set languages = guest.extension_languages %}
+                    {% set languages = guest.extension_languages(true) %}
                     {% if languages|length > 1 %}
                     <div class="nav-item me-3">
                         <select name="lang" class="form-select js-language-selector">

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -49,7 +49,7 @@
                     <div class="nav-item me-3">
                         <select name="lang" class="form-select js-language-selector">
                             {% for lang in languages %}
-                                <option value="{{ lang }}" class="lang_{{ lang }}">{{ lang|trans }}</option>
+                                <option value="{{ lang.locale }}" class="lang_{{ lang.locale }}">{{ lang.title }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -65,7 +65,7 @@
             {% if settings.show_page_header %}
                 <nav>
                 <ul class="f16">
-                    {% set languages = guest.extension_languages %}
+                    {% set languages = guest.extension_languages(true) %}
                     {% if languages|length > 1 %}
                     {% set currentLang = guest.system_locale %}
                     {% set countryCode = currentLang | slice(3, 2) %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -73,14 +73,18 @@
                             <div class="btn-group">
                                 <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                                     <span class="flag  {{ countryCode | lower }}"></span>
-                                    {{ countryCode }}
+                                    {% for lang in languages %}
+                                    {% if lang.locale == currentLang %}
+                                            {{ lang.title }}
+                                       {% endif %}
+                                    {% endfor %}
                                     <span class="caret"></span>
                                 </a>
                                 <ul class="dropdown-menu">
                                     {% for lang in languages %}
-                                    {% set countryCode = lang | slice(3, 2) %}
+                                    {% set countryCode = lang.locale | slice(3, 2) %}
                                     {% if lang != currentLang %}
-                                            <li class="language_selector" data-language-code="{{ lang }}"><a href="javascript:;"> <span class="flag {{ countryCode | lower }}"></span> {{ lang | trans }}</a></li>
+                                            <li class="language_selector" data-language-code="{{ lang.locale }}"><a href="javascript:;"> <span class="flag {{ countryCode | lower }}"></span> {{ lang.title }}</a></li>
                                         {% endif %}
                                     {% endfor %}
                                 </ul>
@@ -226,7 +230,7 @@
                         </section>
                     </div>
                 </article>
-                
+
                 <article class="span6 data-block decent">
                     <div class="data-container">
                         <header>


### PR DESCRIPTION
Current "System" depends on the locale translation in the current local. 

Option 1:  Keep as is ignore this PR 
Option 2: Create a new file in Locale repo and add there the follow key pair
'en_US' => 'English',
'nl_NL' => 'Nederlands'

And apply the changes as suggested. See for the following screenshots
