### PR TITLE
🐛 Fix slashes mixup (#670)

### DIFF
--- a/src/load.php
+++ b/src/load.php
@@ -19,13 +19,13 @@ use Whoops\Run;
 
 defined('APPLICATION_ENV') || define('APPLICATION_ENV', getenv('APPLICATION_ENV') ?: 'production');
 const PATH_ROOT = __DIR__;
-const PATH_VENDOR = PATH_ROOT . '/vendor';
-const PATH_LIBRARY = PATH_ROOT . '/library';
-const PATH_THEMES = PATH_ROOT . '/themes';
-const PATH_MODS = PATH_ROOT . '/modules';
-const PATH_LANGS = PATH_ROOT . '/locale';
-const PATH_UPLOADS = PATH_ROOT . '/uploads';
-const PATH_DATA = PATH_ROOT . '/data';
+const PATH_VENDOR = PATH_ROOT . DIRECTORY_SEPARATOR. 'vendor';
+const PATH_LIBRARY = PATH_ROOT . DIRECTORY_SEPARATOR. 'library';
+const PATH_THEMES = PATH_ROOT . DIRECTORY_SEPARATOR. 'themes';
+const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR. 'modules';
+const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR. 'locale';
+const PATH_UPLOADS = PATH_ROOT . DIRECTORY_SEPARATOR. 'uploads';
+const PATH_DATA = PATH_ROOT . DIRECTORY_SEPARATOR. 'data';
 const isCLI = 'cli' === PHP_SAPI;
 
 // Deprecated aliases


### PR DESCRIPTION
This PR fixes the slashes mixup by replacing the hardcoded forward slash with the DIRECTORY_SEPARATOR PHP constant.

There are some additional forward slashes used in the same file (and potentially others, such as [bin/gettext.php](https://github.com/FOSSBilling/FOSSBilling/blob/main/bin/gettext.php)) that I left untouched because I am unsure if they're okay to replace. Tested on my local instance and it works normally, and the message described in #670 seems to be displayed correctly now.

Feel free to (ask me to) add or change anything.