### PR TITLE
Two small fixes

### DIFF
--- a/src/htaccess.txt
+++ b/src/htaccess.txt
@@ -33,6 +33,9 @@ RewriteRule .* index.php [F]
 # This line is for Windows Environment when API is giving authorization error
 RewriteRule .? - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+# Setup an alias from bb-ipn to ipn.php for those who have upgraded from BoxBilling.
+RewriteRule ^bb-ipn\.php$ /ipn.php [L]
+
 # Block access to sensitive files and return 404 to make it indistinguishable from a missing file
 RewriteCond %{THE_REQUEST} /.+\.(htaccess|htpasswd|ini|log|sh|inc|bak|twig|sql|_) [NC]
 RewriteRule ^ - [R=404,L]
@@ -43,9 +46,6 @@ RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
 RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
 RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
-
-# Setup an alias from bb-ipn to ipn.php for those who have upgraded from BoxBilling.
-Alias /bb-ipn.php /ipn.php
 
 <IfModule mod_headers.c>
     # MONTH

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -311,7 +311,11 @@ class Client implements InjectionAwareInterface
             return true;
         }
 
-        $data = json_decode(file_get_contents('php://input'));
+        $input = file_get_contents('php://input') ?? '';
+        $data = json_decode($input);
+        if(!is_object($data)){
+            $data = new \stdClass();
+        }
 
         $token = $data->CSRFToken ?? $_POST["CSRFToken"] ?? $_GET["CSRFToken"] ?? null;
         $expectedToken = (!is_null(session_id())) ? hash('md5', session_id()) : null;


### PR DESCRIPTION
This PR fixes the alias with Apache and adds an additional check during the CSRF check for when ``php://input`` is empty or unreadable.

While I am unable to replicate the issues some people have been reporting in our Discord server, I suspect this change should resolve them