### PR TITLE
BugFix: Renewal failures do not properly save in order history

### DIFF
--- a/src/library/Model/ClientOrder.php
+++ b/src/library/Model/ClientOrder.php
@@ -17,6 +17,7 @@ class Model_ClientOrder extends RedBean_SimpleModel
 {
 	const STATUS_PENDING_SETUP = "pending_setup";
 	const STATUS_FAILED_SETUP = "failed_setup";
+    const STATUS_FAILED_RENEW = "failed_renew";
 	const STATUS_ACTIVE = "active";
 	const STATUS_CANCELED = "canceled";
 	const STATUS_SUSPENDED = "suspended";

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -202,7 +202,6 @@ class Payment_Adapter_Stripe implements \Box\InjectionAwareInterface
                     var handler = StripeCheckout.configure({
                         key: \':key\',
                         image: ":image",
-                        label: ":label",
                         allowRememberMe: false,
                         token: handleStripeToken
                     });
@@ -221,7 +220,7 @@ class Payment_Adapter_Stripe implements \Box\InjectionAwareInterface
                         handler.open({
                                name: ":name",
                                description: ":description" ,
-                               amount: ":amount" ,
+                               amount: parseInt(":amount") ,
                                email: ":email" ,
                                currency: ":currency"
                         });
@@ -248,7 +247,6 @@ class Payment_Adapter_Stripe implements \Box\InjectionAwareInterface
             ':description' => $title,
             ':image' => $company['logo_url'],
             ':email' => $invoice->buyer_email,
-            ':label' => __trans('Pay now'),
             ':callbackUrl' => $payGatewayService->getCallbackUrl($payGateway, $invoice),
             ':redirectUrl' => $this->di['tools']->url('invoice/'.$invoice->hash)
         );

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -75,6 +75,7 @@ class Service implements InjectionAwareInterface
             'total' => array_sum($data),
             \Model_ClientOrder::STATUS_PENDING_SETUP => $this->di['array_get']($data, \Model_ClientOrder::STATUS_PENDING_SETUP, 0),
             \Model_ClientOrder::STATUS_FAILED_SETUP => $this->di['array_get']($data, \Model_ClientOrder::STATUS_FAILED_SETUP, 0),
+            \Model_ClientOrder::STATUS_FAILED_RENEW => $this->di['array_get']($data, \Model_ClientOrder::STATUS_FAILED_RENEW, 0),
             \Model_ClientOrder::STATUS_ACTIVE => $this->di['array_get']($data, \Model_ClientOrder::STATUS_ACTIVE, 0),
             \Model_ClientOrder::STATUS_SUSPENDED => $this->di['array_get']($data, \Model_ClientOrder::STATUS_SUSPENDED, 0),
             \Model_ClientOrder::STATUS_CANCELED => $this->di['array_get']($data, \Model_ClientOrder::STATUS_CANCELED, 0),
@@ -398,6 +399,7 @@ class Service implements InjectionAwareInterface
 
         $search = $this->di['array_get']($data, 'search', false);
         $hide_addons = $this->di['array_get']($data, 'hide_addons', null);
+        $show_action_required = $this->di['array_get']($data, 'show_action_required', null);
         $id = $this->di['array_get']($data, 'id', null);
         $product_id = $this->di['array_get']($data, 'product_id', null);
         $status = $this->di['array_get']($data, 'status', null);
