### PR TITLE
A little overhaul for the SEO module

### DIFF
--- a/src/modules/Seo/Api/Admin.php
+++ b/src/modules/Seo/Api/Admin.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * FOSSBilling.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * Copyright FOSSBilling 2022
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+namespace Box\Mod\Seo\Api;
+
+class Admin extends \Api_Abstract
+{
+    /**
+     * Returns SEO information. When the pings were was last sent
+     *
+     * @return array
+     */
+    public function info($data)
+    {
+        return $this->getService()->getInfo();
+    }
+
+    /**
+     * Ping every search engine to let them know that the sitemap has been updated
+     *
+     * @return bool
+     */
+    public function ping_all()
+    {
+        $extensionService = $this->di['mod_service']('extension');
+        $config = $extensionService->getConfig('mod_seo');
+
+        return $this->getService()->pingSitemap($config, true);
+    }
+}

--- a/src/modules/Seo/Engines/Google.php
+++ b/src/modules/Seo/Engines/Google.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * FOSSBilling.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * Copyright FOSSBilling 2023
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+namespace Box\Mod\Seo\Engines;
+
+class Google implements \Box\InjectionAwareInterface
+{
+    protected $di;
+
+    public function setDi($di)
+    {
+        $this->di = $di;
+    }
+
+    public function getDi()
+    {
+        return $this->di;
+    }
+
+    public function getDetails()
+    {
+        return [
+            'id' => 'google',
+            'name' => 'Google',
+        ];
+    }
+
+    public function pingSitemap(string $url)
+    {
+        $link = 'https://www.google.com/ping';
+        
+        $request = $this->di['http_client']->request('GET', $link, [
+            'query' => [
+                'sitemap'   => $url,
+            ],
+        ]);
+
+        return $request->getStatusCode() == 200;
+    }
+}

--- a/src/modules/Seo/html_admin/mod_seo_settings.html.twig
+++ b/src/modules/Seo/html_admin/mod_seo_settings.html.twig
@@ -28,21 +28,49 @@
         <h3 class="card-title">{{ 'SEO settings'|trans }}</h3>
     </div>
 
+    {% set info = admin.seo_info %}
+
     {% set params = admin.extension_config_get({ "ext": "mod_seo" }) %}
     <form method="post" action="{{ 'api/admin/extension/config_save'|link }}" class="api-form" data-api-msg="{{ 'Configuration updated'|trans }}">
         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">
         <input type="hidden" name="ext" value="mod_seo">
         <div class="card-body">
-            <h3 class="card-title">Sitemap</h3>
+            <h3 class="card-title">Enabled engines</h3>
+
+            {% for i, engine in info.engines %}
             <div class="row">
-                <label class="col-md-3 form-label">{{ 'Ping sitemap to Google'|trans }}</label>
+                <label class="col-md-3 form-label">{{ engine.name }}</label>
                 <span class="col-md-5">
                     <label class="form-check form-check-single form-switch">
-                        <input class="form-check-input" type="checkbox" name="sitemap_google" {% if params.sitemap_google %}checked="checked"{% endif %}>
+                        <input class="form-check-input" type="checkbox" name="sitemap_{{ engine.id }}" {% if engine.enabled %}checked="checked"{% endif %}>
                     </label>
                 </span>
             </div>
+            {% endfor %}
         </div>
+
+        <div class="card-body border-bottom">
+            <span class="card-subtitle">{{ 'FOSSBilling will automatically ping every enabled search engine every 24 hours. Cron jobs must be working for this to work.'|trans }}</span>
+        </div>
+        
+        <div class="table-responsive">
+            <table class="table card-table table-vcenter table-striped text-nowrap">
+                <tbody>
+                    <tr>
+                        <td class="text-end">{{ 'Last time a ping was sent'|trans }}:</td>
+                        <td>
+                            {% if info.last_exec %}
+                                {{ info.last_exec|format_datetime }}
+                                ({{ info.last_exec|timeago }} ago)
+                            {% else %}
+                                {{ 'A ping wasn\'t sent yet'|trans }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
         <div class="card-footer text-end">
             <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary">
         </div>

--- a/src/modules/Seo/manifest.json
+++ b/src/modules/Seo/manifest.json
@@ -2,11 +2,8 @@
   "id": "seo",
   "type": "mod",
   "name": "SEO Tools",
-  "description": "Ping sitemap to Google, Yahoo and Bing",
+  "description": "Ping your sitemap to the search engines.",
   "icon_url": "icon.svg",
-  "homepage_url": "https://github.com/FOSSBilling",
-  "author": "FOSSBilling",
-  "author_url": "http://extensions.fossbilling.org/",
-  "license": "https://github.com/FOSSBilling/FOSSBilling/blob/main/LICENSE",
-  "version": "1.0.0"
+  "license": "Apache-2.0",
+  "version": "0.4.0"
 }


### PR DESCRIPTION
* Moved away from hardcoded engine endpoints. There is now a new `/Engines` directory under the module. See [/Engines/Google.php](https://github.com/FOSSBilling/FOSSBilling/blob/4de3d2374f6771251ec0baf1413066e5644af6ef/src/modules/Seo/Engines/Google.php) for an example. The engines will be dynamically loaded from that directory.
* Got rid of the RSS stuff. They were marked as `TODO` and weren't working anyway.
* Created API endpoints for the module.
** `/info` will list the sitemap URL, the timedate of the last execution and some information about the engines.
** `/run_all` will force a ping to every engine no matter if 24 hours passed or not.
* The Twig template was adjusted to dynamically render the engine data instead of the hardcoded Google. It also now shows the last time a ping was sent.

This PR shouldn't be a breaking change and doesn't require anything to be added to the update.php.

The new admin page:
![image](https://user-images.githubusercontent.com/35808275/229288414-b95c8d11-f1d3-4968-964f-3315c4a29819.png)

Example request:
![image](https://user-images.githubusercontent.com/35808275/229289113-7d6bbfa8-58eb-4b05-97de-d99c8780841a.png)
