### PR TITLE
Create a workflow to automate CKEditor updates

### DIFF
--- a/.github/workflows/ckeditor_update.yml
+++ b/.github/workflows/ckeditor_update.yml
@@ -1,0 +1,33 @@
+name: Check for CKEditor updates
+
+on:
+  schedule:
+    - cron: '* 12 * * *'  # Runs once per day
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+
+      - name: Install npm-check-updates
+        run: npm install -g npm-check-updates
+
+      - name: Apply any available updates.
+        run: ncu -u
+        working-directory: ./src/modules/Wysiwyg
+
+      - name: Create a Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update CKEditor and Related Dependencies
+          commit-message: Update CKEditor and Related Dependencies
+          branch: CKEditor-deps
+          body: Automated update of all CKEditor related dependencies. CKEditor release notes [here](https://github.com/ckeditor/ckeditor5/releases/latest)
+          delete-branch: true


### PR DESCRIPTION
This PR adds a new workflow that will run once per day and apply any NPM updates to the WYSIWYG packages (primarily CKEditor). If there were any changes, it will then create a new branch called `CKEditor-deps` with the changes and submit a PR.
Here's what the PR looks like: https://github.com/BelleNottelling/FOSSBilling/pull/81 (the added yaml and weird commit history in it is because I force-pushed my main branch and it no longer has that file, so it's showing as a new addition, this won't happen with our branch)