### PR TITLE
Re-add support for prependOrderConfig

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -148,6 +148,11 @@ class Service implements InjectionAwareInterface
 
             $productServiceFromList = $productFromList->getService();
 
+            // @deprecated logic
+            if (method_exists($productServiceFromList, 'prependOrderConfig')) {
+                $productFromListConfig = $productServiceFromList->prependOrderConfig($productFromList, $productFromListConfig);
+            }
+
             if (method_exists($productServiceFromList, 'attachOrderConfig')) {
                 $model = $this->di['db']->load('Product', $productFromList->id);
                 $productFromListConfig = $productServiceFromList->attachOrderConfig($model, $productFromListConfig);

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -543,6 +543,10 @@ class Service implements InjectionAwareInterface
             $config['period'] = $period;
         }
         $se = $this->di['mod_service']('service' . $product->type);
+        // @deprecated logic
+        if (method_exists($se, 'prependOrderConfig')) {
+            $config = $se->prependOrderConfig($product, $config);
+        }
 
         // @migration script
         $se = $this->di['mod_service']('service' . $product->type);


### PR DESCRIPTION
Looks like the Servicehosting module still relies on this, so let's add it back for now