### PR TITLE
Improve date/datetime format handling and customisability

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -37,7 +37,8 @@
         "symfony/webpack-encore-bundle": "^1.16",
         "lcharette/webpack-encore-twig": "1.1.0",
         "league/csv": "^9.8",
-        "symfony/http-client": "^6.0"
+        "symfony/http-client": "^6.0",
+        "twig/intl-extra": "^3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9db4b3dacd84982f90b22feda0a6fd3",
+    "content-hash": "09cccff8f21218d962b2abf1a15ce575",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3141,6 +3141,86 @@
             "time": "2023-02-01T08:22:55+00:00"
         },
         {
+            "name": "symfony/intl",
+            "version": "v6.0.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/intl.git",
+                "reference": "a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c",
+                "reference": "a2e1ce9048ea549ee1e8d9ce521cbe9a9ec7d92c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Eriksen Costa",
+                    "email": "eriksen.costa@infranology.com.br"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a PHP replacement layer for the C intl extension that includes additional data from the ICU library",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "i18n",
+                "icu",
+                "internationalization",
+                "intl",
+                "l10n",
+                "localization"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v6.0.19"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:36:10+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.27.0",
             "source": {
@@ -4321,6 +4401,75 @@
                 }
             ],
             "time": "2023-01-18T19:37:55+00:00"
