### PR TITLE
Stop sending password in plain text.

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -428,7 +428,7 @@ final class Box_Installer
         $content .= 'Access client area at: ' . BB_URL . PHP_EOL;
         $content .= 'Access admin area at: ' . BB_URL_ADMIN . ' with login details:' . PHP_EOL;
         $content .= 'E-mail: ' . $admin_email . PHP_EOL;
-        $content .= 'Password: The password you choose during installation' . PHP_EOL . PHP_EOL;
+        $content .= 'Password: The password you chose during installation' . PHP_EOL . PHP_EOL;
 
         $content .= "Read FOSSBilling documentation to get started https://docs.fossbilling.org/" . PHP_EOL;
         $content .= "Thank You for using FOSSBilling." . PHP_EOL;

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -100,7 +100,7 @@ class Service implements InjectionAwareInterface
             $email = [];
             $email['to_client'] = $params['id'];
             $email['code'] = 'mod_client_signup';
-            $email['password'] = $params['password'];
+            $email['password'] = 'The password you choose when creating your account.';
             $email['require_email_confirmation'] = false;
             if (isset($config['require_email_confirmation']) && $config['require_email_confirmation']) {
                 $clientService = $di['mod_service']('client');

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -100,7 +100,7 @@ class Service implements InjectionAwareInterface
             $email = [];
             $email['to_client'] = $params['id'];
             $email['code'] = 'mod_client_signup';
-            $email['password'] = 'The password you chose when creating your account.';
+            $email['password'] = __trans('The password you chose when creating your account.');
             $email['require_email_confirmation'] = false;
             if (isset($config['require_email_confirmation']) && $config['require_email_confirmation']) {
                 $clientService = $di['mod_service']('client');

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -100,7 +100,7 @@ class Service implements InjectionAwareInterface
             $email = [];
             $email['to_client'] = $params['id'];
             $email['code'] = 'mod_client_signup';
-            $email['password'] = 'The password you choose when creating your account.';
+            $email['password'] = 'The password you chose when creating your account.';
             $email['require_email_confirmation'] = false;
             if (isset($config['require_email_confirmation']) && $config['require_email_confirmation']) {
                 $clientService = $di['mod_service']('client');


### PR DESCRIPTION
Fix sending the user's password in plain text via email upon signing up. 
#192 #81 