### PR TITLE
Fix email history templates

### DIFF
--- a/src/modules/Email/html_admin/mod_email_details.html.twig
+++ b/src/modules/Email/html_admin/mod_email_details.html.twig
@@ -1,60 +1,72 @@
-{% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
+{% extends request.ajax ? 'layout_blank.html.twig' : 'layout_default.html.twig' %}
 
 {% set active_menu = 'activity' %}
 
 {% block meta_title %}{{ email.subject }}{% endblock %}
 
 {% block breadcrumbs %}
-<ul>
-    <li class="firstB"><a href="{{ '/'|alink }}">{{ 'Home'|trans }}</a></li>
-    <li><a href="{{ 'email/history'|alink }}">{{ 'Email history'|trans }}</a></li>
-    <li class="lastB">{{ email.subject }}</li>
-</ul>
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+            <a href="{{ '/'|alink }}">
+                <svg class="icon">
+                    <use xlink:href="#home" />
+                </svg>
+            </a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{{ 'email/history'|alink }}">{{ 'Email history'|trans }}</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">{{ email.subject }}</li>
+    </ol>
 {% endblock %}
 
 {% block content %}
-<div class="widget">
-    <div class="head">
-        <h5>{{email.subject}}</h5>
+<div class="card">
+    <div class="card-body">
+        <h5>{{ email.subject }}</h5>
     </div>
-    
-    <table class="tableStatic wide">
+
+    <table class="table card-table table-vcenter table-striped text-nowrap">
         <tbody>
-            <tr class="noborder">
-                <td>{{ 'From'|trans }}</td>
+            <tr>
+                <td class="w-50 text-end">{{ 'From'|trans }}:</td>
                 <td>{{ email.sender }}</td>
             </tr>
 
             <tr>
-                <td>{{ 'To'|trans }}</td>
+                <td class="text-end">{{ 'To'|trans }}:</td>
                 <td>{{ email.recipients }}</td>
             </tr>
 
             <tr>
-                <td>{{ 'Sent'|trans }}</td>
+                <td class="text-end">{{ 'Sent'|trans }}:</td>
                 <td>{{ email.created_at|date('l, d F Y') }}</td>
             </tr>
          </tbody>
-         <tfoot>
-             <tr>
-                 <td colspan="2">
-                    <div class="aligncenter">
-                        <a class="btn55 mr10 api-link" href="{{'api/admin/email/email_resend'|link({ 'id': email.id }) }}" data-api-msg="Email resent"><img src="images/icons/middlenav/refresh2.png" alt="">
-                            <span>{{ 'Resend'|trans }}</span>
-                        </a>
-                        <a class="btn55 mr10 api-link" href="{{'api/admin/email/email_delete'|link({ 'id': email.id }) }}" data-api-confirm="Are you sure?" data-api-redirect="{{'email/history'|alink}}"><img src="images/icons/middlenav/trash.png" alt="">
-                            <span>{{ 'Delete'|trans }}</span>
-                        </a>
-                    </div>
-                 </td>
-             </tr>
-         </tfoot>
     </table>
-    
-    <div class="body">
-        {{email.content_html|raw}}
-    </div>
-    
-</div>
 
+    <div class="card-footer text-center">
+        <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
+            href="{{'api/admin/email/email_resend'|link({ 'id': email.id }) }}"
+            data-api-msg="{{ 'Email resent'|trans }}">
+            <svg class="mb-2 text-secondary" width="24" height="24">
+                <use xlink:href="#refresh" />
+            </svg>
+            <span class="d-block text-secondary">{{ 'Resend'|trans }}</span>
+        </a>
+        <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
+            href="{{'api/admin/email/email_delete'|link({ 'id': email.id }) }}"
+            data-api-confirm="{{ 'Are you sure?'|trans }}"
+            data-api-redirect="{{ 'email/history'|alink }}">
+            <svg class="mb-2 text-secondary" width="24" height="24">
+                <use xlink:href="#delete" />
+            </svg>
+            <span class="d-block text-secondary">{{ 'Delete'|trans }}</span>
+        </a>
+    </div>
+
+    <div class="card-body">
+        {{ email.content_html|raw }}
+    </div>
+</div>
 {% endblock %}

--- a/src/modules/Email/html_admin/mod_email_history.html.twig
+++ b/src/modules/Email/html_admin/mod_email_history.html.twig
@@ -1,72 +1,80 @@
 {% extends request.ajax ? 'layout_blank.html.twig' : 'layout_default.html.twig' %}
 
+{% import 'macro_functions.html.twig' as mf %}
+
+{% block meta_title %}{{ 'Email history'|trans }}{% endblock %}
+
 {% set active_menu = 'activity' %}
 
-{% block meta_title %}{{ email.subject }}{% endblock %}
-
-{% block breadcrumbs %}
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item">
-            <a href="{{ '/'|alink }}">
-                <svg class="icon">
-                    <use xlink:href="#home" />
-                </svg>
-            </a>
-        </li>
-        <li class="breadcrumb-item">
-            <a href="{{ 'email/history'|alink }}">{{ 'Email history'|trans }}</a>
-        </li>
-        <li class="breadcrumb-item active" aria-current="page">{{ email.subject }}</li>
-    </ol>
-{% endblock %}
-
 {% block content %}
+    {% set config = admin.extension_config_get({ 'ext': 'mod_email' }) %}
+    {% if config.log_enabled is not defined or config.log_enabled != 1 %}
+        <div class="alert alert-primary alert-dismissible fade show mb-3" role="alert">
+            <strong>{{ 'Information'|trans }}:</strong> {{ 'Email logging is not enabled. If you want to log sent mails to database, enable it in'|trans }}
+                <a href="{{ 'extension/settings/email'|alink }}"> {{ 'email settings.'|trans }}</a>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    {% endif %}
+
 <div class="card">
     <div class="card-body">
-        <h5>{{ email.subject }}</h5>
+        <h3>{{ 'Email history'|trans }}</h3>
     </div>
 
+    {% include 'partial_search.html.twig' %}
     <table class="table card-table table-vcenter table-striped text-nowrap">
+        <thead>
+            <tr>
+                <th class="w-1">
+                    <input class="form-check-input m-0 align-middle batch-delete-master-checkbox" type="checkbox">
+                </th>
+                <th>{{ 'To'|trans }}</th>
+                <th>{{ 'From'|trans }}</th>
+                <th>{{ 'Subject'|trans }}</th>
+                <th>{{ 'Date'|trans }}</th>
+                <th class="w-1"></th>
+            </tr>
+        </thead>
         <tbody>
+        {% set emails = admin.email_email_get_list({ 'per_page': 30, 'page': request.page }|merge(request)) %}
+        {% for i, email in emails.list %}
+        <tr>
+            <td>
+                <input class="form-check-input m-0 align-middle batch-delete-checkbox" type="checkbox" data-item-id="{{ email.id }}">
+            </td>
+            <td>{{ email.recipients }}</td>
+            <td>{{ email.sender }}</td>
+            <td>
+                <a href="{{ '/email'|alink }}/{{ email.id }}">{{ email.subject|truncate(40) }}</a>
+            </td>
+            <td>{{ email.created_at|date('Y-m-d') }}</td>
+            <td>
+                <a class="btn btn-icon" href="{{ '/email'|alink }}/{{ email.id }}">
+                    <svg class="icon">
+                        <use xlink:href="#edit" />
+                    </svg>
+                </a>
+                <a class="btn btn-icon api-link"
+                    href="{{ 'api/admin/email/email_delete'|link({ 'id': email.id }) }}"
+                    data-api-redirect="{{ 'email/history'|alink }}"
+                    data-api-confirm="{{ 'Are you sure?'|trans }}">
+                    <svg class="icon">
+                        <use xlink:href="#delete" />
+                    </svg>
+                </a>
+            </td>
+        </tr>
+        {% else %}
             <tr>
-                <td class="w-50 text-end">{{ 'From'|trans }}:</td>
-                <td>{{ email.sender }}</td>
+                <td class="text-muted" colspan="7">{{ 'The list is empty'|trans }}</td>
             </tr>
-
-            <tr>
-                <td class="text-end">{{ 'To'|trans }}:</td>
-                <td>{{ email.recipients }}</td>
-            </tr>
-
-            <tr>
-                <td class="text-end">{{ 'Sent'|trans }}:</td>
-                <td>{{ email.created_at|date('l, d F Y') }}</td>
-            </tr>
-         </tbody>
+        {% endfor %}
+        </tbody>
     </table>
 
-    <div class="card-footer text-center">
-        <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-            href="{{'api/admin/email/email_resend'|link({ 'id': email.id }) }}"
-            data-api-msg="{{ 'Email resent'|trans }}">
-            <svg class="mb-2 text-secondary" width="24" height="24">
-                <use xlink:href="#refresh" />
-            </svg>
-            <span class="d-block text-secondary">{{ 'Resend'|trans }}</span>
-        </a>
-        <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
-            href="{{'api/admin/email/email_delete'|link({ 'id': email.id }) }}"
-            data-api-confirm="{{ 'Are you sure?'|trans }}"
-            data-api-redirect="{{ 'email/history'|alink }}">
-            <svg class="mb-2 text-secondary" width="24" height="24">
-                <use xlink:href="#delete" />
-            </svg>
-            <span class="d-block text-secondary">{{ 'Delete'|trans }}</span>
-        </a>
-    </div>
-
-    <div class="card-body">
-        {{ email.content_html|raw }}
+    <div class="card-footer d-flex align-items-center justify-content-between">
+        {% include "partial_batch_delete.html.twig" with { 'action': 'admin/email/batch_delete' } %}
+        {% include "partial_pagination.html.twig" with { 'list': emails, 'url': 'email/history' } %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Closes issue #662 
It looks like the wrong templates were brought over in this commit: https://github.com/FOSSBilling/FOSSBilling/commit/aff9d22ffdab4d471f7307694aa964d49f3aa4a9

This PR reverts the module templates to the ones that were in the admin theme before that commit, restoring the functionality & fixing the styling to match the current admin theme. Yay for git :)