### PR TITLE
Move PHPStan to it's own action & bump the scanning level

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -52,9 +52,9 @@ jobs:
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md
-    #- name: Run test suite for composer updates.
-    #  run: composer install --prefer-dist --no-progress --no-suggest
-    #  working-directory: ./src
+    - name: Run test suite for composer updates.
+      run: composer install --prefer-dist --no-progress --no-suggest
+      working-directory: ./src
 
     - name: Configure environment for Tests
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer & PHPStan
+name: PHP Composer
 
 on:
   push:
@@ -19,6 +19,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: Install PHP
       uses: shivammathur/setup-php@v2
       with:
@@ -43,15 +44,18 @@ jobs:
         key: ${{ runner.os }}-php-${{ hashFiles('composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-php-
+
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
       run: composer install --prefer-dist --no-progress --no-suggest
       working-directory: ./src
+
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md
-    - name: Run test suite for composer updates.
-      run: composer install --prefer-dist --no-progress --no-suggest
-      working-directory: ./src
+    #- name: Run test suite for composer updates.
+    #  run: composer install --prefer-dist --no-progress --no-suggest
+    #  working-directory: ./src
+
     - name: Configure environment for Tests
       run: |
         cp ./src/config-sample.php ./src/config.php
@@ -69,9 +73,3 @@ jobs:
     - name: Run test suite for library
       run: |
         php ./src/vendor/bin/phpunit ./tests/library/
-
-    - name: Run PHPStan analysis
-      uses: php-actions/phpstan@v3
-      with:
-        configuration: phpstan.neon
-        memory_limit: 512M

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -45,6 +45,12 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
       working-directory: ./src
 
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+    - name: Run test suite for composer updates.
+      run: composer install --prefer-dist --no-progress --no-suggest
+      working-directory: ./src
+
     - Name: Run PHPStan
       uses: php-actions/phpstan@v3
       with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -51,6 +51,16 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
       working-directory: ./src
 
+    - name: Configure environment for Tests
+      run: |
+        cp ./src/config-sample.php ./src/config.php
+        mkdir -p ./src/data/cache
+        mkdir -p ./src/data/log
+        echo > ./src/data/log/license.log
+        echo > ./src/data/log/application.log
+        echo > ./src/data/log/php_error.log
+        rm -rf ./src/install
+
     - name: Run PHPStan
       uses: php-actions/phpstan@v3
       with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-        with: 
-        php-version: latest
 
     - name: Install PHP
       uses: shivammathur/setup-php@v2
+        with: 
+        php-version: latest
 
     - name: Check PHP Version
       run: php -v

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -51,7 +51,7 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
       working-directory: ./src
 
-    - Name: Run PHPStan
+    - name: Run PHPStan
       uses: php-actions/phpstan@v3
       with:
         configuration: phpstan.neon

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,52 @@
+name: PHPStan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+
+    name: PHPStan
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+        with: 
+        php-version: latest
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+
+    - name: Check PHP Version
+      run: php -v
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+      working-directory: ./src
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: ./src/vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-progress --no-suggest
+      working-directory: ./src
+
+    - Name: Run PHPStan
+      uses: php-actions/phpstan@v3
+      with:
+        configuration: phpstan.neon
+        memory_limit: 512M

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install PHP
       uses: shivammathur/setup-php@v2
-        with: 
+      with:
         php-version: latest
 
     - name: Check PHP Version

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 0
+	level: 1
 	paths:
 		- src
 	excludePaths:
@@ -11,7 +11,13 @@ parameters:
 		- src/rb.php
 		- src/library/Registrar/Adapter/srsx.php
 		- src/library/Box/Request.php
+		- src/library/Box/Response.php
+		- src/library/Model/Admin.php
+		- src/library/Model/Client.php
+		- src/library/Model/ServiceLicense.php
+		- src/library/Model/Product.php
 		- src/library/Server/Manager/Custom.php
+		- src/library/Server/Manager/Whm.php
 	ignoreErrors:
 		- '#^Function __trans not found\.$#'
 		- message: '#^Access to an undefined property FOSSPatchAbstract\:\:\$di\.$#'
@@ -22,3 +28,5 @@ parameters:
 		- message: '#^Result of function header \(void\) is used\.$#'
 		  path: src/modules/Custompages/Controller/Client.php
 		- '#^Method Box\\Mod\\Currency\\Service\:\:_getRate\(\) should return float but return statement is missing\.$#'
+		- message: '#^Variable \$ext_id on left side of \?\?\= is never defined\.$#'
+		  path: src/modules/Extension/Service.php

--- a/src/library/Box/Ftp.php
+++ b/src/library/Box/Ftp.php
@@ -524,10 +524,6 @@ class Box_Ftp
 		if ( ! $dirlist ) {
 			return false;
         }
-		if ( empty($dirlist) ) {
-			return array();
-        }
-
 		$ret = array();
 		foreach ( $dirlist as $struc ) {
 

--- a/src/library/Box/Mail.php
+++ b/src/library/Box/Mail.php
@@ -29,7 +29,7 @@ class Box_Mail
     public function send($transport = 'sendmail', $options = array())
     {
         if($transport == 'sendmail') {
-            $this->_sendMail($options);
+            $this->_sendMail();
         } else if($transport == 'smtp') {
             $this->_sendSmtpMail($options);
         } else if($transport == 'sendgrid') {

--- a/src/library/Box/Translate.php
+++ b/src/library/Box/Translate.php
@@ -74,7 +74,7 @@ class Box_Translate implements \Box\InjectionAwareInterface
             define('LC_TIME', 2);
         }
         _setlocale(LC_MESSAGES, $locale.'.'.$codeset);
-        _textdomain(LC_TIME, $locale.'.'.$codeset);
+        _setlocale(LC_TIME, $locale.'.'.$codeset);
         _bindtextdomain($this->domain, PATH_LANGS);
         _bind_textdomain_codeset($this->domain, $codeset);
         _textdomain($this->domain);

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -258,6 +258,7 @@ function twig_timeago_filter($iso8601)
     $dif = $cur_tm - strtotime($iso8601);
     $pds = [__trans('second'), __trans('minute'), __trans('hour'), __trans('day'), __trans('week'), __trans('month'), __trans('year'), __trans('decade')];
     $lngh = [1, 60, 3600, 86400, 604800, 2630880, 31570560, 315705600];
+    $no = 0;
     
     for ($v = sizeof($lngh) - 1; ($v >= 0) && (($no = $dif / $lngh[$v]) <= 1); --$v) {
     }

--- a/src/library/Payment/Adapter/AliPay.php
+++ b/src/library/Payment/Adapter/AliPay.php
@@ -109,6 +109,10 @@ class Payment_Adapter_AliPay extends Payment_AdapterAbstract
                 break;
         }
 
+        if(!isset($service)){
+            throw new Payment_Exception("Error getting service for contract");
+        }
+
         $parameter = array(
             'service'           => $service,
             'partner'           => $this->getParam('partner'),

--- a/src/library/Registrar/Adapter/Custom.php
+++ b/src/library/Registrar/Adapter/Custom.php
@@ -550,7 +550,7 @@ class Whois {
             }
         }
 
-        if(!$found) {
+        if(!$found || !isset($server)) {
             throw new Exception(sprintf('Whois server for TLD %s not found', $tldname));
         }
         return $server;
@@ -618,7 +618,6 @@ class Whois {
      */
     private function get_notfound_string()
     {
-        $found=false;
         $tldname=$this->get_tld();
         $servers = self::getServers();
         $counted = count($servers);
@@ -626,6 +625,9 @@ class Whois {
             if($servers[$i][0]==$tldname) {
                 $notfound=$servers[$i][2];
             }
+        }
+        if(!isset($notfound)){
+            throw new \Box_Exception("Error getting TLD!");
         }
         return $notfound;
     }

--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -606,7 +606,7 @@ class Whois2 {
             }
         }
 
-        if(!$found) {
+        if(!$found || !isset($server)) {
             throw new Exception(sprintf('Whois server for TLD %s not found', $tldname));
         }
         return $server;
@@ -674,7 +674,6 @@ class Whois2 {
      */
     private function get_notfound_string()
     {
-        $found=false;
         $tldname=$this->get_tld();
         $servers = self::getServers();
         $counted = count($servers);
@@ -682,6 +681,9 @@ class Whois2 {
             if($servers[$i][0]==$tldname) {
                 $notfound=$servers[$i][2];
             }
+        }
+        if(!isset($notfound)){
+            throw new \Box_Exception("Error getting TLD!");
         }
         return $notfound;
     }

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -410,6 +410,7 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
     {
         $type = 'contacts_registrant_';
         $tel = explode('.', $result[$type . 'phonenumber']);
+        $name = '';
 
         // domain specific
         if (array_key_exists($type . 'firstname', $result))

--- a/src/library/Server/Manager/Ispconfig3.php
+++ b/src/library/Server/Manager/Ispconfig3.php
@@ -735,6 +735,10 @@ class Server_Manager_Ispconfig3 extends Server_Manager
             throw new Server_Exception($e->getMessage(), $e->getCode(), $e);
         }
 
-        return $soap_result;
+        if(isset($soap_result)){
+            return $soap_result;
+        } else {
+            throw new Server_Exception("Error when making request to the server");
+        }
     }
 }

--- a/src/modules/Servicedomain/Api/Guest.php
+++ b/src/modules/Servicedomain/Api/Guest.php
@@ -45,9 +45,7 @@ class Guest extends \Api_Abstract
             $where[] = 'allow_transfer = 1';
         }
 
-        if (!empty($where)) {
-            $query = implode(' AND ', $where);
-        }
+        $query = implode(' AND ', $where);
 
         $tlds = $this->di['db']->find('Tld', $query, []);
         $result = [];

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -626,6 +626,7 @@ class Service implements \Box\InjectionAwareInterface
     private function _getTuple($data)
     {
         $action = $data['action'];
+        [$sld, $tld] = [null, null];
 
         if ('owndomain' == $action) {
             $sld = $data['owndomain_sld'];
@@ -652,11 +653,16 @@ class Service implements \Box\InjectionAwareInterface
 
         $tldRegistrar = $this->di['db']->load('TldRegistrar', $model->tld_registrar_id);
 
+        /*
+            TODO: registrarGetRegistrarAdapter Only accepts one parameter
         if ($order instanceof \Model_ClientOrder) {
             $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar, $order);
         } else {
             $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
         }
+        */
+
+        $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
 
         $d = new \Registrar_Domain();
 

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -520,6 +520,8 @@ class Service implements InjectionAwareInterface
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $data['domain']);
 
+        [$sld, $tld] = [null, null];
+
         if ('owndomain' == $data['domain']['action']) {
             $sld = $data['domain']['owndomain_sld'];
             $tld = $data['domain']['owndomain_tld'];

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -87,7 +87,7 @@ class Guest extends \Api_Abstract
         // check ip
         if (isset($config['allowed_ips']) && isset($config['check_ip']) && $config['check_ip']) {
             $allowed_ips = explode(PHP_EOL, $config['allowed_ips']);
-            if (!empty($allowed_ips)) {
+            if ($allowed_ips) {
                 $allowed_ips = array_map('trim', $allowed_ips);
                 if (!in_array($this->getIp(), $allowed_ips)) {
                     throw new \Box_Exception('You are not allowed to login to admin area from :ip address', [':ip' => $this->getIp()], 403);

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -306,6 +306,7 @@ class Service implements InjectionAwareInterface
     public function getThemeConfig($client = true, $mod = null)
     {
         if ($client) {
+            $default = 'huraga';
             $theme = $this->getCurrentClientAreaThemeCode();
         } else {
             $default = 'admin_default';

--- a/tests/library/Box/Box_MailTest.php
+++ b/tests/library/Box/Box_MailTest.php
@@ -14,8 +14,7 @@ class Box_MailTest extends PHPUnit\Framework\TestCase
             ->getMock();
 
         $mailMock->expects($this->once())
-            ->method('_sendMail')
-            ->with(array());
+            ->method('_sendMail');
 
         $mailMock->send($transport);
     }


### PR DESCRIPTION
This PR moves PHPStan to it's own action, with the latest version of PHP.
It also increases the scanning level from 0 to 1 which adds scanning for the following:
```possibly undefined variables, unknown magic methods and properties on classes with __call and __get```

Also fixes a handful of the potential issues it caught with the new level