### PR TITLE
Replace the error page and start work on #195

### DIFF
--- a/src/library/Box/Translate.php
+++ b/src/library/Box/Translate.php
@@ -64,6 +64,11 @@ class Box_Translate implements \Box\InjectionAwareInterface
         PhpMyAdmin\MoTranslator\Loader::loadFunctions();
 
         $locale = $this->getLocale();
+        if(empty($locale)){
+            //We are using the standard PHP Exception here rather than our custom one as ours requires translations to be setup, which we cannot do without the locale being defined.
+            throw new Exception("Unable to setup FOSSBilling translation functionality, locale was undefined.");
+        }
+
         $codeset = "UTF-8";
         @putenv('LANG=' . $locale . '.' . $codeset);
         @putenv('LANGUAGE=' . $locale . '.' . $codeset);
@@ -80,7 +85,7 @@ class Box_Translate implements \Box\InjectionAwareInterface
         _bind_textdomain_codeset($this->domain, $codeset);
         _textdomain($this->domain);
 
-        function __trans(string $msgid, array $values = NULL)
+        function __trans(string $msgid, array $values = null)
         {
             $translated = _gettext($msgid);
 
@@ -91,7 +96,7 @@ class Box_Translate implements \Box\InjectionAwareInterface
             return $translated;
         }
 
