### PR TITLE
Revert fix for sub-folder installations

### DIFF
--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -410,9 +410,7 @@ class Service implements InjectionAwareInterface
 
     public function getCurrentRouteTheme(): string
     {
-        $base = str_replace(['https://', 'http://'], "", BB_URL);
-        $request = str_replace($base, "", $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
-        if (str_starts_with('/' . $request, ADMIN_PREFIX)) {
+        if (str_starts_with($_SERVER['REQUEST_URI'], ADMIN_PREFIX)) {
             return $this->getCurrentAdminAreaTheme()['code'];
         }
 


### PR DESCRIPTION
Closes #1070 by reverting the change the fixed support for installing FOSSBillng to a sub-folder. It does however, retain the fix for anyone who was using a custom admin prefix.

I think it would be best to consider a sub-folder installation unsupported going forward and announce this change in the discord / forum. It only adds extra complexity and complicates things needlessly. People should instead be using sub-domains.