### PR TITLE
Move Payment Gateways into folders

### DIFF
--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -92,7 +92,7 @@ class ServicePayGateway implements InjectionAwareInterface
                 $adapters[] = $adapter;
             }
         }
-        $pattern = PATH_LIBRARY . '/Payment/Adapter/*/Adapter.php';
+        $pattern = PATH_LIBRARY . '/Payment/Adapter/*/*.php';
         foreach (glob($pattern) as $path) {
             $directory = explode('/',pathinfo($path, PATHINFO_DIRNAME));
             $adapter = end($directory);
@@ -273,7 +273,7 @@ class ServicePayGateway implements InjectionAwareInterface
     {
         $class = $this->getAdapterClassName($pg);
         if (!file_exists(PATH_LIBRARY . '/Payment/Adapter/' . $pg->gateway . '.php')) {
-            if(!file_exists(PATH_LIBRARY . '/Payment/Adapter/' . $pg->gateway . '/Adapter.php')){
+            if(!file_exists(PATH_LIBRARY . '/Payment/Adapter/' . $pg->gateway . '/'.$pg->gateway.'.php')){
                 throw new \Box_Exception('Payment gateway :adapter was not found', [':adapter' => $pg->gateway]);
             }
         }
@@ -295,7 +295,8 @@ class ServicePayGateway implements InjectionAwareInterface
     {
         $class = sprintf('Payment_Adapter_%s', $pg->gateway);
         if(!class_exists($class)){
-            return sprintf('Payment_Adapter_%s_Adapter', $pg->gateway);
+            include PATH_LIBRARY . '/Payment/Adapter/' . $pg->gateway . '/'.$pg->gateway.'.php';
+            return sprintf('Payment_Adapter_%s', $pg->gateway);
         }else{
             return $class;
         }

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -97,7 +97,9 @@ class ServicePayGateway implements InjectionAwareInterface
             $directory = explode('/',pathinfo($path, PATHINFO_DIRNAME));
             $adapter = end($directory);
             if (!array_key_exists($adapter, $exists)) {
+                if($path == PATH_LIBRARY . '/Payment/Adapter/'.$adapter.'/'.$adapter.'.php'){
                 $adapters[] = $adapter;
+                }
             }
         }
 


### PR DESCRIPTION
Add support for payment gateways in folders

Current structure is "PaymentProvider.php" in /src/library/Payment/Adapter

With this PR we add support for creating a folder for "PaymentProvider" and in the folder contents "Adapter.php" 

Advantages
- Allow support for composer that does't need to be loaded into the core
- Flexibility in the future for allowing to add logo's of the payment provider
- Easier install as we can treat it more closer as a Module. Just download zip and extract it into /src/library/Payment/Adapter/ 
- Setup Dependabot for each Payment provider in repo. 

As we still have backward compability with the old system I don't see any issues for implentening it.

They only thing we should consider is renaming the the classnames

As we currently autoload php classes it need to be the same name as 
Payment_Adapter_Mollie_Adapter

How ever it would be nicer if it can be Payment_Adapter_Mollie but then it doesn't get auto loaded.  

So far I have testing it with activating / edit settings but currently in the process for writing a "Dutch/EU" based payment provider so I don't know if this works in all the cases so far. How ever I think it is important to start the discussion faster if this something we want. If not we can always revert it and change it now and not continue when we are done. 