### PR TITLE
Translation work

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
 		- src/rector.php
 	ignoreErrors:
 		- '#^Function __trans not found\.$#'
+		- '#^Function __pluralTrans not found\.$#'
 		- message: '#^Access to an undefined property FOSSPatchAbstract\:\:\$di\.$#'
 		  path: src/foss-update.php
 		- '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'

--- a/src/library/Box/Period.php
+++ b/src/library/Box/Period.php
@@ -127,16 +127,16 @@ class Box_Period
 
         switch ($this->unit) {
             case self::UNIT_DAY:
-                $shift = __pluralTrans('Every :number day', 'Every :number days', $qty, $placeholders);
+                $shift = __pluralTrans('Every day', 'Every :number days', $qty, $placeholders);
                 break;
             case self::UNIT_WEEK:
-                $shift = __pluralTrans('Every :number week', 'Every :number weeks', $qty, $placeholders);
+                $shift = __pluralTrans('Every week', 'Every :number weeks', $qty, $placeholders);
                 break;
             case self::UNIT_MONTH:
-                $shift = __pluralTrans('Every :number month', 'Every :number months', $qty, $placeholders);
+                $shift = __pluralTrans('Every month', 'Every :number months', $qty, $placeholders);
                 break;
             case self::UNIT_YEAR:
-                $shift = __pluralTrans('Every :number year', 'Every :number years', $qty, $placeholders);
+                $shift = __pluralTrans('Every year', 'Every :number years', $qty, $placeholders);
                 break;
             default:
                 throw new \Box_Exception('Unit not defined');

--- a/src/library/Box/Period.php
+++ b/src/library/Box/Period.php
@@ -127,16 +127,16 @@ class Box_Period
 
         switch ($this->unit) {
             case self::UNIT_DAY:
-                $shift = __pluralTrans('Every day', 'Every :number days', $qty, $placeholders);
+                $shift = __pluralTrans('Every :number day', 'Every :number days', $qty, $placeholders);
                 break;
             case self::UNIT_WEEK:
-                $shift = __pluralTrans('Every week', 'Every :number weeks', $qty, $placeholders);
+                $shift = __pluralTrans('Every :number week', 'Every :number weeks', $qty, $placeholders);
                 break;
             case self::UNIT_MONTH:
-                $shift = __pluralTrans('Every month', 'Every :number months', $qty, $placeholders);
+                $shift = __pluralTrans('Every :number month', 'Every :number months', $qty, $placeholders);
                 break;
             case self::UNIT_YEAR:
-                $shift = __pluralTrans('Every year', 'Every :number years', $qty, $placeholders);
+                $shift = __pluralTrans('Every :number year', 'Every :number years', $qty, $placeholders);
                 break;
             default:
                 throw new \Box_Exception('Unit not defined');

--- a/src/library/Box/Period.php
+++ b/src/library/Box/Period.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -25,8 +26,8 @@ class Box_Period
     const PERIOD_QUARTER    = '3M';
     const PERIOD_BIANNUAL   = '6M';
     const PERIOD_ANNUAL     = '1Y';
-    const PERIOD_BIENNIAL	= '2Y';
-    const PERIOD_TRIENNIAL	= '3Y';
+    const PERIOD_BIENNIAL    = '2Y';
+    const PERIOD_TRIENNIAL    = '3Y';
 
     /**
      * Predefined periods
@@ -36,8 +37,8 @@ class Box_Period
         self::PERIOD_QUARTER    =>  3,
         self::PERIOD_BIANNUAL   =>  6,
         self::PERIOD_ANNUAL     =>  12,
-        self::PERIOD_BIENNIAL	=>	24,
-        self::PERIOD_TRIENNIAL	=>	36,
+        self::PERIOD_BIENNIAL    =>    24,
+        self::PERIOD_TRIENNIAL    =>    36,
     );
 
     private $unit;
@@ -45,7 +46,7 @@ class Box_Period
 
     public function __construct($code)
     {
-        if(strlen($code) != 2) {
+        if (strlen($code) != 2) {
             throw new \Box_Exception("Invalid period code. Period definition must be 2 chars length");
         }
 
@@ -54,11 +55,11 @@ class Box_Period
         $units = $this->getUnits();
         $qty = (int)$qty;
         $unit = strtoupper($unit);
-        if(!array_key_exists($unit, $units)) {
-            throw new \Box_Exception("Period Error. Unit :unit is not defined", array(':unit'=>$unit));
+        if (!array_key_exists($unit, $units)) {
+            throw new \Box_Exception("Period Error. Unit :unit is not defined", array(':unit' => $unit));
         }
 
-        if($qty < $units[$unit][0] || $qty > $units[$unit][1]) {
+        if ($qty < $units[$unit][0] || $qty > $units[$unit][1]) {
             $d = array(
                 ':qty'  =>  $qty,
                 ':unit'  =>  $unit,
@@ -85,18 +86,18 @@ class Box_Period
     public static function getPredefined($simple = true)
     {
         $periods = array(
-            self::PERIOD_WEEK       =>  array('rec_qty'=>1, 'title'=>__trans('Every week'), 'code'=>self::PERIOD_WEEK, 'rec_unit'=>self::UNIT_WEEK),
-            self::PERIOD_MONTH      =>  array('rec_qty'=>1, 'title'=>__trans('Every month'), 'code'=>self::PERIOD_MONTH, 'rec_unit'=>self::UNIT_MONTH),
-            self::PERIOD_QUARTER    =>  array('rec_qty'=>3, 'title'=>__trans('Every 3 months'), 'code'=>self::PERIOD_QUARTER, 'rec_unit'=>self::UNIT_MONTH),
-            self::PERIOD_BIANNUAL   =>  array('rec_qty'=>6, 'title'=>__trans('Every 6 months'), 'code'=>self::PERIOD_BIANNUAL, 'rec_unit'=>self::UNIT_MONTH),
-            self::PERIOD_ANNUAL     =>  array('rec_qty'=>1, 'title'=>__trans('Every year'), 'code'=>self::PERIOD_ANNUAL, 'rec_unit'=>self::UNIT_YEAR),
-            self::PERIOD_BIENNIAL	=>	array('rec_qty'=>2, 'title'=>__trans('Every 2 years'), 'code'=>self::PERIOD_BIENNIAL, 'rec_unit'=>self::UNIT_YEAR),
-            self::PERIOD_TRIENNIAL	=>	array('rec_qty'=>3, 'title'=>__trans('Every 3 years'), 'code'=>self::PERIOD_TRIENNIAL, 'rec_unit'=>self::UNIT_YEAR),
+            self::PERIOD_WEEK       =>  array('rec_qty' => 1, 'title' => __trans('Every week'), 'code' => self::PERIOD_WEEK, 'rec_unit' => self::UNIT_WEEK),
+            self::PERIOD_MONTH      =>  array('rec_qty' => 1, 'title' => __trans('Every month'), 'code' => self::PERIOD_MONTH, 'rec_unit' => self::UNIT_MONTH),
+            self::PERIOD_QUARTER    =>  array('rec_qty' => 3, 'title' => __trans('Every 3 months'), 'code' => self::PERIOD_QUARTER, 'rec_unit' => self::UNIT_MONTH),
+            self::PERIOD_BIANNUAL   =>  array('rec_qty' => 6, 'title' => __trans('Every 6 months'), 'code' => self::PERIOD_BIANNUAL, 'rec_unit' => self::UNIT_MONTH),
+            self::PERIOD_ANNUAL     =>  array('rec_qty' => 1, 'title' => __trans('Every year'), 'code' => self::PERIOD_ANNUAL, 'rec_unit' => self::UNIT_YEAR),
+            self::PERIOD_BIENNIAL    =>    array('rec_qty' => 2, 'title' => __trans('Every 2 years'), 'code' => self::PERIOD_BIENNIAL, 'rec_unit' => self::UNIT_YEAR),
+            self::PERIOD_TRIENNIAL    =>    array('rec_qty' => 3, 'title' => __trans('Every 3 years'), 'code' => self::PERIOD_TRIENNIAL, 'rec_unit' => self::UNIT_YEAR),
         );
 
-        if($simple) {
+        if ($simple) {
             $new = array();
-            foreach($periods as $pp) {
+            foreach ($periods as $pp) {
                 $new[$pp['code']] = $pp['title'];
             }
             $periods = $new;
@@ -116,23 +117,26 @@ class Box_Period
 
     public function getCode()
     {
-        return $this->qty.$this->unit;
+        return $this->qty . $this->unit;
     }
 
     public function getTitle()
     {
+        $qty = $this->qty;
+        $placeholders = [':number' => $qty];
+
         switch ($this->unit) {
             case self::UNIT_DAY:
-                $shift = __trans('Every :number day(s)', array(':number'=>$this->qty));
+                $shift = __pluralTrans('Every :number day', 'Every :number days', $qty, $placeholders);
                 break;
             case self::UNIT_WEEK:
-                $shift = __trans('Every :number week(s)', array(':number'=>$this->qty));
+                $shift = __pluralTrans('Every :number week', 'Every :number weeks', $qty, $placeholders);
                 break;
             case self::UNIT_MONTH:
-                $shift = __trans('Every :number month(s)', array(':number'=>$this->qty));
+                $shift = __pluralTrans('Every :number month', 'Every :number months', $qty, $placeholders);
                 break;
             case self::UNIT_YEAR:
-                $shift = __trans('Every :number year(s)', array(':number'=>$this->qty));
+                $shift = __pluralTrans('Every :number year', 'Every :number years', $qty, $placeholders);
                 break;
             default:
                 throw new \Box_Exception('Unit not defined');
@@ -140,6 +144,7 @@ class Box_Period
 
         return $shift;
     }
+
 
     public function getDays()
     {
@@ -176,7 +181,7 @@ class Box_Period
 
     public function getExpirationTime($now = NULL)
     {
-        if(NULL === $now) {
+        if (NULL === $now) {
             $now = time();
         }
 

--- a/src/library/Box/Translate.php
+++ b/src/library/Box/Translate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -64,8 +65,8 @@ class Box_Translate implements \Box\InjectionAwareInterface
 
         $locale = $this->getLocale();
         $codeset = "UTF-8";
-        @putenv('LANG='.$locale.'.'.$codeset);
-        @putenv('LANGUAGE='.$locale.'.'.$codeset);
+        @putenv('LANG=' . $locale . '.' . $codeset);
+        @putenv('LANGUAGE=' . $locale . '.' . $codeset);
         // set locale
         if (!defined('LC_MESSAGES')) {
             define('LC_MESSAGES', 5);
@@ -73,23 +74,32 @@ class Box_Translate implements \Box\InjectionAwareInterface
         if (!defined('LC_TIME')) {
             define('LC_TIME', 2);
         }
-        _setlocale(LC_MESSAGES, $locale.'.'.$codeset);
-        _setlocale(LC_TIME, $locale.'.'.$codeset);
+        _setlocale(LC_MESSAGES, $locale . '.' . $codeset);
+        _setlocale(LC_TIME, $locale . '.' . $codeset);
         _bindtextdomain($this->domain, PATH_LANGS);
         _bind_textdomain_codeset($this->domain, $codeset);
         _textdomain($this->domain);
-        
-        function __trans($msgid, array $values = NULL)
+
+        function __trans(string $msgid, array $values = NULL)
         {
-            if (empty($msgid) || is_null($msgid)) {
-                return null;
+            $translated = _gettext($msgid);
+
+            if (is_array($values)) {
+                $translated = strtr($translated, $values);
             }
-            if (is_null($values)){
-                return _gettext($msgid);
-            } else {
-                $string = strtr($msgid, $values);
-                return _gettext($string);
+
+            return $translated;
+        }
+
+        function __pluralTrans(string $msgid, string $msgidPlural, int $number, array $values = NULL)
+        {
+            $translated = _ngettext($msgid, $msgidPlural, $number);
+
+            if (is_array($values)) {
+                $translated = strtr($translated, $values);
             }
+
+            return $translated;
         }
     }
 

--- a/src/library/Payment/Exception.php
+++ b/src/library/Payment/Exception.php
@@ -12,20 +12,18 @@
  * with this source code in the file LICENSE
  */
 
-class Payment_Exception extends Exception
+class Payment_Exception extends Box_Exception
 {
-    /**
-     * Creates a new translated exception.
-     *
-     * @param   string   error message
-     * @param   array    translation variables
-     */
-    public function __construct($message, array $variables = NULL, $code = 0)
+	/**
+	 * Creates a new translated exception, using the Box_Exception class.
+	 *
+	 * @param   string   error message
+	 * @param   array|null    translation variables
+	 * @param   int 	 The exception code.
+	 * @param 	bool 	 If the varibles in this should be considered protect, if so, disable stacktracing abilities.
+	 */
+    public function __construct(string $message, array $variables = NULL, int $code = 0)
     {
-        // Set the message
-        $message = __trans($message, $variables);
-
-        // Pass the message to the parent
-        parent::__construct($message, $code);
+        parent:: __construct($message, $variables, $code, true);
     }
 }

--- a/src/library/Registrar/Exception.php
+++ b/src/library/Registrar/Exception.php
@@ -1,5 +1,16 @@
 <?php
-class Registrar_Exception extends Exception
+class Registrar_Exception extends Box_Exception
 {
-
+    /**
+     * Creates a new translated exception, using the Box_Exception class.
+     *
+     * @param   string   error message
+     * @param   array|null    translation variables
+     * @param   int 	 The exception code.
+     * @param 	bool 	 If the varibles in this should be considered protect, if so, disable stacktracing abilities.
+     */
+    public function __construct(string $message, array $variables = NULL, int $code = 0)
+    {
+        parent::__construct($message, $variables, $code, true);
+    }
 }

--- a/src/library/Server/Exception.php
+++ b/src/library/Server/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -12,7 +13,18 @@
  * with this source code in the file LICENSE
  */
 
-class Server_Exception extends Exception
+class Server_Exception extends Box_Exception
 {
-    
+    /**
+     * Creates a new translated exception, using the Box_Exception class.
+     *
+     * @param   string   error message
+     * @param   array|null    translation variables
+     * @param   int 	 The exception code.
+     * @param 	bool 	 If the varibles in this should be considered protect, if so, disable stacktracing abilities.
+     */
+    public function __construct(string $message, array $variables = NULL, int $code = 0)
+    {
+        parent::__construct($message, $variables, $code, true);
+    }
 }

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -43,19 +43,19 @@ class Service implements InjectionAwareInterface
         return array(
             'active' => array(
                 'path' => '/client?status=active',
-                'label' => 'Active clients',
+                'label' => __trans('Active clients'),
             ),
             'suspended' => array(
                 'path' => '/client?status=suspended',
-                'label' => 'Suspended clients',
+                'label' => __trans('Suspended clients'),
             ),
             'canceled' => array(
                 'path' => '/client?status=canceled',
-                'label' => 'Canceled clients',
+                'label' => __trans('Canceled clients'),
             ),
             'all' => array(
                 'path' => '/client',
-                'label' => 'All clients',
+                'label' => __trans('All clients'),
             ),
         );
     }

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -35,7 +35,7 @@ class Service
         return array(
             'exec' => array(
                 'path' => BB_URL . 'cron.php',
-                'label' => 'Execute now',
+                'label' => __trans('Execute now'),
             ),
         );
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -35,7 +35,7 @@ class Service implements \Box\InjectionAwareInterface
         return [
             'history' => [
                 'path' => 'email/history',
-                'label' => 'Email history',
+                'label' => __trans('Email history'),
             ],
         ];
     }