+        },
+        {
+            "name": "twig/intl-extra",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/intl-extra.git",
+                "reference": "c3ebfac1624228c0556de57a34af6b7d83a1a408"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/intl-extra/zipball/c3ebfac1624228c0556de57a34af6b7d83a1a408",
+                "reference": "c3ebfac1624228c0556de57a34af6b7d83a1a408",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/intl": "^4.4|^5.0|^6.0",
+                "twig/twig": "^2.7|^3.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Intl",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "intl",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/intl-extra/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-08T07:44:55+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -93,29 +93,22 @@ return [
      */
     'sef_urls' => true,
 
-    /*
-     * System timezone.
+    /* 
+     * These configuration options allow you to configure the default localisation.
      */
-    'timezone' => 'UTC',
+    'i18n' => [
+        'locale' => 'en_US',
+        'timezone' => 'UTC',
 
-    /*
-     * FOSSBilling locale.
-     */
-    'locale' => 'en_US',
+        // Short names for formats (none, short, medium, long).
+        // @see https://www.php.net/manual/en/class.intldateformatter.php
+        'date_format' => 'medium',
+        'time_format' => 'short',
 
-    /*
-     * Set default date format for localized strings.
-     *
-     * @see https://www.php.net/manual/en/datetime.format.php
-     */
-    'locale_date_format' => 'l, d F o',
-
-    /*
-     * Set default time format for localized strings.
-     *
-     * @see https://www.php.net/manual/en/datetime.format.php
-     */
-    'locale_time_format' => ' G:i:s',
+        // Specifying a pattern will override the above date/time options. 
+        // @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax
+        'datetime_pattern' => '',
+    ],
 
     /*
      * Set location to store sensitive data.

--- a/src/di.php
+++ b/src/di.php
@@ -28,6 +28,7 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\DebugExtension;
 use Twig\Extension\StringLoaderExtension;
+use Twig\Extra\Intl\IntlExtension;
 
 $di = new Box_Di();
 
@@ -325,10 +326,10 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addExtension(new DebugExtension());
     $twig->addExtension(new TranslationExtension());
     $twig->addExtension($box_extensions);
-    $twig->getExtension(CoreExtension::class)
-        ->setDateFormat($config['locale_date_format']);
-    $twig->getExtension(CoreExtension::class)
-        ->setTimezone($config['timezone']);
+    $twig->getExtension(CoreExtension::class)->setTimezone($config['timezone']);
+
+    $dateFormatter = new \IntlDateFormatter($config['locale'], \IntlDateFormatter::MEDIUM, \IntlDateFormatter::MEDIUM, $config['timezone']);
+    $twig->addExtension(new IntlExtension($dateFormatter));
 
     // add globals
     if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && 'XMLHttpRequest' === $_SERVER['HTTP_X_REQUESTED_WITH']) {

--- a/src/foss-update.php
+++ b/src/foss-update.php
@@ -28,6 +28,23 @@ class FOSSPatch_29 extends FOSSPatchAbstract
 }
 
 /**
+ * Patch to update email templates to use format_date/format_datetime filters
+ * instead of removed bb_date/bb_datetime filters. 
+ * 
+ * @see https://github.com/FOSSBilling/FOSSBilling/pull/948
+ */
+class FOSSPatch_29 extends FOSSPatchAbstract
+{
+    public function patch()
+    {
+        $q = "UPDATE email_template SET content = REPLACE(content, 'bb_date', 'format_date')";
+        $this->execSql($q);
+        $q = "UPDATE email_template SET content = REPLACE(content, 'bb_datetime', 'format_datetime')";
+        $this->execSql($q);
+    }
+}
+
+/**
  * Patch to remove .html from email templates action code, see https://github.com/FOSSBilling/FOSSBilling/issues/863
  */
 class FOSSPatch_28 extends FOSSPatchAbstract

--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -32,7 +32,7 @@
 
 <div id="footer">
 	<div class="wrapper">
-    <span>&copy; Copyright {{ now|date('Y') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="FOSSBilling" target="_blank">FOSSBilling {{version}}</a></span>
+    <span>&copy; Copyright {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="FOSSBilling" target="_blank">FOSSBilling {{version}}</a></span>
   </div>
 </div>
 

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -475,10 +475,14 @@ final class Box_Installer
             'admin_area_prefix' => '/admin',
             'disable_auto_cron' => false,
             'sef_urls' => true,
-            'timezone' => 'UTC',
-            'locale' => 'en_US',
-            'locale_date_format' => 'l, d F o',
-            'locale_time_format' => ' G:i:s',
+
+            'i18n' => [
+                'locale' => 'en_US',
+                'timezone' => 'UTC',
+                'date_format' => 'medium',
+                'time_format' => 'short',
+            ],
+
             'path_data' => PATH_ROOT . '/data',
             'path_logs' => PATH_ROOT . '/data/log/application.log',
 

--- a/src/library/Box/Requirements.php
+++ b/src/library/Box/Requirements.php
@@ -70,7 +70,7 @@ class Box_Requirements implements \Box\InjectionAwareInterface
         $data['PHP_VERSION']    = PHP_VERSION;
 
         $data['bb']    = array(
-            'BB_LOCALE'     =>  $this->di['config']['locale'],
+            'BB_LOCALE'     =>  $this->di['config']['i18n']['locale'],
             'BB_SEF_URLS'   =>  BB_SEF_URLS,
             'version'       =>  Box_Version::VERSION,
         );

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -406,8 +406,11 @@ class Box_Tools
         $newConfig['maintenance_mode']['allowed_ips'] ??= [];
 
         $newConfig['disable_auto_cron'] ??= false;
-        $newConfig['locale_date_format'] = ($currentConfig['locale_date_format'] === '%A, %d %B %G') ? 'l, d F o' : $currentConfig['locale_date_format'];
-        $newConfig['locale_time_format'] = ($currentConfig['locale_time_format'] === ' %T') ? ' G:i:s' : $currentConfig['locale_time_format'];
+
+        $newConfig['i18n']['locale'] = $currentConfig['locale'] ?? 'en_US';
+        $newConfig['i18n']['timezone'] = $currentConfig['timezone'] ?? 'UTC';
+        $newConfig['i18n']['date_format'] ??= 'medium';
+        $newConfig['i18n']['time_format'] ??= 'short';
 
         $newConfig['db']['port'] ??= '3306';
 
@@ -415,6 +418,14 @@ class Box_Tools
         $newConfig['api']['rate_span_login'] ??= 60;
         $newConfig['api']['rate_limit_login'] ??= 20;
         $newConfig['api']['CSRFPrevention'] ??= true;
+
+        // Remove depreciated config keys/subkeys.
+        $depreciatedConfigKeys = [ 'guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone' ];
+        $depreciatedConfigSubkeys = [];
+        $newConfig = array_diff_key($newConfig, array_flip($depreciatedConfigKeys));
+        foreach ($depreciatedConfigSubkeys as $key => $subkey) {
+            unset($newConfig[$key][$subkey]);
+        }
 
         $output = '<?php ' . PHP_EOL;
         $output .= 'return ' . var_export($newConfig, true) . ';';

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -78,10 +78,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
             'autolink' => new TwigFilter('autolink', [$this, 'twig_autolink_filter']),
 
-            'bb_date' => new TwigFilter('bb_date', [$this, 'twig_bb_date']),
-
-            'bb_datetime' => new TwigFilter('bb_datetime', [$this, 'twig_bb_datetime']),
-
             'img_tag' => new TwigFilter('img_tag', [$this, 'twig_img_tag'], ['needs_environment' => false, 'is_safe' => ['html']]),
 
             'script_tag' => new TwigFilter('script_tag', [$this, 'twig_script_tag'], ['needs_environment' => false, 'is_safe' => ['html']]),
@@ -112,23 +108,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
     public function getName()
     {
         return 'bb';
-    }
-
-    public function twig_bb_date($time, $format = null)
-    {
-        $locale_date_format = $this->di['config']['locale_date_format'];
-        $format = is_null($format) ? $locale_date_format : $format;
-
-        return date($format, strtotime($time));
-    }
-
-    public function twig_bb_datetime($time, $format = null)
-    {
-        $locale_date_format = $this->di['config']['locale_date_format'];
-        $locale_time_format = $this->di['config']['locale_time_format'];
-        $format = is_null($format) ? $locale_date_format . $locale_time_format : $format;
-
-        return date($format, strtotime($time));
     }
 
     public function twig_ipcountryname_filter($value)

--- a/src/modules/Activity/html_admin/mod_activity_index.html.twig
+++ b/src/modules/Activity/html_admin/mod_activity_index.html.twig
@@ -22,7 +22,7 @@
                 <th class="w-1"></th>
                 <th>{{ 'User'|trans }}</th>
                 <th>{{ 'Message'|trans }}</th>
-                <th>{{ 'Ip'|trans }}</th>
+                <th>{{ 'IP'|trans }}</th>
                 <th>{{ 'Country'|trans }}</th>
                 <th>{{ 'Date'|trans }}</th>
                 <th class="w-1"></th>
@@ -60,7 +60,7 @@
             <td>{{ event.message }}</td>
             <td>{{ event.ip }}</td>
             <td>{{ event.ip|ipcountryname|default('Unknown') }}</td>
-            <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
+            <td>{{ event.created_at|format_datetime }}</td>
             <td>
                 <a class="btn btn-icon api-link"
                     href="{{ 'api/admin/activity/log_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -252,7 +252,7 @@
                                     {% endif %}
                                     {{ mf.status_name(client.status) }}
                                 </td>
-                                <td>{{ client.created_at|date('Y-m-d') }}</td>
+                                <td>{{ client.created_at|format_date }}</td>
                                 <td>
                                     <a class="btn btn-icon" href="{{ 'client/manage'|alink }}/{{ client.id }}">
                                         <svg class="icon">

--- a/src/modules/Client/html_admin/mod_client_login_history.html.twig
+++ b/src/modules/Client/html_admin/mod_client_login_history.html.twig
@@ -45,7 +45,7 @@
             </td>
             <td>{{ event.ip }}</td>
             <td>{{ event.ip|ipcountryname|default('Unknown') }}</td>
-            <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
+            <td>{{ event.created_at|format_datetime }}</td>
             <td>
                 <a class="btn btn-icon api-link"
                     href="{{ 'api/admin/client/login_history_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -129,8 +129,8 @@
                             </td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Registered at'|trans }}:</td>
-                            <td>{{ client.created_at|format_datetime }}</td>
+                            <td class="text-end">{{ 'Registered on'|trans }}:</td>
+                            <td>{{ client.created_at|format_date }}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -520,8 +520,8 @@
                         <tr>
                             <th class="w-1">#</th>
                             <th>{{ 'Amount'|trans }}</th>
-                            <th>{{ 'Issued at'|trans }}</th>
-                            <th>{{ 'Paid at'|trans }}</th>
+                            <th>{{ 'Issued on'|trans }}</th>
+                            <th>{{ 'Paid on'|trans }}</th>
                             <th>{{ 'Status'|trans }}</th>
                             <th class="w-1"></th>
                         </tr>
@@ -534,8 +534,8 @@
                                 <a href="{{ '/invoice/manage'|alink }}/{{ invoice.id }}">{{ invoice.serie_nr }}</a>
                             </td>
                             <td>{{ mf.currency_format( invoice.total, invoice.currency) }}</td>
-                            <td>{{ invoice.created_at|date('Y-m-d') }}</td>
-                            <td>{% if invoice.paid_at %}{{ invoice.paid_at|date('Y-m-d') }}{% else %}-{% endif %}</td>
+                            <td>{{ invoice.created_at|format_date }}</td>
+                            <td>{% if invoice.paid_at %}{{ invoice.paid_at|format_date }}{% else %}-{% endif %}</td>
                             <td>
                                 {% if invoice.status == 'paid' %}
                                     <span class="badge bg-success me-1"></span>
@@ -665,7 +665,7 @@
                         <tr>
                             <td>{{ mf.currency_format(tx.amount, tx.currency) }}</td>
                             <td>{{ tx.description }}</td>
-                            <td>{{ tx.created_at|date("Y-m-d H:i") }}</td>
+                            <td>{{ tx.created_at|format_datetime }}</td>
                             <td>
                                 <a class="btn btn-icon api-link"
                                     href="{{ 'api/admin/client/balance_delete'|link({ 'id': tx.id, 'CSRFToken': CSRFToken }) }}"
@@ -743,7 +743,7 @@
                         <tr>
                             <td>{{ login.ip }}</td>
                             <td>{{ login.ip|ipcountryname|default('Unknown') }}</td>
-                            <td>{{ login.created_at|date('l, d F Y') }}</td>
+                            <td>{{ login.created_at|format_datetime }}</td>
                         </tr>
                         {% else %}
                         <tr>
@@ -766,7 +766,7 @@
                         <tr>
                             <th>{{ 'Email subject'|trans }}</th>
                             <th>{{ 'To'|trans }}</th>
-                            <th>{{ 'Date sent'|trans }}</th>
+                            <th>{{ 'Date'|trans }}</th>
                             <th class="w-1"></th>
                         </tr>
                     </thead>
@@ -777,7 +777,7 @@
                         <tr>
                             <td>{{ email.subject }}</td>
                             <td>{{ email.recipients }}</td>
-                            <td>{{ email.created_at|date('l, d F Y') }}</td>
+                            <td>{{ email.created_at|format_datetime }}</td>
                             <td>
                                 <a class="bb-button btn14" href="{{ 'email'|alink }}/{{ email.id }}">
                                     <img src="assets/icons/edit.svg" alt="">

--- a/src/modules/Client/html_admin/mod_client_manage.html.twig
+++ b/src/modules/Client/html_admin/mod_client_manage.html.twig
@@ -130,7 +130,7 @@
                         </tr>
                         <tr>
                             <td class="text-end">{{ 'Registered at'|trans }}:</td>
-                            <td>{{ client.created_at|date('M d, Y') }}</td>
+                            <td>{{ client.created_at|format_datetime }}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -822,7 +822,7 @@
                             <td>{{ tx.gateway }}</td>
                             <td>{{ mf.currency_format(tx.amount, tx.currency) }}</td>
                             <td>{{ mf.status_name(tx.status) }}</td>
-                            <td>{{ tx.created_at|bb_datetime }}</td>
+                            <td>{{ tx.created_at|format_datetime }}</td>
                             <td>
                                 <a class="btn btn-icon" href="{{ '/invoice/transaction'|alink }}/{{ tx.id }}">
                                     <svg class="icon">

--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -32,7 +32,7 @@
                 {% for i, tx in transactions.list %}
                 <tr class="{{ cycle(['odd', 'even'], i) }}">
                     <td>{{ tx.description }}</td>
-                    <td>{{ tx.created_at|bb_date }}</td>
+                    <td>{{ tx.created_at|format_date }}</td>
                     <td>{{ tx.amount|money(tx.currency) }}</td>
                 </tr>
                 {% else %}

--- a/src/modules/Cron/html_admin/mod_cron_settings.html.twig
+++ b/src/modules/Cron/html_admin/mod_cron_settings.html.twig
@@ -34,17 +34,17 @@
             <tbody>
                 <tr>
                     <td class="w-50 text-end">{{ 'Timezone'|trans }}:</td>
-                    <td>{{ "now"|date('e') }}</td>
+                    <td>{{ "now"|format_date(pattern='zzz') }}</td>
                 </tr>
                 <tr>
                     <td class="text-end">{{ 'Time on server'|trans }}:</td>
-                    <td>{{ "now"|date('Y-m-d H:i:s') }}</td>
+                    <td>{{ "now"|format_datetime }}</td>
                 </tr>
                 <tr>
                     <td class="text-end">{{ 'Last time scheduled tasks were executed'|trans }}:</td>
                     <td>
                         {% if cron.last_cron_exec %}
-                            {{ cron.last_cron_exec|date('Y-m-d H:i:s') }}
+                            {{ cron.last_cron_exec|format_datetime }}
                             ({{ cron.last_cron_exec|timeago }} ago)
                         {% else %}
                             {{ 'Scheduled tasks were never executed'|trans }}

--- a/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
+++ b/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
@@ -43,7 +43,7 @@
             <th>{{ 'Subject'|trans }}</th>
             <th>{{ 'Help desk'|trans }}</th>
             <th>{{ 'Status'|trans }}</th>
-            <th>{{ 'Submitted'|trans }}</th>
+            <th>{{ 'Last Updated'|trans }}</th>
             <th>{{ 'Actions'|trans }}</th>
         </tr>
         </thead>
@@ -54,7 +54,7 @@
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}">{{ ticket.subject }}</a></td>
             <td>{{ ticket.helpdesk.name }}</td>
             <td><span class="label">{{ mf.status_name(ticket.status) }}</span></td>
-            <td>{{ ticket.created_at|format_date }}</td>
+            <td title="{{ ticket.updated_at|format_datetime }}">{{ ticket.updated_at|timeago }} {{ 'ago'|trans }}</td>
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}" class="btn btn-small btn-inverse">{{ 'Reply'|trans }}</a></td>
         </tr>
         {% else %}
@@ -209,7 +209,7 @@
                     {% for i, email in client.email_get_list({ "per_page": 5 }).list %}
                     <tr class="{{ cycle(['odd', 'even'], i) }}">
                         <td><a href="{{ 'email'|link }}/{{ email.id }}">{{ email.subject|truncate(30) }}</a></td>
-                        <td title="{{ email.created_at|format_date }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
+                        <td title="{{ email.created_at|format_datetime }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
                     </tr>
                     {% else %}
                     <tr>

--- a/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
+++ b/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
@@ -54,7 +54,7 @@
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}">{{ ticket.subject }}</a></td>
             <td>{{ ticket.helpdesk.name }}</td>
             <td><span class="label">{{ mf.status_name(ticket.status) }}</span></td>
-            <td>{{ ticket.created_at|bb_date }}</td>
+            <td>{{ ticket.created_at|format_date }}</td>
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}" class="btn btn-small btn-inverse">{{ 'Reply'|trans }}</a></td>
         </tr>
         {% else %}
@@ -209,7 +209,7 @@
                     {% for i, email in client.email_get_list({ "per_page": 5 }).list %}
                     <tr class="{{ cycle(['odd', 'even'], i) }}">
                         <td><a href="{{ 'email'|link }}/{{ email.id }}">{{ email.subject|truncate(30) }}</a></td>
-                        <td title="{{ email.created_at|bb_date }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
+                        <td title="{{ email.created_at|format_date }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
                     </tr>
                     {% else %}
                     <tr>

--- a/src/modules/Email/html_admin/mod_email_details.html.twig
+++ b/src/modules/Email/html_admin/mod_email_details.html.twig
@@ -40,7 +40,7 @@
 
             <tr>
                 <td class="text-end">{{ 'Sent'|trans }}:</td>
-                <td>{{ email.created_at|date('l, d F Y') }}</td>
+                <td>{{ email.created_at|format_date }}</td>
             </tr>
          </tbody>
     </table>

--- a/src/modules/Email/html_admin/mod_email_history.html.twig
+++ b/src/modules/Email/html_admin/mod_email_history.html.twig
@@ -47,7 +47,7 @@
             <td>
                 <a href="{{ '/email'|alink }}/{{ email.id }}">{{ email.subject|truncate(40) }}</a>
             </td>
-            <td>{{ email.created_at|date('Y-m-d') }}</td>
+            <td>{{ email.created_at|format_date }}</td>
             <td>
                 <a class="btn btn-icon" href="{{ '/email'|alink }}/{{ email.id }}">
                     <svg class="icon">

--- a/src/modules/Email/html_client/mod_email_email.html.twig
+++ b/src/modules/Email/html_client/mod_email_email.html.twig
@@ -26,7 +26,7 @@
                     <div class="well well-small">
                         <p><strong>{{ 'From:'|trans }}</strong> {{email.sender}}</p>
                         <p><strong>{{ 'To:'|trans }}</strong> {{email.recipients}}</p>
-                        <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|bb_date}}</p>
+                        <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|format_date}}</p>
                     </div>
                     <div class="well">
                         <h3>{{ email.subject }}</h3>

