### PR TITLE
Add css body classes to modules client html

### DIFF
--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -7,6 +7,7 @@
 
 {% set profile = client.client_get %}
 
+{% block body_class %}client-balance{% endblock %}
 {% block content %}
 <div class="row">
 <article class="span12 data-block">

--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -4,6 +4,7 @@
 {% block page_header %}{{ 'User profile settings'|trans }}{% endblock %}
 {% block breadcrumb %} <li class="active">{{ 'Profile'|trans }}</li>{% endblock %}
 
+{% block body_class %}client-profile{% endblock %}
 {% block content %}
 <div class="row-fluid">
 

--- a/src/modules/Custompages/html_client/mod_custompages_content.html.twig
+++ b/src/modules/Custompages/html_client/mod_custompages_content.html.twig
@@ -5,6 +5,7 @@
 {% block meta_keywords %}{{ page.keywords }}{% endblock %}
 {% block breadcrumb %} <li class="active">{{ page.title }}</li>{% endblock %}
 
+{% block body_class %}custom-page{% endblock %}
 {% block page_header %}
 <article class="page-header">
     <h1>{{ page.title }}</h1>

--- a/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
+++ b/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
@@ -3,6 +3,8 @@
 {% block meta_title %}{{ 'Client Area'|trans }}{% endblock %}
 {% block page_header %}{{ 'Dashboard'|trans }}{% endblock %}
 
+{% block body_class %}dashboard{% endblock %}
+
 {% block breadcrumbs %}
     {% if not settings.hide_dashboard_breadcrumb %}
         <ul class="breadcrumb">

--- a/src/modules/Email/html_client/mod_email_email.html.twig
+++ b/src/modules/Email/html_client/mod_email_email.html.twig
@@ -6,7 +6,7 @@
 <li><a href="{{ 'email' | link}}">{{ 'Emails'|trans }}</a><span class="divider">/</span></li>
 {{ email.subject }}
 {% endblock %}
-
+{% block body_class %}email-email{% endblock %}
 {% block content %}
 <div class="row">
     <article class="span12 data-block">

--- a/src/modules/Email/html_client/mod_email_index.html.twig
+++ b/src/modules/Email/html_client/mod_email_index.html.twig
@@ -5,6 +5,7 @@
 
 {% set emails = client.email_get_list({"per_page":10, "page":request.page}) %}
 
+{% block body_class %}email-index{% endblock %}
 {% block content %}
 <div class="row">
     <article class="span12 data-block">

--- a/src/modules/Example/html_client/mod_example_index.html.twig
+++ b/src/modules/Example/html_client/mod_example_index.html.twig
@@ -1,6 +1,8 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
 {% block meta_title %}{{ 'Example module'|trans }}{% endblock %}
+
+{% block body_class %}example{% endblock %}
 {% block breadcrumb %} <li class="active">{{ 'Example module'|trans }}</li>{% endblock %}
 
 {% block page_header %}

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -3,6 +3,7 @@
 {% block meta_title %}{{ 'Client Area'|trans }}{% endblock %}
 {% block page_header %}{{ 'Dashboard'|trans }}{% endblock %}
 
+{% block body_class %}dashboard{% endblock %}
 {% block breadcrumbs %}
     {% if not settings.hide_dashboard_breadcrumb %}
         <ul class="breadcrumb">

--- a/src/modules/Invoice/html_client/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_index.html.twig
@@ -3,6 +3,7 @@
 {% block meta_title %}{{ 'Invoice management'|trans }}{% endblock %}
 {% block page_header %}{{ 'Invoice management'|trans }}{% endblock %}
 
+{% block body_class %}invoice-index{% endblock %}
 {% block breadcrumb %}
     <li class="active">{{ 'Invoices'|trans }}</li>
 {% endblock %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -6,6 +6,7 @@
 
 {% block meta_title %}{{ 'Proforma invoice'|trans }}{% endblock %}
 
+{% block body_class %}invoice-invoice{% endblock %}
 {% block breadcrumb %}
     <li><a href="{{ '/invoice'|link }}">{{ 'Invoices'|trans }}</a> <span class="divider">/</span></li>
     <li class="active">{% if invoice.status == 'paid' %} {{ 'Receipt'|trans }} {% else %}  {{ 'Invoice'|trans }} {% endif %}{{ nr }}</li>

--- a/src/modules/Kb/html_client/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_article.html.twig
@@ -2,6 +2,7 @@
 
 {% block meta_title %}{{ article.title }}{% endblock %}
 
+{% block body_class %}kb-article{% endblock %}
 {% block breadcrumb %}
 <li>
     <a href="{{ '/kb'|link }}">{{ 'Knowledge base'|trans }}</a> <span class="divider">/</span>

--- a/src/modules/Kb/html_client/mod_kb_category.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_category.html.twig
@@ -2,6 +2,7 @@
 
 {% block meta_title %}{{ category.title }}{% endblock %}
 
+{% block body_class %}kb-category{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ '/kb'|link }}">{{ 'Knowledge base'|trans }}</a> <span class="divider">/</span></li>
 <li class="active">{{ category.title }}</li>

--- a/src/modules/Kb/html_client/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_index.html.twig
@@ -1,6 +1,8 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
 {% block meta_title %}{{ 'Knowledge base'|trans }}{% endblock %}
+
+{% block body_class %}kb-index{% endblock %}
 {% block breadcrumb %}{{ 'Knowledge base'|trans }}{% endblock %}
 
 {% block content %}

--- a/src/modules/News/html_client/mod_news_index.html.twig
+++ b/src/modules/News/html_client/mod_news_index.html.twig
@@ -1,6 +1,8 @@
 {% extends request.ajax ? "layout_blank.html.twig" : "layout_default.html.twig" %}
 
 {% block meta_title %}{{ 'News'|trans }}{% endblock %}
