### PR TITLE
Fix downloading extensions

### DIFF
--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -649,8 +649,6 @@ class ServiceTest extends \BBTestCase {
         $httpClientMock = new MockHttpClient();
 
         $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('emptyFolder');
 
         $di = new \Box_Di();
         $di['extension'] = $extensionMock;

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -606,12 +606,6 @@ class ServiceTest extends \BBTestCase {
 
         $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(false));
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('rename')
-            ->will($this->returnValue(true));
-        $toolsMock->expects($this->atLeastOnce())
             ->method('emptyFolder');
 
         $di = new \Box_Di();
@@ -640,7 +634,7 @@ class ServiceTest extends \BBTestCase {
         
         $this->service->setDi($di);
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('Extension does not support auto-install feature. Extension must be installed manually');
+        $this->expectExceptionMessage('Extension type (notDefinedType) cannot be automatically installed.');
         $this->service->downloadAndExtract('notDefinedType', 'extensionId', true);
     }
 
@@ -656,14 +650,6 @@ class ServiceTest extends \BBTestCase {
 
         $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(false));
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('mkdir');
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('rename')
-            ->will($this->returnValue(false));
-        $toolsMock->expects($this->atLeastOnce())
             ->method('emptyFolder');
 
         $di = new \Box_Di();
@@ -673,69 +659,9 @@ class ServiceTest extends \BBTestCase {
 
         $this->service->setDi($di);
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionCode(440);
-        $this->expectExceptionMessage('Locale files can not be moved. Make sure your server allows you to write to the locale folder');
-        $this->service->downloadAndExtract('translation', 'extensionId', true);
-    }
-
-    public function testdownloadAndExtractThemeTypeException()
-    {
-        $extensionMock = $this->getMockBuilder(\Box_Extension::class)->getMock();
-
-        $extensionMock->expects($this->atLeastOnce())
-            ->method('getExtension')
-            ->will($this->returnValue(array('download_url' => 'www.fossbilling.com')));
-
-        $httpClientMock = new MockHttpClient();
-
-        $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(false));
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('rename')
-            ->will($this->returnValue(false));
-
-        $di = new \Box_Di();
-        $di['extension'] = $extensionMock;
-        $di['http_client'] = $httpClientMock;
-        $di['tools'] = $toolsMock;
-
-        $this->service->setDi($di);
-        $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage(439);
-        $this->expectExceptionMessage('Theme can not be moved. Make sure your server allows you to write to the themes folder.');
-        $this->service->downloadAndExtract('theme', 'extensionId', true);
-    }
-
-    public function testdownloadAndExtractRenameException()
-    {
-        $extensionMock = $this->getMockBuilder(\Box_Extension::class)->getMock();
-
-        $extensionMock->expects($this->atLeastOnce())
-            ->method('getExtension')
-            ->will($this->returnValue(array('download_url' => 'www.fossbilling.com')));
-
-        $httpClientMock = new MockHttpClient();
-
-        $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(false));
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('rename')
-            ->will($this->returnValue(false));
-
-        $di = new \Box_Di();
-        $di['extension'] = $extensionMock;
-        $di['http_client'] = $httpClientMock;
-        $di['tools'] = $toolsMock;
-
-        $this->service->setDi($di);
-        $this->expectException(\Box_Exception::class);
         $this->expectExceptionCode(437);
-        $this->expectExceptionMessage('Extension can not be moved. Make sure your server allows you to write to the modules folder.');
-        $this->service->downloadAndExtract('mod', 'extensionId', true);
+        $this->expectExceptionMessage("Failed to move extension to it's final destination. Please check permissions for the destination folder. (/home/runner/work/FOSSBilling/FOSSBilling/src/locale/extensionId/LC_MESSAGES)");
+        $this->service->downloadAndExtract('translation', 'extensionId', true);
     }
 
     public function testdownloadAndExtractFileExistsException()
@@ -749,9 +675,6 @@ class ServiceTest extends \BBTestCase {
         $httpClientMock = new MockHttpClient();
 
         $toolsMock = $this->getMockBuilder(\Box_tools::class)->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(true));
 
         $di = new \Box_Di();
         $di['extension'] = $extensionMock;
@@ -761,7 +684,7 @@ class ServiceTest extends \BBTestCase {
         $this->service->setDi($di);
         $this->expectException(\Box_Exception::class);
         $this->expectExceptionCode(436);
-        $this->expectExceptionMessage('Module seems to be already installed.');
+        $this->expectExceptionMessage('Extension extensionId seems to be already installed.');
         $this->service->downloadAndExtract('mod', 'extensionId', true);
     }
 


### PR DESCRIPTION
This PR fixes an issue introduced by #861 that prevented the system from downloading extensions from the extension store.
Looking at the docs for the symfony HTTP package, the `buffer` option is a boolean which is used to enable or disable writing to the PHP temp path, and not a way to specify a location to store the contents of the response