### PR TITLE
Basic CSV export functionality

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -37,7 +37,8 @@
         "league/commonmark": "^2.3",
         "gabordemooij/redbean": "^5.7",
         "symfony/webpack-encore-bundle": "^1.16",
-        "lcharette/webpack-encore-twig": "1.1.0"
+        "lcharette/webpack-encore-twig": "1.1.0",
+        "league/csv": "^9.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e36b1aa1ac89da0cd036cdfaba9a016",
+    "content-hash": "e7639ebfdaa98a5d1a260a5b4969b074",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1029,6 +1029,90 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^v3.4.0",
+                "phpstan/phpstan": "^1.3.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.11"
+            },
+            "suggest": {
+                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CSV data manipulation made easy in PHP",
+            "homepage": "https://csv.thephpleague.com",
+            "keywords": [
+                "convert",
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "transform",
+                "write"
+            ],
+            "support": {
+                "docs": "https://csv.thephpleague.com",
+                "issues": "https://github.com/thephpleague/csv/issues",
+                "rss": "https://github.com/thephpleague/csv/releases.atom",
+                "source": "https://github.com/thephpleague/csv"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-04T00:13:07+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/src/di.php
+++ b/src/di.php
@@ -789,6 +789,15 @@ $di['array_get'] = $di->protect(function (array $array, $key, $default = null) {
     return ('' === $result) ? null : $result;
 });
 
+/*
+ * Creates a CSV export of data from a specified table and sends it to the browser.
+ * 
+ * @param string $table Name of the table to export data from
+ * @param string $outputName Name of the exported CSV file
+ * @param array $headers Optional array of column headers for the CSV file
+ * @param int $limit Optional limit of the number of rows to export from the table
+ * @return void
+ */
 $di['table_export_csv'] = $di->protect(function (string $table, string $outputName = 'export.csv', array $headers = [], int $limit = 0) use ($di) {
     if ($limit > 0) {
         $beans = $di['db']->findAll($table, "LIMIT :limit", array(':limit' => $limit));

--- a/src/library/Box/Database.php
+++ b/src/library/Box/Database.php
@@ -104,6 +104,15 @@ class Box_Database implements InjectionAwareInterface
         return $beans;
     }
 
+    public function findAll(string $table, string $sql = null)
+    {
+        if (is_null($sql)) {
+            return $this->orm->findAll($table);
+        } else {
+            return $this->orm->findAll($table, $sql);
+        }
+    }
+
     /**
      * @param string $modelName
      * @param integer $id

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -32,7 +32,7 @@ class Admin extends \Api_Abstract
      * @param int $data['per_page'] [optional] Number of clients to display per page.
      * 
      * @return array List of clients in a paginated manner.
-    */
+     */
     public function get_list($data)
     {
         $per_page = $this->di['array_get']($data, 'per_page', $this->di['pager']->getPer_page());
@@ -55,7 +55,7 @@ class Admin extends \Api_Abstract
      * @param int $data['per_page'] [optional] Number of clients to display per page.
      * 
      * @return array List of clients in a paginated manner
-    */
+     */
     public function get_pairs($data)
     {
         $service = $this->di['mod_service']('client');
@@ -665,5 +665,11 @@ class Admin extends \Api_Abstract
         }
 
         return true;
+    }
+
+    public function export_csv($data)
+    {
+        $data['headers'] ??= [];
+        return $this->getService()->exportCSV($data['headers']);
     }
 }

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -664,9 +664,11 @@ class Service implements InjectionAwareInterface
     {
         $config = $this->di['mod_config']('client');
 
-        if ($client->email != $email
+        if (
+            $client->email != $email
             && isset($config['allow_change_email'])
-            && !$config['allow_change_email']) {
+            && !$config['allow_change_email']
+        ) {
             throw new \Box_Exception('Email can not be changed');
         }
 
@@ -699,5 +701,21 @@ class Service implements InjectionAwareInterface
                 }
             }
         }
+    }
+
+    public function exportCSV(array $headers)
+    {
+        if ($headers) {
+            // Prevent the password / salt columns from being exported
+            if (isset($headers['pass'])) {
+                unset($headers['pass']);
+            }
+            if (isset($headers['salt'])) {
+                unset($headers['salt']);
+            }
+        } else {
+            $headers = ['id', 'email', 'status', 'first_name', 'last_name', 'phone_cc', 'phone', 'company', 'company_vat', 'company_number', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'currency'];
+        }
+        return $this->di['table_export_csv']('client', 'clients.csv', $headers);
     }
 }

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -276,8 +276,18 @@
                 </div>
 
                 <div class="card-footer d-flex align-items-center justify-content-between">
-                    {% include 'partial_batch_delete.html.twig' with { 'action': 'admin/client/batch_delete' } %}
-                    {% include 'partial_pagination.html.twig' with { 'list': clients, 'url': 'client' } %}
+                    <div>
+                        {% include 'partial_batch_delete.html.twig' with { 'action': 'admin/client/batch_delete' } %}
+                        {% include 'partial_pagination.html.twig' with { 'list': clients, 'url': 'client' } %}
+                    </div>
+                    <div>
+                        <a class="btn btn-secondary" href="{{ '/api/admin/client/export_csv'|link({ 'CSRFToken': CSRFToken }) }}" title="{{ 'Export Clients'|trans }}">
+                            <svg class="icon">
+                                <use xlink:href="#download" />
+                            </svg>
+                            {{ 'Export Clients'|trans }}
+                        </a>
+                    </div>
                 </div>
             </div>
 

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -1081,4 +1081,10 @@ class Admin extends \Api_Abstract
 
         return true;
     }
