### PR TITLE
Update docs URL & enforce FOSSBilling naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ We've tried to keep this document as short as possible but there is a lot of inf
  * [Translating FOSSBilling](#translating-fossbilling)
  * [Sponsor the project](#sponsoring-the-project)
 
-[style Guides](#styleguides)
+[Style Guides](#styleguides)
 
 [But, I still have a question!](#but-i=stil-have-a-question)
 
@@ -75,7 +75,7 @@ There are a lot of different ways that you can get involved in the FOSSBilling p
 
 ### Reporting bugs
 
-If you find a bug in FOSSBilling, please report it. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior:computer:, and find related reports :mag_right:.
+If you find a bug in FOSSBilling, please report it. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer:, and find related reports :mag_right:.
 
 #### Before submitting a bug report
 
@@ -154,9 +154,9 @@ Before a PR can be merged it must pass all of the automated tests and also be re
 
 Great code is only one-half of any successful project, and great documentation is just as important. The reality is that open source projects can stand or fall based on the quality of their documentation.
 
-The documentation for FOSSBilling is hosted here: [FOSSBilling Docs](https://docs.fossbilling.org/)
+The documentation for FOSSBilling is hosted here: [FOSSBilling Docs](https://fossbilling.org/docs)
 
-Documentation is built using [docusaurus](https://docusaurus.io/) from this [GitHub repository](https://github.com/FOSSBilling/docs). You can contribute directly to the repo on GitHub or using the *Edit this page* links on each page of the docs site.
+Documentation is built using [Nextra](https://nextra.site/) from this [GitHub repository](https://github.com/FOSSBilling/docs). You can contribute directly to the repo on GitHub or using the *Edit this page* links on each page of the docs site.
 
 Please try to be thorough and clear when writing directions. Something might seem obvious to you, but do not assume that it is to everybody else. 
 
@@ -172,7 +172,7 @@ We use Crowdin to manage translations. You can take a look at the [getting start
 
 If you do not have the time or necessary skills to actively take part in the development or documentation of the project then you can still play a part by making a financial contribution to the project. This could be a one-time contribution or a recurring monthly donation.
 
-You can do this using [GitHub Sponsors](https://github.com/sponsors/FOSSBilling) or on [Open Collective](https://opencollective.com/fossbilling). 
+You can do this using [GitHub Sponsors](https://github.com/sponsors/FOSSBilling) or on [Open Collective](https://opencollective.com/FOSSBilling). 
 
 
 ## Style Guides
@@ -205,7 +205,7 @@ The lara branch is a work in progress and is being built in Laravel. If you are 
 
 We don't have a formal documentation style guide yet, but we will be developing one soon. In the meantime please take a look at the existing documentation and follow the tone and writing style so that everything stays coherent. 
 
-Docusaurus uses Markdown and MDX. Please [see their guides](https://docusaurus.io/docs/markdown-features) for how to use them if you are not sure. 
+Nextra uses Markdown and MDX. Please [see their guides](https://nextra.site/docs/guide/markdown) for how to use them if you are not sure. 
 
 ## But, I still have a question!
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,7 @@ We really appreciate user contributions but if you just want to download, instal
 
 Third-party modules and integrations for FOSSBilling are welcomed. We would appreciate if your third-party work was announced to the community so that it can be added to the list of known working extensions, however this is not mandatory. In all cases, please be aware of the restrictions attached to usage of the [FOSSBilling name and branding](https://github.com/FOSSBilling/branding#readme), and approach us for permission if you wish to use the branding in any way other than explicitly listed. 
 
-If you do want to be more involved in the community then the project [GitHub](https://github.com/FOSSBilling/FOSSBilling) page, the [Contribution Guidelines](https://github.com/FOSSBilling/FOSSBilling/blob/main/CONTRIBUTING.md), and [Discord](https://fossbilling.org/discord) are great places to start. You can also sponsor the project on [GitHub Sponsors](https://github.com/sponsors/FOSSBilling) or with [Open Collective](https://opencollective.com/fossbilling).
+If you do want to be more involved in the community then the project [GitHub](https://github.com/FOSSBilling/FOSSBilling) page, the [Contribution Guidelines](https://github.com/FOSSBilling/FOSSBilling/blob/main/CONTRIBUTING.md), and [Discord](https://fossbilling.org/discord) are great places to start. You can also sponsor the project on [GitHub Sponsors](https://github.com/sponsors/FOSSBilling) or with [Open Collective](https://opencollective.com/FOSSBilling).
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 
 <a href="https://fossbilling.org/downloads/"><img src="https://raw.githubusercontent.com/FOSSBilling/fossbilling.org/main/public/img/gh-download-button.png" alt="Download button" width="400"/></a>
 
-[![PHP Composer](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml/badge.svg)](https://github.com/fossbilling/fossbilling/actions/workflows/php.yml)
-[![Download Latest](https://img.shields.io/github/downloads/fossbilling/fossbilling/total)](https://github.com/fossbilling/fossbilling/releases/latest)
+[![PHP Composer](https://github.com/FOSSBilling/FOSSBilling/actions/workflows/php.yml/badge.svg)](https://github.com/FOSSBilling/FOSSBilling/actions/workflows/php.yml)
+[![Download Latest](https://img.shields.io/github/downloads/FOSSBilling/FOSSBilling/total)](https://github.com/FOSSBilling/FOSSBilling/releases/latest)
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
 [![Discord](https://img.shields.io/discord/747432407757488179?color=%237289FA&logo=discord&logoColor=%23FFF)](https://fossbilling.org/discord)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
-[![CodeFactor](https://www.codefactor.io/repository/github/fossbilling/fossbilling/badge)](https://www.codefactor.io/repository/github/fossbilling/fossbilling)
-[![Financial Contributors](https://opencollective.com/fossbilling/tiers/badge.svg?color=brightgreen)](https://opencollective.com/fossbilling)
-[![Crowdin](https://badges.crowdin.net/e/c70c78b4ab1e71424ce53dcf6bca9b12/localized.svg)](https://fossbilling.crowdin.com/fossbilling)
+[![CodeFactor](https://www.codefactor.io/repository/github/FOSSBilling/FOSSBilling/badge)](https://www.codefactor.io/repository/github/fossbilling/fossbilling)
+[![Financial Contributors](https://opencollective.com/FOSSBilling/tiers/badge.svg?color=brightgreen)](https://opencollective.com/fossbilling)
+[![Crowdin](https://badges.crowdin.net/e/c70c78b4ab1e71424ce53dcf6bca9b12/localized.svg)](https://fossbilling.crowdin.com/FOSSBilling)
 </div>
 
 > **Warning**
@@ -66,8 +66,8 @@ The following environment is highly recommended for running FOSSBilling. It *may
     - zlib
 
 ## Example Configurations
-- [nginx](https://github.com/fossbilling/fossbilling/blob/master/data/nginx.conf)
-- [Lighttpd](https://github.com/fossbilling/fossbilling/blob/master/data/lighttpd.conf)
+- [nginx](https://github.com/FOSSBilling/FOSSBilling/blob/master/data/nginx.conf)
+- [Lighttpd](https://github.com/FOSSBilling/FOSSBilling/blob/master/data/lighttpd.conf)
 
 ## Installation
 Installing FOSSBilling is pretty easy. Depending on how you plan to use it there are three different ways to install it:
@@ -95,7 +95,7 @@ Next, you will also need to create a new empty MySQL database using the command 
 Now, you have everything ready to start the installation of FOSSBilling, navigate to your domain using a web browser, and simply follow the on-screen instructions to complete the installation using the web installer. Ta-da, you've done it! 🎉
 
 ### Install from latest source code
-To install the latest development version of FOSSBilling, you will need to get the [latest up-to-date ZIP archive](https://github.com/fossbilling/fossbilling/archive/master.zip) from the Github repository.
+To install the latest development version of FOSSBilling, you will need to get the [latest up-to-date ZIP archive](https://github.com/FOSSBilling/FOSSBilling/archive/master.zip) from the Github repository.
 
 You can either download the .zip file to your local computer and then upload it to your server using FTP, or download it directly to your web server using wget or git clone. In either case, you will need to unzip it and make sure that the files contained in the archive are in the public folder of your site (usually, that's called **"htdocs"** or **"public_html"**).
 
@@ -143,9 +143,9 @@ First of all, thank you for your interest, and for taking your time to contribut
 
 FOSSBilling is undergoing a revival and major code update. We are making steps forward day by day but there is still a lot of work to do, and we are happy to welcome new contributors. 
 
-We have a set of guidelines for those wishing to contribute to FOSSBilling, and we encourage you to take a look at them here: **[contributors' guidelines](https://github.com/fossbilling/fossbilling/blob/master/CONTRIBUTING.md)**.
+We have a set of guidelines for those wishing to contribute to FOSSBilling, and we encourage you to take a look at them here: **[contributors' guidelines](https://github.com/FOSSBilling/FOSSBilling/blob/master/CONTRIBUTING.md)**.
 
-Your [pull requests](https://github.com/fossbilling/fossbilling/pulls) will be highly welcomed. If you're looking for something to start with, you can check the [open issues](https://github.com/fossbilling/fossbilling/issues) on our GitHub repository.
+Your [pull requests](https://github.com/FOSSBilling/FOSSBilling/pulls) will be highly welcomed. If you're looking for something to start with, you can check the [open issues](https://github.com/FOSSBilling/FOSSBilling/issues) on our GitHub repository.
 
 ## Star History
 
@@ -154,19 +154,19 @@ Your [pull requests](https://github.com/fossbilling/fossbilling/pulls) will be h
 
 **Got questions? Found a bug? Ideas for improvements?**
 
-Don't hesitate to create an [issue](https://github.com/fossbilling/fossbilling/issues), or join us on [Discord](https://fossbilling.org/discord) to say hi.
+Don't hesitate to create an [issue](https://github.com/FOSSBilling/FOSSBilling/issues), or join us on [Discord](https://fossbilling.org/discord) to say hi.
 
 ⭐ Not a developer? Feel free to help by starring the repository. It helps us catch the attention of new developers who'd like to contribute. 
 
 ## Licensing
 
-FOSSBilling is open source software and is released under the Apache v2.0 license. See [LICENSE](https://github.com/fossbilling/fossbilling/blob/master/LICENSE) for the full license terms.
+FOSSBilling is open source software and is released under the Apache v2.0 license. See [LICENSE](https://github.com/FOSSBilling/FOSSBilling/blob/master/LICENSE) for the full license terms.
 
 This product includes GeoLite2 data created by MaxMind, available from [https://www.maxmind.com](https://www.maxmind.com).
 
 ## Links
 
 * [Website](https://www.fossbilling.org/)
-* [Documentation](https://docs.fossbilling.org/)
-* [Twitter](https://twitter.com/fossbilling/)
+* [Documentation](https://fossbilling.org/docs)
+* [Twitter](https://twitter.com/FOSSBilling)
 * [Discord](https://fossbilling.org/discord)

--- a/src/composer.json
+++ b/src/composer.json
@@ -3,7 +3,7 @@
     "description": "Free and Open Source Billing System",
     "version": "4.22.0-beta.5",
     "support": {
-        "docs": "https://docs.fossbilling.org",
+        "docs": "https://fossbilling.org/docs",
         "source": "https://github.com/FOSSBilling/FOSSBilling",
         "issues": "https://github.com/FOSSBilling/FOSSBilling/issues",
         "chat": "https://fossbilling.org/discord"

--- a/src/htaccess.txt
+++ b/src/htaccess.txt
@@ -1,4 +1,4 @@
-# Read documentation https://docs.fossbilling.org/ for more information
+# Read documentation https://fossbilling.org/docs for more information
 # If you are receiving "Internal Server Error" message, make sure mod_rewrite is enabled in apache
 
 Options     -Indexes    +SymLinksIfOwnerMatch

--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -14,7 +14,7 @@
     <div class="middleNav">
       <ul>
         <li class="iForum"><a href="https://github.com/FOSSBilling/FOSSBilling/issues" target="_blank" title="Report a bug on GitHub"><span>Report a bug</span></a></li>
-        <li class="iDocs"><a href="https://docs.fossbilling.org/" target="_blank" title="FOSSBilling documentation"><span>Documentation</span></a></li>
+        <li class="iDocs"><a href="https://fossbilling.org/docs" target="_blank" title="FOSSBilling documentation"><span>Documentation</span></a></li>
       </ul>
     </div>
     <div class="fix"></div>

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -430,7 +430,7 @@ final class Box_Installer
         $content .= 'E-mail: ' . $admin_email . PHP_EOL;
         $content .= 'Password: The password you chose during installation' . PHP_EOL . PHP_EOL;
 
-        $content .= "Read FOSSBilling documentation to get started https://docs.fossbilling.org/" . PHP_EOL;
+        $content .= "Read FOSSBilling documentation to get started https://fossbilling.org/docs" . PHP_EOL;
         $content .= "Thank You for using FOSSBilling." . PHP_EOL;
 
         $subject = sprintf('FOSSBilling is ready at "%s"', BB_URL);

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -257,7 +257,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
         error_log('AFTER NS MODIFY: ' . $domain->__toString());
 
         // TODO
-        // problem here: fossbilling doesn't display our error and will display 'nameservers updates' evern when this fails
+        // problem here: FOSSBilling doesn't display our error and will display 'nameservers updates' evern when this fails
 
         if (!isset($result->CommandResponse->DomainDNSSetCustomResult['Updated']) && $result->CommandResponse->DomainDNSSetCustomResult['Updated'] != 'true') {
             throw new Registrar_Exception($message = 'Could not update NameServers');

--- a/src/load.php
+++ b/src/load.php
@@ -233,7 +233,7 @@ function handler_exception($e)
             }
             echo sprintf('<p>%s</p>', $e->getMessage());
 
-            echo sprintf('<center><p><a href="https://docs.fossbilling.org/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
+            echo sprintf('<center><p><a href="https://fossbilling.org/docs/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
             echo '<center><hr><p>Powered by <a href="https://fossbilling.org">FOSSBilling</a></p></center>
       </body>
 

--- a/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
@@ -93,7 +93,7 @@
                     <li>{{ 'After file is uploaded in place, reload this page.'|trans }}</li>
                     <li>{{ 'Select uploaded file name and click on install.'|trans }}</li>
                     <li>{{ 'Payment gateway will be installed in FOSSBilling and can be configured in \"Payment gateways\" tab.'|trans }}</li>
-                    <li>{{ 'For developers. Read'|trans }} <a href="https://docs.fossbilling.org/en/latest/reference/extension.html#payment-gateway" target="_blank">FOSSBilling documentation</a> {{ 'to learn how to create your own payment gateway and share it with community'|trans }}</li>
+                    <li>{{ 'For developers. Read'|trans }} <a href="https://fossbilling.org/docs/en/latest/reference/extension.html#payment-gateway" target="_blank">FOSSBilling documentation</a> {{ 'to learn how to create your own payment gateway and share it with community'|trans }}</li>
                 </ul>
             </div>
 

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -236,7 +236,7 @@
                         <li>{{ 'Download domain registrar file and place to'|trans }} <strong>{{ constant('PATH_LIBRARY') }}/Registrar/Adapter</strong></li>
                         <li>{{ 'Reload this page to see newly detected domain registrar'|trans }}</li>
                         <li>{{ 'Click on install button. Now you will be able to create top level domains with new domain registrar'|trans }}</li>
-                        <li>{{ 'For developers. Read'|trans }} <a href="https://docs.fossbilling.org/en/latest/reference/extension.html#domain-registrar" target="_blank">{{ 'FOSSBilling documentation'|trans }}</a> {{ 'to learn how to create your own domain registrar.'|trans }}</li>
+                        <li>{{ 'For developers. Read'|trans }} <a href="https://fossbilling.org/docs/en/latest/reference/extension.html#domain-registrar" target="_blank">{{ 'FOSSBilling documentation'|trans }}</a> {{ 'to learn how to create your own domain registrar.'|trans }}</li>
                     </ul>
                 </div>
             </div>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
@@ -85,7 +85,7 @@
             <li>{{ 'Take a look at default plugin at'|trans }} <strong>src/modules/Servicelicense/Plugin/Simple.php</strong></li>
             <li>{{ 'Create your plugin and place it to'|trans }} <strong>src/modules/Servicelicense/Plugin/PluginName.php</strong></li>
             <li>{{ 'FOSSBilling will automatically detect new plugin'|trans }}</li>
-            <li>{{ 'Read'|trans }} <a href="http://docs.fossbilling.org/en/latest/reference/service-license.html#license-plugin" target="_blank">{{ 'FOSSBilling documentation'|trans }}</a> {{ 'for more information.'|trans }}</li>
+            <li>{{ 'Read'|trans }} <a href="http://fossbilling.org/docs/en/latest/reference/service-license.html#license-plugin" target="_blank">{{ 'FOSSBilling documentation'|trans }}</a> {{ 'for more information.'|trans }}</li>
         </ul>
     </div>
 </div>

--- a/src/themes/admin_default/html/partial_sidebar.html.twig
+++ b/src/themes/admin_default/html/partial_sidebar.html.twig
@@ -55,7 +55,7 @@
                         <span class="nav-link-title">{{ 'Help'|trans }}</span>
                     </a>
                     <div class="dropdown-menu" data-bs-popper="none">
-                        <a class="dropdown-item" href="https://docs.fossbilling.org/" target="_blank"
+                        <a class="dropdown-item" href="https://fossbilling.org/docs" target="_blank"
                             rel="noopener">{{ 'Documentation'|trans }}</a>
                         <a class="dropdown-item" href="https://github.com/FOSSBilling/FOSSBilling" target="_blank"
                             rel="noopener">{{ 'Source code'|trans }}</a>


### PR DESCRIPTION
Keeping in line with some changes I made in https://github.com/FOSSBilling/.github/pull/2, this PR updates the documentation URL to https://fossbilling.org/docs and replaces instances of "fossbilling" with "FOSSBilling" where applicable (for example, URLs where "fossbilling" is meant to be used in lowercase have been left intact).

I also corrected some mentions to Docusaurus by changing them to Nextra.

### Known issues:
Some URLs that were using documentation search or linking to files that no longer exist were broken, and they remain broken in this patch. For one URL which I'll reference in another comment, I thought about updating it but was unsure. As for the search functionality, I've unfortunately been unable to locate the endpoint which Nextra uses for searching, so I couldn't update those.

Feel free to (ask me to) change anything.