### PR TITLE
Fix sitemap content type header

### DIFF
--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -81,6 +81,10 @@ class Box_AppClient extends Box_App
             throw new \Box_Exception('Page not found', null, 404);
         }
 
+        if ($fileName . '.' . $ext == 'mod_page_sitemap.xml') {
+            header('Content-Type: application/xml');
+        }
+
         return $template->render($variableArray);
     }
 
@@ -91,7 +95,8 @@ class Box_AppClient extends Box_App
         $theme = $service->getTheme($code);
         $settings = $service->getThemeSettings($theme);
 
-        $loader = new Box_TwigLoader([
+        $loader = new Box_TwigLoader(
+            [
                 'mods' => PATH_MODS,
                 'theme' => PATH_THEMES . DIRECTORY_SEPARATOR . $code,
                 'type' => 'client',


### PR DESCRIPTION
Closes #1029 by correcting the content type header.

Before:
![image](https://user-images.githubusercontent.com/17304943/229315689-1db9978f-a375-438a-b89a-876fa421c60c.png)

After:
![image](https://user-images.githubusercontent.com/17304943/229315669-9a88c8b8-0f68-4a21-acfd-fd99639b17cf.png)