+
+{% block body_class %}news-index{% endblock %}
 {% block breadcrumb %}{{ 'News'|trans }}{% endblock %}
 
 {% block content %}

--- a/src/modules/News/html_client/mod_news_post.html.twig
+++ b/src/modules/News/html_client/mod_news_post.html.twig
@@ -3,6 +3,7 @@
 {% block meta_title %}{{ post.title }}{% endblock %}
 {% block meta_description %}{{ post.description }}{% endblock %}
 
+{% block body_class %}news-post{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ 'news' | link}}">{{ 'News'|trans }}</a><span class="divider">/</span></li>
 <li class="active">{{post.title}}</li>

--- a/src/modules/Order/html_client/mod_order_index.html.twig
+++ b/src/modules/Order/html_client/mod_order_index.html.twig
@@ -7,6 +7,7 @@
 {% set loader_nr = request.loader | default("8")%}
 {% set loader_url = ('img/assets/loaders/loader'~loader_nr~'.gif') %}
 
+{% block body_class %}order-index{% endblock %}
 {% block content_before %}{% endblock %}
 
 {% block content %}

--- a/src/modules/Order/html_client/mod_order_list.html.twig
+++ b/src/modules/Order/html_client/mod_order_list.html.twig
@@ -4,6 +4,7 @@
 
 {% block meta_title %}{{ 'My Products & Services'|trans }}{% endblock %}
 
+{% block body_class %}order-list{% endblock %}
 {% block breadcrumb %}
 <li class="service">{{ 'Orders'|trans }}</li>
 {% endblock %}

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -6,6 +6,7 @@
 
 {% set addons = client.order_addons({ "id": order.id }) %}
 
+{% block body_class %}order-manage{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ 'service' | link}}">{{ 'Orders'|trans }}</a><span class="divider">/</span></li>
 {{ order.title }}

--- a/src/modules/Order/html_client/mod_order_product.html.twig
+++ b/src/modules/Order/html_client/mod_order_product.html.twig
@@ -7,6 +7,7 @@
 {% set loader_nr = request.loader | default("8")%}
 {% set loader_url = ('img/assets/loaders/loader'~loader_nr~'.gif') %}
 
+{% block body_class %}order-product{% endblock %}
 {% block content_before %}{% endblock %}
 
 {% block content %}

--- a/src/modules/Page/html_client/mod_page_about-us.html.twig
+++ b/src/modules/Page/html_client/mod_page_about-us.html.twig
@@ -4,6 +4,7 @@
 
 {% set company = guest.system_company %}
 
+{% block body_class %}about-us{% endblock %}
 {% block body %}
 <br/>
 <section class="container" role="main">

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -2,6 +2,7 @@
 
 {% block meta_title %}{{ 'Log in'|trans }}{% endblock %}
 
+{% block body_class %}login{% endblock %}
 {% block body %}
 
 <section class="container login" role="main">

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -2,6 +2,7 @@
 
 {% block meta_title %}{{ 'Reset password'|trans }}{% endblock %}
 
+{% block body_class %}password-reset{% endblock %}
 {% block body %}
 
 <section class="container login" role="main">

--- a/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
+++ b/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
@@ -4,6 +4,8 @@
 
 {% set company = guest.system_company %}
 
+{% block body_class %}privacy-policy{% endblock %}
+
 {% block body %}
 <br/>
 <section class="container" role="main">

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -4,6 +4,7 @@
 
 {% block meta_title %}{{ 'Sign up'|trans }}{% endblock %}
 
+{% block body_class %}signup{% endblock %}
 {% block body %}
 <section class="container login" role="main">
     {% if settings.login_page_show_logo %}

--- a/src/modules/Page/html_client/mod_page_tos.html.twig
+++ b/src/modules/Page/html_client/mod_page_tos.html.twig
@@ -4,6 +4,7 @@
 
 {% set company = guest.system_company %}
 
+{% block body_class %}tos{% endblock %}
 {% block body %}
 <br/>
 <section class="container" role="main">

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -3,6 +3,8 @@
 {% import "macro_functions.html.twig" as mf %}
 
 {% block meta_title %}{{ 'Contact us'|trans }}{% endblock %}
+
+{% block body_class %}support-contact-us{% endblock %}
 {% block breadcrumb %}{{ 'Contact us'|trans }}{% endblock %}
 
 {% block content %}

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -4,6 +4,7 @@
 
 {% block meta_title %}{{ ticket.subject }}{% endblock %}
 
+{% block body_class %}support-contact-us-conversation{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ 'support/contact-us' | link}}">{{ 'Contact us'|trans }}</a><span class="divider">/</span></li>
 <li class="active">{{ ticket.subject }}</li>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -3,6 +3,8 @@
 {% import "macro_functions.html.twig" as mf %}
 
 {% block meta_title %}{{ ticket.subject }}{% endblock %}
+
+{% block body_class %}support-ticket{% endblock %}
 {% block breadcrumb %}
 <li><a href="{{ 'support' | link}}">{{ 'Support tickets'|trans }}</a><span class="divider">/</span></li>
 {{ticket.subject}}

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -4,6 +4,8 @@
 
 {% block meta_title %}{{ 'Support tickets'|trans }}{% endblock %}
 {% block page_header %}{{ 'Support tickets'|trans }}{% endblock %}
+
+{% block body_class %}support-tickets{% endblock %}
 {% block breadcrumb %}{{ 'Support tickets'|trans }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Adds a body class with the name of the module or page to client facing html pages. 

This makes theming easier because there is a quick way to specify selectors on only certain pages using the body._whatever_ class.