### PR TITLE
Slightly improved twig locale handling 

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -309,7 +309,7 @@ $di['twig'] = $di->factory(function () use ($di) {
 
     // Get internationalisation settings from config, or use sensible defaults for
     // missing required settings.
-    $locale = $config['i18n']['locale'] ?? 'en_US';
+    $locale = $_COOKIE['BBLANG'] ?? $config['i18n']['locale'] ?? 'en_US';
     $timezone = $config['i18n']['timezone'] ?? 'UTC';
     $date_format = !empty($config['i18n']['date_format']) ? strtoupper($config['i18n']['date_format']) : 'MEDIUM';
     $time_format = !empty($config['i18n']['time_format']) ? strtoupper($config['i18n']['time_format']) : 'SHORT';
@@ -339,7 +339,7 @@ $di['twig'] = $di->factory(function () use ($di) {
     try {
         $dateFormatter = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
     } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodArgumentValueNotImplementedException $e) {
-        if (($config['i18n']['locale'] ?? 'en_US') == 'en_UsS') {
+        if (($config['i18n']['locale'] ?? 'en_US') == 'en_US') {
             $dateFormatter = new \IntlDateFormatter('en', constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
         } else {
             throw new \Box_Exception("It appears you are trying to use FOSSBilling without the php intl extension enabled. FOSSBilling includes a polyfill for the intl extension, however it does not support :locale. Please enable the intl extension.", [':locale' => $config['i18n']['locale']]);
@@ -363,7 +363,6 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addGlobal('CSRFToken', $token);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);
-
     return $twig;
 });
 

--- a/src/di.php
+++ b/src/di.php
@@ -336,7 +336,16 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addExtension($box_extensions);
     $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
 
-    $dateFormatter = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
+    try {
+        $dateFormatter = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
+    } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodArgumentValueNotImplementedException $e) {
+        if (($config['i18n']['locale'] ?? 'en_US') == 'en_UsS') {
+            $dateFormatter = new \IntlDateFormatter('en', constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
+        } else {
+            throw new \Box_Exception("It appears you are trying to use FOSSBilling without the php intl extension enabled. FOSSBilling includes a polyfill for the intl extension, however it does not support :locale. Please enable the intl extension.", [':locale' => $config['i18n']['locale']]);
+        }
+    }
+
     $twig->addExtension(new IntlExtension($dateFormatter));
 
     // add globals


### PR DESCRIPTION
This PR does two things:
1) It implements a try-catch to handle when the `symfony/polyfill-intl-icu` is in use. As long as the system is still set to using `en_US`, it'll instantiate the polyfill with `en` for the locale, which is the only one it supports. For anything else, it will display this error message which should be more helpful to end users:
![image](https://user-images.githubusercontent.com/17304943/229952658-1fb3b3c4-1477-426a-a3a8-5b4b493eb77c.png)
2) This PR enables the usage of the `BBLANG` cookie to set the locale for twig, which enables a bit more localization for end-users.
en_US:
![image](https://user-images.githubusercontent.com/17304943/229952851-cde5f426-5140-427e-b342-03fe7d10c1b5.png)
es_ES:
![image](https://user-images.githubusercontent.com/17304943/229953078-836ef59b-2174-41eb-9c62-7fa9a451cfbf.png)
zh_TW:
![image](https://user-images.githubusercontent.com/17304943/229954125-dfec7cb8-4819-4728-a3e8-cef9665cda87.png)