--- a/src/modules/Example/Service.php
+++ b/src/modules/Example/Service.php
@@ -42,11 +42,11 @@ class Service
         return array(
             'source' => array(
                 'path' => 'https://github.com/FOSSBilling/example', // An example external link
-                'label' => 'View source code',
+                'label' => __trans('View source code'),
             ),
             'example' => array(
                 'path' => 'extension/settings/example', // An example internal link. Internal links are relative to the custom admin panel path.
-                'label' => 'This is an example!',
+                'label' => __trans('This is an example!'),
             ),
         );
     }

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -47,19 +47,19 @@ class Service implements InjectionAwareInterface
         return array(
             'unpaid' => array(
                 'path' => '/invoice?status=unpaid',
-                'label' => 'Unpaid invoices',
+                'label' => __trans('Unpaid invoices'),
             ),
             'paid' => array(
                 'path' => '/invoice?status=paid',
-                'label' => 'Paid invoices',
+                'label' => __trans('Paid invoices'),
             ),
             'refunded' => array(
                 'path' => '/invoice?status=refunded',
-                'label' => 'Refunded invoices',
+                'label' => __trans('Refunded invoices'),
             ),
             'all' => array(
                 'path' => '/invoice',
-                'label' => 'All invoices',
+                'label' => __trans('All invoices'),
             ),
         );
     }

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -43,19 +43,19 @@ class Service implements InjectionAwareInterface
         return array(
             'pending_setup' => array(
                 'path' => '/order?status=pending_setup',
-                'label' => 'Orders pending setup',
+                'label' => __trans('Orders pending setup'),
             ),
             'active' => array(
                 'path' => '/order?status=active',
-                'label' => 'Active orders',
+                'label' => __trans('Active orders'),
             ),
             'suspended' => array(
                 'path' => '/order?status=suspended',
-                'label' => 'Suspended orders',
+                'label' => __trans('Suspended orders'),
             ),
             'all' => array(
                 'path' => '/order',
-                'label' => 'All orders',
+                'label' => __trans('All orders'),
             ),
         );
     }

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -35,19 +35,19 @@ class Service implements \Box\InjectionAwareInterface
         return array(
             'open' => array(
                 'path' => '/support?status=open',
-                'label' => 'Tickets waiting for staff reply',
+                'label' => __trans('Tickets waiting for staff reply'),
             ),
             'on_hold' => array(
                 'path' => '/support?status=on_hold',
-                'label' => 'Tickets waiting for client reply',
+                'label' => __trans('Tickets waiting for client reply'),
             ),
             'closed' => array(
                 'path' => '/support?status=closed',
-                'label' => 'Resolved tickets',
+                'label' => __trans('Resolved tickets'),
             ),
             'all' => array(
                 'path' => '/support',
-                'label' => 'All tickets',
+                'label' => __trans('All tickets'),
             ),
         );
     }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -30,15 +30,15 @@ class Service
         return array(
             'report_bug' => array(
                 'path' => 'https://github.com/FOSSBilling/FOSSBilling/issues/',
-                'label' => 'Report a bug',
+                'label' => __trans('Report a bug'),
             ),
             'activity' => array(
                 'path' => 'activity',
-                'label' => 'Event history',
+                'label' => __trans('Event history'),
             ),
             'languages' => array(
                 'path' => 'extension/languages',
-                'label' => 'Languages',
+                'label' => __trans('Languages'),
             ),
         );
     }
