### PR TITLE
Use the PHPSESSID cookie as a fallback if PHP can't detect a valid session

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -317,7 +317,13 @@ $di['twig'] = $di->factory(function () use ($di) {
     }
 
     //CSRF token
-    $token = (session_status() == PHP_SESSION_ACTIVE) ? hash('md5', session_id()) : '';
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        $token = hash('md5', $_COOKIE['PHPSESSID'] ?? '');
+    } else {
+        $token = hash('md5', session_id());
+    }
+
     $twig->addGlobal('CSRFToken', $token);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);

--- a/src/di.php
+++ b/src/di.php
@@ -91,7 +91,8 @@ $di['crypt'] = function () use ($di) {
 $di['pdo'] = function () use ($di) {
     $c = $di['config']['db'];
 
-    $pdo = new PDO($c['type'] . ':host=' . $c['host'] . ';port=' . $c['port'] . ';dbname=' . $c['name'],
+    $pdo = new PDO(
+        $c['type'] . ':host=' . $c['host'] . ';port=' . $c['port'] . ';dbname=' . $c['name'],
         $c['user'],
         $c['password'],
         [
@@ -227,7 +228,7 @@ $di['events_manager'] = function () use ($di) {
 $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
     $mode = (isset($di['config']['security']['mode'])) ? $di['config']['security']['mode'] : 'strict';
-    $lifespan =(isset($di['config']['security']['cookie_lifespan'])) ? $di['config']['security']['cookie_lifespan'] : 7200;
+    $lifespan = (isset($di['config']['security']['cookie_lifespan'])) ? $di['config']['security']['cookie_lifespan'] : 7200;
     $secure = (isset($di['config']['security']['force_https'])) ? $di['config']['security']['force_https'] : true;
 
     return new Box_Session($handler, $mode, $lifespan, $secure);
@@ -265,7 +266,9 @@ $di['request'] = function () use ($di) {
  *
  * @return \FileCache
  */
-$di['cache'] = function () { return new FileCache(); };
+$di['cache'] = function () {
+    return new FileCache();
+};
 
 /**
  *
@@ -273,7 +276,9 @@ $di['cache'] = function () { return new FileCache(); };
  *
  * @return \Box_Authorization
  */
-$di['auth'] = function () use ($di) { return new Box_Authorization($di); };
+$di['auth'] = function () use ($di) {
+    return new Box_Authorization($di);
+};
 
 /**
  * Creates a new Twig environment that's configured for FOSSBilling.
@@ -311,6 +316,9 @@ $di['twig'] = $di->factory(function () use ($di) {
         $_GET['ajax'] = true;
     }
 
+    //CSRF token
+    $token = (session_status() == PHP_SESSION_ACTIVE) ? hash('md5', session_id()) : '';
+    $twig->addGlobal('CSRFToken', $token);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);
 
@@ -359,7 +367,7 @@ $di['is_client_logged'] = function () use ($di) {
 $di['is_admin_logged'] = function () use ($di) {
     if (!$di['auth']->isAdminLoggedIn()) {
         $api_str = '/api/';
-        $url = $di['request']->getQuery('_url',null,'');
+        $url = $di['request']->getQuery('_url', null, '');
         if (0 === strncasecmp($url, $api_str, strlen($api_str))) {
             // Throw Exception if api request
             throw new Exception('Admin is not logged in');
@@ -437,7 +445,9 @@ $di['api'] = $di->protect(function ($role) use ($di) {
  *
  * @return \Api_Handler
  */
-$di['api_guest'] = function () use ($di) { return $di['api']('guest'); };
+$di['api_guest'] = function () use ($di) {
+    return $di['api']('guest');
+};
 
 /**
  *
@@ -445,7 +455,9 @@ $di['api_guest'] = function () use ($di) { return $di['api']('guest'); };
  *
  * @return \Api_Handler
  */
-$di['api_client'] = function () use ($di) { return $di['api']('client'); };
+$di['api_client'] = function () use ($di) {
+    return $di['api']('client');
+};
 
 /**
  *
@@ -453,7 +465,9 @@ $di['api_client'] = function () use ($di) { return $di['api']('client'); };
  *
  * @return \Api_Handler
  */
-$di['api_admin'] = function () use ($di) { return $di['api']('admin'); };
+$di['api_admin'] = function () use ($di) {
+    return $di['api']('admin');
+};
 
 /**
  *
@@ -461,7 +475,9 @@ $di['api_admin'] = function () use ($di) { return $di['api']('admin'); };
  *
  * @return \Api_Handler
  */
-$di['api_system'] = function () use ($di) { return $di['api']('system'); };
+$di['api_system'] = function () use ($di) {
+    return $di['api']('system');
+};
 
 /**
  *
@@ -561,21 +577,27 @@ $di['curl'] = function ($url) use ($di) {
  *
  * @return Server_Package
  */
-$di['server_package'] = function () {return new Server_Package(); };
+$di['server_package'] = function () {
+    return new Server_Package();
+};
 
 /**
  * @param void
  *
  * @return Server_Client
  */
-$di['server_client'] = function () {return new Server_Client(); };
+$di['server_client'] = function () {
+    return new Server_Client();
+};
 
 /**
  * @param void
  *
  * @return Server_Account
  */
-$di['server_account'] = function () {return new Server_Account(); };
+$di['server_account'] = function () {
+    return new Server_Account();
+};
 
 /**
  * Creates a new server manager object and returns it.
@@ -610,7 +632,9 @@ $di['requirements'] = function () use ($di) {
  *
  * @return \Box_Period The new period object that was just created.
  */
-$di['period'] = $di->protect(function ($code) { return new \Box_Period($code); });
+$di['period'] = $di->protect(function ($code) {
+    return new \Box_Period($code);
+});
 
 /**
  * Gets the current client area theme.
@@ -671,21 +695,27 @@ $di['license_server'] = function () use ($di) {
  *
  * @return \Box_Ftp The new FTP object that was just created.
  */
-$di['ftp'] = $di->protect(function ($params) { return new \Box_Ftp($params); });
+$di['ftp'] = $di->protect(function ($params) {
+    return new \Box_Ftp($params);
+});
 
 /**
  * @param void
  *
  * @return \GeoIp2\Database\Reader
  */
-$di['geoip'] = function () { return new \GeoIp2\Database\Reader(PATH_LIBRARY . '/GeoLite2-Country.mmdb'); };
+$di['geoip'] = function () {
+    return new \GeoIp2\Database\Reader(PATH_LIBRARY . '/GeoLite2-Country.mmdb');
+};
 
 /**
  * @param void
  *
  * @return \Box_Password
  */
-$di['password'] = function () { return new Box_Password(); };
+$di['password'] = function () {
+    return new Box_Password();
+};
 
 /**
  * Creates a new Box_Translate object and sets the specified text domain, locale, and other options.

--- a/src/di.php
+++ b/src/di.php
@@ -317,7 +317,6 @@ $di['twig'] = $di->factory(function () use ($di) {
     }
 
     //CSRF token
-
     if (session_status() !== PHP_SESSION_ACTIVE) {
         $token = hash('md5', $_COOKIE['PHPSESSID'] ?? '');
     } else {

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -54,10 +54,6 @@ class Box_AppAdmin extends Box_App
         $twig->setLoader($loader);
 
         $twig->addGlobal('theme', $theme);
-        
-        //CSRF token
-        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
-        $twig->addGlobal('CSRFToken', $token);
 
         if ($this->di['auth']->isAdminLoggedIn()) {
             $twig->addGlobal('admin', $this->di['api_admin']);

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -104,10 +104,6 @@ class Box_AppClient extends Box_App
         $twig->addGlobal('current_theme', $code);
         $twig->addGlobal('settings', $settings);
 
-        //CSRF token
-        $token = (!is_null(session_id())) ? hash('md5', session_id()) : null;
-        $twig->addGlobal('CSRFToken', $token);
-
         if ($this->di['auth']->isClientLoggedIn()) {
             $twig->addGlobal('client', $this->di['api_client']);
         }

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -318,7 +318,7 @@ class Client implements InjectionAwareInterface
         }
 
         $token = $data->CSRFToken ?? $_POST["CSRFToken"] ?? $_GET["CSRFToken"] ?? null;
-        $expectedToken = (!is_null(session_id())) ? hash('md5', session_id()) : null;
+        $expectedToken = (session_status() == PHP_SESSION_ACTIVE) ? hash('md5', session_id()) : null;
 
         /* Due to the way the cart works, it creates a new session which causes issues with the CSRF token system.
          * Due to this, we whitelist the checkout URL. 


### PR DESCRIPTION
Closes #745 and likely more similar issues.

I wasn't able to diagnose why, but for some reason under certain paths, PHP was no longer detecting a session, even if the `PHPSESSID` cookie was still available.

As a workaround, this PR attempts to use the `PHPSESSID` cookie if it exists and there isn't a valid session detected. In all other situations, it continues to use the same system for creating the token internally.

I also slightly reworked how the token is sent to twig by moving it to the twig element in the DI rather than separately in `AppClient.php` and `AppAdmin.php`