### PR TITLE
Fix dashboard responsiveness for mobile

### DIFF
--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -130,7 +130,7 @@
             </header>
 
                 <div class="container-xl navbar">
-                    <div class="ms-auto mt-4 mb-3 d-flex gap-3">
+                    <div class="ms-auto mt-4 mb-3 d-flex gap-3 overflow-x-auto">
                         {% if admin.system_is_allowed({ 'mod': 'client' }) %}
                             <a href="{{ 'client'|alink }}" class="btn position-relative">
                                 <svg class="icon">

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -111,7 +111,7 @@
         </div>
 
         <div class="col-12">
-            <div class="card">
+            <div class="card overflow-x-auto">
                 <div class="card-body">
                     <h5>{{ 'Statistics'|trans }}</h5>
                 </div>


### PR DESCRIPTION
Add scrollbar to overflowing contents on mobile devices.

Before |  After
-|-
![image](https://user-images.githubusercontent.com/11484121/220255942-e247eadd-a8c0-43f5-8e2a-fb73a2642b57.png) | ![image](https://user-images.githubusercontent.com/11484121/220255862-b88ba84d-99d2-4127-a869-b5df4d254559.png)
![image](https://user-images.githubusercontent.com/11484121/220256398-42f1963f-a80c-45ce-a205-95212c1ad39c.png) | ![image](https://user-images.githubusercontent.com/11484121/220256312-170edd81-447f-4a2b-ae38-7830d2927d1f.png)
