### PR TITLE
Fix check debug mode enabled

### DIFF
--- a/src/library/Box/Exception.php
+++ b/src/library/Box/Exception.php
@@ -23,7 +23,7 @@ class Box_Exception extends Exception
 	public function __construct($message, array $variables = NULL, $code = 0)
 	{
 		$config = include PATH_ROOT.'/config.php';
-		$debug = (isset($config['debug'])) ? isset($config['debug']) : false;
+		$debug = (isset($config['debug'])) ? $config['debug'] : false;
 		$logStack = (isset($config['log_stacktrace'])) ? isset($config['log_stacktrace']) : true;
 		$stackLength = (isset($config['stacktrace_length'])) ? isset($config['stacktrace_length']) : 25;
 
@@ -47,11 +47,11 @@ class Box_Exception extends Exception
 	private function stackTrace($Length = 25) {
 		$stack = debug_backtrace($Length);
 		$output = '';
-	
+
 		$stackLen = count($stack);
 		for ($i = 1; $i < $stackLen; $i++) {
 			$entry = $stack[$i];
-	
+
 			$func = $entry['function'] . '(';
 			if(isset($entry['args'])){
 				$argsLen = count($entry['args']);
@@ -64,15 +64,15 @@ class Box_Exception extends Exception
 				}
 			}
 			$func .= ')';
-	
+
 			$entry_file = 'NO_FILE';
 			if (array_key_exists('file', $entry)) {
-				$entry_file = str_replace(PATH_ROOT, '' , $entry['file']);               
+				$entry_file = str_replace(PATH_ROOT, '' , $entry['file']);
 			}
 			$entry_line = 'NO_LINE';
 			if (array_key_exists('line', $entry)) {
 				$entry_line = $entry['line'];
-			}           
+			}
 			$output .= $entry_file . ':' . $entry_line . ' - ' . $func . PHP_EOL;
 		}
 		return $output;

--- a/src/library/Box/Exception.php
+++ b/src/library/Box/Exception.php
@@ -24,8 +24,8 @@ class Box_Exception extends Exception
 	{
 		$config = include PATH_ROOT.'/config.php';
 		$debug = (isset($config['debug'])) ? $config['debug'] : false;
-		$logStack = (isset($config['log_stacktrace'])) ? isset($config['log_stacktrace']) : true;
-		$stackLength = (isset($config['stacktrace_length'])) ? isset($config['stacktrace_length']) : 25;
+		$logStack = (isset($config['log_stacktrace'])) ? $config['log_stacktrace'] : true;
+		$stackLength = (isset($config['stacktrace_length'])) ? $config['stacktrace_length'] : 25;
 
 		if($debug && $logStack){
 			error_log('An exception has been thrown. Stacktrace:');


### PR DESCRIPTION
isset($config['debug'])  return true if set to false

We still need a way to "delete" the passwords from logs if failed username/password is entered. How ever this should resolve the "major" bug when debug mode is disabled