### PR TITLE
Fix email action code generation

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -316,7 +316,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','25',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','28',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -501,7 +501,7 @@ class Service implements \Box\InjectionAwareInterface
         $pattern = PATH_MODS . '/*/html_email/*.html.twig';
         $list = glob($pattern);
         foreach ($list as $path) {
-            $code = pathinfo($path, PATHINFO_FILENAME);
+            $code = str_replace('.html', '', pathinfo($path, PATHINFO_FILENAME));
             $dir = pathinfo($path, PATHINFO_DIRNAME);
             $dir = pathinfo($dir, PATHINFO_DIRNAME);
             $dir = pathinfo($dir, PATHINFO_FILENAME);
@@ -614,7 +614,7 @@ class Service implements \Box\InjectionAwareInterface
             error_log($message);
 
             // Prevent mass retries of emails if one of them is "invalid"
-            if(str_contains($message, 'Invalid address:')) {
+            if (str_contains($message, 'Invalid address:')) {
 
                 try {
                     $this->di['db']->trash($queue);


### PR DESCRIPTION
Closes #863
When we migrated from `.phtml` to `.html.twig`, it broke this functionality, as the `pathinfo` function would strip off the `.twig` extension and leave `.html`

This PR removes `.html` from the end of the code string during twig generation, and also introduces a new patch to remove it from existing email templates.

They now generate correctly:
![image](https://user-images.githubusercontent.com/17304943/221445082-bd144a48-dc4f-4647-9dde-bc49942161fa.png)

I also tweaked `foss-update.php` so it outputs HTML and everything appears on new lines, because I thought it looked dumb:
![image](https://user-images.githubusercontent.com/17304943/221445109-b51b8c99-dba9-4b36-bd27-17c3e24e09f7.png)
