### PR TITLE
Use Rector to modernize code for PHP 8.0

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,6 +18,7 @@ parameters:
 		- src/library/Model/Product.php
 		- src/library/Server/Manager/Custom.php
 		- src/library/Server/Manager/Whm.php
+		- src/rector.php
 	ignoreErrors:
 		- '#^Function __trans not found\.$#'
 		- message: '#^Access to an undefined property FOSSPatchAbstract\:\:\$di\.$#'

--- a/src/composer.json
+++ b/src/composer.json
@@ -41,7 +41,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "friendsofphp/php-cs-fixer": "^3.8",
-        "symfony/deprecation-contracts": "^3.0.0"
+        "symfony/deprecation-contracts": "^3.0.0",
+        "rector/rector": "^0.15.4"
     },
     "suggest": {
         "ext-gettext": "*",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6808b556277708f8640a2e920b1db6d",
+    "content-hash": "eaa78c2960176b186f52732ae1155607",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3985,6 +3985,65 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "1.9.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "f68d7cc3d0638a01bc6321cb826e4cae7fa6884d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f68d7cc3d0638a01bc6321cb826e4cae7fa6884d",
+                "reference": "f68d7cc3d0638a01bc6321cb826e4cae7fa6884d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-11T14:39:22+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "9.2.19",
             "source": {
@@ -4453,6 +4512,62 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.15.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "1dcdf54ebf502d9f7cf9b5f89df613da1774d050"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/1dcdf54ebf502d9f7cf9b5f89df613da1774d050",
+                "reference": "1dcdf54ebf502d9f7cf9b5f89df613da1774d050",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.9.7"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-php-parser": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.14-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.15.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-01-10T11:09:49+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6320,5 +6435,5 @@
         "ext-mbstring": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/foss-update.php
+++ b/src/foss-update.php
@@ -56,7 +56,7 @@ abstract class FOSSPatchAbstract
     {
         $this->di = $di;
         $this->pdo = $di['pdo'];
-        $c = get_class($this);
+        $c = static::class;
         $this->version = (int) substr($c, strpos($c, '_') + 1);
     }
 

--- a/src/modules/Activity/Controller/Admin.php
+++ b/src/modules/Activity/Controller/Admin.php
@@ -60,7 +60,7 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/activity', 'get_index', [], get_class($this));
+        $app->get('/activity', 'get_index', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -46,12 +46,12 @@ class Client implements InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->post('/api/:role/:class/:method', 'post_method', ['role', 'class', 'method'], get_class($this));
-        $app->get('/api/:role/:class/:method', 'get_method', ['role', 'class', 'method'], get_class($this));
+        $app->post('/api/:role/:class/:method', 'post_method', ['role', 'class', 'method'], static::class);
+        $app->get('/api/:role/:class/:method', 'get_method', ['role', 'class', 'method'], static::class);
 
         // all other requests are error requests
-        $app->get('/api/:page', 'show_error', ['page' => '(.?)+'], get_class($this));
-        $app->post('/api/:page', 'show_error', ['page' => '(.?)+'], get_class($this));
+        $app->get('/api/:page', 'show_error', ['page' => '(.?)+'], static::class);
+        $app->post('/api/:page', 'show_error', ['page' => '(.?)+'], static::class);
     }
 
     public function show_error(\Box_App $app, $page)
@@ -132,7 +132,7 @@ class Client implements InjectionAwareInterface
         if ($check_referer_header) {
             $url = strtolower(BB_URL);
             $referer = isset($_SERVER['HTTP_REFERER']) ? strtolower($_SERVER['HTTP_REFERER']) : null;
-            if (!$referer || $url != substr($referer, 0, strlen($url))) {
+            if (!$referer || !str_starts_with($referer, $url)) {
                 throw new \Box_Exception('Invalid request. Make sure request origin is :from', [':from' => BB_URL], 1004);
             }
         }
@@ -178,7 +178,7 @@ class Client implements InjectionAwareInterface
             if($role == 'client' || $role == 'admin'){
                 $this->_checkCSRFToken();
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->_tryTokenLogin();
         }
 
@@ -323,7 +323,7 @@ class Client implements InjectionAwareInterface
         /* Due to the way the cart works, it creates a new session which causes issues with the CSRF token system.
          * Due to this, we whitelist the checkout URL. 
          */
-        if(strpos($_SERVER['REQUEST_URI'], "/api/client/cart/checkout") !== false){
+        if(str_contains($_SERVER['REQUEST_URI'], "/api/client/cart/checkout")){
             return true;
         }
 

--- a/src/modules/Cart/Controller/Client.php
+++ b/src/modules/Cart/Controller/Client.php
@@ -38,7 +38,7 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/cart', 'get_cart', [], get_class($this));
+        $app->get('/cart', 'get_cart', [], static::class);
     }
 
     public function get_cart(\Box_App $app)

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -395,7 +395,7 @@ class Service implements InjectionAwareInterface
 
         try {
             $client = $this->di['loggedin_client'];
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $client = null;
         }
 

--- a/src/modules/Client/Controller/Admin.php
+++ b/src/modules/Client/Controller/Admin.php
@@ -75,14 +75,14 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/client', 'get_index', [], get_class($this));
-        $app->get('/client/', 'get_index', [], get_class($this));
-        $app->get('/client/index', 'get_index', [], get_class($this));
-        $app->get('/client/login/:id', 'get_login', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/client/manage/:id', 'get_manage', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/client/group/:id', 'get_group', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/client/create', 'get_create', [], get_class($this));
-        $app->get('/client/logins', 'get_history', [], get_class($this));
+        $app->get('/client', 'get_index', [], static::class);
+        $app->get('/client/', 'get_index', [], static::class);
+        $app->get('/client/index', 'get_index', [], static::class);
+        $app->get('/client/login/:id', 'get_login', ['id' => '[0-9]+'], static::class);
+        $app->get('/client/manage/:id', 'get_manage', ['id' => '[0-9]+'], static::class);
+        $app->get('/client/group/:id', 'get_group', ['id' => '[0-9]+'], static::class);
+        $app->get('/client/create', 'get_create', [], static::class);
+        $app->get('/client/logins', 'get_history', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Client/Controller/Client.php
+++ b/src/modules/Client/Controller/Client.php
@@ -39,18 +39,16 @@ class Client implements \Box\InjectionAwareInterface
     public function register(\Box_App &$app)
     {
         // @deprecated
-        $app->get('/client/me', 'get_profile', [], get_class($this));
+        $app->get('/client/me', 'get_profile', [], static::class);
 
-        $app->get('/client/reset-password-confirm/:hash', 'get_reset_password_confirm', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->get('/client', 'get_client_index', [], get_class($this));
-        $app->get('/client/logout', 'get_client_logout', [], get_class($this));
-        $app->get('/client/:page', 'get_client_page', ['page' => '[a-z0-9-]+'], get_class($this));
-        $app->get('/client/confirm-email/:hash', 'get_client_confirmation', ['page' => '[a-z0-9-]+'], get_class($this));
+        $app->get('/client/reset-password-confirm/:hash', 'get_reset_password_confirm', ['hash' => '[a-z0-9]+'], static::class);
+        $app->get('/client', 'get_client_index', [], static::class);
+        $app->get('/client/logout', 'get_client_logout', [], static::class);
+        $app->get('/client/:page', 'get_client_page', ['page' => '[a-z0-9-]+'], static::class);
+        $app->get('/client/confirm-email/:hash', 'get_client_confirmation', ['page' => '[a-z0-9-]+'], static::class);
     }
 
     /**
-     * @param Box_App $app
-     *
      * @deprecated
      */
     public function get_profile(\Box_App $app)
@@ -59,8 +57,6 @@ class Client implements \Box\InjectionAwareInterface
     }
 
     /**
-     * @param Box_App $app
-     *
      * @deprecated
      */
     public function get_balance(\Box_App $app)

--- a/src/modules/Cookieconsent/Controller/Admin.php
+++ b/src/modules/Cookieconsent/Controller/Admin.php
@@ -53,7 +53,7 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/cookieconsent', 'get_index', [], get_class($this));
+        $app->get('/cookieconsent', 'get_index', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -20,10 +20,7 @@ class Service
 {
     protected $di;
 
-    /**
-     * @param mixed $di
-     */
-    public function setDi($di)
+    public function setDi(mixed $di)
     {
         $this->di = $di;
     }

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -80,28 +80,13 @@ class Guest extends \Api_Abstract
             $p = $price * $c['conversion_rate'];
         }
 
-        switch ($c['price_format']) {
-            case 2:
-                $p = number_format($p, 2, '.', ',');
-                break;
-
-            case 3:
-                $p = number_format($p, 2, ',', '.');
-                break;
-
-            case 4:
-                $p = number_format($p, 0, '', ',');
-                break;
-
-            case 5:
-                $p = number_format($p, 0, '', '');
-                break;
-
-            case 1:
-            default:
-                $p = number_format($p, 2, '.', '');
-                break;
-        }
+        $p = match ($c['price_format']) {
+            2 => number_format($p, 2, '.', ','),
+            3 => number_format($p, 2, ',', '.'),
+            4 => number_format($p, 0, '', ','),
+            5 => number_format($p, 0, '', ''),
+            default => number_format($p, 2, '.', ''),
+        };
 
         if ($without_currency) {
             return $p;

--- a/src/modules/Currency/Controller/Admin.php
+++ b/src/modules/Currency/Controller/Admin.php
@@ -38,7 +38,7 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/currency/manage/:code', 'get_manage', ['code' => '[a-zA-Z]+'], get_class($this));
+        $app->get('/currency/manage/:code', 'get_manage', ['code' => '[a-zA-Z]+'], static::class);
     }
 
     public function get_manage(\Box_App $app, $code)

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -454,7 +454,7 @@ class Service implements InjectionAwareInterface
 
     public function validateCurrencyFormat($format)
     {
-        if (false === strpos($format, '{{price}}')) {
+        if (!str_contains($format, '{{price}}')) {
             throw new \Exception('Currency format must include {{price}} tag', 3569);
         }
     }

--- a/src/modules/Custompages/Controller/Admin.php
+++ b/src/modules/Custompages/Controller/Admin.php
@@ -53,8 +53,8 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/custompages', 'get_index', [], get_class($this));
-        $app->get('/custompages/:id', 'get_page', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/custompages', 'get_index', [], static::class);
+        $app->get('/custompages/:id', 'get_page', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Custompages/Controller/Client.php
+++ b/src/modules/Custompages/Controller/Client.php
@@ -50,7 +50,7 @@ class Client implements \Box\InjectionAwareInterface
      */
     public function register(\Box_App &$app)
     {
-        $app->get('/custompages/:slug', 'get_page', ['slug' => '[a-z0-9-]+'], get_class($this));
+        $app->get('/custompages/:slug', 'get_page', ['slug' => '[a-z0-9-]+'], static::class);
     }
 
     public function get_page(\Box_App $app, $slug)

--- a/src/modules/Dashboard/Controller/Client.php
+++ b/src/modules/Dashboard/Controller/Client.php
@@ -38,7 +38,7 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/dashboard', 'get_dashboard_index', [], get_class($this));
+        $app->get('/dashboard', 'get_dashboard_index', [], static::class);
     }
 
     public function get_dashboard_index(\Box_App $app)

--- a/src/modules/Email/Controller/Admin.php
+++ b/src/modules/Email/Controller/Admin.php
@@ -53,11 +53,11 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/email/history/', 'get_history', [], get_class($this));
-        $app->get('/email/history', 'get_history', [], get_class($this));
-        $app->get('/email/templates', 'get_index', [], get_class($this));
-        $app->get('/email/template/:id', 'get_template', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/email/:id', 'get_email', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/email/history/', 'get_history', [], static::class);
+        $app->get('/email/history', 'get_history', [], static::class);
+        $app->get('/email/templates', 'get_index', [], static::class);
+        $app->get('/email/template/:id', 'get_template', ['id' => '[0-9]+'], static::class);
+        $app->get('/email/:id', 'get_email', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_history(\Box_App $app)

--- a/src/modules/Email/Controller/Client.php
+++ b/src/modules/Email/Controller/Client.php
@@ -38,8 +38,8 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/email', 'get_emails', [], get_class($this));
-        $app->get('/email/:id', 'get_email', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/email', 'get_emails', [], static::class);
+        $app->get('/email/:id', 'get_email', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_emails(\Box_App $app)

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -604,7 +604,7 @@ class Service implements \Box\InjectionAwareInterface
             error_log($message);
 
             // Prevent mass retries of emails if one of them is "invalid"
-            if(strpos($message, 'Invalid address:') !== false) {
+            if(str_contains($message, 'Invalid address:')) {
                 try {
                     $this->di['db']->trash($queue);
                 } catch (\Exception $e) {

--- a/src/modules/Embed/Controller/Admin.php
+++ b/src/modules/Embed/Controller/Admin.php
@@ -53,7 +53,7 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/embed', 'get_index', [], get_class($this));
+        $app->get('/embed', 'get_index', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Embed/Controller/Client.php
+++ b/src/modules/Embed/Controller/Client.php
@@ -45,7 +45,7 @@ class Client implements \Box\InjectionAwareInterface
      */
     public function register(\Box_App &$app)
     {
-        $app->get('/embed/:what', 'get_object', ['what' => '[a-z0-9-]+'], get_class($this));
+        $app->get('/embed/:what', 'get_object', ['what' => '[a-z0-9-]+'], static::class);
     }
 
     public function get_object(\Box_App $app, $what)

--- a/src/modules/Example/Controller/Admin.php
+++ b/src/modules/Example/Controller/Admin.php
@@ -79,10 +79,10 @@ class Admin implements \Box\InjectionAwareInterface
      */
     public function register(\Box_App &$app)
     {
-        $app->get('/example', 'get_index', [], get_class($this));
-        $app->get('/example/test', 'get_test', [], get_class($this));
-        $app->get('/example/user/:id', 'get_user', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/example/api', 'get_api', [], get_class($this));
+        $app->get('/example', 'get_index', [], static::class);
+        $app->get('/example/test', 'get_test', [], static::class);
+        $app->get('/example/user/:id', 'get_user', ['id' => '[0-9]+'], static::class);
+        $app->get('/example/api', 'get_api', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Example/Controller/Client.php
+++ b/src/modules/Example/Controller/Client.php
@@ -50,8 +50,8 @@ class Client implements \Box\InjectionAwareInterface
      */
     public function register(\Box_App &$app)
     {
-        $app->get('/example', 'get_index', [], get_class($this));
-        $app->get('/example/protected', 'get_protected', [], get_class($this));
+        $app->get('/example', 'get_index', [], static::class);
+        $app->get('/example/protected', 'get_protected', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Example/Service.php
+++ b/src/modules/Example/Service.php
@@ -27,10 +27,7 @@ class Service
 {
     protected $di;
 
-    /**
-     * @param mixed $di
-     */
-    public function setDi($di)
+    public function setDi(mixed $di)
     {
         $this->di = $di;
     }

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -49,7 +49,7 @@ class Admin extends \Api_Abstract
         $type = $this->di['array_get']($data, 'type', null);
         try {
             $list = $this->di['extension']->getLatest($type);
-        } catch(\Exception $e) {
+        } catch(\Exception) {
             $list = array();
         }
         return $list;

--- a/src/modules/Extension/Controller/Admin.php
+++ b/src/modules/Extension/Controller/Admin.php
@@ -67,9 +67,9 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/extension', 'get_index', [], get_class($this));
-        $app->get('/extension/settings/:mod', 'get_settings', ['mod' => '[a-z0-9-]+'], get_class($this));
-        $app->get('/extension/languages', 'get_langs', [], get_class($this));
+        $app->get('/extension', 'get_index', [], static::class);
+        $app->get('/extension/settings/:mod', 'get_settings', ['mod' => '[a-z0-9-]+'], static::class);
+        $app->get('/extension/languages', 'get_langs', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -80,7 +80,7 @@ class Service implements InjectionAwareInterface
             try {
                 $mod = $this->di['mod']($ext->name);
                 $mod->getManifest();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $this->di['db']->trash($ext);
                 ++$removedItems;
             }
@@ -193,7 +193,7 @@ class Service implements InjectionAwareInterface
 
         if (!empty($search)) {
             foreach ($result as $idx => $mod) {
-                if (false === strpos(strtolower($mod['name']), $search)) {
+                if (!str_contains(strtolower($mod['name']), $search)) {
                     unset($result[$idx]);
                 }
             }

--- a/src/modules/Formbuilder/Controller/Client.php
+++ b/src/modules/Formbuilder/Controller/Client.php
@@ -38,7 +38,7 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/formbuilder/:id', 'get_form', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/formbuilder/:id', 'get_form', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_form(\Box_App $app, $id)

--- a/src/modules/Formbuilder/Service.php
+++ b/src/modules/Formbuilder/Service.php
@@ -294,7 +294,7 @@ class Service implements InjectionAwareInterface
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $result, null, 2575);
 
-        if ('{' == substr($result['options'], 0, 1) || '[' == substr($result['options'], 0, 1)) {
+        if (str_starts_with($result['options'], '{') || str_starts_with($result['options'], '[')) {
             $result['options'] = json_decode($result['options']);
         }
 

--- a/src/modules/Index/Controller/Admin.php
+++ b/src/modules/Index/Controller/Admin.php
@@ -40,10 +40,10 @@ class Admin implements InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('', 'get_index', [], get_class($this));
-        $app->get('/', 'get_index', [], get_class($this));
-        $app->get('/index', 'get_index', [], get_class($this));
-        $app->get('/index/', 'get_index', [], get_class($this));
+        $app->get('', 'get_index', [], static::class);
+        $app->get('/', 'get_index', [], static::class);
+        $app->get('/index', 'get_index', [], static::class);
+        $app->get('/index/', 'get_index', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Invoice/Controller/Admin.php
+++ b/src/modules/Invoice/Controller/Admin.php
@@ -103,17 +103,17 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/invoice', 'get_index', [], get_class($this));
-        $app->get('/invoice/subscriptions', 'get_subscriptions', [], get_class($this));
-        $app->get('/invoice/transactions', 'get_transactions', [], get_class($this));
-        $app->get('/invoice/gateways', 'get_gateways', [], get_class($this));
-        $app->get('/invoice/gateway/:id', 'get_gateway', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/invoice/manage/:id', 'get_invoice', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/invoice/transaction/:id', 'get_transaction', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/invoice/subscription/:id', 'get_subscription', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/invoice/tax', 'get_taxes', [], get_class($this));
-        $app->get('/invoice/tax/:id', 'get_tax', [], get_class($this));
-        $app->get('/invoice/pdf/:hash', 'get_pdf', ['hash' => '[a-z0-9]+'], get_class($this));
+        $app->get('/invoice', 'get_index', [], static::class);
+        $app->get('/invoice/subscriptions', 'get_subscriptions', [], static::class);
+        $app->get('/invoice/transactions', 'get_transactions', [], static::class);
+        $app->get('/invoice/gateways', 'get_gateways', [], static::class);
+        $app->get('/invoice/gateway/:id', 'get_gateway', ['id' => '[0-9]+'], static::class);
+        $app->get('/invoice/manage/:id', 'get_invoice', ['id' => '[0-9]+'], static::class);
+        $app->get('/invoice/transaction/:id', 'get_transaction', ['id' => '[0-9]+'], static::class);
+        $app->get('/invoice/subscription/:id', 'get_subscription', ['id' => '[0-9]+'], static::class);
+        $app->get('/invoice/tax', 'get_taxes', [], static::class);
+        $app->get('/invoice/tax/:id', 'get_tax', [], static::class);
+        $app->get('/invoice/pdf/:hash', 'get_pdf', ['hash' => '[a-z0-9]+'], static::class);
     }
 
     public function get_taxes(\Box_App $app)

--- a/src/modules/Invoice/Controller/Client.php
+++ b/src/modules/Invoice/Controller/Client.php
@@ -38,15 +38,15 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/invoice', 'get_invoices', [], get_class($this));
-        $app->post('/invoice', 'get_invoices', [], get_class($this));
-        $app->get('/invoice/:hash', 'get_invoice', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->post('/invoice/:hash', 'get_invoice', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->get('/invoice/print/:hash', 'get_invoice_print', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->post('/invoice/print/:hash', 'get_invoice_print', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->get('/invoice/banklink/:hash/:id', 'get_banklink', ['id' => '[0-9]+', 'hash' => '[a-z0-9]+'], get_class($this));
-        $app->get('/invoice/thank-you/:hash', 'get_thankyoupage', ['hash' => '[a-z0-9]+'], get_class($this));
-        $app->get('/invoice/pdf/:hash', 'get_pdf', ['hash' => '[a-z0-9]+'], get_class($this));
+        $app->get('/invoice', 'get_invoices', [], static::class);
+        $app->post('/invoice', 'get_invoices', [], static::class);
+        $app->get('/invoice/:hash', 'get_invoice', ['hash' => '[a-z0-9]+'], static::class);
+        $app->post('/invoice/:hash', 'get_invoice', ['hash' => '[a-z0-9]+'], static::class);
+        $app->get('/invoice/print/:hash', 'get_invoice_print', ['hash' => '[a-z0-9]+'], static::class);
+        $app->post('/invoice/print/:hash', 'get_invoice_print', ['hash' => '[a-z0-9]+'], static::class);
+        $app->get('/invoice/banklink/:hash/:id', 'get_banklink', ['id' => '[0-9]+', 'hash' => '[a-z0-9]+'], static::class);
+        $app->get('/invoice/thank-you/:hash', 'get_thankyoupage', ['hash' => '[a-z0-9]+'], static::class);
+        $app->get('/invoice/pdf/:hash', 'get_pdf', ['hash' => '[a-z0-9]+'], static::class);
     }
 
     public function get_invoices(\Box_App $app)

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1283,7 +1283,7 @@ class Service implements InjectionAwareInterface
                 }
             }
             // Workaround to get SVG images to render. Please see https://github.com/dompdf/dompdf/issues/320
-            if ('.svg' === substr($url, -4)) {
+            if (str_ends_with($url, '.svg')) {
                 $html .= '<img src="data:image/svg+xml;base64,' . base64_encode(file_get_contents($url)) . '" height="50" class="CompanyLogo"></img>';
             } else {
                 $html .= '<img src="' . $url . '" height="50" class="CompanyLogo"></img>';
@@ -1405,7 +1405,6 @@ class Service implements InjectionAwareInterface
      * Return list of unpaid invoices which can be covered from client balance.
      * Deposit invoices are excluded as they cannot be covered from client balance.
      *
-     * @param array $filter
      *
      * @return array
      */

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -417,26 +417,13 @@ class ServiceTransaction implements InjectionAwareInterface
         try {
             $this->_parseIpnAndApprove($transaction);
 
-            switch ($transaction->type) {
-                case \Payment_Transaction::TXTYPE_PAYMENT:
-                    $this->_debit($transaction);
-                    break;
-
-                case \Payment_Transaction::TXTYPE_REFUND:
-                    $this->_refund($transaction);
-                    break;
-
-                case \Payment_Transaction::TXTYPE_SUBSCR_CREATE:
-                    $this->_subscribe($transaction);
-                    break;
-
-                case \Payment_Transaction::TXTYPE_SUBSCR_CANCEL:
-                    $this->_unsubscribe($transaction);
-                    break;
-
-                default:
-                    throw new \Box_Exception('Unknown transaction #:id type: :type', [':id' => $transaction->id, ':type' => $transaction->type], 632);
-            }
+            match ($transaction->type) {
+                \Payment_Transaction::TXTYPE_PAYMENT => $this->_debit($transaction),
+                \Payment_Transaction::TXTYPE_REFUND => $this->_refund($transaction),
+                \Payment_Transaction::TXTYPE_SUBSCR_CREATE => $this->_subscribe($transaction),
+                \Payment_Transaction::TXTYPE_SUBSCR_CANCEL => $this->_unsubscribe($transaction),
+                default => throw new \Box_Exception('Unknown transaction #:id type: :type', [':id' => $transaction->id, ':type' => $transaction->type], 632),
+            };
         } catch (\Exception $e) {
             $transaction->status = \Model_Transaction::STATUS_ERROR;
             $transaction->error = $e->getMessage();

--- a/src/modules/Kb/Controller/Admin.php
+++ b/src/modules/Kb/Controller/Admin.php
@@ -61,9 +61,9 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/kb', 'get_index', [], get_class($this));
-        $app->get('/kb/article/:id', 'get_post', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/kb/category/:id', 'get_cat', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/kb', 'get_index', [], static::class);
+        $app->get('/kb/article/:id', 'get_post', ['id' => '[0-9]+'], static::class);
+        $app->get('/kb/category/:id', 'get_cat', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Kb/Controller/Client.php
+++ b/src/modules/Kb/Controller/Client.php
@@ -38,9 +38,9 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/kb', 'get_kb', [], get_class($this));
-        $app->get('/kb/:category', 'get_kb_category', ['category' => '[a-z0-9-]+'], get_class($this));
-        $app->get('/kb/:category/:slug', 'get_kb_article', ['category' => '[a-z0-9-]+', 'slug' => '[a-z0-9-]+'], get_class($this));
+        $app->get('/kb', 'get_kb', [], static::class);
+        $app->get('/kb/:category', 'get_kb_category', ['category' => '[a-z0-9-]+'], static::class);
+        $app->get('/kb/:category/:slug', 'get_kb_article', ['category' => '[a-z0-9-]+', 'slug' => '[a-z0-9-]+'], static::class);
     }
 
     public function get_kb(\Box_App $app)

--- a/src/modules/Kb/Service.php
+++ b/src/modules/Kb/Service.php
@@ -20,10 +20,7 @@ class Service
 {
     protected $di;
 
-    /**
-     * @param mixed $di
-     */
-    public function setDi($di)
+    public function setDi(mixed $di)
     {
         $this->di = $di;
     }

--- a/src/modules/Massmailer/Controller/Admin.php
+++ b/src/modules/Massmailer/Controller/Admin.php
@@ -53,8 +53,8 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/massmailer', 'get_index', [], get_class($this));
-        $app->get('/massmailer/message/:id', 'get_edit', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/massmailer', 'get_index', [], static::class);
+        $app->get('/massmailer/message/:id', 'get_edit', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/News/Controller/Admin.php
+++ b/src/modules/News/Controller/Admin.php
@@ -53,11 +53,11 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/news', 'get_index', [], get_class($this));
-        $app->get('/news/', 'get_index', [], get_class($this));
-        $app->get('/news/index', 'get_index', [], get_class($this));
-        $app->get('/news/index/', 'get_index', [], get_class($this));
-        $app->get('/news/post/:id', 'get_post', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/news', 'get_index', [], static::class);
+        $app->get('/news/', 'get_index', [], static::class);
+        $app->get('/news/index', 'get_index', [], static::class);
+        $app->get('/news/index/', 'get_index', [], static::class);
+        $app->get('/news/post/:id', 'get_post', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/News/Controller/Client.php
+++ b/src/modules/News/Controller/Client.php
@@ -38,8 +38,8 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/news', 'get_news', [], get_class($this));
-        $app->get('/news/:slug', 'get_news_item', ['slug' => '[a-z0-9-]+'], get_class($this));
+        $app->get('/news', 'get_news', [], static::class);
+        $app->get('/news/:slug', 'get_news_item', ['slug' => '[a-z0-9-]+'], static::class);
     }
 
     public function get_news(\Box_App $app)

--- a/src/modules/News/Service.php
+++ b/src/modules/News/Service.php
@@ -20,10 +20,7 @@ class Service
 {
     protected $di;
 
-    /**
-     * @param mixed $di
-     */
-    public function setDi($di)
+    public function setDi(mixed $di)
     {
         $this->di = $di;
     }

--- a/src/modules/Notification/Api/Admin.php
+++ b/src/modules/Notification/Api/Admin.php
@@ -71,7 +71,7 @@ class Admin extends \Api_Abstract
      *
      * @return int|false - new message id
      */
-    public function add($data)
+    public function add($data): int|false
     {
         if (!isset($data['message'])) {
             return false;

--- a/src/modules/Notification/Controller/Admin.php
+++ b/src/modules/Notification/Controller/Admin.php
@@ -38,7 +38,7 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/notification', 'get_index', [], get_class($this));
+        $app->get('/notification', 'get_index', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Order/Controller/Admin.php
+++ b/src/modules/Order/Controller/Admin.php
@@ -68,11 +68,11 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/order', 'get_index', [], get_class($this));
-        $app->get('/order/', 'get_index', [], get_class($this));
-        $app->get('/order/index', 'get_index', [], get_class($this));
-        $app->get('/order/manage/:id', 'get_order', ['id' => '[0-9]+'], get_class($this));
-        $app->post('/order/new', 'get_new', [], get_class($this));
+        $app->get('/order', 'get_index', [], static::class);
+        $app->get('/order/', 'get_index', [], static::class);
+        $app->get('/order/index', 'get_index', [], static::class);
+        $app->get('/order/manage/:id', 'get_order', ['id' => '[0-9]+'], static::class);
+        $app->post('/order/new', 'get_new', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Order/Controller/Client.php
+++ b/src/modules/Order/Controller/Client.php
@@ -38,11 +38,11 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/order', 'get_products', [], get_class($this));
-        $app->get('/order/service', 'get_orders', [], get_class($this));
-        $app->get('/order/:id', 'get_configure_product', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/order/:slug', 'get_configure_product_by_slug', ['slug' => '[a-z0-9-]+'], get_class($this));
-        $app->get('/order/service/manage/:id', 'get_order', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/order', 'get_products', [], static::class);
+        $app->get('/order/service', 'get_orders', [], static::class);
+        $app->get('/order/:id', 'get_configure_product', ['id' => '[0-9]+'], static::class);
+        $app->get('/order/:slug', 'get_configure_product_by_slug', ['slug' => '[a-z0-9-]+'], static::class);
+        $app->get('/order/service/manage/:id', 'get_order', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_products(\Box_App $app)

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -273,7 +273,7 @@ class Service implements InjectionAwareInterface
 
     public function getServiceOrder($service)
     {
-        $type = $this->di['tools']->from_camel_case(str_replace('Model_Service', '', get_class($service)));
+        $type = $this->di['tools']->from_camel_case(str_replace('Model_Service', '', $service::class));
 
         $bindings = [
             'service_type' => $type,

--- a/src/modules/Orderbutton/Controller/Client.php
+++ b/src/modules/Orderbutton/Controller/Client.php
@@ -38,8 +38,8 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/orderbutton', 'get_index', [], get_class($this));
-        $app->get('/orderbutton/js', 'get_js', [], get_class($this));
+        $app->get('/orderbutton', 'get_index', [], static::class);
+        $app->get('/orderbutton/js', 'get_js', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Product/Api/Guest.php
+++ b/src/modules/Product/Api/Guest.php
@@ -154,7 +154,7 @@ class Guest extends \Api_Abstract
                 'pricing' => $product['pricing'],
             ];
             foreach ($pc as $k => $v) {
-                if (false !== strpos($k, 'slider_')) {
+                if (str_contains($k, 'slider_')) {
                     $s[substr($k, strlen('slider_'))] = $v;
                 }
             }

--- a/src/modules/Product/Controller/Admin.php
+++ b/src/modules/Product/Controller/Admin.php
@@ -75,13 +75,13 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/product', 'get_index', [], get_class($this));
-        $app->get('/product/promos', 'get_promos', [], get_class($this));
-        $app->get('/product/promo/:id', 'get_promo', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/product/manage/:id', 'get_manage', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/product/addons', 'get_addons', [], get_class($this));
-        $app->get('/product/addon/:id', 'get_addon_manage', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/product/category/:id', 'get_cat_manage', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/product', 'get_index', [], static::class);
+        $app->get('/product/promos', 'get_promos', [], static::class);
+        $app->get('/product/promo/:id', 'get_promo', ['id' => '[0-9]+'], static::class);
+        $app->get('/product/manage/:id', 'get_manage', ['id' => '[0-9]+'], static::class);
+        $app->get('/product/addons', 'get_addons', [], static::class);
+        $app->get('/product/addon/:id', 'get_addon_manage', ['id' => '[0-9]+'], static::class);
+        $app->get('/product/category/:id', 'get_cat_manage', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -151,7 +151,7 @@ class Service implements InjectionAwareInterface
         $extensionService = $this->di['mod_service']('extension');
         $list = $extensionService->getInstalledMods();
         foreach ($list as $mod) {
-            if ('service' == substr($mod, 0, strlen('service'))) {
+            if (str_starts_with($mod, 'service')) {
                 $n = substr($mod, strlen('service'));
                 $data[$n] = ucfirst($n);
             }
@@ -201,7 +201,7 @@ class Service implements InjectionAwareInterface
         // try save with slug
         try {
             $productId = $this->di['db']->store($model);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $model->slug = $this->di['tools']->slug($title) . '-' . random_int(1, 9999);
         }
         $productId = $this->di['db']->store($model);
@@ -416,7 +416,7 @@ class Service implements InjectionAwareInterface
         // try save with slug
         try {
             $productId = $this->di['db']->store($model);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $model->slug = $this->di['tools']->slug($title) . '-' . random_int(1, 9999);
             $productId = $this->di['db']->store($model);
         }

--- a/src/modules/Queue/Api/Admin.php
+++ b/src/modules/Queue/Api/Admin.php
@@ -104,7 +104,7 @@ class Admin extends \Api_Abstract
         $service = $mod->getService();
         $handler = $data['handler'] ?? $data['queue'];
         if (!method_exists($service, $handler)) {
-            throw new \Box_Exception('Message handler function :method does not exists', [':ext' => $data['mod'], ':method' => get_class($service) . ':' . $handler]);
+            throw new \Box_Exception('Message handler function :method does not exists', [':ext' => $data['mod'], ':method' => $service::class . ':' . $handler]);
         }
 
         $interval = isset($data['interval']) ? (int) $data['interval'] : 30;
@@ -222,7 +222,7 @@ class Admin extends \Api_Abstract
         $result = [];
         foreach ($msgs as $msg) {
             try {
-                $this->di['logger']->info(sprintf('Executing %s queue message #%s with handler %s(%s)', $q->name, $msg['id'], get_class($service) . ':' . $msg['handler'], $msg['json']));
+                $this->di['logger']->info(sprintf('Executing %s queue message #%s with handler %s(%s)', $q->name, $msg['id'], $service::class . ':' . $msg['handler'], $msg['json']));
                 call_user_func([$service, $msg['handler']], $msg['params']);
                 $this->di['db']->exec($dsql, ['id' => $msg['id']]);
                 $result[$msg['id']] = ['status' => 'executed', 'error' => null];

--- a/src/modules/Redirect/Controller/Client.php
+++ b/src/modules/Redirect/Controller/Client.php
@@ -53,7 +53,7 @@ class Client implements \Box\InjectionAwareInterface
         $service = $this->di['mod_service']('redirect');
         $redirects = $service->getRedirects();
         foreach ($redirects as $redirect) {
-            $app->get('/' . $redirect['path'], 'do_redirect', [], get_class($this));
+            $app->get('/' . $redirect['path'], 'do_redirect', [], static::class);
         }
     }
 

--- a/src/modules/Seo/Service.php
+++ b/src/modules/Seo/Service.php
@@ -55,7 +55,7 @@ class Service implements InjectionAwareInterface
                 $link = 'https://www.google.com/ping?sitemap=' . $url;
                 $this->di['guzzle_client']->get($link);
                 error_log('Submitted sitemap to Google');
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 error_log('Exception :(');
             }
         }+

--- a/src/modules/Servicedomain/Controller/Admin.php
+++ b/src/modules/Servicedomain/Controller/Admin.php
@@ -53,9 +53,9 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/servicedomain', 'get_index', null, get_class($this));
-        $app->get('/servicedomain/tld/:tld', 'get_tld', ['tld' => '[/.a-z0-9]+'], get_class($this));
-        $app->get('/servicedomain/registrar/:id', 'get_registrar', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/servicedomain', 'get_index', null, static::class);
+        $app->get('/servicedomain/tld/:tld', 'get_tld', ['tld' => '[/.a-z0-9]+'], static::class);
+        $app->get('/servicedomain/registrar/:id', 'get_registrar', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Servicedownloadable/Controller/Client.php
+++ b/src/modules/Servicedownloadable/Controller/Client.php
@@ -38,7 +38,7 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/servicedownloadable/get-file/:id', 'get_download', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/servicedownloadable/get-file/:id', 'get_download', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_download(\Box_App $app, $id)

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -229,24 +229,16 @@ class Service implements InjectionAwareInterface
 
     private function _error_message($error_code)
     {
-        switch ($error_code) {
-            case UPLOAD_ERR_INI_SIZE:
-                return 'The uploaded file exceeds the upload_max_filesize directive in php.ini';
-            case UPLOAD_ERR_FORM_SIZE:
-                return 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form';
-            case UPLOAD_ERR_PARTIAL:
-                return 'The uploaded file was only partially uploaded';
-            case UPLOAD_ERR_NO_FILE:
-                return 'No file was uploaded';
-            case UPLOAD_ERR_NO_TMP_DIR:
-                return 'Missing a temporary folder';
-            case UPLOAD_ERR_CANT_WRITE:
-                return 'Failed to write file to disk';
-            case UPLOAD_ERR_EXTENSION:
-                return 'File upload stopped by extension';
-            default:
-                return 'Unknown upload error';
-        }
+        return match ($error_code) {
+            UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
+            UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
+            UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded',
+            UPLOAD_ERR_NO_FILE => 'No file was uploaded',
+            UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder',
+            UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
+            UPLOAD_ERR_EXTENSION => 'File upload stopped by extension',
+            default => 'Unknown upload error',
+        };
     }
 
     public function sendDownload($filename, $path)

--- a/src/modules/Servicehosting/Controller/Admin.php
+++ b/src/modules/Servicehosting/Controller/Admin.php
@@ -53,9 +53,9 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/servicehosting', 'get_index', null, get_class($this));
-        $app->get('/servicehosting/plan/:id', 'get_plan', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/servicehosting/server/:id', 'get_server', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/servicehosting', 'get_index', null, static::class);
+        $app->get('/servicehosting/plan/:id', 'get_plan', ['id' => '[0-9]+'], static::class);
+        $app->get('/servicehosting/server/:id', 'get_server', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Servicelicense/Server.php
+++ b/src/modules/Servicelicense/Server.php
@@ -18,8 +18,6 @@ namespace Box\Mod\Servicelicense;
 
 class Server implements \Box\InjectionAwareInterface
 {
-    private $_log = null;
-
     private $_result = [
         'licensed_to' => null,
         'created_at' => null,
@@ -39,9 +37,8 @@ class Server implements \Box\InjectionAwareInterface
         return $this->di;
     }
 
-    public function __construct(\Box_Log $log)
+    public function __construct(private \Box_Log $_log)
     {
-        $this->_log = $log;
     }
 
     /**

--- a/src/modules/Spamchecker/akismet.curl.class.php
+++ b/src/modules/Spamchecker/akismet.curl.class.php
@@ -161,10 +161,8 @@ class akismet
      *
      * @param string $request The data to be $_POST'ed
      * @param string $url     The URL to send it too
-     *
-     * @return bool|string
      */
-    private function send_data($request = null, $url = null)
+    private function send_data($request = null, $url = null): bool|string
     {
         // Set the url to send data too
         curl_setopt($this->connection_handle, CURLOPT_URL, $url);

--- a/src/modules/Staff/Controller/Admin.php
+++ b/src/modules/Staff/Controller/Admin.php
@@ -55,11 +55,11 @@ class Admin implements InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/staff/login', 'get_login', [], get_class($this));
-        $app->get('/staff/manage/:id', 'get_manage', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/staff/group/:id', 'get_group', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/staff/profile', 'get_profile', [], get_class($this));
-        $app->get('/staff/logins', 'get_history', [], get_class($this));
+        $app->get('/staff/login', 'get_login', [], static::class);
+        $app->get('/staff/manage/:id', 'get_manage', ['id' => '[0-9]+'], static::class);
+        $app->get('/staff/group/:id', 'get_group', ['id' => '[0-9]+'], static::class);
+        $app->get('/staff/profile', 'get_profile', [], static::class);
+        $app->get('/staff/logins', 'get_history', [], static::class);
     }
 
     public function get_login(\Box_App $app)

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -482,7 +482,7 @@ class Service implements InjectionAwareInterface
 
         try {
             $newId = $this->di['db']->store($model);
-        } catch (\RedBeanPHP\RedException $e) {
+        } catch (\RedBeanPHP\RedException) {
             throw new \Box_Exception('Staff member with email :email is already registered', [':email' => $data['email']], 788954);
         }
 

--- a/src/modules/Support/Controller/Admin.php
+++ b/src/modules/Support/Controller/Admin.php
@@ -81,18 +81,18 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/support', 'get_index', [], get_class($this));
-        $app->get('/support/', 'get_index', [], get_class($this));
-        $app->get('/support/index', 'get_index', [], get_class($this));
-        $app->get('/support/ticket/:id', 'get_ticket', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/support/ticket/:id/message/:messageid', 'get_ticket', ['id' => '[0-9]+', 'messageid' => '[0-9]+'], get_class($this));
-        $app->get('/support/public-tickets', 'get_public_tickets', [], get_class($this));
-        $app->get('/support/public-ticket/:id', 'get_public_ticket', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/support/helpdesks', 'get_helpdesks', [], get_class($this));
-        $app->get('/support/helpdesk/:id', 'get_helpdesk', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/support/canned-responses', 'get_canned_list', [], get_class($this));
-        $app->get('/support/canned/:id', 'get_canned', ['id' => '[0-9]+'], get_class($this));
-        $app->get('/support/canned-category/:id', 'get_canned_cat', ['id' => '[0-9]+'], get_class($this));
+        $app->get('/support', 'get_index', [], static::class);
+        $app->get('/support/', 'get_index', [], static::class);
+        $app->get('/support/index', 'get_index', [], static::class);
+        $app->get('/support/ticket/:id', 'get_ticket', ['id' => '[0-9]+'], static::class);
+        $app->get('/support/ticket/:id/message/:messageid', 'get_ticket', ['id' => '[0-9]+', 'messageid' => '[0-9]+'], static::class);
+        $app->get('/support/public-tickets', 'get_public_tickets', [], static::class);
+        $app->get('/support/public-ticket/:id', 'get_public_ticket', ['id' => '[0-9]+'], static::class);
+        $app->get('/support/helpdesks', 'get_helpdesks', [], static::class);
+        $app->get('/support/helpdesk/:id', 'get_helpdesk', ['id' => '[0-9]+'], static::class);
+        $app->get('/support/canned-responses', 'get_canned_list', [], static::class);
+        $app->get('/support/canned/:id', 'get_canned', ['id' => '[0-9]+'], static::class);
+        $app->get('/support/canned-category/:id', 'get_canned_cat', ['id' => '[0-9]+'], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/Support/Controller/Client.php
+++ b/src/modules/Support/Controller/Client.php
@@ -38,10 +38,10 @@ class Client implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/support', 'get_tickets', [], get_class($this));
-        $app->get('/support/ticket/:id', 'get_ticket', [], get_class($this));
-        $app->get('/support/contact-us', 'get_contact_us', [], get_class($this));
-        $app->get('/support/contact-us/conversation/:hash', 'get_contact_us_conversation', ['hash' => '[a-z0-9]+'], get_class($this));
+        $app->get('/support', 'get_tickets', [], static::class);
+        $app->get('/support/ticket/:id', 'get_ticket', [], static::class);
+        $app->get('/support/contact-us', 'get_contact_us', [], static::class);
+        $app->get('/support/contact-us/conversation/:hash', 'get_contact_us_conversation', ['hash' => '[a-z0-9]+'], static::class);
     }
 
     public function get_tickets(\Box_App $app)

--- a/src/modules/System/Controller/Admin.php
+++ b/src/modules/System/Controller/Admin.php
@@ -60,10 +60,10 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/system', 'get_index', [], get_class($this));
-        $app->get('/system/', 'get_index', [], get_class($this));
-        $app->get('/system/index', 'get_index', [], get_class($this));
-        $app->get('/system/activity', 'get_activity', [], get_class($this));
+        $app->get('/system', 'get_index', [], static::class);
+        $app->get('/system/', 'get_index', [], static::class);
+        $app->get('/system/index', 'get_index', [], static::class);
+        $app->get('/system/activity', 'get_activity', [], static::class);
     }
 
     public function get_index(\Box_App $app)

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -20,10 +20,7 @@ class Service
 {
     protected $di;
 
-    /**
-     * @param mixed $di
-     */
-    public function setDi($di)
+    public function setDi(mixed $di)
     {
         $this->di = $di;
     }
@@ -160,18 +157,18 @@ class Service
 
         $baseUrl = $this->di['config']['url'];
         $logoUrl = $this->di['array_get']($results, 'company_logo', null);
-        if (null !== $logoUrl && false === strpos($logoUrl, 'http')) {
+        if (null !== $logoUrl && !str_contains($logoUrl, 'http')) {
             $logoUrl = $baseUrl . $logoUrl;
         }
 
         $logoUrlDark = $this->di['array_get']($results, 'company_logo_dark', null);
-        if (null !== $logoUrlDark && false === strpos($logoUrlDark, 'http')) {
+        if (null !== $logoUrlDark && !str_contains($logoUrlDark, 'http')) {
             $logoUrlDark = $baseUrl . $logoUrlDark;
         }
         $logoUrlDark = (null === $logoUrlDark) ? $logoUrl : $logoUrlDark;
 
         $faviconUrl = $this->di['array_get']($results, 'company_favicon', null);
-        if (null !== $faviconUrl && false === strpos($faviconUrl, 'http')) {
+        if (null !== $faviconUrl && !str_contains($faviconUrl, 'http')) {
             $faviconUrl = $baseUrl . $faviconUrl;
         }
 
@@ -344,7 +341,7 @@ class Service
             // attempt adding admin api to twig
             try {
                 $twig->addGlobal('admin', $this->di['api_admin']);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // skip if admin is not logged in
             }
         }
@@ -355,7 +352,7 @@ class Service
         try {
             $template = $twig->load($tpl);
             $parsed = $template->render($vars);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // $twig->load throws error when $tpl is string
             $parsed = $this->createTemplateFromString($tpl, $try_render, $vars);
         }
@@ -391,7 +388,7 @@ class Service
         if (isset($ip)) {
             try {
                 return $this->di['tools']->get_url('https://api.ipify.org', 2);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 return '';
             }
         }
@@ -421,7 +418,7 @@ class Service
         }
 
         $this_page = $request->getURI();
-        if (false !== strpos($this_page, '?')) {
+        if (str_contains($this_page, '?')) {
             $a = explode('?', $this_page);
             $this_page = reset($a);
         }

--- a/src/modules/Theme/Controller/Admin.php
+++ b/src/modules/Theme/Controller/Admin.php
@@ -38,8 +38,8 @@ class Admin implements \Box\InjectionAwareInterface
 
     public function register(\Box_App &$app)
     {
-        $app->get('/theme/:theme', 'get_theme', ['theme' => '[a-z0-9-_]+'], get_class($this));
-        $app->post('/theme/:theme', 'save_theme_settings', ['theme' => '[a-z0-9-_]+'], get_class($this));
+        $app->get('/theme/:theme', 'get_theme', ['theme' => '[a-z0-9-_]+'], static::class);
+        $app->post('/theme/:theme', 'save_theme_settings', ['theme' => '[a-z0-9-_]+'], static::class);
     }
 
     /**

--- a/src/modules/Theme/Model/Theme.php
+++ b/src/modules/Theme/Model/Theme.php
@@ -18,12 +18,8 @@ namespace Box\Mod\Theme\Model;
 
 class Theme
 {
-    private $name;
-
-    public function __construct($name)
+    public function __construct(private $name)
     {
-        $this->name = $name;
-
         if (!file_exists($this->getPath())) {
             throw new \Box_Exception('Theme ":name" does not exist', [':name' => $name]);
         }
@@ -36,7 +32,7 @@ class Theme
 
     public function isAdminAreaTheme()
     {
-        return false !== strpos($this->name, 'admin_');
+        return str_contains($this->name, 'admin_');
     }
 
     public function isAssetsPathWritable()

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -286,11 +286,11 @@ class Service implements InjectionAwareInterface
             while (false !== ($file = readdir($handle))) {
                 if (is_dir($path . DIRECTORY_SEPARATOR . $file) && '.' != $file[0]) {
                     try {
-                        if (!$client && false !== strpos($file, 'admin')) {
+                        if (!$client && str_contains($file, 'admin')) {
                             $list[] = $this->_loadTheme($file);
                         }
 
-                        if ($client && false === strpos($file, 'admin')) {
+                        if ($client && !str_contains($file, 'admin')) {
                             $list[] = $this->_loadTheme($file);
                         }
                     } catch (\Exception $e) {

--- a/src/rector.php
+++ b/src/rector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/',
+    ]);
+
+    $rectorConfig->skip([
+        __DIR__ . '/vendor',
+        __DIR__ . '/dache',
+        UnionTypesRector::class,
+        MixedTypeRector::class,
+    ]);
+
+    $rectorConfig->sets([
+        SetList::PHP_80,
+    ]);
+};

--- a/src/rector.php
+++ b/src/rector.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -13,7 +12,8 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         __DIR__ . '/vendor',
-        __DIR__ . '/dache',
+        __DIR__ . '/data',
+        __DIR__ . '/library',
         UnionTypesRector::class,
         MixedTypeRector::class,
     ]);


### PR DESCRIPTION
As the tin says, uses [Rector](https://github.com/rectorphp/rector) to "upgrade" (modernize) the code for PHP 8.0.
Most changes are pretty minimal, it's mostly replacing functions like `substr`, `get_class`, and `strpos` with newer functions that are cleaner to read in the code & therefore make it more obvious what it's doing