@@ -429,6 +431,10 @@ class Service implements InjectionAwareInterface
         if ($id) {
             $where[] = 'co.id = :id';
             $bindings[':id'] = $id;
+        }
+
+        if ($show_action_required) {
+            $where[] = 'co.status = \'pending_setup\' OR co.status = \'failed_setup\' OR co.status =\'failed_renew\'';
         }
 
         if ($status) {
@@ -950,7 +956,17 @@ class Service implements InjectionAwareInterface
 
     public function renewFromOrder(\Model_ClientOrder $order)
     {
-        $this->_callOnService($order, \Model_ClientOrder::ACTION_RENEW);
+        // renew order, update order history if failure on renewal
+        try {
+            $result = $this->_callOnService($order, \Model_ClientOrder::ACTION_RENEW);
+        } catch (\Exception $e) {
+            $order->status = \Model_ClientOrder::STATUS_FAILED_RENEW;
+            $this->di['db']->store($order);
+
+            $this->saveStatusChange($order, $e->getMessage());
+
+            throw $e;
+        }
 
         // set automatic order expiration
         if (!empty($order->period)) {

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -198,6 +198,12 @@
                                     {% if order.status == 'pending_setup' %}
                                         <span class="badge bg-warning me-1"></span>
                                     {% endif %}
+                                    {% if order.status == 'failed_setup' %}
+                                    <span class="badge bg-warning me-1"></span>
+                                    {% endif %}
+                                    {% if order.status == 'failed_renew' %}
+                                    <span class="badge bg-warning me-1"></span>
+                                    {% endif %}
                                     {% if order.status == 'active' %}
                                         <span class="badge bg-success me-1"></span>
                                     {% endif %}

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -100,19 +100,19 @@
                         <tr>
                             <td class="text-end">{{ 'Order status'|trans }}:</td>
                             <td>
-                                {% if order.status == 'pending_setup' %}
-                                    <span class="badge bg-warning me-1"></span>
-                                {% endif %}
-                                {% if order.status == 'active' %}
-                                    <span class="badge bg-success me-1"></span>
-                                {% endif %}
-                                {% if order.status == 'suspended' %}
-                                    <span class="badge bg-danger me-1"></span>
-                                {% endif %}
-                                {% if order.status == 'canceled' %}
-                                    <span class="badge bg-secondary me-1"></span>
-                                {% endif %}
-                                {{ mf.status_name(order.status) }}
+                            {% if order.status == 'pending_setup' or order.status == 'failed_setup' or order.status == 'failed_renew' %}
+                                <span class="badge bg-warning me-1"></span>
+                            {% endif %}
+                            {% if order.status == 'active' %}
+                                <span class="badge bg-success me-1"></span>
+                            {% endif %}
+                            {% if order.status == 'suspended' %}
+                                <span class="badge bg-danger me-1"></span>
+                            {% endif %}
+                            {% if order.status == 'canceled' %}
+                                <span class="badge bg-secondary me-1"></span>
+                            {% endif %}
+                            {{ mf.status_name(order.status) }}
                             </td>
                         </tr>
                         {% if order.notes %}
@@ -179,7 +179,7 @@
                     </a>
                     {% endif %}
 
-                    {% if order.status == 'active' %}
+                    {% if order.status == 'active' or order.status == 'failed_renew' %}
                     {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
                     <a class="d-inline-block mx-1 btn bg-light bg-gradient api-link"
                         href="{{ 'api/admin/order/renew'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
@@ -457,7 +457,7 @@
                         <td>{{ mf.currency_format( addon.total, addon.currency) }}</td>
                         <td>{% if addon.expires_at %}{{ addon.expires_at|date('l, d F Y') }}{% else %}-{% endif %}</td>
                         <td>
-                            {% if addon.status == 'pending_setup' %}
+                            {% if order.status == 'pending_setup' or order.status == 'failed_setup' or order.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>
                             {% endif %}
                             {% if addon.status == 'active' %}
@@ -569,7 +569,7 @@
                     <tr>
                         <td>{{ sh.created_at|date('Y-m-d H:i') }}</td>
                         <td>
-                            {% if sh.status == 'pending_setup' %}
+                            {% if sh.status == 'pending_setup' or sh.status == 'failed_setup' or sh.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>
                             {% endif %}
                             {% if sh.status == 'active' %}

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -457,7 +457,7 @@
                         <td>{{ mf.currency_format( addon.total, addon.currency) }}</td>
                         <td>{% if addon.expires_at %}{{ addon.expires_at|date('l, d F Y') }}{% else %}-{% endif %}</td>
                         <td>
-                            {% if order.status == 'pending_setup' or order.status == 'failed_setup' or order.status == 'failed_renew' %}
+                            {% if addon.status == 'pending_setup' or addon.status == 'failed_setup' or addon.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>
                             {% endif %}
                             {% if addon.status == 'active' %}

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -93,7 +93,7 @@
                     <tfoot>
                         <tr>
                             <td colspan="2">
-                                {% if order.period %}
+                                {% if order.period and order.status != 'failed_renew' %}
                                     <button class="btn btn-primary btn-small" type="button" id="renewal-button">{{ 'Renew now'|trans }}</button>
                                 {% endif %}
 

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_js.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_js.html.twig
@@ -252,20 +252,6 @@
     })("docReady", window);
 
     docReady(function() {
-        if (typeof jQuery === "undefined") {
-            (function(d, script) {
-                script = d.createElement('script');
-                script.type = 'text/javascript';
-                script.async = true;
-                script.onload = function(){
-                    ob = new orderbutton();
-                    ob.attachEvents();
-                };
-                script.src = 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js';
-                d.getElementsByTagName('head')[0].appendChild(script);
-            }(document));
-        }else{
-            ob = new orderbutton();
-            ob.attachEvents();
-        }
+        ob = new orderbutton();
+        ob.attachEvents();
     });

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -1,4 +1,4 @@
-{% if order.status == 'active' %}
+{% if order.status == 'active' or order.status == 'failed_renew' %}
 
 <div class="row">
     <article class="span12 data-block">

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -151,8 +151,8 @@
                         {% endif %}
 
                         {% if admin.system_is_allowed({ 'mod': 'order' }) %}
-                            {% set count_orders = admin.order_get_statuses.failed_setup %}
-                            <a href="{{ 'order'|alink({ 'status': 'failed_setup' }) }}" class="btn position-relative">
+                            {% set count_orders = admin.order_get_statuses.pending_setup + admin.order_get_statuses.failed_setup + admin.order_get_statuses.failed_renew %}
+                            <a href="{{ 'order'|alink({ 'status': 'pending_action' }) }}" class="btn position-relative">
                                 <svg class="icon">
                                     <use xlink:href="#orders" />
                                 </svg>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -152,7 +152,7 @@
 
                         {% if admin.system_is_allowed({ 'mod': 'order' }) %}
                             {% set count_orders = admin.order_get_statuses.pending_setup + admin.order_get_statuses.failed_setup + admin.order_get_statuses.failed_renew %}
-                            <a href="{{ 'order'|alink({ 'status': 'pending_action' }) }}" class="btn position-relative">
+                            <a href="{{ 'order'|alink({ 'show_action_required': 'true' }) }}" class="btn position-relative">
                                 <svg class="icon">
                                     <use xlink:href="#orders" />
                                 </svg>


### PR DESCRIPTION
Bugfixes found running regression tests of registering a domain (activate new order), followed by various sequences of renewing the domain order. Intentionally insert fatal exceptions in the renewal process demonstrated that you could renew a product and the order would update its length and status despite the underlying renewal action having failed. Additionally, renewal action failure reason was not getting captured and saved to the order history.

This corrects those behaviors to be in parity with what would happen on an activation failure. Also, minor javascript warning fixes when testing this workflow through the Stripe payment adapter.