### PR TITLE
Move issue templates (& change bug report to form)

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -3,90 +3,89 @@ description: Create a report to help us improve FOSSBilling
 title: "[Bug]"
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that there is no existing issue for your bug, and fill out the title before continuing.
+        **Important: DO NOT include any private/sensitive information such as email addresses, passwords, IP addresses, or hostnames.**
 
-- type: markdown
-  attributes:
-    value: |
-      Please ensure that there is no existing issue for your bug, and fill out the title before continuing.
-      **Important: DO NOT include any private/sensitive information such as email addresses, passwords, IP addresses, or hostnames.**
+  - type: textarea
+    id: describe
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you're facing! Include as much detail as possible.
+    validations:
+      required: true
 
-- type: textarea
-  id: describe
-  attributes:
-    label: Describe the bug
-    description: A clear and concise description of what the bug is.
-    placeholder: Tell us what you're facing! Include as much detail as possible.
-  validations:
-    required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: What steps did you take when the bug occured? Help us reproduce it!
+      placeholder: |
+        Steps to reproduce the behavior:
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
 
-- type: textarea
-  id: reproduce
-  attributes:
-    label: How to reproduce
-    description: What steps did you take when the bug occured? Help us reproduce it!
-    placeholder: |
-      Steps to reproduce the behavior:
-      1. Go to '...'
-      2. Click on '....'
-      3. Scroll down to '....'
-      4. See error
-  validations:
-    required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What is the expected behavior of the action you took? Help us understand!
+    validations:
+      required: true
 
-- type: textarea
-  id: expected
-  attributes:
-    label: Expected behavior
-    description: A clear and concise description of what you expected to happen.
-    placeholder: What is the expected behavior of the action you took? Help us understand!
-  validations:
-    required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+      placeholder: Use the "Attach an image or video" button or link your images manually using the Markdown syntax, if you're familiar with it.
 
-- type: textarea
-  id: screenshots
-  attributes:
-    label: Screenshots
-    description: If applicable, add screenshots to help explain your problem.
-    placeholder: Use the "Attach an image or video" button or link your images manually using the Markdown syntax, if you're familiar with it.
+  - type: input
+    id: version
+    attributes:
+      label: FOSSBilling version
+      description: Please fill out the version of FOSSBilling you encountered this in.
+      placeholder: x.x.x (the latest stable release) / preview (the latest preview)
+    validations:
+      required: true
 
-- type: input
-  id: version
-  attributes:
-    label: FOSSBilling version
-    description: Please fill out the version of FOSSBilling you encountered this in.
-    placeholder: x.x.x (the latest stable release) / preview (the latest preview)
-  validations:
-    required: true
+  - type: input
+    id: module
+    attributes:
+      label: Module version
+      description: If the bug is related to a module, fill out the version of the module you encountered this in.
 
-- type: input
-  id: module
-  attributes:
-    label: Module version
-    description: If the bug is related to a module, fill out the version of the module you encountered this in.
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      description: Please select the type of device you encountered the issue in.
+      multiple: true
+      options:
+        - Desktop
+        - Smartphone
 
-- type: dropdown
-  id: device
-  attributes:
-    label: Device
-    description: Please select the type of device you encountered the issue in.
-    multiple: true
-    options:
-      - Desktop
-      - Smartphone
- 
-- type: textarea
-  id: info
-  attributes:
-    label: Information
-    description: Please complete the following information.
-    placeholder: |
-      - Device: [e.g. iPhone 6] (only applicable for smartphones)
-      - OS: [e.g. Fedora 37]
-      - Browser [e.g. chrome, safari]
-      - Version [e.g. 22]
+  - type: textarea
+    id: info
+    attributes:
+      label: Information
+      description: Please complete the following information.
+      placeholder: |
+        - Device: [e.g. iPhone 6] (only applicable for smartphones)
+        - OS: [e.g. Fedora 37]
+        - Browser [e.g. chrome, safari]
+        - Version [e.g. 22]
 
-- type: textarea
-  id: additional
-  attributes:
-    label: Additional context
-    description: Add any other context about the problem here.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Create a report to help us improve FOSSBilling
+title: "[Bug]"
+labels: [bug]
+body:
+
+- type: markdown
+  attributes:
+    value: |
+      Please ensure that there is no existing issue for your bug, and fill out the title before continuing.
+      **Important: DO NOT include any private/sensitive information such as email addresses, passwords, IP addresses, or hostnames.**
+
+- type: textarea
+  id: describe
+  attributes:
+    label: Describe the bug
+    description: A clear and concise description of what the bug is.
+    placeholder: Tell us what you're facing! Include as much detail as possible.
+  validations:
+    required: true
+
+- type: textarea
+  id: reproduce
+  attributes:
+    label: How to reproduce
+    description: What steps did you take when the bug occured? Help us reproduce it!
+    placeholder: |
+      Steps to reproduce the behavior:
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: true
+
+- type: textarea
+  id: expected
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen.
+    placeholder: What is the expected behavior of the action you took? Help us understand!
+  validations:
+    required: true
+
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Screenshots
+    description: If applicable, add screenshots to help explain your problem.
+    placeholder: Use the "Attach an image or video" button or link your images manually using the Markdown syntax, if you're familiar with it.
+
+- type: input
+  id: version
+  attributes:
+    label: FOSSBilling version
+    description: Please fill out the version of FOSSBilling you encountered this in.
+    placeholder: x.x.x (the latest stable release) / preview (the latest preview)
+  validations:
+    required: true
+
+- type: input
+  id: module
+  attributes:
+    label: Module version
+    description: If the bug is related to a module, fill out the version of the module you encountered this in.
+
+- type: dropdown
+  id: device
+  attributes:
+    label: Device
+    description: Please select the type of device you encountered the issue in.
+    multiple: true
+    options:
+      - Desktop
+      - Smartphone
+ 
+- type: textarea
+  id: info
+  attributes:
+    label: Information
+    description: Please complete the following information.
+    placeholder: |
+      - Device: [e.g. iPhone 6] (only applicable for smartphones)
+      - OS: [e.g. Fedora 37]
+      - Browser [e.g. chrome, safari]
+      - Version [e.g. 22]
+
+- type: textarea
+  id: additional
+  attributes:
+    label: Additional context
+    description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[Feature Request]'
+labels: 'feature request'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Move issue templates to the main repo. Port the changes from https://github.com/FOSSBilling/.github/pull/2 (Replace the bug report template with a template form).

Copying from the previous pull request:
> Replace the bug report template with a template form. 
More specifically:
> 
> - Rewrite the bug report template into an issue form. Rename into "BUG-REPORT" as per [GitHub's "Creating issue forms" @2](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms), although that could be changed if a common styling for all files is preferred.
>
> The form can be tested by opening an issue on my fork.

