### PR TITLE
Allow usage of admin default encore with client themes

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -88,7 +88,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
             'asset_url' => new TwigFilter('asset_url', [$this, 'twig_asset_url'], ['needs_environment' => true, 'is_safe' => ['html']]),
 
-            'library_url' => new TwigFilter('library_url', [$this, 'twig_library_url'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            'library_url' => new TwigFilter('library_url', [$this, 'twig_library_url'], ['is_safe' => ['html']]),
 
             'money' => new TwigFilter('money', [$this, 'twig_money'], ['needs_environment' => true, 'is_safe' => ['html']]),
 
@@ -199,10 +199,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         return BB_URL . 'themes/' . $globals['current_theme'] . '/assets/' . $asset;
     }
 
-    public function twig_library_url(Twig\Environment $env, $path)
+    public function twig_library_url($path)
     {
-        $globals = $env->getGlobals();
-
         return BB_URL . 'library/' . $path;
     }
 

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -410,9 +410,7 @@ class Service implements InjectionAwareInterface
 
     public function getCurrentRouteTheme(): string
     {
-        $base = str_replace(['https://', 'http://'], "", BB_URL);
-        $request = str_replace($base, "", $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
-        if (str_starts_with('/' . $request, ADMIN_PREFIX)) {
+        if ($this->isRouteAdmin()) {
             return $this->getCurrentAdminAreaTheme()['code'];
         }
 
@@ -432,11 +430,39 @@ class Service implements InjectionAwareInterface
         $encoreInfo[$entrypoint] = $this->getEncoreJsonPath($entrypoint);
         $encoreInfo[$manifest] = $this->getEncoreJsonPath($manifest);
 
+        if ($this->useAdminDefaultEncore()) {
+            $encoreInfo['is_encore_theme'] = true;
+            $encoreInfo[$entrypoint] = $this->getThemesPath() . 'admin_default' . DIRECTORY_SEPARATOR . "build" . DIRECTORY_SEPARATOR . "{$entrypoint}.json";
+            $encoreInfo[$manifest] = $this->getThemesPath() . 'admin_default' . DIRECTORY_SEPARATOR . "build" . DIRECTORY_SEPARATOR . "{$manifest}.json";
+        }
+
         return $encoreInfo;
     }
 
     protected function getEncoreJsonPath($filename): string
     {
         return $this->getThemesPath() . $this->getCurrentRouteTheme() . DIRECTORY_SEPARATOR . "build" . DIRECTORY_SEPARATOR . "{$filename}.json";
+    }
+
+    protected function useAdminDefaultEncore()
+    {
+        if ($this->isRouteAdmin()) {
+            return false;
+        }
+
+        $config = $this->getThemeConfig();
+        return $config['use_admin_default_encore'] ?? false;
+    }
+
+    protected function isRouteAdmin()
+    {
+        $base = str_replace(['https://', 'http://'], "", BB_URL);
+        $request = str_replace($base, "", $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+
+        if (str_starts_with('/' . $request, ADMIN_PREFIX)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR adds the ability for client themes to use the encore config from the `admin_default` theme.
This makes sharing the CSS and JS bundle super straightforward so that client theme's don't also need to keep copies of all of those assets if they need the same functionality.

Client themes just need to add `use_admin_default_encore` to their `manifest.json` and set it to `true`. Then, FOSSBilling automatically loads the entry point & manifest files.

To show it works, here's the admin theme copied & pasted into a client theme:
![image](https://user-images.githubusercontent.com/17304943/229966002-e8204295-1cae-49b2-a458-4a2cd23d8ac1.png)

No icons, though. Those are brought in through an `include` tag in twig and I'm not sure how we want to make those accessible to the client area
