### PR TITLE
Fix a few warnings with PHP 8.1

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -16,7 +16,7 @@
 
 require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
-$url = $di['request']->getQuery('_url');
+$url = $di['request']->getQuery('_url') ?? '';
 $admin_prefix = $di['config']['admin_area_prefix'];
 if (0 === strncasecmp($url, $admin_prefix, strlen($admin_prefix))) {
     $url = str_replace($admin_prefix, '', preg_replace('/\?.+/', '', $url));

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -80,6 +80,8 @@ class Guest extends \Api_Abstract
             $p = $price * $c['conversion_rate'];
         }
 
+        $p ??= 0;
+
         $p = match ($c['price_format']) {
             2 => number_format($p, 2, '.', ','),
             3 => number_format($p, 2, ',', '.'),


### PR DESCRIPTION
As the tin says. Just fixes a couple instances where warnings would be thrown because `null` was being passed