### PR TITLE
API Wrapper: reformat malformed JSON data

### DIFF
--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -50,7 +50,7 @@ const Tools = {
      * @param {boolean} [returnObj=false] Determines if the function returns a reformatted object or the stringified json
      * @returns {object|string} The reformatted object or stringified version of the object.
      */
-    reformatJson: function (jsonString, returnObj = false) {
+    reformatJSON: function (jsonString, returnObj = false) {
         let obj = jsonString;
         let reformattedObj = {};
         Object.keys(obj).forEach(function (key) {
@@ -203,9 +203,9 @@ const API = {
             if (Tools.isJSON(postParams)) {
                 postParams = JSON.parse(postParams);
             }
-            // Now we run the object through the reformatJson function, setting the body to the returned JSON string
+            // Now we run the object through the reformatJSON function, setting the body to the returned JSON string
             if (typeof postParams === "object") {
-                postParams = Tools.reformatJson(postParams);
+                postParams = Tools.reformatJSON(postParams);
                 body = postParams;
             } else {
                 body = params;

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -31,9 +31,9 @@ const Tools = {
     },
 
     /**
-     * Used to check if a string is valid JSON or not
-     * @param {string} jsonString The string whch to check if it's valid JSON or not
-     * @returns {bool}
+     * Check if a string is valid JSON or not.
+     * @param {string} jsonString The string to check if it's valid JSON or not
+     * @returns {boolean} Returns true if the string is valid JSON, or false if it is not
      */
     isJSON: function (jsonString) {
         try {
@@ -45,10 +45,10 @@ const Tools = {
     },
 
     /**
-     * Reformats JSON data to be correct for the FOSSBilling back-end. For more in-depth information, please see 
-     * @param {object} jsonString the object to reformat to proper JSON data for the FOSSBilling back-end
-     * @param {bool} returnObj Determines if the function returns a reformatted object or the stringified json
-     * @returns {mixed} Either the object or string for the reformatted JSON data.0
+     * Reformats malformed JSON data to conform to proper JSON format. 
+     * @param {object|string} jsonString The object to reformat to proper JSON data, correcting malformed data
+     * @param {boolean} [returnObj=false] Determines if the function returns a reformatted object or the stringified json
+     * @returns {object|string} The reformatted object or stringified version of the object.
      */
     reformatJson: function (jsonString, returnObj = false) {
         let obj = jsonString;
@@ -193,7 +193,9 @@ const API = {
             if (Tools.isJSON(params)) {
                 getParams = JSON.parse(params);
             }
-            Object.keys(getParams).forEach(key => url.searchParams.append(key, getParams[key]));
+            if (typeof getParams === "object") {
+                Object.keys(getParams).forEach(key => url.searchParams.append(key, getParams[key]));
+            }
             body = null
         } else if (method.toLowerCase() === "post") {
             var postParams = params;
@@ -201,7 +203,7 @@ const API = {
             if (Tools.isJSON(postParams)) {
                 postParams = JSON.parse(postParams);
             }
-            // Now we run the object through the reformatJson function, setting the body to the returned json string
+            // Now we run the object through the reformatJson function, setting the body to the returned JSON string
             if (typeof postParams === "object") {
                 postParams = Tools.reformatJson(postParams);
                 body = postParams;

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -231,7 +231,7 @@ const API = {
                         errorHandler(response.error);
                     } else {
                         console.error(`${response.error.message} (Code: ${response.error.code})`);
-                        console.warn("No error handler was specified. The error was logged to the console. Documentation: https://fossbilling.org/docs/api/javascript   ");
+                        console.warn("No error handler was specified. The error was logged to the console. Documentation: https://fossbilling.org/docs/api/javascript");
                     }
                     return;
                 }

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -18,7 +18,7 @@
     {% include 'partial_bb_meta.html.twig' %}
 
     <link rel="stylesheet" href="build/css/fossbilling-bundle.min.css?v={{ guest.system_version }}">
-    <script src="{{ ('Api/API.js') | library_url }}"></script>
+    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
     <script src="build/js/fossbilling-bundle.min.js?v={{ guest.system_version }}"></script>
 
     {% block head %}{% endblock %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -31,7 +31,7 @@
 
     <link rel="shortcut icon" href="{{ 'favicon.ico' | asset_url }}">
 
-    <script src="{{ ('Api/API.js') | library_url }}"></script>
+    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
     <script src="{{ 'js/libs/jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/bb-jquery.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'js/libs/modernizr.js' | asset_url }}" defer="defer"></script>

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -29,7 +29,7 @@
 
     <link rel="shortcut icon" href="{{ 'favicon.ico' | asset_url }}">
 
-    <script src="{{ ('Api/API.js') | library_url }}"></script>
+    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
     <script src="{{ 'js/libs/jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/bb-jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/libs/modernizr.js' | asset_url }}"></script>


### PR DESCRIPTION
Closes issue #654

Verified this change allows the product configuration to be updated & all settings appear to apply correctly

Reformatted JSON looks like this:
```
{
  "CSRFToken": "a1285a5d9d9d5071ef44e371832a3863",
  "product_category_id": "2",
  "status": "disabled",
  "hidden": "0",
  "setup": "after_payment",
  "icon_url": "",
  "title": "Professional Hosting",
  "slug": "professional-hosting",
  "pricing": {
    "type": "recurrent",
    "once": {
      "setup": "0.00",
      "price": "0.00"
    },
    "recurrent": {
      "1W": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      },
      "1M": {
        "setup": "0.00",
        "price": "10.00",
        "enabled": "1"
      },
      "3M": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      },
      "6M": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      },
      "1Y": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      },
      "2Y": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      },
      "3Y": {
        "setup": "0.00",
        "price": "0.00",
        "enabled": "1"
      }
    }
  },
  "description": "",
  "id": "4"
}
```