### PR TITLE
Removed overflow that caused a bug

### DIFF
--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -127,7 +127,7 @@
             </header>
             <header class="navbar-expand-lg">
                 <div class="collapse navbar-collapse" id="navbar-menu">
-                    <div class="navbar navbar-light overflow-auto">
+                    <div class="navbar navbar-light">
                         <div class="container-xl">
                              {% set navigation = admin.extension_get_navigation({ 'url': guest.system_current_url }) %}
                              <ul class="navbar-nav">


### PR DESCRIPTION
Removes an overflow that was added in this commit https://github.com/FOSSBilling/FOSSBilling/pull/947/commits/88b737e7d15a230b6058dc825f485b76236ef69c

It prevents the navbar dropdown from being displayed