### PR TITLE
Fix patch class being duplicated

### DIFF
--- a/src/foss-update.php
+++ b/src/foss-update.php
@@ -16,7 +16,12 @@
 
 const DIR_SEP = DIRECTORY_SEPARATOR;
 
-class FOSSPatch_29 extends FOSSPatchAbstract
+/**
+ * Patch to remove the old guzzlehttp package, as we no longer use it. Also serves as an example for how to perform file action.
+ * 
+ * @see https://github.com/FOSSBilling/FOSSBilling/pull/987
+ */
+class FOSSPatch_30 extends FOSSPatchAbstract
 {
     public function patch()
     {


### PR DESCRIPTION
As the tin says. We accidentally created two pach 29s, so this bumps one of them to 30 so that things work as intended