### PR TITLE
Fix custom fields not being displayed on the client profile

### DIFF
--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -187,6 +187,19 @@
                           </div>
                       </div>
 
+                      {% for i in 1..10 %}
+                      {% set custom = 'custom_' ~ i %}
+                      {% set current = guest.client_custom_fields[custom] %}
+                      {% if current.active %}
+                      <div class="control-group">
+                          <label class="control-label" for="input">{{ current.title }}</label>
+                          <div class="controls">
+                            <input type="text" name="{{ custom }}" value="{{ profile[custom] }}" {% if current.required %} required="required" {% endif %}>
+                          </div>
+                      </div>
+                      {% endif %}
+                      {% endfor %}
+
                     <div class="form-actions">
                         <button class="btn btn-alt btn-large btn-primary" type="submit">{{ 'Update profile'|trans }}</button>
                     </div>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -180,7 +180,6 @@
                         {% endif %}
                     {% endfor %}
 
-
                     <div class="control-group">
                         <label class="control-label" for="reg-password">{{ 'Password'|trans }}</label>
                         <div class="controls">


### PR DESCRIPTION
Closes #739 by loading the list of active custom fields, then pulling their values for the current client. Also sets the `required` attribute if the custom field is required.
(and yes, the bottom test field is supposed to be blank)
![image](https://user-images.githubusercontent.com/17304943/218373319-dcf5d4f7-0e68-4a92-92ab-a432021af41b.png)
