### PR TITLE
Replace usage of the bbmd filter

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -329,10 +329,10 @@ function twig_truncate_filter(Twig\Environment $env, $value, $length = 30, $pres
 
 /**
  * BoxBilling markdown.
+ * @deprecated
  */
 function twig_bbmd_filter(Twig\Environment $env, $value)
 {
-    $value = twig_markdown_filter($env, $value);
-
-    return $value;
+    error_log('Usage for deprected bbmd filter, please use the markdown filter instead for twig templates.');
+    return twig_markdown_filter($env, $value);
 }

--- a/src/modules/Custompages/html_client/mod_custompages_content.html.twig
+++ b/src/modules/Custompages/html_client/mod_custompages_content.html.twig
@@ -19,7 +19,7 @@
                 <h1>{{ page.title }}</h1>
             </header>
             <section>
-                {{ page.content | bbmd }}
+                {{ page.content | markdown }}
             </section>
         </div>
     </article>

--- a/src/modules/Example/html_admin/mod_example_index.html.twig
+++ b/src/modules/Example/html_admin/mod_example_index.html.twig
@@ -64,7 +64,7 @@
 		<h5>{{ 'README'|trans }}</h5>
     </div>
     <div class="card-body markdown">
-        {{ guest.example_readme | bbmd }}
+        {{ guest.example_readme | markdown }}
     </div>
 </div>
 {% endblock %}

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -106,7 +106,7 @@
                 <h3>{{ 'Automatic update'|trans }}</h3>
                 <p class="text-muted">{{ 'Automatic updater is a tool to update FOSSBilling to latest version in one click. Works on these hosting environments where PHP has permissions to overwrite files uploaded via FTP.'|trans }}</p>
 
-                {{ admin.system_release_notes|bbmd }}
+                {{ admin.system_release_notes|markdown }}
                 <a href="{{ 'api/admin/extension/update_core'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. You will need to log back into your account. Click OK when you are ready to continue." data-api-msg="Update complete. Please refresh your page to login back in.">
                     <svg class="icon">
                         <use xlink:href="#refresh" />

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -115,7 +115,7 @@
                     {% if invoice.notes %}
                     <tr>
                         <td class="text-end">{{ 'Notes'|trans }}:</td>
-                        <td>{{ invoice.notes|bbmd }}</td>
+                        <td>{{ invoice.notes|markdown }}</td>
                     </tr>
                     {% endif %}
                 </tbody>

--- a/src/modules/Kb/html_client/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_article.html.twig
@@ -24,7 +24,7 @@
                     <p>{{ 'Article views'|trans }}: {{ article.views }}</p>
                 </header>
                 <section>
-                    {{ article.content|bbmd }}
+                    {{ article.content|markdown }}
                     <hr/>
                     <p><a class="btn btn-small" href="{{ 'kb'|link }}">{{ 'Back to list'|trans }}</a></p>
                 </section>

--- a/src/modules/News/html_client/mod_news_post.html.twig
+++ b/src/modules/News/html_client/mod_news_post.html.twig
@@ -35,7 +35,7 @@
             </header>
             <section>
                 {% if post.image %}<img src="{{ post.image }}" alt="{{ post.title }}">{% endif %}
-                {{ post.content|bbmd }}
+                {{ post.content|markdown }}
                 {# if post.tags %}Tags: {{ post.tags|join(', ') }}{% endif #}
 
                 {% if guest.extension_is_on({ "mod": "comment" }) %}{% include "mod_comment_block.html.twig" %}{% endif %}

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -75,7 +75,7 @@
                     {% if order.notes %}
                     <tr>
                         <td><label>{{ 'Order notes'|trans }}</label></td>
-                        <td>{{ order.notes|bbmd }}</td>
+                        <td>{{ order.notes|markdown }}</td>
                     </tr>
                     {% endif %}
 

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
@@ -22,7 +22,7 @@
 
                 <td>
                     <label for="addon_{{ addon.id }}"><h3>{{ addon.title }}</h3></label>
-                    {{ addon.description|bbmd }}
+                    {{ addon.description|markdown }}
                 </td>
 
                 <td class="currency">

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -11,7 +11,7 @@
             {% set product_details %}
             <div class="well">
                 <strong>{{ product.title }}</strong>
-                {{ product.description | bbmd }}
+                {{ product.description | markdown }}
 
                 {% if product.pricing.type == 'recurrent' %}
                 {% set periods = guest.system_periods %}

--- a/src/modules/Page/html_client/mod_page_about-us.html.twig
+++ b/src/modules/Page/html_client/mod_page_about-us.html.twig
@@ -17,7 +17,7 @@
                         <p>{{ company.signature }}</p>
                     </header>
                     <section>
-                        {{ company.note|bbmd }}
+                        {{ company.note|markdown }}
                     </section>
                 </div>
             </article>

--- a/src/modules/Page/html_client/mod_page_preview_markdown.html.twig
+++ b/src/modules/Page/html_client/mod_page_preview_markdown.html.twig
@@ -14,7 +14,7 @@
 </head>
 <body style="background-color: white; padding:10px;">
     <div class="markdown">
-        {{ post.content|bbmd }}
+        {{ post.content|markdown }}
     </div>
 </body>
 </html>

--- a/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
+++ b/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
@@ -18,7 +18,7 @@
                         <p>{{ company.signature }}</p>
                     </header>
                     <section>
-                        {{ company.privacy_policy|bbmd }}
+                        {{ company.privacy_policy|markdown }}
                     </section>
                 </div>
             </article>

--- a/src/modules/Page/html_client/mod_page_tos.html.twig
+++ b/src/modules/Page/html_client/mod_page_tos.html.twig
@@ -17,7 +17,7 @@
                         <p>{{ company.signature }}</p>
                     </header>
                     <section>
-                        {{ company.tos|bbmd }}
+                        {{ company.tos|markdown }}
                     </section>
                 </div>
             </article>

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -157,7 +157,7 @@
                 <span class="ms-auto text-muted">{{ message.created_at|bb_datetime }}</span>
             </div>
             <div class="card-body">
-                {{ message.content|bbmd }}
+                {{ message.content|markdown }}
             </div>
         </div>
     {% endfor %}

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -287,7 +287,7 @@
             <span class="ms-auto text-muted">{{ message.created_at|bb_datetime }}</span>
         </div>
         <div class="card-body" style="display:{{ loop.last or loop.index + 1 == ticket.messages|length ? 'block' : 'none' }};">
-            {{ message.content|bbmd }}
+            {{ message.content|markdown }}
         </div>
     </div>
     {% endfor %}

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -89,7 +89,7 @@
                             </div>
                         </header>
                         <section>
-                            <div class="well" id="message-{{ message.id }}">{{ message.content|bbmd }}</div>
+                            <div class="well" id="message-{{ message.id }}">{{ message.content|markdown }}</div>
                         </section>
                     </div>
                 </div>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -135,7 +135,7 @@
                                     {% endif %}
                                 </header>
                                 <section>
-                                    <div class="well" id="message-{{message.id}}">{{ message.content|bbmd }}</div>
+                                    <div class="well" id="message-{{message.id}}">{{ message.content|markdown }}</div>
                                 </section>
                             </div>
                         </div>


### PR DESCRIPTION
It's just an alias of the `markdown` one, so let's use that one directly and mark this one as deprecated, with the intention of removing it in the neat future