### PR TITLE
Decrease timeout ssl check

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -42,6 +42,7 @@ if(!isSSL()){
         'ssl' => array(
             'verify_peer' => true,
             'verify_peer_name' => true,
+            'timeout' => 1,
         ),
     ));
     $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
60 seconds is to long and should be shorter. 

In future to be "rewritten" to use the composer libraries