### PR TITLE
Fix currencylayer

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,5 @@ parameters:
 		- '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
 		- message: '#^Result of function header \(void\) is used\.$#'
 		  path: src/modules/Custompages/Controller/Client.php
-		- '#^Method Box\\Mod\\Currency\\Service\:\:_getRate\(\) should return float but return statement is missing\.$#'
 		- message: '#^Variable \$ext_id on left side of \?\?\= is never defined\.$#'
 		  path: src/modules/Extension/Service.php

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -547,7 +547,7 @@ class Service implements InjectionAwareInterface
                     return (float) $rate['rate'];
                 }
             }
-            throw new \Box_Exception("Failed to get currency rates for $to_Currency from the European Central Bank API");
+            throw new \Box_Exception("Failed to get currency rates for :currency from the European Central Bank API", [':currency' => $to_Currency]);
         } else {
             $client = $this->di['http_client'];
             $response = $client->request('GET', 'https://api.apilayer.com/currency_data/live', [
@@ -563,7 +563,7 @@ class Service implements InjectionAwareInterface
             $array = $response->toArray();
 
             if (true !== $array['success']) {
-                throw new \Box_Exception('<b>Currencylayer threw an error:</b><br />' . $array['error']['info']);
+                throw new \Box_Exception('<b>Currencylayer threw an error:</b><br />:errorInfo', [':errorInfo' => $array['error']['info']]);
             } else {
                 return (float) $array['quotes'][$from_Currency . $to_Currency];
             }

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -540,29 +540,23 @@ class Service implements InjectionAwareInterface
         $from_Currency = urlencode($from);
         $to_Currency = urlencode($to);
 
-        if ('EUR' == $from_Currency) {
-            $XML = simplexml_load_file('https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
-            foreach ($XML->Cube->Cube->Cube as $rate) {
-                if ($rate['currency'] == $to_Currency) {
-                    return (float) $rate['rate'];
-                }
-            }
-        } elseif ('USD' == $from_Currency) {
-            $client = $this->di['http_client'];
-            $response = $client->request('GET', 'https://api.currencylayer.com/live', [
-                'query' => [
-                    'access_key'    => $this->getKey(),
-                    'currencies'    => $to_Currency,
-                    'format'        => 1,
-                ],
-            ]);
-            $array = $response->toArray();
+        $client = $this->di['http_client'];
+        $response = $client->request('GET', 'https://api.apilayer.com/currency_data/live', [
+            'query' => [
+                'currencies'    => $to_Currency,
+                'source'        => $from_Currency,
+            ],
+            'headers' => [
+                'Content-Type' => 'text/plain',
+                'apikey' => $this->getKey()
+            ],
+        ]);
+        $array = $response->toArray();
 
-            if (true !== $array['success']) {
-                throw new \Box_Exception('<b>Currencylayer threw an error:</b><br />' . $array['error']['info']);
-            } else {
-                return (float) $array['quotes']['USD' . $to_Currency];
-            }
+        if (true !== $array['success']) {
+            throw new \Box_Exception('<b>Currencylayer threw an error:</b><br />' . $array['error']['info']);
+        } else {
+            return (float) $array['quotes']['USD' . $to_Currency];
         }
     }
 

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -556,7 +556,7 @@ class Service implements InjectionAwareInterface
         if (true !== $array['success']) {
             throw new \Box_Exception('<b>Currencylayer threw an error:</b><br />' . $array['error']['info']);
         } else {
-            return (float) $array['quotes']['USD' . $to_Currency];
+            return (float) $array['quotes'][$from_Currency . $to_Currency];
         }
     }
 

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -48,7 +48,7 @@
         <div class="tab-pane fade show active" id="tab-currencies" role="tabpanel">
             <div class="card-body">
                 <h3>{{ 'Manage currencies'|trans }}</h3>
-                <p class="text-muted">{{ 'Default currency is the one you manage all your prices in admin area. If your client in client area chooses other than default currency, prices will be recalculated according to conversion rate. You can have only one default currency. You can not add same currency once again. Changing default currency is not recommended when active orders are available. Nothing is recalculated on default currency change. Your income is calculated in default currency. Changing default currency after you have paid invoices will distort income statistics. Currency rates are taken from currencylayer.'|trans }}</p>
+                <p class="text-muted">{{ 'Default currency is the one you manage all your prices in admin area. If your client in client area chooses other than default currency, prices will be recalculated according to conversion rate. You can have only one default currency. You can not add same currency once again. Changing default currency is not recommended when active orders are available. Nothing is recalculated on default currency change. Your income is calculated in default currency. Changing default currency after you have paid invoices will distort income statistics. Currency rates are taken from European Central Bank and currencylayer.'|trans }}</p>
             </div>
 
             <table class="table card-table table-vcenter table-striped text-nowrap">
@@ -151,8 +151,8 @@
         <div class="tab-pane fade" id="tab-api-settings" role="tabpanel">
             <div class="card-body">
                 <h3>{{ 'Adjust settings for currency rate updater'|trans }}</h3>
-                <p class="text-muted">FOSSBilling uses data grabbed from <a href="https://currencylayer.com/" target="_blank">currencylayer</a>, however, you'll need an API key to use currencylayer.<br />You can <a href="https://currencylayer.com/product" target="_blank">grab your API key</a> from currencylayer's website. FOSSBilling doesn't make any profits from your purchases on currencylayer.com</p>
-                <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources such as currencylayer.</b></p>
+                <p class="text-muted">FOSSBilling uses data grabbed from <a href="https://www.ecb.europa.eu/home/html/index.en.html" target="_blank">European Central Bank</a> for conversions from Euro to other currencies, and <a href="https://currencylayer.com/" target="_blank">currencylayer</a> for conversations from US Dollar to other currencies.<br />If you choose Euro as your default currency, data from European Central Bank will be used, if you choose US Dollar, data from currencylayer will be used.<br />While European Central Bank decided to keep it's API free to everyone, you won't need an authorization key to use ECB's data. However, you'll need an API key to use currencylayer.<br />You can <a href="https://currencylayer.com/product" target="_blank">grab your API key</a> from currencylayer's website. FOSSBilling doesn't make any profits from your purchases on currencylayer.com</p>
+                <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources, including European Central Bank and currencylayer.</b></p>
 
                 <form method="post" action="{{ 'api/admin/currency/update_rate_settings'|link }}" class="api-form" data-api-msg="{{ 'Successfully updated settings'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -48,7 +48,7 @@
         <div class="tab-pane fade show active" id="tab-currencies" role="tabpanel">
             <div class="card-body">
                 <h3>{{ 'Manage currencies'|trans }}</h3>
-                <p class="text-muted">{{ 'Default currency is the one you manage all your prices in admin area. If your client in client area chooses other than default currency, prices will be recalculated according to conversion rate. You can have only one default currency. You can not add same currency once again. Changing default currency is not recommended when active orders are available. Nothing is recalculated on default currency change. Your income is calculated in default currency. Changing default currency after you have paid invoices will distort income statistics. Currency rates are taken from European Central Bank and currencylayer.'|trans }}</p>
+                <p class="text-muted">{{ 'Default currency is the one you manage all your prices in admin area. If your client in client area chooses other than default currency, prices will be recalculated according to conversion rate. You can have only one default currency. You can not add same currency once again. Changing default currency is not recommended when active orders are available. Nothing is recalculated on default currency change. Your income is calculated in default currency. Changing default currency after you have paid invoices will distort income statistics. Currency rates are taken from currencylayer.'|trans }}</p>
             </div>
 
             <table class="table card-table table-vcenter table-striped text-nowrap">

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -151,8 +151,8 @@
         <div class="tab-pane fade" id="tab-api-settings" role="tabpanel">
             <div class="card-body">
                 <h3>{{ 'Adjust settings for currency rate updater'|trans }}</h3>
-                <p class="text-muted">FOSSBilling uses data grabbed from <a href="https://www.ecb.europa.eu/home/html/index.en.html" target="_blank">European Central Bank</a> for conversions from Euro to other currencies, and <a href="https://currencylayer.com/" target="_blank">currencylayer</a> for conversations from US Dollar to other currencies.<br />If you choose Euro as your default currency, data from European Central Bank will be used, if you choose US Dollar, data from currencylayer will be used.<br />While European Central Bank decided to keep it's API free to everyone, you won't need an authorization key to use ECB's data. However, you'll need an API key to use currencylayer.<br />You can <a href="https://currencylayer.com/product" target="_blank">grab your API key</a> from currencylayer's website. FOSSBilling doesn't make any profits from your purchases on currencylayer.com</p>
-                <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources, including European Central Bank and currencylayer.</b></p>
+                <p class="text-muted">FOSSBilling uses data grabbed from <a href="https://currencylayer.com/" target="_blank">currencylayer</a>, however, you'll need an API key to use currencylayer.<br />You can <a href="https://currencylayer.com/product" target="_blank">grab your API key</a> from currencylayer's website. FOSSBilling doesn't make any profits from your purchases on currencylayer.com</p>
+                <p><b>FOSSBilling does not take any responsibilities for data grabbed from 3rd party sources such as currencylayer.</b></p>
 
                 <form method="post" action="{{ 'api/admin/currency/update_rate_settings'|link }}" class="api-form" data-api-msg="{{ 'Successfully updated settings'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
@@ -173,7 +173,7 @@
                                 <input class="form-check-input" id="radioCronsDisabled" type="radio" name="crons_enabled" value="0"{% if admin.currency_is_cron_enabled == 0 %} checked{% endif %}>
                                 <label class="form-check-label" for="radioCronsDisabled">{{ 'Disabled'|trans }}</label>
                             </div>
-                            <small class="form-hint">{{ 'If you enable this, conversion rates will be automatically updated whenever the CRON job fires up.'|trans }}</small>
+                            <small class="form-hint">{{ 'If you enable this, conversion rates will be automatically updated whenever the CRON job fires up. This should only be used if you have a paid subscription for currencylayer, as otherwise you will quickly hit your rate limit.'|trans }}</small>
                         </div>
                     </div>
 


### PR DESCRIPTION
Please review carefully, it's possible there is something I am missing here.

Their website shows the API endpoint as `https://api.currencylayer.com/live`, which is still responding to API calls, but if you go to signup for it, you are taken to the apilayer website and create your account and get your API key from there. That API key does not work anywhere except on the `https://api.apilayer.com/currency_data/live` endpoint, which is the one shown within the currencylayer docs on the apilayer website.