### PR TITLE
Bumped title sizes

### DIFF
--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -112,8 +112,8 @@
 
         <div class="col-12">
             <div class="card overflow-x-auto">
-                <div class="card-body">
-                    <h5>{{ 'Statistics'|trans }}</h5>
+                <div class="card-header">
+                    <h3 class="card-title">{{ 'Statistics'|trans }}</h3>
                 </div>
                 <div class="table-responsive">
                 <table class="table card-table table-vcenter table-striped text-nowrap">
@@ -394,10 +394,10 @@
 
     <div class="col-12">
         <div class="card">
-            <div class="card-body">
-                <h5>{{ 'Income'|trans }}</h5>
-                <div id="chart-income" style="width: 100%; height: 200px;"></div>
+            <div class="card-header">
+                <h3 class="card-title">{{ 'Income'|trans }}</h3>
             </div>
+            <div id="chart-income" style="width: 100%; height: 200px;"></div>
         </div>
     </div>
 


### PR DESCRIPTION
Just a small change in the dashboard index to adjust the card title text sizes to match the others.

Old:
![image](https://user-images.githubusercontent.com/35808275/228158356-a718e63e-ab67-4592-890e-3eadd5f921aa.png)


New:
![image](https://user-images.githubusercontent.com/35808275/228158247-84aea3da-474e-49f1-9e84-c001c1862730.png)