@@ -206,25 +206,25 @@ class Service
             closedir($handle);
         }
         sort($locales);
-        if(!$deep){
+        if (!$deep) {
             return $locales;
         }
         $array = include PATH_ROOT . '/locale/locales.php';
         $details = [];
-        foreach($locales as $locale){
-            if (empty($array[$locale])){
+        foreach ($locales as $locale) {
+            if (empty($array[$locale])) {
                 //fall back on locale string
                 $details[] = [
                     'locale' => $locale,
-                    'title' => $locale .' ('.$locale.')',
+                    'title' => $locale . ' (' . $locale . ')',
                     'name' => $locale,
                 ];
-            }else{
-            $details[] = [
-                'locale' => $locale,
-                'title' => $array[$locale] .' ('.$locale.')',
-                'name' => $array[$locale],
-            ];
+            } else {
+                $details[] = [
+                    'locale' => $locale,
+                    'title' => $array[$locale] . ' (' . $locale . ')',
+                    'name' => $array[$locale],
+                ];
             }
         }
         return $details;
@@ -345,7 +345,7 @@ class Service
                 // skip if admin is not logged in
             }
         }
-        if(is_null($tpl)){
+        if (is_null($tpl)) {
             $parsed = $this->createTemplateFromString("No template was provided, please contact the site administrator", $try_render, $vars);
             return $parsed;
         }
@@ -992,7 +992,8 @@ class Service
         $list = [
             'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
             'FR', 'GR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL',
-            'PL', 'PT', 'RO', 'SE', 'SI', 'SK', ];
+            'PL', 'PT', 'RO', 'SE', 'SI', 'SK',
+        ];
         $c = $this->getCountries();
         $res = [];
         foreach ($list as $code) {

--- a/tests/library/Box/Box_PeriodTest.php
+++ b/tests/library/Box/Box_PeriodTest.php
@@ -27,7 +27,7 @@ class Box_PeriodTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('M', $p->getUnit());
         $this->assertEquals(1, $p->getQty());
         $this->assertEquals('1M', $p->getCode());
-        $this->assertEquals('Every month', $p->getTitle());
+        $this->assertEquals('Every 1 month', $p->getTitle());
         $this->assertEquals(30, $p->getDays());
         $this->assertEquals(1, $p->getMonths());
         $this->assertEquals(strtotime('+1 month'), $p->getExpirationTime());

--- a/tests/library/Box/Box_PeriodTest.php
+++ b/tests/library/Box/Box_PeriodTest.php
@@ -27,7 +27,7 @@ class Box_PeriodTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('M', $p->getUnit());
         $this->assertEquals(1, $p->getQty());
         $this->assertEquals('1M', $p->getCode());
-        $this->assertEquals('Every 1 month', $p->getTitle());
+        $this->assertEquals('Every month', $p->getTitle());
         $this->assertEquals(30, $p->getDays());
         $this->assertEquals(1, $p->getMonths());
         $this->assertEquals(strtotime('+1 month'), $p->getExpirationTime());

--- a/tests/library/Box/Box_PeriodTest.php
+++ b/tests/library/Box/Box_PeriodTest.php
@@ -1,18 +1,18 @@
 <?php
+
 /**
  * @group Core
  */
 class Box_PeriodTest extends PHPUnit\Framework\TestCase
 {
-    
+
     public function testException()
     {
         $this->expectException(\Box_Exception::class);
         $this->expectExceptionMessage('Invalid period code. Period definition must be 2 chars length');
         $p = new Box_Period('1');
-
     }
-    
+
     public function testException2()
     {
         $this->expectException(\Box_Exception::class);
@@ -27,9 +27,22 @@ class Box_PeriodTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('M', $p->getUnit());
         $this->assertEquals(1, $p->getQty());
         $this->assertEquals('1M', $p->getCode());
-        $this->assertEquals('Every 1 month(s)', $p->getTitle());
+        $this->assertEquals('Every 1 month', $p->getTitle());
         $this->assertEquals(30, $p->getDays());
         $this->assertEquals(1, $p->getMonths());
         $this->assertEquals(strtotime('+1 month'), $p->getExpirationTime());
+    }
+
+    public function testTwoMonths()
+    {
+        $p = new Box_Period('2M');
+
+        $this->assertEquals('M', $p->getUnit());
+        $this->assertEquals(2, $p->getQty());
+        $this->assertEquals('2M', $p->getCode());
+        $this->assertEquals('Every 2 months', $p->getTitle());
+        $this->assertEquals(60, $p->getDays());
+        $this->assertEquals(2, $p->getMonths());
+        $this->assertEquals(strtotime('+2 month'), $p->getExpirationTime());
     }
 }


### PR DESCRIPTION
Closes #748 and #699.
Changes:

- All custom exception classes now extend `Box_Exception`, this makes them translatable. I also added the option to the exception class that will hide parameters from stack traces and will instead replace them with stars
- I've cleaned up the existing `__trans` function, making it more simpler and fixing the usage of placeholders
- I've created a new `__pluralTrans` function which can be used to add plural functionality, it also has support for placeholders just like the `__trans` function. I added some tests for the period library to test and verify this functionality works as intended
- The settings routes for our existing modules have been updated to be translatable (just the label)

~~Just trying to figure out how to properly extract the plural translations with poedit.~~ Got it!