### PR TITLE
Start removing multi selects

### DIFF
--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -292,12 +292,20 @@ class Service implements InjectionAwareInterface
         $model->hidden = (int) $this->di['array_get']($data, 'hidden', $model->hidden);
         $model->slug = $this->di['array_get']($data, 'slug', $model->slug);
         $model->setup = $this->di['array_get']($data, 'setup', $model->setup);
+        //remove empty value in data['upgrades];
         if (isset($data['upgrades']) && is_array($data['upgrades'])) {
-            $model->upgrades = json_encode($data['upgrades']);
-        } elseif (isset($data['upgrades']) && empty($data['upgrades'])) {
-            $model->upgrades = null;
+            $upgrades = [];
+            foreach($data['upgrades'] as $upgrade => $value){
+                if(!empty($value)){
+                    $upgrades[] = $value;
+                }
+            }
+            if(!empty($upgrades)){
+                $model->upgrades = json_encode($upgrades);
+            }else{
+                $model->upgrades = null;
+            }
         }
-
         if (isset($data['addons']) && is_array($data['addons'])) {
             $addons = [];
             foreach ($data['addons'] as $addon => $on) {
@@ -751,24 +759,24 @@ class Service implements InjectionAwareInterface
 
     public function getProductCategorySearchQuery($data)
     {
-        $sql = 'SELECT m.id, 
-                       m.title, 
-                       m.description, 
-                       m.icon_url, 
-                       m.created_at, 
-                       m.updated_at, 
+        $sql = 'SELECT m.id,
+                       m.title,
+                       m.description,
+                       m.icon_url,
+                       m.created_at,
+                       m.updated_at,
                        Max(p.priority) AS MaxPrio
-                FROM   product_category AS m 
-                       LEFT JOIN product p 
-                              ON p.product_category_id = m.id 
-                WHERE  p.status = \'enabled\' 
-                       AND p.hidden = 0 
-                GROUP  BY m.id, 
-                          m.title, 
-                          m.description, 
-                          m.icon_url, 
-                          m.created_at, 
-                          m.updated_at 
+                FROM   product_category AS m
+                       LEFT JOIN product p
+                              ON p.product_category_id = m.id
+                WHERE  p.status = \'enabled\'
+                       AND p.hidden = 0
+                GROUP  BY m.id,
+                          m.title,
+                          m.description,
+                          m.icon_url,
+                          m.created_at,
+                          m.updated_at
                 ORDER  BY MaxPrio ASC;';
 
         $params = [];

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -295,7 +295,6 @@ class Service implements InjectionAwareInterface
         //remove empty value in data['upgrades];
         if(is_array($data['upgrades'])){
             $upgrades = array_values(array_filter($data['upgrades']));
-            var_dump($upgrades);
             if (empty($upgrades)){
                 $model->upgrades = null;
             } else{

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -633,19 +633,47 @@ class Service implements InjectionAwareInterface
         if (empty($products) && !is_null($products)) {
             $model->products = null;
         } else {
-            $model->products = json_encode($products);
+            $products = [];
+            foreach($data['products'] as $product => $value){
+                if(!empty($value)){
+                    $products[] = $value;
+                }
+            }
+            if(!empty($products)){
+                $model->products = json_encode($products);
+            }else{
+                $model->products = null
+            }
         }
 
         $client_groups = $this->di['array_get']($data, 'client_groups');
         if (empty($client_groups) && !is_null($client_groups)) {
             $model->client_groups = null;
         } else {
-            $model->client_groups = json_encode($client_groups);
+            $client_groups = [];
+            foreach($data['client_groups'] as $client_group => $value){
+                if(!empty($value)){
+                    $client_groups[] = $value;
+                }
+            }
+            if(!empty($client_groups)){
+                $model->client_groups = json_encode($client_groups);
+            }else{
+                $model->client_groups = null
+            }
         }
 
         $periods = $this->di['array_get']($data, 'periods');
-        if (isset($periods) && is_array($periods)) {
-            $model->periods = json_encode($periods);
+        if (!empty($periods) && is_null($periods)) {
+            $periods = [];
+            foreach($data['periods'] as $period => $value){
+                if(!empty($value)){
+                    $periods[] = $value;
+                }
+            }
+            if(!empty($periods)){
+                $model->periods = json_encode($periods);
+            }
         }
 
         $model->updated_at = date('Y-m-d H:i:s');

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -293,27 +293,18 @@ class Service implements InjectionAwareInterface
         $model->slug = $this->di['array_get']($data, 'slug', $model->slug);
         $model->setup = $this->di['array_get']($data, 'setup', $model->setup);
         //remove empty value in data['upgrades];
-        if (isset($data['upgrades']) && is_array($data['upgrades'])) {
-            $upgrades = [];
-            foreach($data['upgrades'] as $upgrade => $value){
-                if(!empty($value)){
-                    $upgrades[] = $value;
-                }
-            }
-            if(!empty($upgrades)){
-                $model->upgrades = json_encode($upgrades);
-            }else{
+        if(is_array($data['upgrades'])){
+            $upgrades = array_values(array_filter($data['upgrades']));
+            var_dump($upgrades);
+            if (empty($upgrades)){
                 $model->upgrades = null;
+            } else{
+                $model->upgrades = json_encode($upgrades);
             }
         }
-        if (isset($data['addons']) && is_array($data['addons'])) {
-            $addons = [];
-            foreach ($data['addons'] as $addon => $on) {
-                if ($on) {
-                    $addons[] = $addon;
-                }
-            }
-            if (empty($addons)) {
+        if(is_array($data['addons'])){
+            $addons =  array_values(array_filter($data['addons']));
+            if (is_null($addons)) {
                 $model->addons = null;
             } else {
                 $model->addons = json_encode($addons);
@@ -629,53 +620,35 @@ class Service implements InjectionAwareInterface
             $model->end_at = date('Y-m-d H:i:s', strtotime($end_at));
         }
 
-        $products = $this->di['array_get']($data, 'products');
-        if (empty($products) && !is_null($products)) {
+        if(!is_array($this->di['array_get']($data, 'products'))){
             $model->products = null;
-        } else {
-            $array = [];
-            foreach($products as $product => $value){
-                if($value != ''){
-                    $array[] = $value;
-                }
-            }
-            if(!empty($array)){
-                $model->products = json_encode($array);
-            }else{
+        }else{
+            $products =  array_values(array_filter($this->di['array_get']($data, 'products')));
+            if (empty($products)) {
                 $model->products = null;
+            }else{
+                $model->products = json_encode($products);
             }
         }
-        $client_groups = $this->di['array_get']($data, 'client_groups');
-        if (empty($client_groups) && !is_null($client_groups)) {
+        if(!is_array($this->di['array_get']($data, 'client_groups'))){
             $model->client_groups = null;
-        } else {
-            $array = [];
-            foreach($data['client_groups'] as $client_group => $value){
-                if($value != ''){
-                    $array[] = $value;
-                }
-            }
-            if(!empty($client_groups)){
-                $model->client_groups = json_encode($array);
-            }else{
+        }else{
+            $client_groups = array_values(array_filter($this->di['array_get']($data, 'client_groups')));
+            if (empty($client_groups)) {
                 $model->client_groups = null;
+            }else{
+                $model->client_groups = json_encode($client_groups);
             }
         }
 
-        $periods = $this->di['array_get']($data, 'periods');
-        if (empty($periods) && !is_null($periods)) {
+        if(!is_array($this->di['array_get']($data, 'periods'))){
             $model->periods = null;
-        } else {
-            $array = [];
-            foreach($data['periods'] as $period => $value){
-                if($value != ''){
-                    $array[] = $value;
-                }
-            }
-            if(!empty($periods)){
-                $model->periods = json_encode($array);
-            }else{
+        }else{
+            $periods = array_values(array_filter($this->di['array_get']($data, 'periods')));
+            if (empty($periods)) {
                 $model->periods = null;
+            }else{
+                $model->periods = json_encode($periods);
             }
         }
 

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -633,46 +633,49 @@ class Service implements InjectionAwareInterface
         if (empty($products) && !is_null($products)) {
             $model->products = null;
         } else {
-            $products = [];
-            foreach($data['products'] as $product => $value){
-                if(!empty($value)){
-                    $products[] = $value;
+            $array = [];
+            foreach($products as $product => $value){
+                if($value != ''){
+                    $array[] = $value;
                 }
             }
-            if(!empty($products)){
-                $model->products = json_encode($products);
+            if(!empty($array)){
+                $model->products = json_encode($array);
             }else{
-                $model->products = null
+                $model->products = null;
             }
         }
-
         $client_groups = $this->di['array_get']($data, 'client_groups');
         if (empty($client_groups) && !is_null($client_groups)) {
             $model->client_groups = null;
         } else {
-            $client_groups = [];
+            $array = [];
             foreach($data['client_groups'] as $client_group => $value){
-                if(!empty($value)){
-                    $client_groups[] = $value;
+                if($value != ''){
+                    $array[] = $value;
                 }
             }
             if(!empty($client_groups)){
-                $model->client_groups = json_encode($client_groups);
+                $model->client_groups = json_encode($array);
             }else{
-                $model->client_groups = null
+                $model->client_groups = null;
             }
         }
 
         $periods = $this->di['array_get']($data, 'periods');
-        if (!empty($periods) && is_null($periods)) {
-            $periods = [];
+        if (empty($periods) && !is_null($periods)) {
+            $model->periods = null;
+        } else {
+            $array = [];
             foreach($data['periods'] as $period => $value){
-                if(!empty($value)){
-                    $periods[] = $value;
+                if($value != ''){
+                    $array[] = $value;
                 }
             }
             if(!empty($periods)){
-                $model->periods = json_encode($periods);
+                $model->periods = json_encode($array);
+            }else{
+                $model->periods = null;
             }
         }
 

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -230,13 +230,25 @@
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Product Upgrades'|trans }}</label>
                         <div class="col">
+                        <input type="hidden" name="upgrades[]" value=""/>
                             {% set products = admin.product_get_pairs %}
-                            <input type="hidden" name="upgrades">
-                            <select name="upgrades[]" multiple="multiple" class="form-select" size="{{ products|length }}">
-                                {% for id,ptitle in products %}
-                                <option value="{{ id }}"{% if product.upgrades[id] %} selected{% endif %}>{{ ptitle }}</option>
-                                {% endfor %}
-                            </select>
+                            <table class="table card-table table-vcenter table-striped text-nowrap">
+                                <tbody>
+                                    {% set products = admin.product_get_pairs %}
+                                    {% for id,ptitle in products %}
+                                    {% if id != product.id %}
+                                    <tr>
+                                        <td class="w-1">
+                                            <input class="form-check-input" type="checkbox" name="upgrades[]" value="{{id}}" id="upgrades{{ id }}" {% if product.upgrades[id] %} checked{% endif %}>
+                                        </td>
+                                        <td>
+                                            <label for="upgrades[{{ id }}]">{{ ptitle }}</label>
+                                        </td>
+                                    </tr>
+                                    {% endif %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                         </div>
                     </div>
 

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -180,14 +180,13 @@
                 <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="card-body">
                     <h5>{{ 'Choose which addons you would like to offer with'|trans }} {{ product.title }}</h5>
-                </div>
+                </div><input type="hidden" name="addons[]" value="">
                 <table class="table card-table table-vcenter table-striped text-nowrap">
                     <tbody>
                         {% for addon_id, addon_title in admin.product_addon_get_pairs %}
                         <tr>
                             <td class="w-1">
-                                <input type="hidden" name="addons[{{ addon_id }}]" value="0">
-                                <input class="form-check-input" type="checkbox" name="addons[{{ addon_id }}]" value="1" id="addon_{{ addon_id }}"{% if addon_id in assigned_addons %} checked{% endif %}>
+                                <input class="form-check-input" type="checkbox" name="addons[]" value="{{ addon_id }}" id="addon_{{ addon_id }}"{% if addon_id in assigned_addons %} checked{% endif %}>
                             </td>
                             <td>
                                 <label for="addon_{{ addon_id }}">{{ addon_title }}</label>

--- a/src/modules/Product/html_admin/mod_product_promo.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promo.html.twig
@@ -136,7 +136,7 @@
                             <tr><td class="w-1"><input type="checkbox" name="products[]" value="{{ id }}" {% if id in promo.products %} checked{% endif %} /></td><td>{{ product }}</td></tr>
                             {% endfor %}
                         </tbody>
-                    <table>
+                    </table>
                 </div>
             </div>
             <div class="mb-3 row">

--- a/src/modules/Product/html_admin/mod_product_promo.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promo.html.twig
@@ -128,37 +128,43 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Products'|trans }}</label>
                 <div class="col">
-                    {% set products = admin.product_get_pairs %}
-                    <input type="hidden" name="products" value="">
-                    <select class="form-select" name="products[]" multiple="multiple" size="{{ products|length }}">
-                        {% for id,product in products %}
-                        <option value="{{ id }}"{% if id in promo.products %} selected{% endif %}>{{ product }}</option>
-                        {% endfor %}
-                    </select>
+                    <input type="hidden" name="products[]" value=""/>
+                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                        <tbody>
+                            {% set products = admin.product_get_pairs %}
+                            {% for id,product in products %}
+                            <tr><td class="w-1"><input type="checkbox" name="products[]" value="{{ id }}" {% if id in promo.products %} checked{% endif %} /></td><td>{{ product }}</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    <table>
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Periods (Select none to apply to all periods)'|trans }}</label>
                 <div class="col">
-                    {% set periods = guest.system_periods %}
-                    <input type="hidden" name="periods" value="">
-                    <select class="form-select" name="periods[]" multiple="multiple" size="{{ periods|length }}">
-                        {% for id,period in periods %}
-                        <option value="{{ id }}"{% if id in promo.periods %} selected{% endif %}>{{ period }}</option>
-                        {% endfor %}
-                    </select>
+                    <input type="hidden" name="periods[]" value=""/>
+                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                        <tbody>
+                            {% set periods = guest.system_periods %}
+                            {% for id, period in periods %}
+                            <tr><td class="w-1"><input type="checkbox" name="periods[]" value="{{ id }}" {% if id in promo.periods %} checked{% endif %} /></td><td>{{ period }}</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Client Groups (Select none to apply to all client groups)'|trans }}</label>
                 <div class="col">
-                    {% set client_groups = admin.client_group_get_pairs %}
-                    <input type="hidden" name="client_groups" value="">
-                    <select class="form-select" name="client_groups[]" multiple="multiple" size="{{ groups|length }}">
-                        {% for id, client_group in client_groups %}
-                        <option value="{{ id }}"{% if id in promo.client_groups %} selected{% endif %}>{{ client_group }}</option>
-                        {% endfor %}
-                    </select>
+                    <input type="hidden" name="client_groups[]" value="{{ id }}"/>
+                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                        <tbody>
+                            {% set client_groups = admin.client_group_get_pairs %}
+                            {% for id, client_group in client_groups %}
+                            <tr><td class="w-1"><input type="checkbox" name="client_groups[]" value="{{ id }}" {% if id in promo.client_groups %} checked{% endif %} /></td><td>{{ client_group }}</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
 

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -214,45 +214,53 @@
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Products (Select none to apply to all products)'|trans }}</label>
                             <div class="col">
-                                {% set products = admin.product_get_pairs %}
-                                <select class="form-select" name="products[]" multiple="multiple" size="{{ products|length }}">
-                                    {% for id,product in products %}
-                                    <option value="{{ id }}">{{ product }}</option>
-                                    {% endfor %}
-                                </select>
+                                <table class="table card-table table-vcenter table-striped text-nowrap">
+                                    <tbody>
+                                        {% set products = admin.product_get_pairs %}
+                                        {% for id,product in products %}
+                                        <tr><td class="w-1"><input type="checkbox" name="products[]" value="{{ id }}" /></td><td>{{ product }}</td></tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
                             </div>
                         </div>
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Periods (Select none to apply to all periods)'|trans }}</label>
                             <div class="col">
-                                {% set periods = guest.system_periods %}
-                                <select class="form-select" name="periods[]" multiple="multiple" size="{{ periods|length }}">
-                                    {% for id, period in periods %}
-                                    <option value="{{ id }}">{{ period }}</option>
-                                    {% endfor %}
-                                </select>
+                                <table class="table card-table table-vcenter table-striped text-nowrap">
+                                    <tbody>
+                                        {% set periods = guest.system_periods %}
+                                        {% for id, period in periods %}
+                                        <tr><td class="w-1"><input type="checkbox" name="periods[]" value="{{ id }}" /></td><td>{{ period }}</td></tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
                             </div>
                         </div>
                         <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Client Groups (Select none to apply to all client groups)'|trans }}</label>
                             <div class="col">
-                                {% set client_groups = admin.client_group_get_pairs %}
-                                <select class="form-select" name="client_groups[]" multiple="multiple" size="{{ groups|length }}">
-                                    {% for id, client_group in client_groups %}
-                                    <option value="{{ id }}">{{ client_group }}</option>
-                                    {% endfor %}
-                                </select>
+                                <table class="table card-table table-vcenter table-striped text-nowrap">
+                                    <tbody>
+                                        {% set client_groups = admin.client_group_get_pairs %}
+                                        {% for id, client_group in client_groups %}
+                                        <tr><td class="w-1"><input type="checkbox" name="client_groups[]" value="{{ id }}" /></td><td>{{ client_group }}</td></tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
                             </div>
                         </div>
                         {# <div class="mb-3 row">
                             <label class="form-label col-3 col-form-label">{{ 'Addons (Select none to apply to all addons)'|trans }}</label>
                             <div class="col">
-                                {% set products = admin.product_addon_get_pairs %}
-                                <select name="products[]" multiple="multiple" class="multiple" size="{{ products|length }}">
-                                    {% for id,product in products %}
-                                    <option value="{{ id }}">{{ product }}</option>
-                                    {% endfor %}
-                                </select>
+                                <table class="table card-table table-vcenter table-striped text-nowrap">
+                                    <tbody>
+                                        {% set products = admin.product_addon_get_pairs %}
+                                        {% for id,product in products %}
+                                        <tr><td class="w-1"><input type="checkbox" name="products[]" value="{{ id }}" /></td><td>{{ product }}</td></tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
                             </div>
                             <div class="fix"></div>
                         </div> #}

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
@@ -45,26 +45,30 @@
         <div class="mb-3 row free-tlds-row">
             <label class="form-label col-3 col-form-label">{{ 'Select free tlds'|trans }}</label>
             <div class="col">
+                <table class="table card-table table-vcenter table-striped text-nowrap">
+                    <tbody>
                 {% set tlds = guest.serviceDomain_tlds({ 'allow_register': 1 }) %}
-                <select class="form-select" name="config[free_tlds][]" multiple="multiple" size="{{ tlds|length }}"{% if product.config.free_domain %} required{% endif %}>
-                    {% for id,tld in tlds %}
-                    <option value="{{ tld.tld }}"{% if tld.tld in product.config.free_tlds %} selected{% endif %}>{{ tld.tld }}</option>
+                {% for id,tld in tlds %}
+                    <tr><td class="w-1"><input type="checkbox" name="config[free_tlds][]" value="{{ tld.tld }}"{% if tld.tld in product.config.free_tlds %} checked{% endif %}/></td><td >{{ tld.tld }}</td></tr>
                     {% endfor %}
-                </select>
+                    </tbody>
+                </table>
             </div>
         </div>
             <!-- Select periods to offer free domains -->
             <div class="mb-3 row free-periods-row">
             <label class="form-label col-3 col-form-label">{{ 'Select free periods'|trans }}</label>
             <div class="col">
-                <select class="form-select" name="config[free_domain_periods][]" multiple="multiple" size="6"{% if product.config.free_domain %} required{% endif %}>
-                    <option value="1M"{% if "1M" in product.config.free_domain_periods %} selected{% endif %}>1 {{ 'Month'|trans }}</option>
-                    <option value="3M"{% if "3M" in product.config.free_domain_periods %} selected{% endif %}>3 {{ 'Month'|trans }}</option>
-                    <option value="6M"{% if "6M" in product.config.free_domain_periods %} selected{% endif %}>6 {{ 'Month'|trans }}</option>
-                    <option value="1Y"{% if "1Y" in product.config.free_domain_periods %} selected{% endif %}>1 {{ 'Year'|trans }}</option>
-                    <option value="2Y"{% if "2Y" in product.config.free_domain_periods %} selected{% endif %}>2 {{ 'Years'|trans }}</option>
-                    <option value="3Y"{% if "3Y" in product.config.free_domain_periods %} selected{% endif %}>3 {{ 'Years'|trans }}</option>
-                </select>
+                <table class="table card-table table-vcenter table-striped text-nowrap">
+                    <tbody>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="1M" {% if "1M" in product.config.free_domain_periods %} checked{% endif %}/></td><td>1 {{ 'Month'|trans }}</td></tr>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="2M" {% if "2M" in product.config.free_domain_periods %} checked{% endif %}/></td><td>2 {{ 'Months'|trans }}</td></tr>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="3M" {% if "3M" in product.config.free_domain_periods %} checked{% endif %}/></td><td>3 {{ 'Months'|trans }}</td></tr>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="1Y" {% if "1Y" in product.config.free_domain_periods %} checked{% endif %}/></td><td>1 {{ 'Year'|trans }}</td></tr>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="2Y" {% if "2Y" in product.config.free_domain_periods %} checked{% endif %}/></td><td>2 {{ 'Years'|trans }}</td></tr>
+                        <tr><td class="w-1"><input type="checkbox" name="config[free_domain_periods][]" value="3Y" {% if "3Y" in product.config.free_domain_periods %} checked{% endif %}/></td><td>3 {{ 'Years'|trans }}</td></tr>
+                    </tbody>
+                </table>
             </div>
         </div>
         <div class="mb-3 row">
@@ -173,17 +177,36 @@
         if ($(this).val() == 1){
             freeTldsRow.fadeIn('slow');
             freePerdsRow.fadeIn('slow');
-            $('select[name="config[free_tlds][]"]').prop('required', true);
-            $('select[name="config[free_domain_periods][]"]').prop('required', true);
+            $('input[name="config[free_domain_periods][]"]').prop('required', true);
+            $('input[name="config[free_tlds][]"]').prop('required', this);
         }
 
         if ($(this).val() == 0){
-            $('select[name="config[free_domain_periods][]"]').prop('required', false);
-            $('select[name="config[free_tlds][]"]').prop('required', false);
-            $('select[name="config[free_tlds][]"] option:selected').prop('selected', false);
-            $('select[name="config[free_domain_periods][]"] option:selected').prop('selected', false);
+            $('input[name="config[free_domain_periods][]"]').prop('required', false);
+            $('input[name="config[free_tlds][]"]').prop('required', false);
+            $('input[name="config[free_tlds][]"]').prop( 'checked', false );
+            $('input[name="config[free_domain_periods][]"]').prop( "checked", false )
             freeTldsRow.fadeOut('slow');
             freePerdsRow.fadeOut('slow');
+        }
+    });
+
+    $('input[name="config[free_tlds][]"]').on('change', function(){
+        var check = false;
+        $('input[name="config[free_tlds][]"]').each(function (){ if($(this).prop('checked')==true){ check= true;} });
+        if(check == true){
+            $('input[name="config[free_tlds][]"]').prop('required', false);
+        }else{
+            $('input[name="config[free_tlds][]"]').prop('required', true);
+        }
+    });
+    $('input[name="config[free_domain_periods][]"]').on('change', function(){
+        var check = false;
+        $('input[name="config[free_domain_periods][]"]').each(function (){ if($(this).prop('checked')==true){ check= true;} });
+        if(check == true){
+            $('input[name="config[free_domain_periods][]"]').prop('required', false);
+        }else{
+            $('input[name="config[free_domain_periods][]"]').prop('required', true);
         }
     });
 

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_config.html.twig
@@ -178,14 +178,14 @@
             freeTldsRow.fadeIn('slow');
             freePerdsRow.fadeIn('slow');
             $('input[name="config[free_domain_periods][]"]').prop('required', true);
-            $('input[name="config[free_tlds][]"]').prop('required', this);
+            $('input[name="config[free_tlds][]"]').prop('required', true);
         }
 
         if ($(this).val() == 0){
             $('input[name="config[free_domain_periods][]"]').prop('required', false);
             $('input[name="config[free_tlds][]"]').prop('required', false);
-            $('input[name="config[free_tlds][]"]').prop( 'checked', false );
-            $('input[name="config[free_domain_periods][]"]').prop( "checked", false )
+            $('input[name="config[free_tlds][]"]').prop( 'checked', false);
+            $('input[name="config[free_domain_periods][]"]').prop( "checked", false);
             freeTldsRow.fadeOut('slow');
             freePerdsRow.fadeOut('slow');
         }


### PR DESCRIPTION
Replace the "Multi select" boxes with Checkboxes:

<img width="1060" alt="Screenshot 2023-01-16 at 13 22 40" src="https://user-images.githubusercontent.com/9754650/212699564-31f316b2-d4bd-4b29-ac03-f1cfc49e5e3c.png">
vs 
<img width="1051" alt="Screenshot 2023-01-16 at 13 36 15" src="https://user-images.githubusercontent.com/9754650/212699580-91b7893d-b4ce-4616-9341-ee5335f8bf26.png">

Know issue but I don't know how to solve this:
<img width="1055" alt="Screenshot 2023-01-16 at 15 18 27" src="https://user-images.githubusercontent.com/9754650/212699645-57530ac2-ed03-485a-90ce-69f7886bc384.png">

It is caused by the "required" prop on the element. If one options is removed the check is also remove by some new JavaScript