### PR TITLE
Fix the API wrapper messing with some parameters

### DIFF
--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -73,7 +73,8 @@ const Tools = {
                 }
             } else {
                 keyName = key.slice(0, -2);
-                keyValue = obj[key](",");
+                orgValue = obj[key];
+                keyValue = orgValue.split(",");
                 reformattedObj[keyName] = keyValue;
             }
         });

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -73,7 +73,7 @@ const Tools = {
                 }
             } else {
                 keyName = key.slice(0, -2);
-                keyValue = Array.from(obj[key]);
+                keyValue = obj[key](",");
                 reformattedObj[keyName] = keyValue;
             }
         });

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -56,19 +56,25 @@ const Tools = {
         Object.keys(obj).forEach(function (key) {
             let parts = key.split('[');
             let current = reformattedObj;
-            for (let i = 0; i < parts.length; i++) {
-                let part = parts[i];
-                if (part.endsWith(']')) {
-                    part = part.slice(0, -1);
-                }
-                if (i === parts.length - 1) {
-                    current[part] = obj[key];
-                } else {
-                    if (!(part in current)) {
-                        current[part] = {};
+            if (key.slice(-2) !== "[]") {
+                for (let i = 0; i < parts.length; i++) {
+                    let part = parts[i];
+                    if (part.endsWith(']')) {
+                        part = part.slice(0, -1);
                     }
-                    current = current[part];
+                    if (i === parts.length - 1) {
+                        current[part] = obj[key];
+                    } else {
+                        if (!(part in current)) {
+                            current[part] = {};
+                        }
+                        current = current[part];
+                    }
                 }
+            } else {
+                keyName = key.slice(0, -2);
+                keyValue = Array.from(obj[key]);
+                reformattedObj[keyName] = keyValue;
             }
         });
         var result = (returnObj) ? reformattedObj : JSON.stringify(reformattedObj);

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -224,17 +224,16 @@
 
         <div class="tab-pane fade" id="tab-upgrades" role="tabpanel">
             <div class="card-body">
-                <h5>{{ 'Choose which products can client upgrade to'|trans }}</h5>
+                <h5>{{ 'Choose which products clients can upgrade to'|trans|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">
                             {% set products = admin.product_get_pairs %}
-                            <input type="hidden" name="upgrades">
                             <select name="upgrades[]" multiple="multiple" class="form-select" size="{{ products|length }}">
                                 {% for id,ptitle in products %}
-                                <option value="{{ id }}"{% if product.upgrades[id] %} selected{% endif %}>{{ ptitle }}</option>
+                                <option value="{{ id }}"{% if product.upgrades[id] %} selected {% endif %}>{{ ptitle }}</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -231,6 +231,7 @@
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">
                             {% set products = admin.product_get_pairs %}
+                            <input type="hidden" name="upgrades">
                             <select name="upgrades[]" multiple="multiple" class="form-select" size="{{ products|length }}">
                                 {% for id,ptitle in products %}
                                 <option value="{{ id }}"{% if product.upgrades[id] %} selected {% endif %}>{{ ptitle }}</option>


### PR DESCRIPTION
Resolves an issue with some parameter names by updating the `reformatJSON` function to specifically handle special cases where the variable is named like `upgrades[]`.

Instead of the normal behavior, it'll instead remove the brackets from the name and convert the value to an array.

I also fixed a dumb typo