### PR TITLE
Fix issue #763 (Logging in as "system cron job")

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -398,7 +398,7 @@ $di['loggedin_client'] = function () use ($di) {
  * @throws \Box_Exception If the script is running in CLI or CGI mode and there is no cron admin available.
  */
 $di['loggedin_admin'] = function () use ($di) {
-    if ('cli' === php_sapi_name() || str_starts_with(php_sapi_name(), 'cgi')) {
+    if ('cli' === php_sapi_name() || !http_response_code()) {
         return $di['mod_service']('staff')->getCronAdmin();
     }
 


### PR DESCRIPTION
CGI shouldn't be included in that check, as it would make any server running CGI log the user in as the cron user.

I'm guessing this was done because CGI server's didn't show up as `cli` through `php_sapi_name()`, just in-case I added `http_response_code` as per the PHP docs:
"false will be returned if response_code is not provided and it is not invoked in a web server environment (such as from a CLI application)"

We can probably switch all checks for CLI to using that, but that requires more research