-        function __pluralTrans(string $msgid, string $msgidPlural, int $number, array $values = NULL)
+        function __pluralTrans(string $msgid, string $msgidPlural, int $number, array $values = null)
         {
             $translated = _ngettext($msgid, $msgidPlural, $number);
 

--- a/src/library/Error/ErrorPage.php
+++ b/src/library/Error/ErrorPage.php
@@ -1,0 +1,290 @@
+<?php
+
+class FOSSBillingErrorPage
+{
+    public function __construct()
+    {
+        /* If the __trans function is undefined, this probably means we experienced an unrecoverable error during the initialization of FOSSBilling.
+         * As a workarond, we define a "polyfill" for it here which just returns the original (english) string, handling placeholders in the process.
+         * This allows us to have translation functionality in our error pages, while also handling cases where they aren't setup.
+         */
+        if (!function_exists('__trans')) {
+            function __trans(string $msgid, array $values = null)
+            {
+                if (is_array($values)) {
+                    $msgid = strtr($msgid, $values);
+                }
+
+                return $msgid;
+            }
+        }
+    }
+
+    /** 
+     * Returns the list of error codes and their specialized messages. All Error code parameters are optional.
+     * 
+     * @return array
+     */
+    private function getCodes(): array
+    {
+        return [
+            '1' => [
+                'title' => __trans('Unable to find Composer Packages'),
+                'message' => 'The composer packages appear to be missing. This shouldn\'t happen if you are using a release version of FOSSBilling. If you are developer, you will need to install dependencies using :code', [':code' => '<code>composer install</code>'],
+                'link' => [
+                    'label' => __trans('View more info on the composer website'),
+                    'href' => 'https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
+                ],
+            ],
+            '2' => [
+                'message' => __trans('For security reasons, you must delete the installation directory before you can use FOSSBilling. :code', [':code' => '(<code>/install</code>)']),
+                'link' => [
+                    'label' => __trans('View more info on the Getting Started guide'),
+                    'href' => 'https://fossbilling.org/docs/getting-started/shared#remove-the-installer',
+                ]
+            ],
+            '3' => [
+                'title' => __trans('Your Configuration is Empty'),
+                'message' => __trans('Your FOSSBilling configuration seems to either be empty or non-existient. You may need to re-install FOSSBilling, or re-create the :code file based on the example config' . [':code' => '<code>config.php</code>']),
+                'link' => [
+                    'label' => __trans('See the example config.'),
+                    'href' => 'https://github.com/FOSSBilling/FOSSBilling/blob/main/src/config-sample.php',
+                ]
+            ],
+            '4' => [
+                'title' => __trans('Migration is required'),
+                'message' => __trans('Legacy BoxBilling or FOSSBilling preview files have been found. The file structure within FOSSBilling, along with the configuration format, has since changed. :lineBreak See the migration guide for assistance in migrating to the latest version of FOSSBilling.', [':lineBreak' => '<br>']),
+                'link' => [
+                    'label' => __trans('Check the migration guide.'),
+                    'href' => 'https://fossbilling.org/docs/getting-started/migrate-from-boxbilling',
+                ]
+            ],
+            '5' => [
+                'title' => __trans("Misssing .htaccess file"),
+                'message' => __trans("You appear to be running an Apache or LiteSpeed based webserver without a valid :code file. Please create one using the default FOSSBilling .htaccess file.", [':code', '<b><em>.htaccess</em></b>']),
+                'link' => [
+                    'label' => __trans("Check the default .htaccess"),
+                    'href' => 'https://github.com/FOSSBilling/FOSSBilling/blob/main/src/.htaccess',
+                ]
+            ],
+        ];
+    }
+
+    /* List of code cetegories. The "start" and "end" values are considered valid for a category.
+     * (Example: an error code of 50 will match the "FOSSBilling Loader" category)
+     */
+    private array $codeCategories = [
+        'FOSSBilling Loader' => [
+            'start' => 1,
+            'end' => 50,
+        ],
+        'HTTP Error Codes' => [
+            'start' => 400,
+            'end' => 599,
+        ],
+    ];
+
+    /**
+     * Gets info for a specified error code, using placeholders for anything undefined.
+     * 
+     * @param int $code The error code
+     * @return array 
+     */
+    private function getCodeInfo(int $code): array
+    {
+        $errorDetails = [
+            'title' => __trans('An error has occured.'),
+            'link' => [
+                'label' => __trans('View the FOSSBilling documentation'),
+                'href' => 'https://fossbilling.org/docs',
+            ],
+            'category' => __trans('None')
+        ];
+
+        $codes = $this->getCodes();
+
+        if (key_exists($code, $codes)) {
+            $codeInfo = $codes[$code];
+            $errorDetails = array_merge($errorDetails, $codeInfo);
+        }
+
+        $errorDetails['category'] = 'Generic';
+        foreach ($this->codeCategories as $categoryName => $categoryRange) {
+            if ($code >= $categoryRange['start'] && $code <= $categoryRange['end']) {
+                $errorDetails['category'] = $categoryName;
+                break;
+            }
+        }
+
+        return $errorDetails;
+    }
+
+    /**
+     * @param int $code Error code
+     * @param string $message The original exception message
+     * @return never 
+     */
+    public function generatePage(int $code, string $message)
+    {
+        $error = $this->getCodeInfo($code);
+        $error['message'] ??= __trans('Uh-oh! You\'ve received a generic error message: :errorMessage', ['errorMessage' => $message]);
+
+        $page = '
+        <!DOCTYPE html>
+        <html>
+            <head>
+            <title>FOSSBilling Error | ' . $error['title'] . '</title>
+            <style>
+            body {
+                background-color: #222;
+                color: #fff;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+                font-size: 16px;
+                line-height: 1.5;
+                margin: 0;
+                padding: 0;
+                text-align: left;
+            }
+
+            .container {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+            }
+
+            .error-container {
+                width: 75%;
+                background-color: #313131;
+                border-radius: 25px;
+                padding: 1%;
+            }
+
+            .error-title {
+                font-size: 3.75rem;
+                font-weight: 600;
+                margin-bottom: 0px;
+            }
+
+            .error-code {
+                font-size: 1rem;
+                font-weight: 200;
+                margin: 0px;
+            }
+
+            .error-category {
+                font-size: 1rem;
+                font-weight: 200;
+                margin: 0px;
+            }
+
+            .error-message {
+                font-size: 1.25rem;
+                margin-bottom: 30px;
+                line-height: 1.8;
+            }
+
+            code {
+                background-color: #f2f2f2;
+                color: #333;
+                border-radius: 3px;
+            }
+
+            .footer {
+                color: #fff;
+                padding: 5px;
+                text-align: center;
+                font-size: 14px;
+            }
+
+            .footer a {
+                color: #fff;
+                text-decoration: none;
+                margin: 0 10px;
+            }
+
+            .footer a:hover {
+                text-decoration: underline;
+            }
+
+            a {
+                color: #3291ff;
+            }
+
+            a:visited {
+                color: inherit;
+                text-decoration: none;
+            }
+
+            a:hover {
+                text-decoration: underline;
+            }
+
+            .button {
+                background-color: #3291ff;
+                border: none;
+                color: #fff;
+                padding: 10px 20px;
+                border-radius: 5px;
+                font-size: 15px;
+                cursor: pointer;
+                transition: all 0.3s ease;
+                text-decoration: none;
+            }
+
+            .button:hover {
+                background-color: #3d9dff;
+                text-decoration: none;
+            }
+
+            </style>
+            </head>
+            <body>
+                <div class="container">
+                <div class="error-container">
+                    <p class="error-title">' . $error['title'] . '</p>
+                    <p class="error-code">Error Code: #' . $code . '</p>
+                    <p class="error-category">Error Category: ' . $error['category'] . '</p>
+                    <p class="error-message" id="specialized">' . $error['message'] . '</p>
+                    <p class="error-message" id="original" style="display: none;">' . $message . '</p>
+
+                    <div class="link-container">
+                        <button id="toggle" class="button" onclick="toggle()">' . __trans("Show original message") . '</button>
+                        <a class="button" target="_blank" href="' . $error['link']['href'] . '">' . $error['link']['label'] . '</a>
+                    </div>
+                    
+                    <div class="footer" style="clear:both">
+                        <hr>
+                        <p>Powered By FOSSBilling</p>
+                        <p>
+                            <a href="https://github.com/fossbilling/fossbilling">Source code</a> |
+                            <a href="https://fossbilling.org/discord">Discord</a> |
+                            <a href="https://fossbilling.org/docs">Documentation</a> |
+                            <a href="https://forum.fossbilling.com/">Forum</a> |
+                            <a href="https://opencollective.com/FOSSBilling">Donate</a>
+                        </p>
+                    </div>
+                </div>
+                </div>
+                <script>
+                    function toggle() {
+                        var og = document.getElementById("original");
+                        var specialized = document.getElementById("specialized");
+
+                        if (og.style.display === "none") {
+                            og.style.display = "block";
+                            specialized.style.display = "none";
+                            document.querySelector("#toggle").innerHTML = "' . __trans("Show specialized message") . '";
+                        } else {
+                            og.style.display = "none";
+                            specialized.style.display = "block";
+                            document.querySelector("#toggle").innerHTML = "' . __trans("Show original message") . '";
+                        }
+                    }
+                </script>
+            </body>
+        </html>';
+        echo $page;
+        die();
+    }
+}

--- a/src/library/Error/ErrorPage.php
+++ b/src/library/Error/ErrorPage.php
@@ -243,8 +243,8 @@ class FOSSBillingErrorPage
                 <div class="container">
                 <div class="error-container">
                     <p class="error-title">' . $error['title'] . '</p>
-                    <p class="error-code">Error Code: #' . $code . '</p>
-                    <p class="error-category">Error Category: ' . $error['category'] . '</p>
+                    <p class="error-code">' . __trans('Error Code: #:number', [':number' => $code]) . '</p>
+                    <p class="error-category">' . __trans('Component: :category', [':category' => $error['category']]) . '</p>
                     <p class="error-message" id="specialized">' . $error['message'] . '</p>
                     <p class="error-message" id="original" style="display: none;">' . $message . '</p>
 

--- a/src/load.php
+++ b/src/load.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling.
  *
@@ -19,19 +20,20 @@ use Whoops\Run;
 
 defined('APPLICATION_ENV') || define('APPLICATION_ENV', getenv('APPLICATION_ENV') ?: 'production');
 const PATH_ROOT = __DIR__;
-const PATH_VENDOR = PATH_ROOT . DIRECTORY_SEPARATOR. 'vendor';
-const PATH_LIBRARY = PATH_ROOT . DIRECTORY_SEPARATOR. 'library';
-const PATH_THEMES = PATH_ROOT . DIRECTORY_SEPARATOR. 'themes';
-const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR. 'modules';
-const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR. 'locale';
-const PATH_UPLOADS = PATH_ROOT . DIRECTORY_SEPARATOR. 'uploads';
-const PATH_DATA = PATH_ROOT . DIRECTORY_SEPARATOR. 'data';
+const PATH_VENDOR = PATH_ROOT . DIRECTORY_SEPARATOR . 'vendor';
+const PATH_LIBRARY = PATH_ROOT . DIRECTORY_SEPARATOR . 'library';
+const PATH_THEMES = PATH_ROOT . DIRECTORY_SEPARATOR . 'themes';
+const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
+const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
+const PATH_UPLOADS = PATH_ROOT . DIRECTORY_SEPARATOR . 'uploads';
+const PATH_DATA = PATH_ROOT . DIRECTORY_SEPARATOR . 'data';
 const PATH_CONFIG = PATH_ROOT . '/config.php';
 
 /*
  * Check configuration exists, and is valid.
  */
-function checkConfig() {
+function checkConfig()
+{
     $filesystem = new Filesystem();
 
     $base_url = 'http' . ((isset($_SERVER['HTTPS']) && ('on' === $_SERVER['HTTPS'] || 1 == $_SERVER['HTTPS'])) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && 'https' === $_SERVER['HTTP_X_FORWARDED_PROTO']) ? 's' : '') . '://' . ($_SERVER['HTTP_HOST'] ?? '');
@@ -42,7 +44,7 @@ function checkConfig() {
         if ($filesystem->exists('/install/index.php')) {
             header("Location: " . $base_url . '/install', true, 301);
         } else {
-            throw new Exception("Your <b><em>config.php</em></b> file appears to be invalid. It's possible that your existing configuration file may not contain the required configuration parameters or have become corrupted. FOSSBilling needs to have a valid configuration file in order to function properly.</p> <p>Please use the example config as reference <a target='_blank' href='https://raw.githubusercontent.com/FOSSBilling/FOSSBilling/master/src/config-sample.php'>here</a>. You may need to manually restore an old config file or fix your existing one.</p>");
+            throw new Exception("The FOSSBilling configuration file is empty or invalid.", 3);
         }
     }
 }
@@ -50,23 +52,25 @@ function checkConfig() {
 /*
  * Check if the installer is present.
  */
-function checkInstaller() {
+function checkInstaller()
+{
     $filesystem = new Filesystem();
 
     // Check if /install directory still exists after installation has been completed.
     if ($filesystem->exists('config.php') && $filesystem->exists('/install/index.php')) {
-        throw new Exception('For security you have to delete the <b><em>/install</em></b> directory to start using FOSSBilling.</p><p>Please delete the <b><em>/install</em></b> directory from your web server.');
+        throw new Exception('For security reasons, you have to delete the install directory before you can use FOSSBilling.', 2);
     }
 }
 
 /*
  * Check if any legacy BoxBilling/FOSSBilling files are present.
  */
-function checkLegacyFiles() {
+function checkLegacyFiles()
+{
     $filesystem = new Filesystem();
 
     // Detect old files and folders from legacy BoxBilling or FOSSBilling installations.
-    $toCheck = ['bb-data', 'bb-library', 'bb-locale', 'bb-modules', 'bb-themes', 'bb-uploads', 'bb-cron.php', 'bb-di.php', 'bb-load.php','bb-config.php'];
+    $toCheck = ['bb-data', 'bb-library', 'bb-locale', 'bb-modules', 'bb-themes', 'bb-uploads', 'bb-cron.php', 'bb-di.php', 'bb-load.php', 'bb-config.php'];
     $legacyFound = null;
     foreach ($toCheck as $path) {
         if ($filesystem->exists($path)) {
@@ -77,28 +81,30 @@ function checkLegacyFiles() {
 
     // Show an error if any legacy files/folders found.
     if ($legacyFound) {
-        throw new Exception('Legacy BoxBilling or FOSSBilling preview files have been found. The file structure within FOSSBilling, along with the configuration format, has since changed.<br> See the <a href="https://fossbilling.org/docs/getting-started/migrate-from-boxbilling">migration guide</a> for assistance in migrating to the latest version of FOSSBilling.');
+        throw new Exception('Migration from BoxBilling is required.', 4);
     }
 }
 
 /*
  * Check hard requirements such as PHP version, Composer packages, etc.
  */
-function checkRequirements() {
+function checkRequirements()
+{
     // Check for Composer packages / vendor folder.
     if (!file_exists(PATH_VENDOR)) {
-        throw new Exception("It seems like Composer packages are missing. You have to run \"<code>composer install</code>\" in order to install them. For detailed instruction, you can see <a href=\"https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies\">Composer's getting started guide</a>.<br /><br />If you have downloaded FOSSBilling from <a href=\"https://github.com/FOSSBilling/FOSSBilling/releases\">GitHub releases</a>, this shouldn't happen.");
+        throw new Exception("The composer packages are missing.", 1);
     }
 }
 
 /*
  * Check if SSL required, and enforce if so.
  */
-function checkSSL() {
+function checkSSL()
+{
     $config = include PATH_CONFIG;
     if (isset($config['security']['force_https']) && $config['security']['force_https'] && 'cli' !== PHP_SAPI) {
         $isHTTPS = false;
-    
+
         if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
             $isHTTPS = true;
         }
@@ -109,7 +115,7 @@ function checkSSL() {
             $isHTTPS = true;
         }
 
-        if(!$isHTTPS){
+        if (!$isHTTPS) {
             $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
             header('Location: ' . $url);
             exit;
@@ -120,7 +126,8 @@ function checkSSL() {
 /*
  * Check the web server config.
  */
-function checkWebServer() {
+function checkWebServer()
+{
     $filesystem = new Filesystem();
 
     // Check for missing required .htaccess on Apache and Apache-compatible web servers.
@@ -128,7 +135,7 @@ function checkWebServer() {
     $serverSoftware = $_SERVER['SERVER_SOFTWARE'] ?? '';
     if ($isApache or (stripos($serverSoftware, 'apache') !== false) or (stripos($serverSoftware, 'litespeed')) !== false) {
         if (!$filesystem->exists('.htaccess')) {
-            throw new Exception('Fatal Error: You appear to be running an Apache or LiteSpeed based webserver without a valid <b><em>.htaccess</em></b> file.');
+            throw new Exception('Missing .htaccess file', 5);
         }
     }
 }
@@ -151,180 +158,43 @@ function errorHandler(int $number, string $message, string $file, int $line)
  */
 function exceptionHandler($e)
 {
-        if (APPLICATION_ENV === 'testing') {
-            echo $e->getMessage() . PHP_EOL;
+    if (APPLICATION_ENV === 'testing') {
+        echo $e->getMessage() . PHP_EOL;
 
-            return;
-        }
-        error_log($e->getMessage());
+        return;
+    }
+    error_log($e->getMessage());
 
-        if (defined('BB_MODE_API')) {
-            $code = $e->getCode() ?: 9998;
-            $result = ['result' => null, 'error' => ['message' => $e->getMessage(), 'code' => $code]];
-            echo json_encode($result);
+    if (defined('BB_MODE_API')) {
+        $code = $e->getCode() ?: 9998;
+        $result = ['result' => null, 'error' => ['message' => $e->getMessage(), 'code' => $code]];
+        echo json_encode($result);
 
-            return false;
-        }
+        return false;
+    }
 
-        if (defined('BB_DEBUG') && BB_DEBUG && file_exists(PATH_VENDOR)) {
-            /**
-             * If advanced debugging is enabled, print Whoops instead of our error page.
-             * flip/whoops documentation: https://github.com/filp/whoops/blob/master/docs/API%20Documentation.md.
-             */
-            $whoops = new Run();
-            $prettyPage = new PrettyPageHandler();
-            $prettyPage->setPageTitle('An error ocurred');
-            $prettyPage->addDataTable('FOSSBilling environment', [
-        'PHP Version' => PHP_VERSION,
-        'Error code' => $e->getCode(),
-      ]);
-            $whoops->pushHandler($prettyPage);
-            $whoops->allowQuit(false);
-            $whoops->writeToOutput(false);
+    if (defined('BB_DEBUG') && BB_DEBUG && file_exists(PATH_VENDOR)) {
+        /**
+         * If advanced debugging is enabled, print Whoops instead of our error page.
+         * flip/whoops documentation: https://github.com/filp/whoops/blob/master/docs/API%20Documentation.md.
+         */
+        $whoops = new Run();
+        $prettyPage = new PrettyPageHandler();
+        $prettyPage->setPageTitle('An error ocurred');
+        $prettyPage->addDataTable('FOSSBilling environment', [
+            'PHP Version' => PHP_VERSION,
+            'Error code' => $e->getCode(),
+        ]);
+        $whoops->pushHandler($prettyPage);
+        $whoops->allowQuit(false);
+        $whoops->writeToOutput(false);
 
-            echo $whoops->handleException($e);
-        } else {
-            $page = "<!DOCTYPE html>
-      <html lang=\"en\">
-
-      <head>
-          <meta charset=\"utf-8\">
-          <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
-          <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-          <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-
-          <title>An error ocurred</title>
-
-          <style>
-          * {
-              -webkit-box-sizing: border-box;
-                      box-sizing: border-box;
-            }
-
-            body {
-              padding: 0;
-              margin: 0;
-            }
-
-            #error {
-              position: relative;
-              height: 100vh;
-            }
-
-            #error .error {
-              position: absolute;
-              left: 50%;
-              top: 50%;
-              -webkit-transform: translate(-50%, -50%);
-                  -ms-transform: translate(-50%, -50%);
-                      transform: translate(-50%, -50%);
-            }
-
-            .error {
-              font-family: Arial, Helvetica, sans-serif;
-              max-width: 560px;
-              width: 100%;
-              padding-left: 160px;
-              line-height: 1.1;
-            }
-
-            .error .error-container {
-              position: absolute;
-              left: 0;
-              top: 0;
-              display: inline-block;
-              width: 150px;
-              height: 150px;
-              background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgNTkuNDMgNjguNyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiMwMDgxYzU7fS5jbHMtMntmaWxsOiNmZmY7fS5jbHMtM3tmaWxsOiNmYWM5NjU7fS5jbHMtNHtmaWxsOiMwNTA0MDc7fS5jbHMtNCwuY2xzLTV7c3Ryb2tlOiNmZmY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fS5jbHMtNXtmaWxsOiMxYTExMGY7fTwvc3R5bGU+PC9kZWZzPjxnIGlkPSJMYXllcl8xLTIiPjxnPjxnPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTkuODQsMzcuODZjLTEuMzcsMC0yLjUxLTEuMzUtMi41OC0zLjA4TDUuOTksNi41NmMtLjA4LTEuNzksMS4wMS0zLjMyLDIuNDQtMy40MUw1MS4yMywuNWguMTNjMS4zNywwLDIuNTEsMS4zNSwyLjU4LDMuMDdsMS4yNiwyOC4yM2MuMDgsMS43OS0xLjAxLDMuMzItMi40NCwzLjQxbC00Mi44LDIuNjVoLS4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik01MS4zNiwxYzEuMDksMCwyLjAyLDEuMTcsMi4wOCwyLjZsMS4yNiwyOC4yM2MuMDcsMS40OS0uODQsMi44Mi0xLjk3LDIuODlsLTQyLjgsMi42NXMtLjA3LDAtLjEsMGMtMS4wOSwwLTIuMDItMS4xNy0yLjA4LTIuNkw2LjQ5LDYuNTRjLS4wNy0xLjQ5LC44NC0yLjgyLDEuOTctMi44OUw1MS4yNywxcy4wNywwLC4xLDBNNTEuMzYsMGMtLjA1LDAtLjExLDAtLjE2LDBMOC40LDIuNjVjLTEuNywuMS0zLDEuODYtMi45MSwzLjkzbDEuMjYsMjguMjNjLjA5LDIsMS40NSwzLjU1LDMuMDgsMy41NSwuMDUsMCwuMTEsMCwuMTYsMGw0Mi44LTIuNjVjMS43LS4xMSwzLTEuODYsMi45MS0zLjkzbC0xLjI2LTI4LjIzQzU0LjM2LDEuNTUsNTIuOTksMCw1MS4zNiwwaDBaIi8+PC9nPjxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTQ2LjU3LDIxLjkxbC02LjU3LC4zNGMtMS40NiwuMDgtMi43MS0xLjAxLTIuNzktMi40MmwtLjE0LTIuNTljLS4wOC0xLjQxLDEuMDUtMi42MiwyLjUxLTIuNjlsNi41Ny0uMzRjMS40Ni0uMDgsMi43MSwxLjAxLDIuNzksMi40MmwuMTQsMi41OWMuMDgsMS40MS0xLjA1LDIuNjItMi41MSwyLjY5WiIvPjxyZWN0IGNsYXNzPSJjbHMtNCIgeD0iMS43MiIgeT0iMjguMTYiIHdpZHRoPSI1NiIgaGVpZ2h0PSIzOCIgcng9IjQiIHJ5PSI0IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg0LjIyIC0yLjQxKSByb3RhdGUoNSkiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik00Ny42Myw0NS4wOGgxMHY4aC0xMGMtMS4xLDAtMi0uOS0yLTJ2LTRjMC0xLjEsLjktMiwyLTJaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg0LjQ3IC00LjMxKSByb3RhdGUoNSkiLz48L2c+PC9nPjwvc3ZnPg==');
-              background-repeat: no-repeat;
-              background-size: 124px 144px;
-            }
-
-            .error .error-container:before {
-              content: '';
-              position: absolute;
-              width: 100%;
-              height: 100%;
-              -webkit-transform: scale(2.4);
-                  -ms-transform: scale(2.4);
-                      transform: scale(2.4);
-              border-radius: 50%;
-              background-color: #f2f5f8;
-              z-index: -1;
-            }
-
-            .error h1 {
-              font-size: 65px;
-              font-weight: 700;
-              margin-top: 0px;
-              margin-bottom: 10px;
-              color: #151723;
-              text-transform: uppercase;
-            }
-
-            .error h2 {
-              font-size: 21px;
-              font-weight: 400;
-              margin: 0;
-              text-transform: uppercase;
-              color: #151723;
-            }
-
-            .error p {
-              color: #999fa5;
-              font-weight: 400;
-            }
-
-            .error a {
-              display: inline-block;
-              font-weight: 700;
-              border-radius: 40px;
-              text-decoration: none;
-              color: #388dbc;
-            }
-
-            @media only screen and (max-width: 767px) {
-              .error .error-container {
-                width: 110px;
-                height: 110px;
-              }
-              .error {
-                padding-left: 15px;
-                padding-right: 15px;
-                padding-top: 110px;
-              }
-            }
-
-            code {
-              font-family: Monaco, Menlo, Consolas, 'Courier New', monospace;
-              color: crimson;
-              background-color: #f1f1f1;
-              padding: 2px;
-              font-size: 90%;
-            }
-
-          </style>
-      </head>
-      <body>
-
-      <div id=\"error\">
-          <div class=\"error\">
-              <div class=\"error-container\"></div>
-              <h1>Error</h1>";
-
-            $page = str_replace(PHP_EOL, '', $page);
-            echo $page;
-            if ($e->getCode()) {
-                echo sprintf('<h2>Error code: <em>%s</em></h1>', $e->getCode());
-            }
-            echo sprintf('<p>%s</p>', $e->getMessage());
-
-            echo sprintf('<center><p><a href="https://fossbilling.org/docs/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
-            echo '<center><hr><p>Powered by <a href="https://fossbilling.org">FOSSBilling</a></p></center>
-      </body>
-
-      </html>';
-        }
+        echo $whoops->handleException($e);
+    } else {
+        include PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Error' . DIRECTORY_SEPARATOR . 'ErrorPage.php';
+        $errorPage = new \FOSSBillingErrorPage();
+        $errorPage->generatePage($e->getCode(), $e->getMessage());
+    }
 }
 
 /*
@@ -333,12 +203,15 @@ function exceptionHandler($e)
  *
  */
 
+// Define custom error handlers
+set_exception_handler('exceptionHandler');
+set_error_handler('errorHandler');
+
 // Check hard requirements.
 checkRequirements();
 
 // Requirements met - load required packages/files.
-require PATH_VENDOR . '/autoload.php';
-$config = require PATH_CONFIG;
+require PATH_VENDOR . DIRECTORY_SEPARATOR . 'autoload.php';
 
 // Check web server and web server settings.
 checkWebServer();
@@ -348,6 +221,9 @@ checkLegacyFiles();
 
 // Check config exists.
 checkConfig();
+
+//All seems good, so load the config file
+$config = require PATH_CONFIG;
 
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
@@ -371,8 +247,6 @@ checkSSL();
 ini_set('log_errors', '1');
 ini_set('html_errors', false);
 ini_set('error_log', PATH_LOG . '/php_error.log');
-set_exception_handler('exceptionHandler');
-set_error_handler('errorHandler');
 if ($config['debug']) {
     error_reporting(E_ALL);
     ini_set('display_errors', '1');


### PR DESCRIPTION
This PR works on issue https://github.com/FOSSBilling/FOSSBilling/issues/195 and https://github.com/FOSSBilling/FOSSBilling/issues/196. It implements a new layout and creates some new functionality to allow for the link, message, and title to be configurable per error code. 

I've also added a few codes and defined some placeholder categories that we can build on overtime.
![Animation](https://user-images.githubusercontent.com/17304943/228140301-12ae8212-345c-4d85-9bdb-9cb06a5f8b41.gif)

it's not super pretty, but it is functional