--- a/src/modules/Email/html_client/mod_email_email.html.twig
+++ b/src/modules/Email/html_client/mod_email_email.html.twig
@@ -26,7 +26,7 @@
                     <div class="well well-small">
                         <p><strong>{{ 'From:'|trans }}</strong> {{email.sender}}</p>
                         <p><strong>{{ 'To:'|trans }}</strong> {{email.recipients}}</p>
-                        <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|format_date}}</p>
+                        <p><strong>{{ 'Created at:'|trans }}</strong> {{ email.created_at|format_datetime }}</p>
                     </div>
                     <div class="well">
                         <h3>{{ email.subject }}</h3>

--- a/src/modules/Email/html_client/mod_email_index.html.twig
+++ b/src/modules/Email/html_client/mod_email_index.html.twig
@@ -24,7 +24,7 @@
                         <li class="email-title {% if loop.first%}active{% endif %}" style="line-height: 50%">
                             <a href="#tab{{email.id}}" data-toggle="tab" style="padding-left: 0px; padding-bottom: 0px">
                                 <p><strong>{{email.subject |slice(0,50) }}{% if email.subject | length > 50%}...{% endif%}</strong></p>
-                                <p><small>{{email.created_at|bb_date}}</small></p>
+                                <p><small>{{email.created_at|format_date}}</small></p>
                             </a>
                         </li>
                         {% endfor %}
@@ -35,7 +35,7 @@
                             <div class="well well-small">
                                 <p><strong>{{ 'From:'|trans }}</strong> {{email.sender}}</p>
                                 <p><strong>{{ 'To:'|trans }}</strong> {{email.recipients}}</p>
-                                <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|bb_date}}</p>
+                                <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|format_date}}</p>
                             </div>
                             <div class="well">
                                 <h3>{{ email.subject }}</h3>

--- a/src/modules/Email/html_client/mod_email_index.html.twig
+++ b/src/modules/Email/html_client/mod_email_index.html.twig
@@ -24,7 +24,7 @@
                         <li class="email-title {% if loop.first%}active{% endif %}" style="line-height: 50%">
                             <a href="#tab{{email.id}}" data-toggle="tab" style="padding-left: 0px; padding-bottom: 0px">
                                 <p><strong>{{email.subject |slice(0,50) }}{% if email.subject | length > 50%}...{% endif%}</strong></p>
-                                <p><small>{{email.created_at|format_date}}</small></p>
+                                <p><small>{{ email.created_at|format_datetime }}</small></p>
                             </a>
                         </li>
                         {% endfor %}
@@ -35,7 +35,7 @@
                             <div class="well well-small">
                                 <p><strong>{{ 'From:'|trans }}</strong> {{email.sender}}</p>
                                 <p><strong>{{ 'To:'|trans }}</strong> {{email.recipients}}</p>
-                                <p><strong>{{ 'Created at:'|trans }}</strong> {{email.created_at|format_date}}</p>
+                                <p><strong>{{ 'Created at:'|trans }}</strong> {{ email.created_at|format_date }}</p>
                             </div>
                             <div class="well">
                                 <h3>{{ email.subject }}</h3>

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -59,7 +59,7 @@
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}">{{ ticket.subject }}</a></td>
             <td>{{ ticket.helpdesk.name }}</td>
             <td><span class="label">{{ mf.status_name(ticket.status) }}</span></td>
-            <td>{{ ticket.created_at|bb_date }}</td>
+            <td>{{ ticket.created_at|format_date }}</td>
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}" class="btn btn-small btn-inverse">{{ 'Reply'|trans }}</a></td>
         </tr>
         {% else %}
@@ -214,7 +214,7 @@
                     {% for i, email in client.email_get_list({ "per_page": 5 }).list %}
                     <tr class="{{ cycle(['odd', 'even'], i) }}">
                         <td><a href="{{ 'email'|link }}/{{ email.id }}">{{ email.subject|truncate(30) }}</a></td>
-                        <td title="{{ email.created_at|bb_date }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
+                        <td title="{{ email.created_at|format_date }}">{{ email.created_at|timeago }} {{ 'ago'|trans }}</td>
                     </tr>
                     {% else %}
                     <tr>

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -48,7 +48,7 @@
             <th>{{ 'Subject'|trans }}</th>
             <th>{{ 'Help desk'|trans }}</th>
             <th>{{ 'Status'|trans }}</th>
-            <th>{{ 'Submitted'|trans }}</th>
+            <th>{{ 'Last Updated'|trans }}</th>
             <th>{{ 'Actions'|trans }}</th>
         </tr>
         </thead>
@@ -59,7 +59,7 @@
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}">{{ ticket.subject }}</a></td>
             <td>{{ ticket.helpdesk.name }}</td>
             <td><span class="label">{{ mf.status_name(ticket.status) }}</span></td>
-            <td>{{ ticket.created_at|format_date }}</td>
+            <td title="{{ ticket.updated_at|format_datetime }}">{{ ticket.updated_at|timeago }} {{ 'ago'|trans }}</td>
             <td><a href="{{ 'support/ticket'|link }}/{{ticket.id}}" class="btn btn-small btn-inverse">{{ 'Reply'|trans }}</a></td>
         </tr>
         {% else %}

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1213,7 +1213,12 @@ class Service implements InjectionAwareInterface
             $currencyCode = $client->currency;
         }
 
-        $localeDateFormat = $this->di['config']['locale_date_format'];
+        $config = $this->di['config'];
+        $locale = $config['i18n']['locale'];
+        $timezone = $config['i18n']['timezone'];
+        $date_format = strtoupper($config['i18n']['date_format']);
+        $time_format = strtoupper($config['i18n']['time_format']);
+        $datetime_pattern = $config['i18n']['datetime_pattern'] ?? null;
         $invoice = $this->toApiArray($invoice, false, $identity);
         $systemService = $this->di['mod_service']('System');
         $company = $systemService->getCompany();
@@ -1269,10 +1274,13 @@ class Service implements InjectionAwareInterface
             $html .= '<hr class="Rounded">';
         }
 
+        $format = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone , null, $datetime_pattern);
+
+
         $html .= '<div class="InvoiceInfo">';
         $html .= '<p>Invoice number: ' . $invoice['serie_nr'] . '</p>';
-        $html .= '<p>Invoice date: ' . date($localeDateFormat, strtotime($invoice['created_at'])) . '</p>';
-        $html .= '<p>Due date: ' . date($localeDateFormat, strtotime($invoice['due_at'])) . '</p>';
+        $html .= '<p>Invoice date: ' . $format->format(strtotime($invoice['created_at'])) . '</p>';
+        $html .= '<p>Due date: ' . $format->format(strtotime($invoice['due_at'])) . '</p>';
         $html .= '<p>Invoice status: ' . ucfirst($invoice['status']) . '</p>';
         $html .= '</div>';
 

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -98,19 +98,19 @@
                     </tr>
                     <tr>
                         <td class="text-end">{{ 'Created at'|trans }}:</td>
-                        <td>{{ invoice.created_at|bb_date }}</td>
+                        <td>{{ invoice.created_at|format_date }}</td>
                     </tr>
                     <tr>
                         <td class="text-end">{{ 'Due at'|trans }}:</td>
-                        <td>{{ invoice.due_at|bb_date }}</td>
+                        <td>{{ invoice.due_at|format_date }}</td>
                     </tr>
                     <tr>
                         <td class="text-end">{{ 'Paid at'|trans }}:</td>
