### PR TITLE
Fix HTTP error 500 with the installer

### DIFF
--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -32,7 +32,7 @@
 
 <div id="footer">
 	<div class="wrapper">
-    <span>&copy; Copyright {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="FOSSBilling" target="_blank">FOSSBilling {{version}}</a></span>
+    <span>&copy; Copyright {{ now|date('Y') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="FOSSBilling" target="_blank">FOSSBilling {{version}}</a></span>
   </div>
 </div>
 


### PR DESCRIPTION
Closes #1017 by reverting the installer back to using the original `date` filter, since the installer doesn't need the additional flexibility from the new installer, not is there a way to configure said flexibility