### PR TITLE
Introduced the new Modals toolkit

### DIFF
--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -293,15 +293,19 @@
             var fid = $(this).attr('data-field-id');
             var rm = $(this);
 
-            jConfirm('Are you sure?', 'Confirm', function (r) {
-                if (r) {
-                    bb.post('admin/formbuilder/delete_field', { id: fid, CSRFToken: "{{ CSRFToken }}" }, function () {
+            Modals.create({
+                type: 'small-confirm',
+                title: 'Are you sure?',
+                content: 'Are you sure you want to delete this field?',
+                confirmCallback: function () {
+                    API.admin.post('formbuilder/delete_field', { id: fid }, function () {
                         $(rm).parents('.wrap-field').slideUp("normal", function () {
                             $(rm).remove();
                         });
                     });
                 }
             });
+
             return false;
         });
 

--- a/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_message.html.twig
@@ -109,38 +109,39 @@
 {% autoescape "js" %}
 <script>
 function onAfterMessageUpdate() {
-        bb.post('admin/massmailer/preview', { id: '{{ msg.id }}', CSRFToken: "{{ CSRFToken }}" }, function(result) {
-            $('#preview').show();
-            $('#preview .econtent').html(result.content);
-            $('#preview .esubject').html(result.subject);
-        });
-}
-
-$(function() {
-    $('#send-msg').click(function() {
-        jConfirm('Send message to clients?', 'Confirm', function(confirm) {
-            if (confirm) {
-                bb.post('admin/massmailer/send', { id: {{ msg.id}}, CSRFToken: "{{ CSRFToken }}" }, function(result) {
-                    bb.msg("{{ 'Message was added to mail queue and will be sent with scheduled tasks.'|trans }}");
-                });
-            }
-        });
-        
-        return false;
+    API.admin.post('massmailer/preview', { id: {{ msg.id }} }, function(result) {
+        document.querySelector('#preview').style.display = '';
+        document.querySelector('#preview .econtent').innerHTML = result.content;
+        document.querySelector('#preview .esubject').innerHTML = result.subject;
     });
-    
-    $('#send-test-msg').click(function() {
-        jConfirm('Send test message?', 'Confirm', function(confirm) {
-            if (confirm) {
-                bb.post('admin/massmailer/send_test', { id: {{ msg.id}}, CSRFToken: "{{ CSRFToken }}" }, function(result) {
-                    bb.msg("{{ 'Message was sent'|trans }}");
-                });
-            }
-        });
+};
 
-        return false;
-    });
+document.querySelector('#send-msg').addEventListener('click', () => {
+    Modals.create({
+        type: 'small-confirm',
+        title: 'Send message to clients?',
+        content: 'Are you sure you want to send this message to clients?',
+        confirmCallback: function() {
+            API.admin.post('massmailer/send', { id: {{ msg.id }} }, function(result) {
+                FOSSBilling.message("{{ 'Message was added to mail queue and will be sent with scheduled tasks.'|trans }}");
+            });
+        },
+    })
 });
+    
+document.querySelector('#send-test-msg').addEventListener('click', () => {
+    Modals.create({
+        type: 'small-confirm',
+        title: 'Send test message?',
+        content: 'Are you sure you want to send a test message?',
+        confirmCallback: function() {
+            API.admin.post('massmailer/send_test', { id: {{ msg.id }} }, function(result) {
+                FOSSBilling.message("{{ 'Message was sent.'|trans }}");
+            });
+        },
+    })
+});
+
 </script>
 {% endautoescape %}
 {% endblock %}

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -359,8 +359,8 @@
 <script>
 document.querySelector('a.show-notes').addEventListener('click', function(e) {
     e.preventDefault();
-        
-    API.admin.post('support/ticket_get', { id: $(this).attr('rel'), CSRFToken: "{{ CSRFToken }}" }, function(result){
+
+    API.admin.post('support/ticket_get', { id: e.currentTarget.getAttribute('rel') }, function(result){
         var html = document.createElement('div');
             
         result.notes.forEach(function(entry) {

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -221,7 +221,9 @@
                             </div>
                             {% if ticket.notes|length %}
                                 <a href="#" rel="{{ ticket.id }}" title="{{ ticket.notes|length }}" class="show-notes">
-                                    <img src="images/icons/dark/notebook.png" alt="" />
+                                    <svg class="icon">
+                                        <use xlink:href="#notes" />
+                                    </svg>
                                 </a>
                             {% endif %}
                             <span class="text-muted">{{ ticket.updated_at|timeago }} {{ 'ago'|trans }}</span>
@@ -355,18 +357,24 @@
 
 {% block js %}
 <script>
-$(function() {
-    $('a.show-notes').on('click', function() {
-        bb.post('admin/support/ticket_get', { id: $(this).attr('rel'), CSRFToken: "{{ CSRFToken }}" }, function(result){
-            var html = $('<div>');
-            $.each(result.notes, function(i, v){
-                html.append($('<div>').html(v.note));
-                html.append($('<hr>'));
-            });
-            jAlert(html, "{{ 'Notes'|trans }}");
+document.querySelector('a.show-notes').addEventListener('click', function(e) {
+    e.preventDefault();
+        
+    API.admin.post('support/ticket_get', { id: $(this).attr('rel'), CSRFToken: "{{ CSRFToken }}" }, function(result){
+        var html = document.createElement('div');
+            
+        result.notes.forEach(function(entry) {
+            var div = document.createElement('div');
+            div.innerHTML = entry.note;
+                
+            html.appendChild(div);
+            html.appendChild(document.createElement('hr'));
         });
 
-        return false;
+        Modals.create({
+            title: "{{ 'Notes'|trans }}",
+            content: html.outerHTML,
+        });
     });
 });
 

--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -3,6 +3,7 @@ import './scss/fossbilling.scss';
 import './js/sprite';
 import './js/jquery.min';
 import './js/ui/jquery.alerts';
+import './js/ui/modals'
 import './js/forms/forms';
 import './js/jquery.scrollTo-min';
 import "@melloware/coloris/dist/coloris.css";

--- a/src/themes/admin_default/assets/icons/alert-triangle.svg
+++ b/src/themes/admin_default/assets/icons/alert-triangle.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-alert-triangle" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 9v2m0 4v.01" />
+  <path d="M5 19h14a2 2 0 0 0 1.84 -2.75l-7.1 -12.25a2 2 0 0 0 -3.5 0l-7.1 12.25a2 2 0 0 0 1.75 2.75" />
+</svg>
+
+

--- a/src/themes/admin_default/assets/icons/circle-check.svg
+++ b/src/themes/admin_default/assets/icons/circle-check.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-circle-check" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+  <path d="M9 12l2 2l4 -4" />
+</svg>
+
+

--- a/src/themes/admin_default/assets/icons/notes.svg
+++ b/src/themes/admin_default/assets/icons/notes.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-notes" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M5 3m0 2a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2z" />
+  <path d="M9 7l6 0" />
+  <path d="M9 11l6 0" />
+  <path d="M9 15l4 0" />
+</svg>
+
+

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -173,12 +173,19 @@ globalThis.bb = {
           event.preventDefault();
 
           if (linkElement.hasAttribute('data-api-confirm')) {
-            if (confirm(linkElement.getAttribute('data-api-confirm'))) {
-              API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
-                return bb._afterComplete(linkElement, result)}, function (error) {
-                  FOSSBilling.message(`${error.message} (${error.code})`, 'error');
-                });
-            }
+            
+            Modals.create({
+              type: 'small-confirm',
+              title: linkElement.getAttribute('data-api-confirm'),
+              content: '',
+              confirmCallback: function () {
+                API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
+                  return bb._afterComplete(linkElement, result)}, function (error) {
+                    FOSSBilling.message(`${error.message} (${error.code})`, 'error');
+                  });
+              },
+            })
+
           } else if (linkElement.hasAttribute('data-api-prompt')) {
             jPrompt(linkElement.getAttribute('data-api-prompt-text'), linkElement.getAttribute('data-api-prompt-default'), linkElement.getAttribute('data-api-prompt-title'), function (r) {
               if (r) {

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -177,7 +177,6 @@ globalThis.bb = {
             Modals.create({
               type: 'small-confirm',
               title: linkElement.getAttribute('data-api-confirm'),
-              content: '',
               confirmCallback: function () {
                 API.makeRequest("GET", bb.restUrl(linkElement.getAttribute('href')), {}, function (result) {
                   return bb._afterComplete(linkElement, result)}, function (error) {

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -19,7 +19,7 @@ globalThis.Modals = {
         closeButton: 'Close', // The text for the close button.
         cancelButton: 'Cancel', // The text for the cancel button.
         confirmButton: 'Confirm', // The text for the confirm button.
-        content: 'The modal content would go here.', // The content of the modal.
+        content: '', // The content of the modal.
         extraClasses: '', // The extra class to add to the modal.
         type: 'default', // The type of the modal. Can be default, small, small-confirm, danger or success.
         closeCallback: null, // The callback function to call when the modal is closed.

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -185,7 +185,7 @@ globalThis.Modals = {
                     options.closeCallback();
                 }
             })
-        };
+        }
 
         const cancelButton = modal.querySelector('#cancel-button');
         if (cancelButton) {
@@ -194,7 +194,7 @@ globalThis.Modals = {
                     options.cancelCallback();
                 }
             })
-        };
+        }
 
         const confirmButton = modal.querySelector('#confirm-button');
         if (confirmButton) {
@@ -203,7 +203,7 @@ globalThis.Modals = {
                     options.confirmCallback();
                 }
             })
-        };
+        }
 
         // Show the modal.
         modalInstance.show();

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -1,0 +1,225 @@
+/**
+ * JavaScript for the FOSSBilling modals.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+/**
+ * The modals object.
+ * @type {Object}
+ */
+globalThis.Modals = {
+    // The default options for the modals.
+    defaultOptions: {
+        title: 'Are you sure?', // The default title for the modal.
+        closeButton: 'Close', // The text for the close button.
+        cancelButton: 'Cancel', // The text for the cancel button.
+        confirmButton: 'Confirm', // The text for the confirm button.
+        content: 'The modal content would go here.', // The content of the modal.
+        extraClasses: '', // The extra class to add to the modal.
+        type: 'default', // The type of the modal. Can be simple, danger, success or warning.
+        closeCallback: null, // The callback function to call when the modal is closed.
+        cancelCallback: null, // The callback function to call when the modal is cancelled.
+        confirmCallback: null, // The callback function to call when the modal is confirmed.
+    },
+
+    allowedTypes: ['default', 'danger', 'success'],
+
+    /**
+     * The templates for the modals.
+     * @type {Object}
+     */
+    templates: {
+        default: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title">{{ title }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                {{ content }}
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="close-button" data-bs-dismiss="modal">{{ closeButton }}</button>
+              </div>
+            </div>
+          </div>
+        </div>`,
+        danger: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+          <div class="modal-dialog modal-sm" role="document">
+            <div class="modal-content">
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <div class="modal-status bg-danger"></div>
+              <div class="modal-body text-center py-4">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-danger icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <use xlink:href="#alert-triangle" />
+                </svg>
+                <h3>{{ title }}</h3>
+                <div class="text-muted">{{ content }}</div>
+              </div>
+              <div class="modal-footer">
+                <div class="w-100">
+                  <div class="row">
+                    <div class="col"><a href="#" class="btn w-100" id="cancel-button" data-bs-dismiss="modal">
+                        {{ cancelButton }}
+                      </a></div>
+                    <div class="col"><a href="#" class="btn btn-danger w-100" id="confirm-button" data-bs-dismiss="modal">
+                        {{ confirmButton }}
+                      </a></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>`,
+        success: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+          <div class="modal-dialog modal-sm" role="document">
+            <div class="modal-content">
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <div class="modal-status bg-success"></div>
+              <div class="modal-body text-center py-4">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-green icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <use xlink:href="#circle-check" />
+                </svg>
+                <h3>{{ title }}</h3>
+                <div class="text-muted">{{ content }}</div>
+              </div>
+              <div class="modal-footer">
+                <div class="w-100">
+                  <div class="row">
+                    <div class="col"><a href="#" class="btn w-100" id="cancel-button" data-bs-dismiss="modal">
+                        {{ closeButton }}
+                      </a></div>
+                    <div class="col"><a href="#" class="btn btn-success w-100" id="confirm-button" data-bs-dismiss="modal">
+                        {{ confirmButton }}
+                      </a></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>`
+    },
+
+    /**
+     * Parse the template and replace the placeholders with the given options.
+     *
+     * @param {String} template Name of the template to use.
+     * @param {Object} options The options object to use.
+     * @returns string The final template.
+     */
+    parseTemplate: function (template, options) {
+        if (!template) {
+            console.error('No template for the modal specified. Please specify a template.')
+            return '';
+        }
+
+        if (!options) {
+            console.error('No options for the modal specified. Please specify the options.')
+            return '';
+        }
+
+        if (!this.allowedTypes.includes(options.type)) {
+            console.error('The type of the modal is not allowed. Please use one of the following types: ' + this.allowedTypes.join(', '))
+            return '';
+        }
+
+        return template.replace(/\{\{(\w+)\}\}/g, function (m, key) {
+            return options[key];
+        });
+    },
+
+    /**
+     * Create a new modal.
+     *
+     * @param {Object} options The options object to use.
+     * @returns {Object} The modal instance.
+     * @example
+     * const modal = Modal.create({
+     *     type: 'danger',
+     *     title: 'Are you sure?',
+     *     content: 'Are you sure you want to delete this item?',
+     *     cancelButton: 'Cancel',
+     *     confirmButton: 'Delete',
+     *     closeCallback: function () {
+     *         console.log('The modal has been closed.');
+     *     }
+     * });
+     *
+     */
+    create: function (options) {
+        // Merge the options with the default options.
+        options = Object.assign({}, this.defaultOptions, options);
+
+        let modal;
+
+        // Create the modal container.
+        const modalContainer = document.createElement('div');
+        modalContainer.innerHTML = this.parseTemplate(this.templates[options.type], options);
+        modal = modalContainer.firstChild;
+
+        // Add the modal to the body.
+        document.body.appendChild(modal);
+
+        // Initialize the modal.
+        const modalInstance = new bootstrap.Modal(modal);
+
+        // The event listeners.
+        modal.addEventListener('hidden.bs.modal', function () {
+            if (options.closeCallback) {
+                options.closeCallback();
+            }
+
+            modal.remove();
+        })
+
+        const closeButton = modal.querySelector('#close-button');
+        if (closeButton) {
+            closeButton.addEventListener('click', function () {
+                if (options.closeCallback) {
+                    options.closeCallback();
+                }
+            });
+        };
+
+        const cancelButton = modal.querySelector('#cancel-button');
+        if (cancelButton) {
+            cancelButton.addEventListener('click', function () {
+                if (options.cancelCallback) {
+                    options.cancelCallback();
+                }
+            });
+        };
+
+        const confirmButton = modal.querySelector('#confirm-button');
+        if (confirmButton) {
+            confirmButton.addEventListener('click', function () {
+                if (options.confirmCallback) {
+                    options.confirmCallback();
+                }
+            });
+        };
+
+        // Show the modal.
+        modalInstance.show();
+
+        return modalInstance;
+    },
+
+    /**
+     * Close every existing modal.
+     */
+    closeAll: function () {
+        const modals = document.querySelectorAll('.modal');
+
+        modals.forEach(function (modal) {
+            const modalInstance = bootstrap.Modal.getInstance(modal);
+            modalInstance.hide();
+        });
+    }
+};

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -27,7 +27,7 @@ globalThis.Modals = {
         confirmCallback: null, // The callback function to call when the modal is confirmed.
     },
 
-    allowedTypes: ['default', 'danger', 'success'],
+    allowedTypes: ['default', 'small', 'danger', 'success',],
 
     /**
      * The templates for the modals.
@@ -50,6 +50,19 @@ globalThis.Modals = {
             </div>
           </div>
         </div>`,
+        small: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+        <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+          <div class="modal-content">
+            <div class="modal-body">
+              <div class="modal-title">{{ title }}</div>
+              <div>{{ content }}</div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{{ closeButton }}</button>
+            </div>
+          </div>
+        </div>
+      </div>`,
         emphasis: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
         <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
           <div class="modal-content">
@@ -197,6 +210,8 @@ globalThis.Modals = {
 
     /**
      * Close every existing modal.
+     * 
+     * @returns void
      */
     closeAll: function () {
         const modals = document.querySelectorAll('.modal');

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -50,72 +50,47 @@ globalThis.Modals = {
             </div>
           </div>
         </div>`,
-        danger: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
-          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
-            <div class="modal-content">
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              <div class="modal-status bg-danger"></div>
-              <div class="modal-body text-center py-4">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-danger icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                    <use xlink:href="#alert-triangle" />
-                </svg>
-                <h3>{{ title }}</h3>
-                <div class="text-muted">{{ content }}</div>
-              </div>
-              <div class="modal-footer">
-                <div class="w-100">
-                  <div class="row">
-                    <div class="col"><a href="#" class="btn w-100" id="cancel-button" data-bs-dismiss="modal">
-                        {{ cancelButton }}
-                      </a></div>
-                    <div class="col"><a href="#" class="btn btn-danger w-100" id="confirm-button" data-bs-dismiss="modal">
-                        {{ confirmButton }}
-                      </a></div>
-                  </div>
+        emphasis: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+        <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+          <div class="modal-content">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <div class="modal-status bg-{{ emphasis }}"></div>
+            <div class="modal-body text-center py-4">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-{{ textColor }} icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <use xlink:href="#{{ emphasisIcon }}" />
+              </svg>
+              <h3>{{ title }}</h3>
+              <div class="text-muted">{{ content }}</div>
+            </div>
+            <div class="modal-footer">
+              <div class="w-100">
+                <div class="row">
+                  <div class="col"><a href="#" class="btn w-100" id="cancel-button" data-bs-dismiss="modal">
+                      {{ cancelButton }}
+                    </a></div>
+                  <div class="col"><a href="#" class="btn btn-{{ emphasis }}  w-100" id="confirm-button" data-bs-dismiss="modal">
+                      {{ confirmButton }}
+                    </a></div>
                 </div>
               </div>
             </div>
           </div>
-        </div>`,
-        success: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
-          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
-            <div class="modal-content">
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              <div class="modal-status bg-success"></div>
-              <div class="modal-body text-center py-4">
-                <svg xmlns="http://www.w3.org/2000/svg" class="icon mb-2 text-green icon-lg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                    <use xlink:href="#circle-check" />
-                </svg>
-                <h3>{{ title }}</h3>
-                <div class="text-muted">{{ content }}</div>
-              </div>
-              <div class="modal-footer">
-                <div class="w-100">
-                  <div class="row">
-                    <div class="col"><a href="#" class="btn w-100" id="cancel-button" data-bs-dismiss="modal">
-                        {{ closeButton }}
-                      </a></div>
-                    <div class="col"><a href="#" class="btn btn-success w-100" id="confirm-button" data-bs-dismiss="modal">
-                        {{ confirmButton }}
-                      </a></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>`
+        </div>
+      </div>`,
     },
 
     /**
      * Parse the template and replace the placeholders with the given options.
      *
-     * @param {String} template Name of the template to use. 
+     * @param {String} type Type of the modal. 
      * @param {Object} options The options object to use. 
      * @returns string The final template.
      */
-    parseTemplate: function (template, options) {
-        if (!template) {
-            console.error('No template for the modal specified. Please specify a template.')
+    parseTemplate: function (type, options) {
+        let template = this.templates[type];
+
+        if (!type) {
+            console.error('You must specify a type when creating a modal.')
             return '';
         }
 
@@ -127,6 +102,15 @@ globalThis.Modals = {
         if (!this.allowedTypes.includes(options.type)) {
             console.error('The type of the modal is not allowed. Please use one of the following types: ' + this.allowedTypes.join(', '))
             return '';
+        }
+
+        // Use the combined emphasis template if the type is danger or success.
+        if (options.type == 'danger' || options.type == 'success') {
+            template = this.templates.emphasis;
+
+            options['emphasis'] = options.type;
+            options['textColor'] = options.type == 'danger' ? 'danger' : 'green';
+            options['emphasisIcon'] = options.type == 'danger' ? 'alert-triangle' : 'circle-check';
         }
 
         return template.replace(/{{\s?(\w+)\s?}}/g, function (match, key) {
@@ -160,7 +144,7 @@ globalThis.Modals = {
 
         // Create the modal container.
         const modalContainer = document.createElement('div');
-        modalContainer.innerHTML = this.parseTemplate(this.templates[options.type], options);
+        modalContainer.innerHTML = this.parseTemplate(options.type, options);
         modal = modalContainer.firstChild;
 
         // Add the modal to the body.

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -21,13 +21,13 @@ globalThis.Modals = {
         confirmButton: 'Confirm', // The text for the confirm button.
         content: 'The modal content would go here.', // The content of the modal.
         extraClasses: '', // The extra class to add to the modal.
-        type: 'default', // The type of the modal. Can be simple, danger, success or warning.
+        type: 'default', // The type of the modal. Can be default, small, small-confirm, danger or success.
         closeCallback: null, // The callback function to call when the modal is closed.
         cancelCallback: null, // The callback function to call when the modal is cancelled.
         confirmCallback: null, // The callback function to call when the modal is confirmed.
     },
 
-    allowedTypes: ['default', 'small', 'danger', 'success',],
+    allowedTypes: ['default', 'small', 'danger', 'success', 'small-confirm'],
 
     /**
      * The templates for the modals.
@@ -58,7 +58,21 @@ globalThis.Modals = {
               <div>{{ content }}</div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{{ closeButton }}</button>
+              <button type="button" class="btn btn-primary" id="close-button" data-bs-dismiss="modal">{{ closeButton }}</button>
+            </div>
+          </div>
+        </div>
+      </div>`,
+        smallConfirm: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
+        <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+          <div class="modal-content">
+            <div class="modal-body">
+              <div class="modal-title">{{ title }}</div>
+              <div>{{ content }}</div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-link link-secondary me-auto" id="cancel-button" data-bs-dismiss="modal">{{ cancelButton }}</button>
+              <button type="button" class="btn btn-primary" id="confirm-button" data-bs-dismiss="modal">{{ confirmButton }}</button>
             </div>
           </div>
         </div>
@@ -125,6 +139,8 @@ globalThis.Modals = {
             options['textColor'] = options.type == 'danger' ? 'danger' : 'green';
             options['emphasisIcon'] = options.type == 'danger' ? 'alert-triangle' : 'circle-check';
         }
+
+        template = options.type === 'small-confirm' ? this.templates.smallConfirm : template;
 
         return template.replace(/{{\s?(\w+)\s?}}/g, function (match, key) {
           return options[key];

--- a/src/themes/admin_default/assets/js/ui/modals.js
+++ b/src/themes/admin_default/assets/js/ui/modals.js
@@ -1,5 +1,5 @@
 /**
- * JavaScript for the FOSSBilling modals.
+ * JavaScript for the FOSSBilling modals. No jQuery required.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license   Apache-2.0
@@ -35,7 +35,7 @@ globalThis.Modals = {
      */
     templates: {
         default: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
-          <div class="modal-dialog" role="document">
+          <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
               <div class="modal-header">
                 <h5 class="modal-title">{{ title }}</h5>
@@ -51,7 +51,7 @@ globalThis.Modals = {
           </div>
         </div>`,
         danger: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
-          <div class="modal-dialog modal-sm" role="document">
+          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
             <div class="modal-content">
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
               <div class="modal-status bg-danger"></div>
@@ -78,7 +78,7 @@ globalThis.Modals = {
           </div>
         </div>`,
         success: `<div class="modal modal-blur fade {{ extraClasses }}" tabindex="-1">
-          <div class="modal-dialog modal-sm" role="document">
+          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
             <div class="modal-content">
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
               <div class="modal-status bg-success"></div>
@@ -109,8 +109,8 @@ globalThis.Modals = {
     /**
      * Parse the template and replace the placeholders with the given options.
      *
-     * @param {String} template Name of the template to use.
-     * @param {Object} options The options object to use.
+     * @param {String} template Name of the template to use. 
+     * @param {Object} options The options object to use. 
      * @returns string The final template.
      */
     parseTemplate: function (template, options) {
@@ -129,14 +129,14 @@ globalThis.Modals = {
             return '';
         }
 
-        return template.replace(/\{\{(\w+)\}\}/g, function (m, key) {
-            return options[key];
+        return template.replace(/{{\s?(\w+)\s?}}/g, function (match, key) {
+          return options[key];
         });
     },
 
     /**
      * Create a new modal.
-     *
+     * 
      * @param {Object} options The options object to use.
      * @returns {Object} The modal instance.
      * @example
@@ -150,7 +150,7 @@ globalThis.Modals = {
      *         console.log('The modal has been closed.');
      *     }
      * });
-     *
+     * 
      */
     create: function (options) {
         // Merge the options with the default options.
@@ -184,7 +184,7 @@ globalThis.Modals = {
                 if (options.closeCallback) {
                     options.closeCallback();
                 }
-            });
+            })
         };
 
         const cancelButton = modal.querySelector('#cancel-button');
@@ -193,7 +193,7 @@ globalThis.Modals = {
                 if (options.cancelCallback) {
                     options.cancelCallback();
                 }
-            });
+            })
         };
 
         const confirmButton = modal.querySelector('#confirm-button');
@@ -202,7 +202,7 @@ globalThis.Modals = {
                 if (options.confirmCallback) {
                     options.confirmCallback();
                 }
-            });
+            })
         };
 
         // Show the modal.
@@ -216,10 +216,10 @@ globalThis.Modals = {
      */
     closeAll: function () {
         const modals = document.querySelectorAll('.modal');
-
+        
         modals.forEach(function (modal) {
             const modalInstance = bootstrap.Modal.getInstance(modal);
             modalInstance.hide();
         });
-    }
+    }    
 };

--- a/src/themes/admin_default/html/partial_batch_delete.html.twig
+++ b/src/themes/admin_default/html/partial_batch_delete.html.twig
@@ -23,7 +23,7 @@
                 });
             } else {
                 Modals.create({
-                    type: 'default',
+                    type: 'small',
                     title: "{{ 'No items selected'|trans }}",
                     content: "{{ 'You need to select at least one item to delete'|trans }}",
                 });

--- a/src/themes/admin_default/html/partial_batch_delete.html.twig
+++ b/src/themes/admin_default/html/partial_batch_delete.html.twig
@@ -8,8 +8,11 @@
     $(function () {
         $('#batch-delete-selected-btn').click(function() {
             if ($('input.batch-delete-checkbox:checked').length) {
-                jConfirm("{{ 'Are you sure?'|trans }}", 'Confirm batch delete', function(r) {
-                    if (r) {
+                Modals.create({
+                    type: 'danger',
+                    title: "{{ 'Are you sure?'|trans }}",
+                    content: "{{ 'Are you sure you want to delete the selected items?'|trans }}",
+                    confirmCallback: function() {
                         var ids = $('input.batch-delete-checkbox:checked').map(function() {
                             return $(this).attr("data-item-id");
                         }).get();
@@ -19,7 +22,11 @@
                     }
                 });
             } else {
-                jAlert('You need to select at least one item to delete');
+                Modals.create({
+                    type: 'default',
+                    title: "{{ 'No items selected'|trans }}",
+                    content: "{{ 'You need to select at least one item to delete'|trans }}",
+                });
             }
         });
 


### PR DESCRIPTION
Related to #475. Supporting our efforts to drop jQuery, I wrote a quick toolkit to use [Tabler's modals](https://preview.tabler.io/modals.html). After the transition is done, we will slowly work towards dropping jAlerts/jConfirm.

The modals accept callbacks. They can be used as alerts or confirmation prompts.

This is how an alert used to look:
jAlert:
![image](https://user-images.githubusercontent.com/35808275/223340214-1f9a89fe-8a1c-496b-81a3-5e887e19023e.png)

Browser alert (Firefox):
![image](https://user-images.githubusercontent.com/35808275/223379889-4bfed54b-8256-4232-949a-d308a61fe4bb.png)

-----

The modal toolkit would be ready to use once it's merged. I've already gone ahead and implemented it to [a couple places](https://github.com/FOSSBilling/FOSSBilling/pull/903/files).

A few examples of how they will now look:
![image](https://user-images.githubusercontent.com/35808275/223378395-2b9f2b20-2256-4533-9c68-5f2a98699da2.png)
![image](https://user-images.githubusercontent.com/35808275/223378742-aaf6753b-6c94-46cd-95f9-be3d4ec8036e.png)
![image](https://user-images.githubusercontent.com/35808275/223378579-9812c886-7177-48d9-8b38-29810fb1d678.png)