-                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|bb_date }}{% else %}-{% endif %}</td>
+                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|format_date }}{% else %}-{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="text-end">{{ 'Reminded at'|trans }}:</td>
-                        <td>{% if invoice.reminded_at %}{{ invoice.reminded_at|bb_date }} ({{ invoice.reminded_at|timeago }} ago) {% endif %}</td>
+                        <td>{% if invoice.reminded_at %}{{ invoice.reminded_at|format_date }} ({{ invoice.reminded_at|timeago }} ago) {% endif %}</td>
                     </tr>
                     {% if invoice.notes %}
                     <tr>
@@ -652,7 +652,7 @@
                     <td>{{ tx.gateway }}</td>
                     <td>{{ mf.currency_format( tx.amount, tx.currency) }}</td>
                     <td>{{ mf.status_name(tx.status) }}</td>
-                    <td>{{ tx.created_at|bb_datetime }}</td>
+                    <td>{{ tx.created_at|format_datetime }}</td>
                     <td>
                         <a class="btn btn-icon" href="{{ '/invoice/transaction'|alink }}/{{ tx.id }}">
                             <svg class="icon">

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -97,20 +97,20 @@
                         <td>{{ invoice.currency }}</td>
                     </tr>
                     <tr>
-                        <td class="text-end">{{ 'Created at'|trans }}:</td>
-                        <td>{{ invoice.created_at|format_date }}</td>
+                        <td class="text-end">{{ 'Date Created'|trans }}:</td>
+                        <td>{{ invoice.created_at|format_datetime }}</td>
                     </tr>
                     <tr>
-                        <td class="text-end">{{ 'Due at'|trans }}:</td>
-                        <td>{{ invoice.due_at|format_date }}</td>
+                        <td class="text-end">{{ 'Date Due'|trans }}:</td>
+                        <td>{{ invoice.due_at|format_datetime }}</td>
                     </tr>
                     <tr>
-                        <td class="text-end">{{ 'Paid at'|trans }}:</td>
-                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|format_date }}{% else %}-{% endif %}</td>
+                        <td class="text-end">{{ 'Date Paid'|trans }}:</td>
+                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|format_datetime }}{% else %}-{% endif %}</td>
                     </tr>
                     <tr>
-                        <td class="text-end">{{ 'Reminded at'|trans }}:</td>
-                        <td>{% if invoice.reminded_at %}{{ invoice.reminded_at|format_date }} ({{ invoice.reminded_at|timeago }} ago) {% endif %}</td>
+                        <td class="text-end">{{ 'Last Reminded'|trans }}:</td>
+                        {% if invoice.reminded_at %}<td title={{ invoice.reminded_at|format_datetime }}>{{ invoice.reminded_at|timeago }} {{ 'ago'|trans }}</td>{% else %}<td>-</td>{% endif %}
                     </tr>
                     {% if invoice.notes %}
                     <tr>

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -72,12 +72,12 @@
                             </tr>
                             <tr>
                                 <td class="text-end">{{ 'Created at'|trans }}:</td>
-                                <td>{{ subscription.created_at|date('l, d F Y') }}</td>
+                                <td>{{ subscription.created_at|format_date }}</td>
                             </tr>
                             {% if subscription.created_at != subscription.updated_at %}
                             <tr>
                                 <td class="text-end">{{ 'Updated at'|trans }}:</td>
-                                <td>{{ subscription.updated_at|date('l, d F Y') }}</td>
+                                <td>{{ subscription.updated_at|format_date }}</td>
                             </tr>
                             {% endif %}
                         </tbody>

--- a/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transaction.html.twig
@@ -98,12 +98,12 @@
                         {% endif %}
                         <tr>
                             <td class="text-end">{{ 'Received at'|trans }}</td>
-                            <td>{{ transaction.created_at|date('l, d F Y') }}</td>
+                            <td>{{ transaction.created_at|format_date }}</td>
                         </tr>
                         {% if transaction.created_at != transaction.updated_at %}
                         <tr>
                             <td class="text-end">{{ 'Updated at'|trans }}</td>
-                            <td>{{ transaction.updated_at|date('l, d F Y') }}</td>
+                            <td>{{ transaction.updated_at|format_date }}</td>
                         </tr>
                         {% endif %}
                     </tbody>

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -196,7 +196,7 @@
                 </td>
                 <td>{{ tx.gateway }}</td>
                 <td>{{ mf.currency_format( tx.amount, tx.currency) }}</td>
-                <td>{{ tx.created_at|date('Y-m-d H:i') }}</td>
+                <td>{{ tx.created_at|format_datetime }}</td>
                 <td>
                     <a class="btn btn-icon" href="{{ 'invoice/transaction'|alink }}/{{ tx.id }}">
                         <svg class="icon">

--- a/src/modules/Invoice/html_client/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_index.html.twig
@@ -43,8 +43,8 @@
                         {% for i, invoice in unpaid_invoices.list %}
                         <tr class="{{ cycle(['odd', 'even'], i) }}">
                             <td>{{ "Proforma invoice #%05s"|format(invoice.id) }}</td>
-                            <td>{{ invoice.created_at|bb_date }}</td>
-                            <td>{{ invoice.due_at|bb_date }}</td>
+                            <td>{{ invoice.created_at|format_date }}</td>
+                            <td>{{ invoice.due_at|format_date }}</td>
                             <td>{{ invoice.total | money(invoice.currency) }}</td>
                             <td><a class="btn btn-small btn-primary" href="{{ 'invoice'|link }}/{{ invoice.hash }}">{{ 'Pay'|trans }}</a></td>
                         </tr>
@@ -80,8 +80,8 @@
 
                         <tr class="{{ cycle(['odd', 'even'], i) }}">
                             <td>{{ "Proforma invoice #%05s"|format(invoice.id) }}</td>
-                            <td>{{ invoice.created_at|bb_date }}</td>
-                            <td>{{ invoice.paid_at|bb_date }}</td>
+                            <td>{{ invoice.created_at|format_date }}</td>
+                            <td>{{ invoice.paid_at|format_date }}</td>
                             <td>{{ invoice.total | money(invoice.currency) }}</td>
                             <td><a href="{{ 'invoice'|link }}/{{ invoice.hash }}" class="btn btn-primary btn-small">{{ 'View'|trans }}</a></td>
                         </tr>

--- a/src/modules/Invoice/html_client/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_index.html.twig
@@ -32,7 +32,7 @@
                         <thead>
                         <tr>
                             <th>{{ 'Title'|trans }}</th>
-                            <th>{{ 'Issue Date'|trans }}</th>
+                            <th>{{ 'Invoice Date'|trans }}</th>
                             <th>{{ 'Due Date'|trans }}</th>
                             <th>{{ 'Total'|trans }}</th>
                             <th>&nbsp</th>
@@ -67,8 +67,8 @@
                         <thead>
                         <tr>
                             <th>{{ 'Title'|trans }}</th>
-                            <th>{{ 'Issue Date'|trans }}</th>
-                            <th>{{ 'Paid at'|trans }}</th>
+                            <th>{{ 'Invoice Date'|trans }}</th>
+                            <th>{{ 'Paid Date'|trans }}</th>
                             <th>{{ 'Total'|trans }}</th>
                             <th>&nbsp</th>
                         </tr>

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -69,14 +69,14 @@
                             <dd>{{ nr }}</dd>
                             <dt>{{ 'Invoice date'|trans }}:</dt>
                             <dd>{% if invoice.paid_at %}
-                                {{ invoice.paid_at|bb_date }}
+                                {{ invoice.paid_at|format_date }}
                                 {% else %}
-                                {{ invoice.created_at|bb_date }}
+                                {{ invoice.created_at|format_date }}
                                 {% endif %}
                             </dd>
                             <dt>{{ 'Due date'|trans }}:</dt>
                             <dd>{% if invoice.due_at %}
-                                {{ invoice.due_at|bb_date }}
+                                {{ invoice.due_at|format_date }}
                                 {% else %}
                                 -----
                                 {% endif %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -65,23 +65,23 @@
                         <img src="{{ company.logo_url }}" alt="Logo">
                         {% endif %}
                         <dl class="dl-horizontal">
-                            <dt>{{ 'Invoice number'|trans }}:</dt>
+                            <dt>{{ 'Invoice Number'|trans }}:</dt>
                             <dd>{{ nr }}</dd>
-                            <dt>{{ 'Invoice date'|trans }}:</dt>
+                            <dt>{{ 'Invoice Date'|trans }}:</dt>
                             <dd>{% if invoice.paid_at %}
                                 {{ invoice.paid_at|format_date }}
                                 {% else %}
                                 {{ invoice.created_at|format_date }}
                                 {% endif %}
                             </dd>
-                            <dt>{{ 'Due date'|trans }}:</dt>
+                            <dt>{{ 'Due Date'|trans }}:</dt>
                             <dd>{% if invoice.due_at %}
                                 {{ invoice.due_at|format_date }}
                                 {% else %}
                                 -----
                                 {% endif %}
                             </dd>
-                            <dt>{{ 'Invoice status'|trans }}:</dt>
+                            <dt>{{ 'Invoice Status'|trans }}:</dt>
                             <dd>
                                 <span class="label {% if invoice.status == 'paid' %} label-success{% elseif invoice.status == 'unpaid' %}label-warning{% endif %}">
                                       {{ invoice.status|capitalize }}

--- a/src/modules/Invoice/html_client/mod_invoice_print.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_print.html.twig
@@ -86,14 +86,14 @@
                                     <dd>{{ nr }}</dd>
                                     <dt>{{ 'Invoice date'|trans }}:</dt>
                                     <dd>{% if invoice.created_at %}
-                                        {{ invoice.created_at | bb_date }}
+                                        {{ invoice.created_at | format_date }}
                                         {% else %}
                                         -----
                                         {% endif %}
                                     </dd>
                                     <dt>{{ 'Due date'|trans }}:</dt>
                                     <dd>{% if invoice.due_at %}
-                                        {{ invoice.due_at | bb_date }}
+                                        {{ invoice.due_at | format_date }}
                                         {% else %}
                                         -----
                                         {% endif %}

--- a/src/modules/Invoice/html_client/mod_invoice_print.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_print.html.twig
@@ -84,21 +84,21 @@
                                 <dl class="dl-horizontal">
                                     <dt>{{ 'Invoice number'|trans }}:</dt>
                                     <dd>{{ nr }}</dd>
-                                    <dt>{{ 'Invoice date'|trans }}:</dt>
+                                    <dt>{{ 'Invoice Date'|trans }}:</dt>
                                     <dd>{% if invoice.created_at %}
                                         {{ invoice.created_at | format_date }}
                                         {% else %}
                                         -----
                                         {% endif %}
                                     </dd>
-                                    <dt>{{ 'Due date'|trans }}:</dt>
+                                    <dt>{{ 'Due Date'|trans }}:</dt>
                                     <dd>{% if invoice.due_at %}
                                         {{ invoice.due_at | format_date }}
                                         {% else %}
                                         -----
                                         {% endif %}
                                     </dd>
-                                    <dt>{{ 'Invoice status'|trans }}:</dt>
+                                    <dt>{{ 'Invoice Status'|trans }}:</dt>
                                     <dd>
                                     <span class="label {% if invoice.status == 'paid' %} label-success{% elseif invoice.status == 'unpaid' %}label-warning{% endif %}">
                                           <span class="{% if invoice.status == 'paid' %}awe-ok-sign{% elseif invoice.status == 'unpaid' %}awe-exclamation-sign{% endif %}"></span>

--- a/src/modules/Invoice/html_email/mod_invoice_created.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_created.html.twig
@@ -5,7 +5,7 @@ Hello {{ c.first_name }} {{ c.last_name }},
 
 This is to notify that proforma invoice {{ invoice.id }} was generated on {{ invoice.created_at|format_date }}.
 Amount Due: {{ invoice.total | money(invoice.currency) }}
-Due Date: {{invoice.due_at|format_date}}
+Due Date: {{ invoice.due_at|format_date }}
 
 You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}
 

