### PR TITLE
Clean up the CWP server manager

### DIFF
--- a/src/library/Server/Manager/CWP.php
+++ b/src/library/Server/Manager/CWP.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -24,58 +25,58 @@ class Server_Manager_CWP extends Server_Manager
 			throw new Server_Exception('cURL extension is not enabled');
 		}
 
-		if(empty($this->_config['ip'])) {
+		if (empty($this->_config['ip'])) {
 			throw new Server_Exception('Server manager "CWP" is not configured properly. IP address is not set!');
 		}
 
-		if(empty($this->_config['host'])) {
+		if (empty($this->_config['host'])) {
 			throw new Server_Exception('Server manager "CWP" is not configured properly. Hostname is not set!');
 		}
 
-		if(empty($this->_config['accesshash'])) {
+		if (empty($this->_config['accesshash'])) {
 			throw new Server_Exception('Server manager "CWP" is not configured properly. API Key / Access Hash is not set!');
 		} else {
-			$this->_config['accesshash'] = preg_replace("'(\r|\n)'","",$this->_config['accesshash']);
+			$this->_config['accesshash'] = preg_replace("'(\r|\n)'", "", $this->_config['accesshash']);
 		}
 
-		if(empty($this->_config['port'])){
+		if (empty($this->_config['port'])) {
 			$this->_config['port'] = '2304';
 		}
 	}
 
-    public static function getForm()
-    {
-        return [
-            'label' => 'CWP',
-            'form' => [
-                'credentials' => [
-                    'fields' => [
-                             [
-                            'name' => 'accesshash',
-                            'type' => 'text',
-                            'label' => 'API key',
-                            'placeholder' => 'API key you generated from within CWP.',
-                            'required' => true,
-                        ],
-                    ],
-                ],
-            ]
-        ];
-    }
+	public static function getForm()
+	{
+		return [
+			'label' => 'CWP',
+			'form' => [
+				'credentials' => [
+					'fields' => [
+						[
+							'name' => 'accesshash',
+							'type' => 'text',
+							'label' => 'API key',
+							'placeholder' => 'API key you generated from within CWP.',
+							'required' => true,
+						],
+					],
+				],
+			]
+		];
+	}
 
-    /**
-     * We can actually generate a direct log-in link from CWP, but I'm not sure if that's a secure thing to do here.
-     */
+	/**
+	 * We can actually generate a direct log-in link from CWP, but I'm not sure if that's a secure thing to do here.
+	 */
 	public function getLoginUrl()
 	{
 		$host = $this->_config['host'];
-		return 'https://'.$host.':2083';
+		return 'https://' . $host . ':2083';
 	}
 
 	public function getResellerLoginUrl()
 	{
 		$host = $this->_config['host'];
-		return 'https://'.$host.':2031';
+		return 'https://' . $host . ':2031';
 	}
 
 	/**
@@ -84,74 +85,53 @@ class Server_Manager_CWP extends Server_Manager
 	 */
 	public function testConnection()
 	{
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'     => $APIKey,
+		$data = [
 			'action'  => 'list',
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'typeserver', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to connect to server');
-        }
+		if ($this->makeAPIRequest('account', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to connect to server');
+		}
 	}
-    
-    /**
-     * FOSSBilling will only sync usernames and IP address, neither can be changed or synced from CWP
-     * That makes this function useless, but we still set what we can incase they are ever used in the future
-     */
+
 	public function synchronizeAccount(Server_Account $a)
 	{
-		$this->getLog()->info('Synchronizing account with server '.$a->getUsername());
+		$this->getLog()->info('Synchronizing account with server ' . $a->getUsername());
 
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'     => $APIKey,
+		$data = [
 			'action'  => 'list',
 			'user'    => $a->getUsername()
-		);
+		];
 
 		$new = clone $a;
-		$acc = makeAPIRequest($host, $port, 'accountdetail', $data);
+		$acc = $this->makeAPIRequest('accountdetail', $data);
 
-		if($acc['account_info']['state'] == 'suspended'){
-		    $new->setSuspended(true);
+		if ($acc['account_info']['state'] == 'suspended') {
+			$new->setSuspended(true);
 		} else {
-		   	$new->setSuspended(false);
+			$new->setSuspended(false);
 		}
-        
-        $new->setPackage($acc['account_info']['package_name']);
-        $new->setReseller($acc['account_info']['reseller']);
+
+		$new->setPackage($acc['account_info']['package_name']);
+		$new->setReseller($acc['account_info']['reseller']);
 		return $new;
 	}
-    
-    /**
-     * Package name must match on both CWP and FOSSBilling!
-     */
+
+	/**
+	 * Package name must match on both CWP and FOSSBilling!
+	 */
 	public function createAccount(Server_Account $a)
 	{
-		$this->getLog()->info('Creating account '.$a->getUsername());
+		$this->getLog()->info('Creating account ' . $a->getUsername());
 
 		$client = $a->getClient();
 		$package = $a->getPackage()->getName();
 
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
 		$ip = $this->_config['ip'];
 
-		$data = array(
-			'key'          => $APIKey,
+		$data = [
 			'action'       => 'add',
 			'domain'       => $a->getDomain(),
 			'user'         => $a->getUsername(),
@@ -160,139 +140,104 @@ class Server_Manager_CWP extends Server_Manager
 			'package'      => $package,
 			'server_ips'   => $ip,
 			'encodepass'   => true
-		);
-		if($a->getReseller()) {
+		];
+
+		if ($a->getReseller()) {
 			$data['reseller'] = 1;
 		}
 
-        if(makeAPIRequest($host, $port, 'account', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to create account!');
-        }
+		if ($this->makeAPIRequest('account', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to create account!');
+		}
 	}
 
 	public function suspendAccount(Server_Account $a)
 	{
-		$this->getLog()->info('Suspending account '.$a->getUsername());
+		$this->getLog()->info('Suspending account ' . $a->getUsername());
 
-		$client = $a->getClient();
-
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'      => $APIKey,
+		$data = [
 			'action'   => 'susp',
 			'user'     => $a->getUsername()
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'account', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to suspend account!');
-        }
+		if ($this->makeAPIRequest('account', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to suspend account!');
+		}
 	}
 
 	public function unsuspendAccount(Server_Account $a)
 	{
-		$this->getLog()->info('Un-suspending account '.$a->getUsername());
+		$this->getLog()->info('Un-suspending account ' . $a->getUsername());
 
-		$client = $a->getClient();
-
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'      => $APIKey,
+		$data = [
 			'action'   => 'unsp',
 			'user'     => $a->getUsername()
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'account', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to unsuspend account!');
-        }
+		if ($this->makeAPIRequest('account', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to unsuspend account!');
+		}
 	}
 
 	public function cancelAccount(Server_Account $a)
 	{
-		$this->getLog()->info('Canceling account '.$a->getUsername());
+		$this->getLog()->info('Canceling account ' . $a->getUsername());
 
 		$client = $a->getClient();
 
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'     => $APIKey,
+		$data = [
 			'action'  => 'del',
 			'user'    => $a->getUsername(),
 			'email'   => $client->getEmail()
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'account', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to cancel / delete account!');
-        }
+		if ($this->makeAPIRequest('account', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to cancel / delete account!');
+		}
 	}
 
 	public function changeAccountPackage(Server_Account $a, Server_Package $p)
 	{
-		$this->getLog()->info('Changing package on account '.$a->getUsername());
+		$this->getLog()->info('Changing package on account ' . $a->getUsername());
 
 		$package = $a->getPackage()->getName();
 
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'      => $APIKey,
+		$data = [
 			'action'   => 'upd',
 			'user'     => $a->getUsername(),
 			'package'  => $package
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'changepack', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to change the account package!');
-        }
+		if ($this->makeAPIRequest('changepack', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to change the account package!');
+		}
 	}
 
 	public function changeAccountPassword(Server_Account $a, $new)
 	{
-		$this->getLog()->info('Changing password on account '.$a->getUsername());
+		$this->getLog()->info('Changing password on account ' . $a->getUsername());
 
-		$client = $a->getClient();
-
-		$APIKey = $this->_config['accesshash'];
-
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-
-		$data = array(
-			'key'     => $APIKey,
+		$data = [
 			'action'  => 'udp',
 			'user'    => $a->getUsername(),
 			'pass'    => $new
-		);
+		];
 
-        if(makeAPIRequest($host, $port, 'changepass', $data)) {
-            return true;
-        } else {
-            throw new Server_Exception('Failed to change the account password!');
-        }
+		if ($this->makeAPIRequest('changepass', $data)) {
+			return true;
+		} else {
+			throw new Server_Exception('Failed to change the account password!');
+		}
 	}
 
 	/**
@@ -312,18 +257,22 @@ class Server_Manager_CWP extends Server_Manager
 	{
 		throw new Server_Exception('CWP does not support changing the IP');
 	}
-}
+
 	/**
 	 * Makes the CURL request to the server
 	 */
-	function makeAPIRequest($host, $port, $func, $data)
+	private function makeAPIRequest($func, $data)
 	{
-		$url = 'https://'.$host.":".$port.'/v1/'.$func;
+		$data['key'] = $this->_config['accesshash'];
+		$host = $this->_config['host'];
+		$port = $this->_config['port'];
+
+		$url = 'https://' . $host . ":" . $port . '/v1/' . $func;
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
 		curl_setopt($ch, CURLOPT_POST, 1);
@@ -331,13 +280,16 @@ class Server_Manager_CWP extends Server_Manager
 		curl_close($ch);
 
 		$status = $response['status'] ?? 'Error';
-		$result = $response['result'] ?? null;		
+		$result = $response['result'] ?? null;
+		$msg = $response['msg'] ?? 'CWP did not return a message in it\'s response.';
 
 		if ($status == 'OK' && $func != 'accountdetail') {
 			return true;
-		} elseif ($status == 'Error') {
+		} elseif ($status !== 'OK') {
+			error_log('CWP Server manager error. Status: ' . $status . '. Message: ' . $msg);
 			return false;
 		} else {
 			return $result;
 		}
 	}
+}


### PR DESCRIPTION
This PR cleans up the existing CWP server manager. No major functional changes, but it does change the following:

1. Moved the `makeAPIRequest` function to inside the class.
2. The API key, host, and port are added to the `$data` variable in the `makeAPIRequest` function, so it no longer has to be defined in each function before making the request, removing some duplicated lines.
3. The usage of the `typeserver` function while making a test connection has been replaced with `account`, as it can be used for the same purpose for testing if the API connection is working, and it makes more sense for people to give the API access to that function rather than `typeserver`.
4. Basic logging has been added to the `makerequest` function, which should aid in debugging if anyone has issues with it.

Once merged, I intend to create some basic docs for people who want to use this server manager and put it on the website. Including info such as what permissions are required for the server manager to work correctly.