### PR TITLE
Quick fix to make CKEditor usable in dark mode

### DIFF
--- a/src/modules/Wysiwyg/html_admin/mod_wysiwyg_js.html.twig
+++ b/src/modules/Wysiwyg/html_admin/mod_wysiwyg_js.html.twig
@@ -11,9 +11,17 @@
                         element.removeAttribute('required');
                         required = true;
                     }
-                    editors[element.name] = {editor, 'required': required};
+                    editors[element.name] = { editor, 'required': required };
                 })
-                .catch(error => {console.error(error)});
+                .catch(error => { console.error(error) });
         });
+
+        if (localStorage.getItem('theme') === 'dark') {
+            setTimeout(() => {
+                document.querySelectorAll('.ck-editor__main').forEach(function (element) {
+                    element.style.color="#1d273b";
+                });
+            }, 1000);
+        }
     });
 </script>


### PR DESCRIPTION
This PR makes it so that CKEditor is usable in dark mode by applying a darker text color, which makes the text visible again.
Long-term we will need a custom theme for dark mode, but this at least makes it functional.

![image](https://user-images.githubusercontent.com/17304943/230367408-60702bcc-b5d6-4b5e-9fd5-bdffeec742b7.png)