--- a/src/modules/Invoice/html_email/mod_invoice_created.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_created.html.twig
@@ -3,9 +3,9 @@
 {% apply markdown %}
 Hello {{ c.first_name }} {{ c.last_name }},
 
-This is to notify that proforma invoice {{ invoice.id }} was generated on {{ invoice.created_at|bb_date }}.
+This is to notify that proforma invoice {{ invoice.id }} was generated on {{ invoice.created_at|format_date }}.
 Amount Due: {{ invoice.total | money(invoice.currency) }}
-Due Date: {{invoice.due_at|bb_date}}
+Due Date: {{invoice.due_at|format_date}}
 
 You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}
 

--- a/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
@@ -6,7 +6,7 @@ Hello {{ c.first_name }} {{ c.last_name }},
 This is a payment reminder that your proforma invoice **{{ invoice.serie_nr }}** is already
 due for {{ days_passed }} days.   
 
-Amount due: {{ invoice.total | money(invoice.currency) }}
+Amount Due: {{ invoice.total | money(invoice.currency) }}
 Due Date: {{ invoice.due_at|format_date }}
 
 You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}

--- a/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
@@ -7,7 +7,7 @@ This is a payment reminder that your proforma invoice **{{ invoice.serie_nr }}**
 due for {{ days_passed }} days.   
 
 Amount due: {{ invoice.total | money(invoice.currency) }}
-Due Date: {{ invoice.due_at|bb_date }}
+Due Date: {{ invoice.due_at|format_date }}
 
 You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}
 

--- a/src/modules/Invoice/html_email/mod_invoice_paid.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_paid.html.twig
@@ -4,7 +4,7 @@
 Hello {{ c.first_name }} {{ c.last_name }},
 
 This is a payment receipt for Invoice **{{ invoice.serie_nr }}** issued on
-{{invoice.created_at|date('Y-m-d')}}
+{{ invoice.created_at|format_date }}
 
 Total Paid: {{ invoice.total | money(invoice.currency) }}
 

--- a/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
@@ -7,7 +7,7 @@ Hello {{ c.first_name }} {{ c.last_name }},
 This is to remind that your proforma invoice **{{ invoice.serie_nr }}** is due
 in {{ invoice.due_at|daysleft }} days.   
 
-Amount due: {{ invoice.total|money(invoice.currency) }}
+Amount Due: {{ invoice.total|money(invoice.currency) }}
 Due Date: {{ invoice.due_at|format_date }}
 
 You can view and pay the invoice at: {{ 'invoice'|link }}/{{ invoice.hash }}

--- a/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
@@ -8,7 +8,7 @@ This is to remind that your proforma invoice **{{ invoice.serie_nr }}** is due
 in {{ invoice.due_at|daysleft }} days.   
 
 Amount due: {{ invoice.total|money(invoice.currency) }}
-Due Date: {{ invoice.due_at|bb_date }}
+Due Date: {{ invoice.due_at|format_date }}
 
 You can view and pay the invoice at: {{ 'invoice'|link }}/{{ invoice.hash }}
 

--- a/src/modules/Kb/html_client/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_article.html.twig
@@ -20,7 +20,7 @@
             <div class="data-container">
                 <header>
                     <h1>{{ article.title }}</h1>
-                    <div class="meta pull-right"><h5>{{ article.created_at|bb_date }}</h5></div>
+                    <div class="meta pull-right"><h5>{{ article.created_at|format_date }}</h5></div>
                     <p>{{ 'Article views'|trans }}: {{ article.views }}</p>
                 </header>
                 <section>

--- a/src/modules/Kb/html_client/mod_kb_article.html.twig
+++ b/src/modules/Kb/html_client/mod_kb_article.html.twig
@@ -20,7 +20,6 @@
             <div class="data-container">
                 <header>
                     <h1>{{ article.title }}</h1>
-                    <div class="meta pull-right"><h5>{{ article.created_at|format_date }}</h5></div>
                     <p>{{ 'Article views'|trans }}: {{ article.views }}</p>
                 </header>
                 <section>

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -58,7 +58,7 @@
                             {% endif %}
                             {{ mf.status_name(post.status) }}
                         </td>
-                        <td>{{ post.created_at|bb_datetime }}</td>
+                        <td>{{ post.created_at|format_datetime }}</td>
                         <td>
                             <a class="btn btn-icon" href="{{ '/news/post'|alink }}/{{ post.id }}">
                                 <svg class="icon">

--- a/src/modules/News/html_client/mod_news_index.html.twig
+++ b/src/modules/News/html_client/mod_news_index.html.twig
@@ -20,7 +20,7 @@
                 <div class="article{% if loop.last %} last{% endif%} data-container">
                     <header>
                         <h2><a href="{{ '/news'|link }}/{{post.slug}}">{{ post.title }}</a></h2>
-                        <div class="pull-right"><h5>{{ post.updated_at|format_date }}</h5></div>
+                        <div class="pull-right"><h5>{{ post.updated_at|format_datetime }}</h5></div>
                     </header>
                    <section>
                        {% if post.excerpt %}

--- a/src/modules/News/html_client/mod_news_index.html.twig
+++ b/src/modules/News/html_client/mod_news_index.html.twig
@@ -20,7 +20,7 @@
                 <div class="article{% if loop.last %} last{% endif%} data-container">
                     <header>
                         <h2><a href="{{ '/news'|link }}/{{post.slug}}">{{ post.title }}</a></h2>
-                        <div class="pull-right"><h5>{{ post.updated_at|bb_date }}</h5></div>
+                        <div class="pull-right"><h5>{{ post.updated_at|format_date }}</h5></div>
                     </header>
                    <section>
                        {% if post.excerpt %}

--- a/src/modules/News/html_client/mod_news_post.html.twig
+++ b/src/modules/News/html_client/mod_news_post.html.twig
@@ -30,7 +30,7 @@
         <div class="data-container">
             <header>
                 <h1>{{post.title}}</h1>
-                <div class="pull-right"><h5>{{ post.created_at|bb_date }}</h5></div>
+                <div class="pull-right"><h5>{{ post.created_at|format_date }}</h5></div>
                 <p>{{ 'by '|trans }} {{ post.author.name }}</p>
             </header>
             <section>

--- a/src/modules/News/html_client/mod_news_post.html.twig
+++ b/src/modules/News/html_client/mod_news_post.html.twig
@@ -30,7 +30,7 @@
         <div class="data-container">
             <header>
                 <h1>{{post.title}}</h1>
-                <div class="pull-right"><h5>{{ post.created_at|format_date }}</h5></div>
+                <div class="pull-right"><h5>{{ post.created_at|format_datetime }}</h5></div>
                 <p>{{ 'by '|trans }} {{ post.author.name }}</p>
             </header>
             <section>

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -906,7 +906,7 @@ class Service implements InjectionAwareInterface
             $order->activated_at = date('Y-m-d H:i:s', strtotime($activated_at));
         }
 
-        $expires_at = $this->di['array_get']($data, 'expires_at');
+        $expires_at = $data['expires_at'];
         if (!empty($expires_at)) {
             $order->expires_at = date('Y-m-d H:i:s', strtotime($expires_at));
         }

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -30,7 +30,7 @@
 {% block content %}
 <div class="card">
     <div class="card-body">
-        <h5>{{ 'Order management'|trans }}</h5>
+        <h5>{{ 'Order Management'|trans }}</h5>
     </div>
 
     <ul class="nav nav-tabs" role="tablist">
@@ -72,33 +72,33 @@
                 <table class="table card-table table-vcenter table-striped text-nowrap">
                     <tbody>
                         <tr>
