### PR TITLE
Fix API wrapper

### DIFF
--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -207,7 +207,13 @@ const API = {
         // Loop through the parameters and add them to the URL as a query string
         // GET requests should have their parameters in the query string and POST requests should have them in the body
         if (method.toLowerCase() === "get") {
-            url.search=params;
+            if(typeof params === 'object'){
+              Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
+            }else{
+              if(params){
+                url.search=params;
+              }
+            }
             body = null
         } else if (method.toLowerCase() === "post") {
             body = params;

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -9,6 +9,14 @@
  */
 
 /**
+  * Converts a form element in valid valid object that can become
+  * @param {object} FormData object
+  * @returns {string} Serialized string of the FormData
+ */
+FormData.prototype.serialize = function(){
+    return new URLSearchParams(this).toString();
+}
+/**
  * Converts a form element in valid valid object that can become
  * @param {object} FormData object
  * @returns {object} The reformatted object or stringified version of the object.
@@ -195,27 +203,11 @@ const API = {
      * @documentation https://fossbilling.org/docs/api/javascript
      */
     makeRequest: function (method, url, params, successHandler, errorHandler) {
-        // If the parameters are not set, set them to an empty object
-        params = (params) ? params : {};
-
-        // If the request didn't specify a CSRF token, use the one set in the page headers
-        params.CSRFToken = (params.CSRFToken) ? params.CSRFToken : Tools.getCSRFToken();
-
         url = new URL(url);
-
-        var body = params;
-
         // Loop through the parameters and add them to the URL as a query string
         // GET requests should have their parameters in the query string and POST requests should have them in the body
         if (method.toLowerCase() === "get") {
-            var getParams = params;
-            // Convert JSON strings to an Object
-            if (Tools.isJSON(params)) {
-                getParams = JSON.parse(params);
-            }
-            if (typeof getParams === "object") {
-                Object.keys(getParams).forEach(key => url.searchParams.append(key, getParams[key]));
-            }
+            url.search=params;
             body = null
         } else if (method.toLowerCase() === "post") {
             body = params;

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -9,7 +9,7 @@
  */
 
 /**
-  * Converts a form element in valid valid object that can become
+  * Converts a form element into a url encoded string
   * @param {object} FormData object
   * @returns {string} Serialized string of the FormData
  */
@@ -20,7 +20,7 @@ FormData.prototype.serialize = function(){
     return new URLSearchParams(this).toString();
 }
 /**
- * Converts a form element in valid valid object that can become
+ * Converts a form element in valid valid object that can be used for JSON
  * @param {object} FormData object
  * @returns {object} The reformatted object or stringified version of the object.
 */

--- a/src/modules/Order/html_admin/mod_order_new.html.twig
+++ b/src/modules/Order/html_admin/mod_order_new.html.twig
@@ -28,7 +28,7 @@
         <h3>{{ 'Create new order'|trans }}</h3>
         <p class="text-muted">{{ product.title }} {{ 'for'|trans }} {{ client.first_name }} {{ client.last_name }}</h2>
 
-        <form method="get" action="{{ 'api/admin/order/create'|link }}" class="api-form" data-api-jsonp="onAfterOrderPlaced">
+        <form method="post" action="{{ 'api/admin/order/create'|link }}" class="api-form" data-api-jsonp="onAfterOrderPlaced">
             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Invoice option'|trans }}</label>

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -130,6 +130,9 @@ var bb = {
           // Prevent the default form submit action. We will handle it ourselves.
           event.preventDefault();
           const formData = new FormData(formElement);
+          if(!formData.get('CSRFToken')){
+            formData.append('CSRFToken', Tools.getCSRFToken());
+          }
           if(formElement.getAttribute('method').toLowerCase() != 'get'){
              data = formData.serializeJSON();
           }else{
@@ -158,7 +161,7 @@ var bb = {
 
           if (linkElement.hasAttribute('data-api-confirm')) {
             if (confirm(linkElement.getAttribute('data-api-confirm'))) {
-              API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
+              API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {'CSRFToken' : Tools.getCSRFToken()}, function (result) {
                 return bb._afterComplete(linkElement, result)}, function (error) {
                   FOSSBilling.message(`${error.message} (${error.code})`, 'error');
                 });
@@ -166,7 +169,7 @@ var bb = {
           } else if (linkElement.hasAttribute('data-api-prompt')) {
             jPrompt(linkElement.getAttribute('data-api-prompt-text'), linkElement.getAttribute('data-api-prompt-default'), linkElement.getAttribute('data-api-prompt-title'), function (r) {
               if (r) {
-                var p = {};
+                var p = {'CSRFToken' : Tools.getCSRFToken()};
                 var name = linkElement.getAttribute('data-api-prompt-key');
                 p[name] = r;
                 API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), p, function (result) {
@@ -176,7 +179,7 @@ var bb = {
               }
             });
           } else {
-            API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
+            API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {'CSRFToken' : Tools.getCSRFToken()}, function (result) {
               return bb._afterComplete(linkElement, result)}, function (error) {
                 FOSSBilling.message(`${error.message} (${error.code})`, 'error');
               });

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -12,7 +12,7 @@ var bb = {
 
     // We don't know which API is called (admin, client, guest), so we are directly using the makeRequest method and not specific methods like API.admin.post().
     // Templates willing to use the new API wrapper should use the corresponding methods and avoid using the makeRequest method directly.
-    API.makeRequest("POST", bb.restUrl(url), params, successHandler, function (error) {
+    API.makeRequest("POST", bb.restUrl(url), JSON.stringify(params), successHandler, function (error) {
       FOSSBilling.message(error.message, 'error');
     });
     console.error("This theme or module is using a deprecated method. Please update it to use the new API wrapper instead. Documentation: https://fossbilling.org/docs/api/javascript");
@@ -130,9 +130,6 @@ var bb = {
           // Prevent the default form submit action. We will handle it ourselves.
           event.preventDefault();
           const formData = new FormData(formElement);
-          if(!formData.get('CSRFToken')){
-            formData.append('CSRFToken', Tools.getCSRFToken());
-          }
           if(formElement.getAttribute('method').toLowerCase() != 'get'){
              data = formData.serializeJSON();
           }else{
@@ -161,7 +158,7 @@ var bb = {
 
           if (linkElement.hasAttribute('data-api-confirm')) {
             if (confirm(linkElement.getAttribute('data-api-confirm'))) {
-              API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {'CSRFToken' : Tools.getCSRFToken()}, function (result) {
+              API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
                 return bb._afterComplete(linkElement, result)}, function (error) {
                   FOSSBilling.message(`${error.message} (${error.code})`, 'error');
                 });
@@ -169,7 +166,7 @@ var bb = {
           } else if (linkElement.hasAttribute('data-api-prompt')) {
             jPrompt(linkElement.getAttribute('data-api-prompt-text'), linkElement.getAttribute('data-api-prompt-default'), linkElement.getAttribute('data-api-prompt-title'), function (r) {
               if (r) {
-                var p = {'CSRFToken' : Tools.getCSRFToken()};
+                var p = {};
                 var name = linkElement.getAttribute('data-api-prompt-key');
                 p[name] = r;
                 API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), p, function (result) {
@@ -179,7 +176,7 @@ var bb = {
               }
             });
           } else {
-            API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {'CSRFToken' : Tools.getCSRFToken()}, function (result) {
+            API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
               return bb._afterComplete(linkElement, result)}, function (error) {
                 FOSSBilling.message(`${error.message} (${error.code})`, 'error');
               });

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -130,7 +130,12 @@ var bb = {
           // Prevent the default form submit action. We will handle it ourselves.
           event.preventDefault();
           const formData = new FormData(formElement);
-          API.makeRequest(formElement.getAttribute('method'), bb.restUrl(formElement.getAttribute('action')),  formData.serializeJSON() , function (result) {
+          if(formElement.getAttribute('method').toLowerCase() != 'get'){
+             data = formData.serializeJSON();
+          }else{
+            data =  formData.serialize();
+          }
+          API.makeRequest(formElement.getAttribute('method'), bb.restUrl(formElement.getAttribute('action')),  data , function (result) {
             return bb._afterComplete(formElement, result);
           }, function (error) {
             FOSSBilling.message(`${error.message} (${error.code})`, 'error');


### PR DESCRIPTION
Old code caused issues with GET requests this time:

Following methods are supported:
1. Form data (POST) via new API wrapper (Use FormData.serializeJSON())
2. Form data (GET) via new API Wrapper (Use FormData.serialize()) 
3. POST via bb.post (Uses objects) added a check for CSRF 
4. Get requests via new API Wrapper 
5. Get requests via bb.get (Should have no changes)