### PR TITLE
Fix loading SVG module icons

### DIFF
--- a/src/library/Box/TwigLoader.php
+++ b/src/library/Box/TwigLoader.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -25,15 +26,15 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
     public function __construct(array $options)
     {
         parent::__construct();
-        if(!isset($options['mods'])) {
+        if (!isset($options['mods'])) {
             throw new \Box_Exception('Missing mods param for Box_TwigLoader');
         }
 
-        if(!isset($options['theme'])) {
+        if (!isset($options['theme'])) {
             throw new \Box_Exception('Missing theme param for Box_TwigLoader');
         }
 
-        if(!isset($options['type'])) {
+        if (!isset($options['type'])) {
             throw new \Box_Exception('Missing type param for Box_TwigLoader');
         }
 
@@ -56,13 +57,17 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
 
         $paths = array();
         $paths[] = $this->options["theme"] . DIRECTORY_SEPARATOR . "html";
-        if(isset($name_split[1])) {
-            $paths[] = $this->options["mods"] . DIRECTORY_SEPARATOR . ucfirst($name_split[1]). DIRECTORY_SEPARATOR . "html_" . $this->options["type"];
+        if (isset($name_split[1])) {
+            $paths[] = $this->options["mods"] . DIRECTORY_SEPARATOR . ucfirst($name_split[1]) . DIRECTORY_SEPARATOR . "html_" . $this->options["type"];
         }
 
-        foreach($paths as $path) {
-            if(file_exists($path . DIRECTORY_SEPARATOR . $name)) {
+        foreach ($paths as $path) {
+            if (file_exists($path . DIRECTORY_SEPARATOR . $name)) {
                 return $this->cache[$name] = $path . '/' . $name;
+            }
+
+            if (str_ends_with($name, 'icon.svg') && file_exists(dirname($path) . DIRECTORY_SEPARATOR . 'icon.svg')) {
+                return $this->cache[$name] = dirname($path) . DIRECTORY_SEPARATOR . 'icon.svg';
             }
         }
 

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -209,6 +209,16 @@ class Service implements InjectionAwareInterface
             $result[$key]['icon_url'] = $iconPath;
         }
 
+        foreach ($result as $key => $value) {
+            $icon_url = $this->di['array_get']($value, 'icon_url');
+            if ($icon_url) {
+                $iconPath = realpath(PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($value['id']) . DIRECTORY_SEPARATOR . basename($icon_url));
+                if (file_exists($iconPath)) {
+                    $result[$key]['icon_path'] = 'mod_' . ucfirst($value['id']) . '_' . basename($icon_url);
+                }
+            }
+        }
+
         return $result;
     }
 
@@ -436,7 +446,7 @@ class Service implements InjectionAwareInterface
 
         $extracted = PATH_CACHE . '/' . md5(uniqid());
         $zip = PATH_CACHE . '/' . md5(uniqid()) . '.zip';
-        
+
         // Create a temporary directory to extract the extension
         mkdir($extracted, 0755, true);
 

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -47,9 +47,9 @@
                     <tr>
                         <td>
                             {% set icon_filename = ext.icon_url|split('/')|last %}
-                            {% if (icon_filename != 'cog.svg') and (icon_filename|split('.')|last == 'svg') %}
+                            {% if (icon_filename != 'cog.svg') and (icon_filename|split('.')|last == 'svg' and ext.icon_path) %}
                                 <div class="text-primary" style="width:24px;height:24px;">
-                                    {% include '../../../modules/' ~ ext.id ~ '/' ~ icon_filename %}
+                                    {{ source (ext.icon_path, ignore_missing = true) }}
                                 </div>
                             {% else %}
                                 <img src="{{ ext.icon_url|default('assets/icons/cog.svg') }}" alt="{{ ext.name }}" style="width:32px;height:32px;">

--- a/src/modules/System/html_admin/mod_system_index.html.twig
+++ b/src/modules/System/html_admin/mod_system_index.html.twig
@@ -19,10 +19,10 @@
                         <div class="datagrid-title">
                             <a href="{{ 'extension/settings'|alink }}/{{ ext.id }}">
                                 {% set icon_filename = ext.icon_url|split('/')|last %}
-                                {% if (icon_filename != 'cog.svg') and (icon_filename|split('.')|last == 'svg') %}
+                                {% if (icon_filename != 'cog.svg') and (icon_filename|split('.')|last == 'svg' and ext.icon_path) %}
                                     <div class="d-flex align-items-center gap-2">
                                         <div class="text-primary" style="width:24px;height:24px;">
-                                            {% include '../../../modules/' ~ ext.id ~ '/' ~ icon_filename %}
+                                            {{ source (ext.icon_path, ignore_missing = true) }}
                                         </div>
                                         <span>{{ ext.name }}</span>
                                     </div>


### PR DESCRIPTION
This fixes loading SVG module icons on case sensitive file systems.

1. The twig loader has been updated to search in the module's main directory if the template name ends in `icon.svg`
2. The `include` has been switched for `source`, with the option to ignore missing files so a missing icon will only be missing, rather than preventing the page from loading.
3. The `getExtensionsList` has been updated to attempt to find the svg icon in the module, and if it can it will add a new array key `icon_path` which will have the template name that can be used with the twig loader.