-                            <td class="w-50 text-end">{{ 'Order'|trans }}:</td>
+                            <td class="w-50 text-end">{{ 'Order'|trans }}</td>
                             <td>#{{ order.id }} ({{ order.service_type }})</td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Client'|trans }}:</td>
+                            <td class="text-end">{{ 'Client'|trans }}</td>
                             <td><a href="{{ 'client/manage'|alink }}/{{order.client.id}}">{{ order.client.first_name }} {{ order.client.last_name }}</a></td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Title'|trans }}:</td>
+                            <td class="text-end">{{ 'Title'|trans }}</td>
                             <td><a href="{{ 'product/manage'|alink }}/{{ order.product_id }}"><strong>{{ order.title }}</strong></a></td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Payment amount'|trans }}:</td>
+                            <td class="text-end">{{ 'Payment amount'|trans }}</td>
                             <td>{{ mf.currency_format( order.total, order.currency) }} {% if order.period %}{{mf.period_name(order.period)}}{% endif %} {% if order.quantity > 1 %}({{ order.quantity }} x {{ mf.currency_format( order.price, order.currency) }}){% endif %}</td>
                         </tr>
                         {% if order.discount and order.discount > 0%}
                         <tr>
-                            <td class="text-end">{{ 'Order discount'|trans }}:</td>
+                            <td class="text-end">{{ 'Order discount'|trans }}</td>
                             <td>-{{ mf.currency_format( order.discount, order.currency) }} </td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Payment amount after discount'|trans }}:</td>
+                            <td class="text-end">{{ 'Payment amount after discount'|trans }}</td>
                             <td>{{ mf.currency_format( order.total - order.discount, order.currency) }} </td>
                         </tr>
                         {% endif %}
                         <tr>
-                            <td class="text-end">{{ 'Order status'|trans }}:</td>
+                            <td class="text-end">{{ 'Order status'|trans }}</td>
                             <td>
                             {% if order.status == 'pending_setup' or order.status == 'failed_setup' or order.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>
@@ -117,7 +117,7 @@
                         </tr>
                         {% if order.notes %}
                         <tr>
-                            <td class="text-end">{{ 'Order notes'|trans }}:</td>
+                            <td class="text-end">{{ 'Order notes'|trans }}</td>
                             <td>
                                 <svg class="icon">
                                     <use xlink:href="#support" />
@@ -127,24 +127,24 @@
                         </tr>
                         {% endif %}
                         <tr>
-                            <td class="text-end">{{ 'Order created'|trans }}:</td>
-                            <td>{{ order.created_at|date('l, d F Y') }}</td>
+                            <td class="text-end">{{ 'Order Date'|trans }}</td>
+                            <td>{{ order.created_at|format_date }}</td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Activated'|trans }} {% if order.activated_at %} {{ order.activated_at|timeago }} {{ 'ago'|trans }}{% endif %}:</td>
-                            <td>{% if order.activated_at %}{{ order.activated_at|date('l, d F Y')}} {% else %}-{% endif %}</td>
+                            <td class="text-end">{{ 'Activation Date'|trans }}</td>
+                            <td>{% if order.activated_at %}{{ order.activated_at|format_date }} ({{ order.activated_at|timeago }} {{ 'ago'|trans }}){% else %}-{% endif %}</td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Renewal date'|trans }} {% if order.expires_at %} in {{ order.expires_at|daysleft }} {{ 'day(s)'|trans }}{% endif %}:</td>
-                            <td>{% if order.expires_at %}{{ order.expires_at|date('l, d F Y')}}{% else %}-{% endif %}</td>
+                            <td class="text-end">{{ 'Renewal Date'|trans }}</td>
+                            <td>{% if order.expires_at %}{{ order.expires_at|format_date }} ({{ order.expires_at|daysleft }} {{ 'day(s)'|trans }}){% else %}-{% endif %}</td>
                         </tr>
                         <tr>
-                            <td class="text-end">{{ 'Order group ID'|trans }}:</td>
+                            <td class="text-end">{{ 'Order group ID'|trans }}</td>
                             <td>{{ order.group_id|default('-') }}</td>
                         </tr>
                         {% if order.promo_id %}
                         <tr>
-                            <td class="text-end">{{ 'Order promo code'|trans }}:</td>
+                            <td class="text-end">{{ 'Order promo code'|trans }}</td>
                             <td>
                                 {% set promo = admin.product_promo_get({ 'id': order.promo_id }) %}
                                 {{ promo.code }}
@@ -153,7 +153,7 @@
                         {% endif %}
                         {% if order.active_tickets > 0 %}
                         <tr>
-                            <td class="text-end">{{ 'Active support tickets'|trans }}:</td>
+                            <td class="text-end">{{ 'Active support tickets'|trans }}</td>
                             <td>
                                 <div class="num">
                                     <a href="{{ 'support'|alink({ 'status': 'open', 'order_id': order.id }) }}" class="redNum">{{ order.active_tickets }}</a>
@@ -297,7 +297,7 @@
 
         <div class="tab-pane fade" id="tab-manage" role="tabpanel">
             <div class="card-body">
-                <h3>{{ 'Order management'|trans }}</h2>
+                <h3>{{ 'Order Management'|trans }}</h2>
                 <form method="post" action="{{ 'api/admin/order/update'|link }}" class="api-form" data-api-reload="1">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
@@ -337,7 +337,7 @@
                         </div>
                     </div>
                     <div class="mb-3 row">
-                        <label class="form-label col-3 col-form-label" for="expires_at">{{ 'Expires at'|trans }}</label>
+                        <label class="form-label col-3 col-form-label" for="expires_at">{{ 'Date Expires'|trans }}</label>
                         <div class="col">
                             <div class="input-group">
                                 <div class="input-icon w-100">
@@ -345,56 +345,6 @@
                                            id="expires_at"
                                            value="{% if order.expires_at %}{{ order.expires_at|date('Y-m-d') }}{% endif %}"
                                            name="expires_at"
-                                    >
-                                    <span class="input-icon-addon">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                                            <path d="M4 5m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z"></path>
-                                            <path d="M16 3l0 4"></path>
-                                            <path d="M8 3l0 4"></path>
-                                            <path d="M4 11l16 0"></path>
-                                            <path d="M11 15l1 0"></path>
-                                            <path d="M12 15l0 3"></path>
-                                        </svg>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mb-3 row">
-                        <label class="form-label col-3 col-form-label" for="created_at">{{ 'Created at'|trans }}</label>
-                        <div class="col">
-                            <div class="input-group">
-                                <div class="input-icon w-100">
-                                    <input class="form-control datepicker"
-                                           id="created_at"
-                                           value="{{ order.created_at|date('Y-m-d') }}"
-                                           name="created_at"
-                                    >
-                                    <span class="input-icon-addon">
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-                                            <path d="M4 5m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z"></path>
-                                            <path d="M16 3l0 4"></path>
-                                            <path d="M8 3l0 4"></path>
-                                            <path d="M4 11l16 0"></path>
-                                            <path d="M11 15l1 0"></path>
-                                            <path d="M12 15l0 3"></path>
-                                        </svg>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mb-3 row">
-                        <label class="form-label col-3 col-form-label" for="activated_at">{{ 'Activated at'|trans }}</label>
-                        <div class="col">
-                            <div class="input-group">
-                                <div class="input-icon w-100">
-                                    <input class="form-control datepicker"
-                                           id="activated_at"
-                                           value="{{ order.activated_at|date('Y-m-d') }}"
-                                           name="activated_at"
                                     >
                                     <span class="input-icon-addon">
                                         <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -451,7 +401,7 @@
                 <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 {% for name, value in order.config %}
                 <div class="mb-3 row">
-                    <label class="topLabel">{{ name }}:</label>
+                    <label class="topLabel">{{ name }}</label>
                         <div class="formBottom">
                             <textarea rows="2" name="config[{{ name }}]">{{ value }}</textarea>
                         </div>
@@ -514,7 +464,7 @@
                         <td>{{ addon.title }}</td>
                         <td>{{ mf.period_name(addon.period) }}</td>
                         <td>{{ mf.currency_format( addon.total, addon.currency) }}</td>
-                        <td>{% if addon.expires_at %}{{ addon.expires_at|date('l, d F Y') }}{% else %}-{% endif %}</td>
+                        <td>{% if addon.expires_at %}{{ addon.expires_at|format_date }}{% else %}-{% endif %}</td>
                         <td>
                             {% if addon.status == 'pending_setup' or addon.status == 'failed_setup' or addon.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>
@@ -575,8 +525,8 @@
                     <tr>
                         <td>{{ invoice.id }}</td>
                         <td>{{ mf.currency_format( invoice.total, invoice.currency, 1) }}</td>
-                        <td>{{ invoice.created_at|date('Y-m-d') }}</td>
-                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|date('Y-m-d') }}{% else %}-{% endif %}</td>
+                        <td>{{ invoice.created_at|format_date }}</td>
+                        <td>{% if invoice.paid_at %}{{ invoice.paid_at|format_date }}{% else %}-{% endif %}</td>
                         <td>
                             {% if invoice.status == 'paid' %}
                                 <span class="badge bg-success me-1"></span>
@@ -626,7 +576,7 @@
                     {% set statuses = admin.order_status_history_get_list({ 'per_page': 50, 'id': order.id }) %}
                     {% for i, sh in statuses.list %}
                     <tr>
-                        <td>{{ sh.created_at|date('Y-m-d H:i') }}</td>
+                        <td>{{ sh.created_at|format_datetime }}</td>
                         <td>
                             {% if sh.status == 'pending_setup' or sh.status == 'failed_setup' or sh.status == 'failed_renew' %}
                                 <span class="badge bg-warning me-1"></span>

