### PR TITLE
Clean up the new form serialize function a bit

### DIFF
--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -27,8 +27,11 @@ FormData.prototype.serializeObject = function(){
       }else{
           obj[key]=pair[1];
       }
+    }
+    let reformattedObj = {};
+    Object.keys(obj).forEach(function (key) {
       let parts = key.split('[');
-      let current = obj;
+      let current = reformattedObj;
       for (let i = 0; i < parts.length; i++) {
           let part = parts[i];
           if (part.endsWith(']')) {
@@ -43,8 +46,8 @@ FormData.prototype.serializeObject = function(){
               current = current[part];
           }
       }
-    }
-    return obj;
+    });
+    return reformattedObj;
 }
 /**
  * Converts a form element into a valid JSON string depends on serializeObject

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -8,6 +8,54 @@
  * with this source code in the file LICENSE
  */
 
+/**
+ * Converts a form element in valid valid object that can become
+ * @param {object} FormData object
+ * @returns {object} The reformatted object or stringified version of the object.
+*/
+FormData.prototype.serializeObject = function(){
+    const obj = {};
+    // reformat input[] fields to arrays
+    for (const pair of this.entries()) {
+      key=pair[0];
+      if(key.endsWith('[]')){
+          key=key.slice(0,-2);
+          if(!obj[key]){
+              obj[key] = [];
+          }
+          obj[key].push(pair[1]);
+      }else{
+          obj[key]=pair[1];
+      }
+      let parts = key.split('[');
+      let current = obj;
+      for (let i = 0; i < parts.length; i++) {
+          let part = parts[i];
+          if (part.endsWith(']')) {
+              part = part.slice(0, -1);
+          }
+          if (i === parts.length - 1) {
+              current[part] = obj[key];
+          } else {
+              if (!(part in current)) {
+                  current[part] = {};
+              }
+              current = current[part];
+          }
+      }
+    }
+    return obj;
+}
+/**
+ * Converts a form element into a valid JSON string depends on serializeObject
+ * @param {object} FormData object
+ * @returns {string} Returns JSON string of the FromData Object
+*/
+FormData.prototype.serializeJSON = function(){
+  return JSON.stringify(this.serializeObject());
+}
+
+
 const Tools = {
     /**
      * Get the full URL from a relative URL to the API
@@ -42,38 +90,7 @@ const Tools = {
         } catch (error) {
             return false;
         }
-    },
-
-    /**
-     * Reformats malformed JSON data to conform to proper JSON format.
-     * @param {object|string} jsonString The object to reformat to proper JSON data, correcting malformed data
-     * @param {boolean} [returnObj=false] Determines if the function returns a reformatted object or the stringified json
-     * @returns {object|string} The reformatted object or stringified version of the object.
-     */
-    reformatJSON: function (jsonString, returnObj = false) {
-        let obj = jsonString;
-        let reformattedObj = {};
-        Object.keys(obj).forEach(function (key) {
-            let parts = key.split('[');
-            let current = reformattedObj;
-            for (let i = 0; i < parts.length; i++) {
-                let part = parts[i];
-                if (part.endsWith(']')) {
-                    part = part.slice(0, -1);
-                }
-                if (i === parts.length - 1) {
-                    current[part] = obj[key];
-                } else {
-                    if (!(part in current)) {
-                        current[part] = {};
-                    }
-                    current = current[part];
-                }
-            }
-        });
-        var result = (returnObj) ? reformattedObj : JSON.stringify(reformattedObj);
-        return result;
-    },
+    }
 }
 
 /**
@@ -198,18 +215,7 @@ const API = {
             }
             body = null
         } else if (method.toLowerCase() === "post") {
-            var postParams = params;
-            // Convert the JSON to an object
-            if (Tools.isJSON(postParams)) {
-                postParams = JSON.parse(postParams);
-            }
-            // Now we run the object through the reformatJSON function, setting the body to the returned JSON string
-            if (typeof postParams === "object") {
-                postParams = Tools.reformatJSON(postParams);
-                body = postParams;
-            } else {
-                body = params;
-            }
+            body = params;
         }
 
         // Call the API and handle the response

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -129,22 +129,8 @@ var bb = {
         formElement.addEventListener("submit", function (event) {
           // Prevent the default form submit action. We will handle it ourselves.
           event.preventDefault();
-
           const formData = new FormData(formElement);
-          const obj = {};
-          for (const pair of formData.entries()) {
-            var key=pair[0];
-            if(key.slice(-2) == '[]'){
-                nkey=key.slice(0,key.length-2);
-                if(!obj[nkey]){
-                    obj[nkey] = new Array();
-                }
-                obj[nkey].push(pair[1]);
-            }else{
-                obj[key]=pair[1];
-            }
-          }
-          API.makeRequest(formElement.getAttribute('method'), bb.restUrl(formElement.getAttribute('action')),  JSON.stringify(obj) , function (result) {
+          API.makeRequest(formElement.getAttribute('method'), bb.restUrl(formElement.getAttribute('action')),  formData.serializeJSON() , function (result) {
             return bb._afterComplete(formElement, result);
           }, function (error) {
             FOSSBilling.message(`${error.message} (${error.code})`, 'error');


### PR DESCRIPTION
Expanded the FormData Object a bit with 2 function 
- serializeObject that convert any html form to a object that can be converted with  JSON.stringify
- serializeJSON  that runs the JSON.stringify for us 

General usage
```
const formData = new FormData(document.getElementById('form'));
formData.serializeJSON()
```
