### PR TITLE
Fixes replication of new css body classes and existing container classes

### DIFF
--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -2,7 +2,7 @@
 
 {% block meta_title %}{{ 'Log in'|trans }}{% endblock %}
 
-{% block body_class %}login{% endblock %}
+{% block body_class %}page-login{% endblock %}
 {% block body %}
 
 <section class="container login" role="main">

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -2,7 +2,7 @@
 
 {% block meta_title %}{{ 'Reset password'|trans }}{% endblock %}
 
-{% block body_class %}password-reset{% endblock %}
+{% block body_class %}page-password-reset{% endblock %}
 {% block body %}
 
 <section class="container login" role="main">

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -4,7 +4,7 @@
 
 {% block meta_title %}{{ 'Sign up'|trans }}{% endblock %}
 
-{% block body_class %}signup{% endblock %}
+{% block body_class %}page-signup{% endblock %}
 {% block body %}
 <section class="container login" role="main">
     {% if settings.login_page_show_logo %}


### PR DESCRIPTION
Simply renames body classes from, i.e. 'login' to 'page-login'. 

