### PR TITLE
Implemented basic support for custom PDF CSS

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1241,6 +1241,19 @@ class Service implements InjectionAwareInterface
         $systemService = $this->di['mod_service']('System');
         $company = $systemService->getCompany();
 
+        $CustomCSSPath  = __DIR__ . DIRECTORY_SEPARATOR . 'pdf_template' . DIRECTORY_SEPARATOR . 'custom-pdf.css';
+        $DefaultCSSPath = __DIR__ . DIRECTORY_SEPARATOR . 'pdf_template' . DIRECTORY_SEPARATOR . 'default-pdf.css';
+        
+        if(file_exists($CustomCSSPath)){
+          $CSS = file_get_contents($CustomCSSPath);
+        } else {
+          $CSS = file_get_contents($DefaultCSSPath);
+        }
+
+        if (empty($CSS)) {
+          $CSS = file_get_contents($DefaultCSSPath);
+        }        
+
         $pdf = new Dompdf();
         $options = $pdf->getOptions();
         $options->setChroot($_SERVER['DOCUMENT_ROOT']);
@@ -1253,70 +1266,11 @@ class Service implements InjectionAwareInterface
                   <head>
                   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>';
         $html .= '<title>' . $invoice['serie_nr'] . '</title>';
-        $html .= '<style>
-                     hr.Rounded {
-                        border-top: 8px solid #bbb;
-                        border-radius: 5px;
-                        position: relative;
-                        top: 35px;  
-                    }
-                    div.InvoiceInfo {
-                        position: absolute;
-                        right: 30px;
-                        top: 0px;
-                        line-height: 0.2;
-                    }
-                    img.CompanyLogo {
-                        position: relative;
-                        left: 40px;
-                        top: 7px;
-                    }
-                    h3.CompanyInfo{
-                        position: absolute;
-                        left: 25px;
-                        top: 110px;
-                    }
-                    div.CompanyInfo{
-                        position: absolute;
-                        left: 25px;
-                        top: 145px;
-                        white-space: normal;
-                        line-height: 15px;
-                        max-width: 300px;
-                    }
-                    h3.ClientInfo{
-                        position: absolute;
-                        top: 110px;
-                        left: 375px;
-                    }
-                    div.ClientInfo{
-                        position: absolute;
-                        top: 145px;
-                        left: 375px;
-                        white-space: normal;
-                        line-height: 15px;
-                        max-width: 45%;
-                    }
-                    div.Breakdown{
-                        position: absolute;
-                        width: 100%;
-                    }
-                    table {
-                        border-collapse: collapse;
-                    }
-                    p {
-                        font-size: 18px;
-                    }
-                    tr:nth-of-type(odd) {
-                        background-color:#ccc;
-                    }
-                    .right{
-                        text-align:right;
-                    }
-                    body { font-family: DejaVu Sans; }
-                    </style>
+        $html .= "<style>
+                  $CSS
+                  </style>
                 </head>
-                <body>';
+                <body>";
 
         if (isset($company['logo_url']) && !empty($company['logo_url'])) {
             $url = parse_url($company['logo_url'], PHP_URL_PATH);

--- a/src/modules/Invoice/pdf_template/default-pdf.css
+++ b/src/modules/Invoice/pdf_template/default-pdf.css
@@ -1,0 +1,85 @@
+/**
+ * This file contains the default CSS used for the PDF generator.
+ * You can copy and rename this file to 'custom-pdf.css' and customize the CSS as you wish. 
+ * The file will be loaded and inserted into the <style> tags for the PDF generation.
+ * The backend used for PDF generation is Dompdf, which has fairly limited CSS support, roughly CSS 2.1
+ */
+
+ hr.Rounded {
+    border-top: 8px solid #bbb;
+    border-radius: 5px;
+    position: relative;
+    top: 35px;
+}
+
+div.InvoiceInfo {
+    position: absolute;
+    right: 30px;
+    top: 0px;
+    line-height: 0.2;
+}
+
+img.CompanyLogo {
+    position: relative;
+    left: 40px;
+    top: 7px;
+}
+
+h3.CompanyInfo{
+    position: absolute;
+    left: 25px;
+    top: 110px;
+}
+
+div.CompanyInfo{
+    position: absolute;
+    left: 25px;
+    top: 145px;
+    white-space: normal;
+    line-height: 15px;
+    max-width: 300px;
+}
+
+h3.ClientInfo{
+    position: absolute;
+    top: 110px;
+    left: 375px;
+}
+
+div.ClientInfo{
+    position: absolute;
+    top: 145px;
+    left: 375px;
+    white-space: normal;
+    line-height: 15px;
+    max-width: 45%;
+}
+
+div.Breakdown{
+    position: absolute;
+    width: 100%;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+p {
+    font-size: 18px;
+}
+
+tr:nth-of-type(odd) {
+    background-color:#ccc;
+}
+
+.right{
+    text-align:right;
+}
+
+/**
+ * The font family used heavily influences the character support for the PDF generator.
+ * DejaVu Sans offers very good support and is the recommended font to use.
+ */
+body {
+    font-family: DejaVu Sans;
+}


### PR DESCRIPTION
This PR moves the CSS for PDF generation to it's own separate file under modules/invoice/pdf_template

Default one is named `default-pdf.css` and custom CSS can be created under `custom-pdf.css` which will then be loaded instead of the default file

It's a simple implementation, but this way people can create custom CSS for their PDF invoices and not have it be overridden with each update