--- a/src/modules/Order/html_client/mod_order_list.html.twig
+++ b/src/modules/Order/html_client/mod_order_list.html.twig
@@ -35,7 +35,7 @@
                 <tr class="{{ cycle(['odd', 'even'], i) }}">
                     <td><a href="{{ '/order/service/manage'|link }}/{{order.id}}">{{ order.title }}</a></td>
                     <td>{{  order.total | money(order.currency) }} {% if order.period %}{{ order.period | period_title }}{% endif %}</td>
-                    <td>{% if order.expires_at %}{{ order.expires_at|bb_date }}{% else %}-{% endif %}</td>
+                    <td>{% if order.expires_at %}{{ order.expires_at|format_date }}{% else %}-{% endif %}</td>
                     <td>
                         <span class="label {% if order.status == 'active' %}label-success{% elseif order.status == 'pending_setup' %}label-warning{% endif %}">{{ mf.status_name(order.status) }}</span>
                     </td>

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -57,18 +57,18 @@
 
                     <tr>
                         <td><label>{{ 'Order created'|trans }}</label></td>
-                        <td>{{ order.created_at|bb_date }}</td>
+                        <td>{{ order.created_at|format_date }}</td>
                     </tr>
 
                     <tr>
                         <td><label>{{ 'Activated at'|trans }}</label></td>
-                        <td>{% if order.activated_at %}{{ order.activated_at|bb_date }}{% else %}-{% endif %}</td>
+                        <td>{% if order.activated_at %}{{ order.activated_at|format_date }}{% else %}-{% endif %}</td>
                     </tr>
 
                     {% if order.period %}
                     <tr>
                         <td><label>{{ 'Renewal date'|trans }} {% if order.expires_at %} in {{ order.expires_at|daysleft }} day(s) {% endif %}</label></td>
-                        <td>{% if order.expires_at %}{{ order.expires_at|bb_date }}{% else %}-{% endif %}</td>
+                        <td>{% if order.expires_at %}{{ order.expires_at|format_date }}{% else %}-{% endif %}</td>
                     </tr>
                     {% endif %}
 
@@ -146,7 +146,7 @@
                                 <td>{{ addon.title }}</td>
                                 <td>{{ addon.total|money(addon.currency) }}</td>
                                 <td>{{ addon.period|period_title }}</td>
-                                <td>{% if addon.expires_at %}{{ addon.expires_at|bb_date }}{% else %}-{% endif %}</td>
+                                <td>{% if addon.expires_at %}{{ addon.expires_at|format_date }}{% else %}-{% endif %}</td>
                                 <td>
                                     <span class="label {% if addon.status == 'active' %}label-success{% elseif addon.status == 'pending_setup' %}label-warning{% endif %}">{{ mf.status_name(addon.status) }}</span>
                                 </td>

--- a/src/modules/Product/html_admin/mod_product_promos.html.twig
+++ b/src/modules/Product/html_admin/mod_product_promos.html.twig
@@ -75,8 +75,8 @@
                             {% endfor %}
                         </td>
                         <td>
-                            From {% if promo.start_at %}{{ promo.start_at|date('Y-m-d') }}{% else %}now{% endif %}
-                            until {% if promo.end_at %}{{ promo.end_at|date('Y-m-d') }}{% else %}disabled{% endif %}
+                            From {% if promo.start_at %}{{ promo.start_at|format_date }}{% else %}now{% endif %}
+                            until {% if promo.end_at %}{{ promo.end_at|format_date }}{% else %}disabled{% endif %}
                         </td>
                         <td>
                             {% if promo.active == true %}

--- a/src/modules/Queue/html_admin/mod_queue_settings.html.twig
+++ b/src/modules/Queue/html_admin/mod_queue_settings.html.twig
@@ -50,7 +50,7 @@
                 <td>{{ queue.name }}</td>
                 <td>{{ queue.mod }}</td>
                 <td class="text-center">{{ queue.messages_count }}</td>
-                <td>{{ queue.created_at|bb_date }}</td>
+                <td>{{ queue.created_at|format_date }}</td>
                 <td class="actions">
                     <a class="btn btn-icon api-link"
                         href="{{ 'api/admin/queue/execute'|link({ 'queue': queue.name, 'CSRFToken': CSRFToken }) }}"

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_canceled.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_canceled.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|bb_date }}* is now canceled
+Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now canceled
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_renewed.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_renewed.html.twig
@@ -8,7 +8,7 @@ Your **{{ order.title }}** has been renewed.
 
 {% if order.expires_at %}
 
-Next renewal date: {{ order.expires_at|bb_date }}
+Next renewal date: {{ order.expires_at|format_date }}
 
 {% endif %}
 

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_suspended.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_suspended.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was activated at *{{ order.activated_at|bb_date }}* is now suspended
+Your *{{ order.title }}* that was activated at *{{ order.activated_at|format_date }}* is now suspended
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_manage.html.twig
@@ -60,11 +60,11 @@
         </tr>
         <tr>
             <td class="text-end">{{ 'Registration date'|trans }}:</td>
-            <td>{{ service.registered_at|date('l, d F Y') }}</td>
+            <td>{{ service.registered_at|format_date }}</td>
         </tr>
         <tr>
             <td class="text-end">{{ 'Expires at'|trans }}:</td>
-            <td>{{ service.expires_at|date('l, d F Y') }}</td>
+            <td>{{ service.expires_at|format_date }}</td>
         </tr>
     </tbody>
 </table>

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -25,12 +25,12 @@
                         </tr>
                         <tr>
                             <td>{{ 'Registration date'|trans }}</td>
-                            <td>{{ service.registered_at|bb_date }}</td>
+                            <td>{{ service.registered_at|format_date }}</td>
                         </tr>
 
                         <tr>
                             <td>{{ 'Expires at'|trans }}</td>
-                            <td>{{ service.expires_at|bb_date }}</td>
+                            <td>{{ service.expires_at|format_date }}</td>
                         </tr>
 
                         </tbody>

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
@@ -15,9 +15,9 @@ Your website and  email will not function until the domain has propagated.
 
 
 Domain: {{ service.domain }}     
-Registration date: {{order.created_at|bb_date}}
+Registration date: {{order.created_at|format_date}}
 Registration period: {{service.period}} Year(s)   
-{% if order.expires_at %}Expires on: {{ order.expires_at|bb_date }} {% endif %}
+{% if order.expires_at %}Expires on: {{ order.expires_at|format_date }} {% endif %}
 {% if order.period %}
 Billing period:
 

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_renewed.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_renewed.html.twig
@@ -8,7 +8,7 @@ Your **{{ order.title }}** has been renewed.
 
 {% if order.expires_at %}
 
-Next renewal date: {{ order.expires_at|bb_date }}
+Next renewal date: {{ order.expires_at|format_date }}
 
 {% endif %}
 

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_suspended.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_suspended.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|bb_date }}* is now suspended.
+Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now suspended.
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
@@ -13,8 +13,8 @@ Your website and email will not function until your domain has propagated.
 
 **{{ order.title }}**
 
-Activated: {{ order.activated_at|bb_date }}
-{% if order.expires_at %}Expires: {{ order.expires_at|bb_date }} {% endif %}
+Activated: {{ order.activated_at|format_date }}
+{% if order.expires_at %}Expires: {{ order.expires_at|format_date }} {% endif %}
 {% if order.period %}
 Billing period:
 

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_canceled.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_canceled.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|bb_date }}* is now canceled.
+Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now canceled.
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_renewed.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_renewed.html.twig
@@ -8,7 +8,7 @@ Your **{{ order.title }}** has been renewed.
 
 {% if order.expires_at %}
 
-Next renewal date: {{ order.expires_at|bb_date }}
+Next renewal date: {{ order.expires_at|format_date }}
 
 {% endif %}
 

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_suspended.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_suspended.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|bb_date }}* is now suspended.
+Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now suspended.
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
@@ -24,7 +24,7 @@
             <td>
                 {{ 'Last ping'|trans }}
             </td>
-            <td>{{ service.pinged_at|bb_date }} ({{ service.pinged_at|timeago }} ago)</td>
+            <td>{{ service.pinged_at|format_date }} ({{ service.pinged_at|timeago }} ago)</td>
         </tr>
 
     </tbody>

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_canceled.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_canceled.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|bb_date }}* is now canceled.
+Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now canceled.
 {% if order.reason %} due to reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_renewed.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_renewed.html.twig
@@ -8,7 +8,7 @@ Your **{{ order.title }}** has been renewed.
 
 {% if order.expires_at %}
 
-Next renewal date: {{ order.expires_at|bb_date }}
+Next renewal date: {{ order.expires_at|format_date }}
 
 {% endif %}
 

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_suspended.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_suspended.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|bb_date }}* is now suspended.
+Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now suspended.
 {% if order.reason %} due to reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_canceled.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_canceled.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|bb_date }}* is now canceled.
+Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now canceled.
 {% if order.reason %} Reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_renewed.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_renewed.html.twig
@@ -8,7 +8,7 @@ Your **{{ order.title }}** has been renewed.
 
 {% if order.expires_at %}
 
-Next renewal date: {{ order.expires_at|bb_date }}
+Next renewal date: {{ order.expires_at|format_date }}
 
 {% endif %}
 

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_suspended.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_suspended.html.twig
@@ -4,7 +4,7 @@
 
 Hello {{ c.first_name }} {{ c.last_name }},
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|bb_date }}* is now suspended.
+Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now suspended.
 {% if order.reason %} due to reason:     
 
 **{{ order.reason }}** {% endif %}   

--- a/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
@@ -47,7 +47,7 @@
             </td>
             <td>{{ event.ip }}</td>
             <td>{{ event.ip|ipcountryname|default('Unknown') }}</td>
-            <td>{{ event.created_at|date('Y-m-d H:i') }}</td>
+            <td>{{ event.created_at|format_datetime }}</td>
             <td>
                 <a class="btn btn-icon api-link"
                     href="{{ 'api/admin/staff/login_history_delete'|link({ 'id': event.id, 'CSRFToken': CSRFToken }) }}"

