### PR TITLE
Define the version for api.js on the login screen

### DIFF
--- a/src/themes/admin_default/html/layout_login.html.twig
+++ b/src/themes/admin_default/html/layout_login.html.twig
@@ -13,7 +13,7 @@
 
     <link rel="stylesheet" href="build/css/fossbilling-bundle.min.css">
 
-    <script src="{{ ('Api/API.js') | library_url }}"></script>
+    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
     <script src="build/js/fossbilling-bundle.min.js?v={{ guest.system_version }}"></script>
 </head>
 


### PR DESCRIPTION
Should help resolve issues we had with the old API.js file being cached & not automatically being reloaded