### PR TITLE
Corrected breadcrumbs and header h1

### DIFF
--- a/src/modules/Custompages/html_client/mod_custompages_content.html.twig
+++ b/src/modules/Custompages/html_client/mod_custompages_content.html.twig
@@ -3,11 +3,11 @@
 {% block meta_title %}{{ page.title }}{% endblock %}
 {% block meta_description %}{{ page.description }}{% endblock %}
 {% block meta_keywords %}{{ page.keywords }}{% endblock %}
-{% block breadcrumb %} <li class="active">{{ 'Example module'|trans }}</li>{% endblock %}
+{% block breadcrumb %} <li class="active">{{ page.title }}</li>{% endblock %}
 
 {% block page_header %}
 <article class="page-header">
-    <h1>{{ 'Example module title'|trans }}</h1>
+    <h1>{{ page.title }}</h1>
 </article>
 {% endblock%}
 {% block content %}


### PR DESCRIPTION
Previously both displayed 'Example module' - now changed to display page name.