### PR TITLE
Login / Signup / Pass reset styling

### DIFF
--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -17,6 +17,7 @@
         {% endif %}
     </h1>
 {% endif %}
+    <h2>{{ 'Login'|trans }}</h2>
 
     <div class="data-block">
         <div class="data-container">

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -7,7 +7,18 @@
 
 <section class="container login" role="main">
 
- <h1>{{ 'Reset password'|trans }}</h1>
+{% if settings.login_page_show_logo %}
+    {% set company = guest.system_company %}
+    <h1 style="text-align: center">
+        {% if settings.login_page_show_logo %}
+        <a href="{{ settings.login_page_logo_url|default('/') }}" target="_blank">
+            <img src="{{ guest.system_company.logo_url }}" alt="{{ guest.system_company.name }}"/>
+        </a>
+        {% endif %}
+        
+    </h1>
+{% endif %}
+    <h2>{{ 'Reset password'|trans }}</h2>
 
 <div class="data-block">
     <div class="data-container">

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -15,6 +15,7 @@
         {% endif %}
     </h1>
     {% endif %}
+    <h2>{{ 'Signup'|trans }}</h2>
     <div class="data-block">
         <div class="data-container">
 

--- a/src/themes/huraga/assets/css/huraga-main.css
+++ b/src/themes/huraga/assets/css/huraga-main.css
@@ -9404,6 +9404,9 @@ div.jGrowl div.success a:hover {
     height: 37px;
     background-image: url("../img/template_logo.png");
 }
+.container.login h2 {
+    text-align: center;
+}
 .container.login form {
     margin: 0;
     border: none;


### PR DESCRIPTION
- Adds logo  to password reset page (if enabled in theme options) so that it is consistent with login and signup pages. 
- Adds heading to login and signup pages. 
- Adds a style rule to Huraga so that changes look ok in theme.