### PR TITLE
Make the CKEditor workflow use our bot's PAT

### DIFF
--- a/.github/workflows/ckeditor_update.yml
+++ b/.github/workflows/ckeditor_update.yml
@@ -2,14 +2,14 @@ name: Check for CKEditor updates
 
 on:
   schedule:
-    - cron: '* 12 * * *'  # Runs once per day
+    - cron: '0 12 * * *'  # Runs once per day
 
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -31,3 +31,6 @@ jobs:
           branch: CKEditor-deps
           body: Automated update of all CKEditor related dependencies. CKEditor release notes [here](https://github.com/ckeditor/ckeditor5/releases/latest)
           delete-branch: true
+          token: ${{ secrets.BOT_TOKEN }}
+          committer: FOSSBilling Bot <fossbilling-bot>
+          author: FOSSBilling Bot <fossbilling-bot>


### PR DESCRIPTION
This should resolve the checks not running as seen in this PR https://github.com/FOSSBilling/FOSSBilling/pull/848, but I guess we will see once it runs again.

PAT has already been added to the secrets