### PR TITLE
Fix issue #964

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -272,7 +272,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         if (is_null($number)) {
             $number = '0';
         }
-        return number_format($number, $decimals, $dec_point, $thousands_sep);
+        return number_format(floatval($number), $decimals, $dec_point, $thousands_sep);
     }
 
     public function twig_daysleft_filter($iso8601)


### PR DESCRIPTION
Closes #964 by wrapping the `$number` variable with the `floatval` function, ensuring that if a string is passed to the function it'll be converted to a float, which is what the `number_format` function expects.

Reporter confirmed fix resolves the issue