### PR TITLE
Fix issue #701

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -305,8 +305,9 @@ function twig_size_filter($value)
 
 function twig_markdown_filter(Twig\Environment $env, $value)
 {
+    $content = $value ?? '';
     $markdownParser = new GithubFlavoredMarkdownConverter(['html_input' => 'escape', 'allow_unsafe_links' => false, 'max_nesting_level' => 50]);
-    return $markdownParser->convert($value);
+    return $markdownParser->convert($content);
 }
 
 function twig_truncate_filter(Twig\Environment $env, $value, $length = 30, $preserve = false, $separator = '...')


### PR DESCRIPTION
Closes #701. I have no idea why null is being sent to the markdown filter, but this accounts for it
![image](https://user-images.githubusercontent.com/17304943/212502707-cfb3a442-5355-488a-8167-06342e06f762.png)
