### PR TITLE
Remove the settings "routes"

### DIFF
--- a/src/modules/System/html_admin/mod_system_index.html.twig
+++ b/src/modules/System/html_admin/mod_system_index.html.twig
@@ -34,15 +34,6 @@
                                 {% endif %}
                             </a>
                         </div>
-                        <div class="datagrid-content">
-                            <ul>
-                                {% for route in ext.settings_routes %}
-                                <li>
-                                    <a href="{{ route.path }}">{{route.label}}</a>
-                                </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
This PR removes the settings "routes" from the settings page, as they aren't actually links to settings for the modules and only seems to cause additional confusion with this page, and introduce some inconsistency in the overall layout. Makes the page a bit cleaner and more intuitive for end users.
Before:
![image](https://user-images.githubusercontent.com/17304943/227377865-52c3ebce-e79d-4e34-9cba-5d7f4a74a836.png)
After:
![image](https://user-images.githubusercontent.com/17304943/227377875-ad6c3e48-f699-4a10-92f4-02c9a4d3dd77.png)
