### PR TITLE
Remove the bbmd filter

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -78,8 +78,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
             'autolink' => new TwigFilter('autolink', [$this, 'twig_autolink_filter']),
 
-            'bbmd' => new TwigFilter('bbmd', [$this, 'twig_bbmd_filter'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
             'bb_date' => new TwigFilter('bb_date', [$this, 'twig_bb_date']),
 
             'bb_datetime' => new TwigFilter('bb_datetime', [$this, 'twig_bb_datetime']),
@@ -350,15 +348,5 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         }
 
         return $value;
-    }
-
-    /**
-     * BoxBilling markdown.
-     * @deprecated
-     */
-    public function twig_bbmd_filter(Twig\Environment $env, $value)
-    {
-        error_log('Usage for deprected bbmd filter, please use the markdown filter instead for twig templates.');
-        return $this->twig_markdown_filter($env, $value);
     }
 }


### PR DESCRIPTION
We deprecated the `bbmd` filter in 0.3.0, as it was just an alias for the `markdown` filter. Since the next release is going to be 0.4.0, I figured we may as well remove this now