+
+    public function export_csv($data)
+    {
+        $data['headers'] ??= [];
+        return $this->getService()->exportCSV($data['headers']);
+    }
 }

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1287,7 +1287,7 @@ class Service implements InjectionAwareInterface
             'Email' => $invoice['seller']['email'],
         ];
         foreach ($sellerData as $label => $data) {
-            if(is_string($data)){
+            if (is_string($data)) {
                 $data = trim($data);
                 if (!empty($data)) {
                     $html .= "<p>$label: $data</p>";
@@ -1306,7 +1306,7 @@ class Service implements InjectionAwareInterface
             'Phone' => $invoice['buyer']['phone'],
         ];
         foreach ($buyerData as $label => $data) {
-            if(is_string($data)){
+            if (is_string($data)) {
                 $data = trim($data);
                 if (!empty($data)) {
                     $html .= "<p>$label: $data</p>";
@@ -1565,5 +1565,13 @@ class Service implements InjectionAwareInterface
         }
 
         return false;
+    }
+
+    public function exportCSV(array $headers)
+    {
+        if (!$headers) {
+            $headers = ['id', 'client_id', 'nr', 'currency', 'credit', 'base_income', 'base_refund', 'refund', 'notes', 'status', 'buyer_first_name', 'buyer_last_name', 'buyer_company', 'buyer_company_vat', 'buyer_company_number', 'buyer_address', 'buyer_city', 'buyer_state', 'buyer_country', 'buyer_zip', 'buyer_phone', 'buyer_phone_cc', 'buyer_email', 'approved', 'taxname', 'taxrate', 'due_at', 'reminded_at', 'paid_at'];
+        }
+        return $this->di['table_export_csv']('invoice', 'invoices.csv', $headers);
     }
 }

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -276,8 +276,18 @@
                 </table>
               </div>
                 <div class="card-footer d-flex align-items-center justify-content-between">
-                    {% include "partial_batch_delete.html.twig" with { 'action': 'admin/invoice/batch_delete' } %}
-                    {% include "partial_pagination.html.twig" with { 'list': invoices, 'url': 'invoice' } %}
+                    <div>
+                        {% include "partial_batch_delete.html.twig" with { 'action': 'admin/invoice/batch_delete' } %}
+                        {% include "partial_pagination.html.twig" with { 'list': invoices, 'url': 'invoice' } %}
+                    </div>
+                    <div>
+                        <a class="btn btn-secondary" href="{{ '/api/admin/invoice/export_csv'|link({ 'CSRFToken': CSRFToken }) }}" title="{{ 'Export Invoices'|trans }}">
+                            <svg class="icon">
+                                <use xlink:href="#download" />
+                            </svg>
+                            {{ 'Export Invoices'|trans }}
+                        </a>
+                    </div>
                 </div>
             </div>
 

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -456,4 +456,10 @@ class Admin extends \Api_Abstract
 
         return true;
     }
+
+    public function export_csv($data)
+    {
+        $data['headers'] ??= [];
+        return $this->getService()->exportCSV($data['headers']);
+    }
 }

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1383,4 +1383,12 @@ class Service implements InjectionAwareInterface
         $stmt = $pdo->prepare($sql);
         $stmt->execute(['id' => $client->id]);
     }
+
+    public function exportCSV(array $headers)
+    {
+        if (!$headers) {
+            $headers = ['id', 'client_id', 'product_id', 'title', 'currency', 'service_type', 'period', 'quantity', 'price', 'discount', 'status', 'reason', 'notes'];
+        }
+        return $this->di['table_export_csv']('client_order', 'orders.csv', $headers);
+    }
 }

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -254,8 +254,18 @@
                 </div>
 
                 <div class="card-footer d-flex align-items-center justify-content-between">
-                    {% include 'partial_batch_delete.html.twig' with { 'action': 'admin/order/batch_delete' } %}
-                    {% include 'partial_pagination.html.twig' with { 'list': orders, 'url': 'order' } %}
+                    <div>
+                        {% include 'partial_batch_delete.html.twig' with { 'action': 'admin/order/batch_delete' } %}
+                        {% include 'partial_pagination.html.twig' with { 'list': orders, 'url': 'order' } %}
+                    </div>
+                    <div>
+                        <a class="btn btn-secondary" href="{{ '/api/admin/order/export_csv'|link({ 'CSRFToken': CSRFToken }) }}" title="{{ 'Export Orders'|trans }}">
+                            <svg class="icon">
+                                <use xlink:href="#download" />
+                            </svg>
+                            {{ 'Export Orders'|trans }}
+                        </a>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
This implements a pretty basic way to export tables as a CSV.
I also added endpoints and interface buttons to export clients, orders, and invoices to CSV.

It's not a particularly advanced function, but it has the basics to limit the number of results (not used presently), and to specify 
which columns (headers in the CSV) to include in the export, which I used for the API endpoints I created so it will by default export what I think is the more useful columns from each table.

This is what the button looks like:
![image](https://user-images.githubusercontent.com/17304943/224063273-7a6e4ff5-0db8-492c-a4cc-a5860f9664bc.png)

And an example CSV it generated (with only two clients)
[clients.csv](https://github.com/FOSSBilling/FOSSBilling/files/10932884/clients.csv)