--- a/src/modules/Staff/html_email/mod_staff_client_order.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_client_order.html.twig
@@ -3,7 +3,7 @@
 {% apply markdown %}
 Hi {{ staff.name }},
 
-Client **{{ order.client.first_name }} {{ order.client.last_name }}** placed a new order for **{{ order.title }}** on {{ order.created_at|bb_date }}
+Client **{{ order.client.first_name }} {{ order.client.last_name }}** placed a new order for **{{ order.title }}** on {{ order.created_at|format_date }}
 
 Manage order {{ 'order/manage'|alink }}/{{ order.id }}
 

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -154,7 +154,7 @@
             <div class="card-header" style="cursor: pointer;">
                 <span class="avatar avatar-xs me-2" style="background-image: url({{ message.author.email|gravatar }}?size=20)"></span>
                 {{ message.author.name }}
-                <span class="ms-auto text-muted">{{ message.created_at|bb_datetime }}</span>
+                <span class="ms-auto text-muted">{{ message.created_at|format_datetime }}</span>
             </div>
             <div class="card-body">
                 {{ message.content|markdown }}

--- a/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_ticket.html.twig
@@ -70,7 +70,7 @@
                     </tr>
                     <tr>
                         <td class="text-end">{{ 'Time opened'|trans }}:</td>
-                        <td>{{ ticket.created_at|date('l, d F Y') }}</td>
+                        <td>{{ ticket.created_at|format_date }}</td>
                     </tr>
                     {% if ticket.created_at != ticket.updated_at %}
                     <tr>

--- a/src/modules/Support/html_admin/mod_support_public_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_tickets.html.twig
@@ -109,7 +109,7 @@
                     {% endif %}
                     {{ mf.status_name(ticket.status) }}
                 </td>
-                <td>{{ ticket.updated_at|date('Y-m-d') }}</td>
+                <td>{{ ticket.updated_at|format_date }}</td>
                 <td>
                     <a class="btn btn-icon" href="{{ '/support/public-ticket'|alink }}/{{ ticket.id }}">
                         <svg class="icon">

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -74,7 +74,7 @@
                     </tr>
                     <tr>
                         <td>{{ 'Time opened'|trans }}</td>
-                        <td>{{ ticket.created_at|date('l, d F Y') }}</td>
+                        <td>{{ ticket.created_at|format_date }}</td>
                     </tr>
                  </tbody>
 

--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -284,7 +284,7 @@
                     <use xlink:href="#link" />
                 </svg>
             </a>
-            <span class="ms-auto text-muted">{{ message.created_at|bb_datetime }}</span>
+            <span class="ms-auto text-muted">{{ message.created_at|format_datetime }}</span>
         </div>
         <div class="card-body" style="display:{{ loop.last or loop.index + 1 == ticket.messages|length ? 'block' : 'none' }};">
             {{ message.content|markdown }}

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -50,7 +50,7 @@
 
                     <tr>
                         <td>{{ 'Time opened'|trans }}</td>
-                        <td>{{ ticket.created_at|bb_date }}</td>
+                        <td>{{ ticket.created_at|format_date }}</td>
                     </tr>
                     </tbody>
 
@@ -83,7 +83,7 @@
                         </div>
                     </div>
                     <div class="span9">
-                        <header>{{ message.created_at|bb_date }}
+                        <header>{{ message.created_at|format_date }}
                             <div class="pull-right">
                                 <a href="#" class="btn btn-inverse reply-to-message" message-quote="{{ mf.markdown_quote(message.content) }}">{{ 'Reply'|trans }}</a>
                             </div>

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -45,7 +45,7 @@
 
                     <tr>
                         <td>{{ 'Time opened'|trans }}</td>
-                        <td>{{ ticket.created_at|bb_date }}</td>
+                        <td>{{ ticket.created_at|format_date }}</td>
                     </tr>
 
                     {% if ticket.rel_type == 'order' and ticket.rel_id %}
@@ -127,7 +127,7 @@
                                 </div>
                             </div>
                             <div class="span9">
-                                <header>#{{ i+1 }} | {{ message.created_at|bb_date }}
+                                <header>#{{ i+1 }} | {{ message.created_at|format_date }}
                                     {% if ticket.status != 'closed' %}
                                     <div class="pull-right">
                                         <a href="#" class="btn btn-inverse reply-to-message" message-quote="{{ mf.markdown_quote(message.content) }}">{{ 'Reply'|trans }}</a>

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -179,7 +179,7 @@ class Guest extends \Api_Abstract
     public function locale()
     {
         $cookie = $this->di['cookie'];
-        $locale = $this->di['config']['locale'];
+        $locale = $this->di['config']['i18n']['locale'];
         if ($cookie->has('BBLANG')) {
             $bblang = $cookie->get('BBLANG');
             if (!empty($bblang)) {

--- a/src/themes/admin_default/assets/js/datepicker.js
+++ b/src/themes/admin_default/assets/js/datepicker.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
     element.autocomplete = 'off';
     new Litepicker({
       element: element,
+      resetButton: true,
+      autoRefresh: true,
       format: 'YYYY-MM-DD',
       dropdowns: {
         minYear: 1930,
@@ -16,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
       buttonText: {
         previousMonth: '<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M15 6l-6 6l6 6"></path></svg>',
         nextMonth: '<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M9 6l6 6l-6 6"></path></svg>',
+        reset: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clock-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M20.926 13.15a9 9 0 1 0 -7.835 7.784"></path><path d="M12 7v5l2 2"></path><path d="M22 22l-5 -5"></path><path d="M17 22l5 -5"></path></svg>',
       },
       setup: (picker) => {
         picker.on('selected', (date, dateTo) => {

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -207,7 +207,7 @@
 
             <footer class="footer footer-transparent d-print-none">
                 <div class="container-xl">
-                    <div>Copyright &copy; {{ now|date('Y') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener">FOSSBilling {{ guest.system_version }}</a></div>
+                    <div>Copyright &copy; {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener">FOSSBilling {{ guest.system_version }}</a></div>
                 </div>
             </footer>
         </div>

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -257,7 +257,7 @@
                                 <a href="{{ 'client'|alink }}/manage/{{ invoice.client.id }}">{{ invoice.buyer.first_name }} {{ invoice.buyer.last_name }}</a>
                             </td>
                             <td class="text-center">{{ mf.currency_format(invoice.total, invoice.currency) }}</td>
-                            <td class="text-center">{{ invoice.created_at|date('Y-m-d') }}</td>
+                            <td class="text-center">{{ invoice.created_at|format_date }}</td>
                             <td>
                                 {% if invoice.status == 'paid' %}
                                     <span class="badge bg-success me-1"></span>
@@ -466,7 +466,7 @@
                                     <a href="{{ 'client/manage'|alink }}/{{ event.client.id }}">{{ event.client.name|truncate(40) }}</a>
                                 </td>
                                 <td>{{ event.message|truncate(50) }}</td>
-                                <td>{{ event.created_at }}</td>
+                                <td>{{ event.created_at|format_datetime }}</td>
                                 <td>{{ event.created_at|timeago }} {{ 'ago'|trans }}</td>
                             </tr>
                             {% else %}
@@ -493,7 +493,7 @@
                                     <a href="{{ 'staff/manage'|alink }}/{{ event.staff.id }}">{{ event.staff.name }}</a>
                                 </td>
                                 <td>{{ event.message|truncate(50) }}</td>
-                                <td>{{ event.created_at }}</td>
+                                <td>{{ event.created_at|format_datetime }}</td>
                                 <td>{{ event.created_at|timeago }} {{ 'ago'|trans }}</td>
                             </tr>
                             {% else %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -293,7 +293,7 @@
 
 {% if settings.footer_enabled %}
 <footer id="footer" class="container">
-    <p>&copy; {{ now|date('Y') }} {{ settings.footer_signature | default(company.signature) | raw }}</p>
+    <p>&copy; {{ now|format_date(pattern='yyyy') }} {{ settings.footer_signature | default(company.signature) | raw }}</p>
     <ul>
         {% if settings.footer_link_1_enabled %}
         <li>

--- a/tests/integration/bb-modules/mod_system/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_system/Api_AdminTest.php
@@ -119,7 +119,7 @@ class Api_Admin_SystemTest extends BBDbApiTestCase
         $result = date($this->di['config']['locale_date_format']);
         $data = [
             'id' => 1,
-            '_tpl' => '{{ now|date("Y-m-d")|bb_date }}',
+            '_tpl' => '{{ now|date("Y-m-d")|format_date }}',
         ];
         $string = $this->api_admin->email_template_render($data);
         $this->assertEquals($result, $string);

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -204,8 +204,7 @@ class GuestTest extends \BBTestCase {
             ->will($this->returnValue($setLang));
 
         $di['cookie'] = $cookieMock;
-        $di['config'] = array('locale' => 'EN');
-
+        $di['config'] = [ 'i18n' => ['locale' => 'en_US' ] ];
 
         $this->api->setDi($di);
 


### PR DESCRIPTION
Improves date/datetime handling by replacing custom `bb_date` and `bb_datetime` Twig filters with `format_date` / `format_datetime` to better support i18n and customisability.

This adds the `locale`, `timezone`, `date_format`, `time_format` and `datetime_pattern` options under `i18n` to config.php. 

Also resolves #938 by adding a reset button to the admin date picker, and fixing an issue with the Order module not accepting blank dates (thanks to @BelleNottelling for assistance with this).

Note: The datepicker does not currently honour specified formats, and additionally does not support selecting times at all. Fixing it beyond the scope of this PR, but the issue should be noted to be addressed at a later date.