### PR TITLE
Fix saving in the form builder

### DIFF
--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_field.html.twig
@@ -1,4 +1,4 @@
-<form method="post" action="" name="field_form{{ field.id }}" class="field-form update-field">
+<form method="post" action="admin/formbuilder/update_field" name="field_form{{ field.id }}" class="field-form update-field api-form" data-api-reload="1">
     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
 <div class="head">
     <h5><span class="awe-edit"></span> {{ 'Edit field'|trans }}</h5>

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -344,31 +344,6 @@
             return false;
         });
 
-        const formElements = document.getElementsByClassName("update-field");
-
-        if (formElements.length > 0) {
-            for (let i = 0; i < formElements.length; i++) {
-                const formElement = formElements[i];
-                
-                formElement.addEventListener("submit", function (event) {
-                    // Prevent the default form submit action. We will handle it ourselves.
-                    event.preventDefault();
-
-                    const formData = new FormData(formElement);
-                    const formDataObject = Object.fromEntries(formData.entries());
-                    const formDataInJSON = JSON.stringify(formDataObject);
-
-                    API.admin.post('formbuilder/update_field', formDataInJSON, function (result) {
-                        formElement.style.display = 'none';
-                        $('#background-loader').show();
-                        bb.reload();
-                    }, function (error) {
-                        FOSSBilling.message(`${error.message} (${error.code})`, 'error');
-                    });
-                });
-            }
-        }
-
        $('#new-form').click(function () {
             jPrompt('Give your new form a title', 'My new form', 'Form title', function (title) {
                 if (title) {


### PR DESCRIPTION
Closes issue #891 by making the form builder use the API wrapper to save rather than custom & broken JS.
Module still needs to be re-written / cleaned up, but at least it should work now,