### PR TITLE
Added a check for PHP version to the installer

### DIFF
--- a/src/install/index.php
+++ b/src/install/index.php
@@ -1,3 +1,7 @@
-<?php 
+<?php
+if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+    echo 'Error: PHP version 8.0.0 or higher is required. You have version ' . PHP_VERSION;
+    exit();
+}
 header("Location: " . pathinfo($_SERVER["PHP_SELF"], PATHINFO_DIRNAME) . "/install.php");
 exit();


### PR DESCRIPTION
Check added to the `index.php` file instead of the `install.php` file. For some reason, on less than PHP 8.0, no matter where I put it in the `install.php` file, I never could get anything to display on the page, regardless of what I tried, so this way it at least is checked before redirecting to that file