### PR TITLE
Add ability to return country name without ISO

### DIFF
--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -213,11 +213,13 @@ class Service
                 $details[] = [
                     'locale' => $locale,
                     'title' => $locale .' ('.$locale.')',
+                    'name' => $locale,
                 ];
             }else{
             $details[] = [
                 'locale' => $locale,
                 'title' => $array[$locale] .' ('.$locale.')',
+                'name' => $array[$locale],
             ];
             }
         }


### PR DESCRIPTION
Adds the option to use {{ lang.name }} in place of {{ lang.title}} to return only the country name without the associated ISO code. 

i.e. 
{{ lang.title }} = Deutsch (de_DE)
{{ lang.name }} = Deutsch