### PR TITLE
Making the event listener work for every instance of the similar element

### DIFF
--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -357,29 +357,31 @@
 
 {% block js %}
 <script>
-document.querySelector('a.show-notes').addEventListener('click', function(e) {
-    e.preventDefault();
+    document.querySelectorAll('a.show-notes').forEach(notes => {
+        notes.addEventListener('click', function(e) {
+            e.preventDefault();
 
-    API.admin.post('support/ticket_get', { id: e.currentTarget.getAttribute('rel') }, function(result){
-        var html = document.createElement('div');
-            
-        result.notes.forEach(function(entry) {
-            var div = document.createElement('div');
-            div.innerHTML = entry.note;
-                
-            html.appendChild(div);
-            html.appendChild(document.createElement('hr'));
+            API.admin.post('support/ticket_get', { id: e.currentTarget.getAttribute('rel') }, function(result){
+                var html = document.createElement('div');
+                    
+                result.notes.forEach(function(entry) {
+                    var div = document.createElement('div');
+                    div.innerHTML = entry.note;
+                        
+                    html.appendChild(div);
+                    html.appendChild(document.createElement('hr'));
+                });
+
+                Modals.create({
+                    title: "{{ 'Notes'|trans }}",
+                    content: html.outerHTML,
+                });
+            });
         });
+    })
 
-        Modals.create({
-            title: "{{ 'Notes'|trans }}",
-            content: html.outerHTML,
-        });
-    });
-});
-
-function onAfterPublicTicketCreate(result) {
-    bb.redirect("{{ 'support/public-ticket'|alink }}/" + result);
-}
+    function onAfterPublicTicketCreate(result) {
+        bb.redirect("{{ 'support/public-ticket'|alink }}/" + result);
+    }
 </script>
 {% endblock %}


### PR DESCRIPTION
This bug was introduced with #903. The problem was, the "show notes" element can exist more than once in the same document. Using `querySelector` only brings the first element. The ones after the first one wouldn't work.

I instead used `querySelectorAll` to loop through all of the instances and add the event listener to every one of them. Now all of them work.