### PR TITLE
Minor admin_default improvements

### DIFF
--- a/src/foss-update.php
+++ b/src/foss-update.php
@@ -17,9 +17,9 @@
 const DIR_SEP = DIRECTORY_SEPARATOR;
 
 /**
- * Patch to remove the old htaccess.txt file, and any old config.php backup.
+ * Patch to remove the old htaccess.txt file, any old config.php backup, and leftover admin_default files.
  * 
- * @see https://github.com/FOSSBilling/FOSSBilling/pull/1075
+ * @see https://github.com/FOSSBilling/FOSSBilling/pull/1075 and https://github.com/FOSSBilling/FOSSBilling/pull/1063
  */
 class FOSSPatch_31 extends FOSSPatchAbstract
 {
@@ -28,6 +28,10 @@ class FOSSPatch_31 extends FOSSPatchAbstract
         $fileActions = [
             __DIR__ . DIR_SEP . 'htaccess.txt' => 'unlink',
             __DIR__ . DIR_SEP . 'config.php.old' => 'unlink',
+            __DIR__ . DIR_SEP . 'themes' . DIR_SEP . 'admin_default' . DIR_SEP . 'images' => 'unlink',
+            __DIR__ . DIR_SEP . 'themes' . DIR_SEP . 'admin_default' . DIR_SEP . 'assets' . DIR_SEP . 'scss' . DIR_SEP . 'bb-deprecated.scss' => 'unlink',
+            __DIR__ . DIR_SEP . 'themes' . DIR_SEP . 'admin_default' . DIR_SEP . 'assets' . DIR_SEP . 'scss' . DIR_SEP . 'dataTable-deprecated.scss' => 'unlink',
+            __DIR__ . DIR_SEP . 'themes' . DIR_SEP . 'admin_default' . DIR_SEP . 'assets' . DIR_SEP . 'scss' . DIR_SEP . 'main-deprecated.scss' => 'unlink',
         ];
         $this->performFileActions($fileActions);
     }
@@ -324,4 +328,5 @@ natsort($patches);
         <p>Update completed. You are using FOSSBilling <strong><?php echo Box_Version::VERSION ?></strong></p>
     </div>
 </body>
+
 </html>

--- a/src/library/Box/Extension.php
+++ b/src/library/Box/Extension.php
@@ -87,9 +87,9 @@
             $client = $this->di['http_client'];
             $response = $client->request('GET', $url, [
                 'timeout' => 5,
-                'query' => [
+                'query' => array_merge($params, [
                     'bb_version' => Box_Version::VERSION,
-                ],
+                ]),
             ]);
             $json = $response->toArray();
 

--- a/src/modules/Activity/html_admin/mod_activity_index.html.twig
+++ b/src/modules/Activity/html_admin/mod_activity_index.html.twig
@@ -7,7 +7,7 @@
 {% set active_menu = 'activity' %}
 
 {% block content %}
-<div class="card">
+<div class="card overflow-auto">
     <div class="card-body">
         <h5>{{ 'System activity'|trans }}</h5>
     </div>
@@ -38,11 +38,11 @@
             <td>
                 {% if event.client %}
                 <a href="{{ 'client/manage'|alink }}/{{ event.client.id }}">
-                    <span class="avatar avatar-sm" style="background-image: url({{ event.client.email|gravatar }}&size=20)"></span>
+                    <span class="avatar avatar-sm d-none d-md-inline-block" style="background-image: url({{ event.client.email|gravatar }}&size=20)"></span>
                 </a>
                 {% elseif event.staff %}
                 <a href="{{ 'staff/manage'|alink }}/{{ event.staff.id }}">
-                    <span class="avatar avatar-sm" style="background-image: url({{ event.staff.email|gravatar }}&size=24)"></span>
+                    <span class="avatar avatar-sm d-none d-md-inline-block" style="background-image: url({{ event.staff.email|gravatar }}&size=24)"></span>
                 </a>
                 {% else %}
                 &nbsp;

--- a/src/modules/Client/html_admin/mod_client_login_history.html.twig
+++ b/src/modules/Client/html_admin/mod_client_login_history.html.twig
@@ -7,7 +7,7 @@
 {% set active_menu = 'activity' %}
 
 {% block content %}
-<div class="card">
+<div class="card overflow-auto">
     <div class="card-body">
         <h5>{{ 'Clients logins history'|trans }}</h5>
     </div>
@@ -37,7 +37,7 @@
             </td>
             <td>
                 <a href="{{ 'client/manage'|alink }}/{{ event.client.id }}">
-                    <span class="avatar avatar-xs" style="background-image: url({{ event.client.email|gravatar }}&size=24)"></span>
+                    <span class="avatar avatar-xs d-none d-md-inline-block" style="background-image: url({{ event.client.email|gravatar }}&size=24)"></span>
                 </a>
             </td>
             <td>

--- a/src/modules/Email/html_admin/mod_email_history.html.twig
+++ b/src/modules/Email/html_admin/mod_email_history.html.twig
@@ -16,7 +16,7 @@
         </div>
     {% endif %}
 
-<div class="card">
+<div class="card overflow-auto">
     <div class="card-body">
         <h3>{{ 'Email history'|trans }}</h3>
     </div>

--- a/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_invoice.html.twig
@@ -626,7 +626,7 @@
 
     {% set transactions = admin.invoice_transaction_get_list({ 'invoice_id': invoice.id, 'per_page': 100 }).list %}
     {% if transactions|length > 0 %}
-    <div class="card">
+    <div class="card overflow-auto">
         <div class="card-body">
             <h5>{{ 'Transactions'|trans }}</h5>
         </div>

--- a/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscription.html.twig
@@ -35,13 +35,13 @@
     <div class="card">
         <div class="tab-content">
             <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
-                <div class="card-body">
+                <div class="card-body overflow-auto">
                     <h3>{{ 'Subscription details'|trans }}</h3>
 
                     <table class="table card-table table-vcenter table-striped text-nowrap">
                         <tbody>
                             <tr>
-                                <td class="w-50 text-end">{{ 'Client'|trans }}:</td>
+                                <td class="text-end">{{ 'Client'|trans }}:</td>
                                 <td>
                                     <a href="{{ 'client/manage'|alink }}/{{ subscription.client.id }}">{{ subscription.client.first_name }} {{ subscription.client.last_name }}</a>
                                 </td>
@@ -55,7 +55,8 @@
                                 <td>{{ subscription.gateway.title }}</td>
                             </tr>
                             <tr>
-                                <td class="text-end">{{ 'Subscription ID on payment gateway'|trans }}:</td>
+                                <td class="text-end d-none d-sm-table-cell">{{ 'Subscription ID on payment gateway'|trans }}:</td>
+                                <td class="text-end d-sm-none">{{ 'Subscription ID on PG'|trans }}:</td>
                                 <td>{{ subscription.sid|default('-') }}</td>
                             </tr>
                             <tr>
@@ -92,7 +93,7 @@
                         <svg class="icon icon-tabler" width="24" height="24">
                             <use xlink:href="#delete" />
                         </svg>
-                        <span class="d-block text-secondary">{{ 'Delete'|trans }}</span>
+                        <span>{{ 'Delete'|trans }}</span>
                     </a>
                 </div>
             </div>

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -66,7 +66,7 @@
 
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-info" role="tabpanel">
-            <div class="card-body">
+            <div class="card-body overflow-auto">
                 <h3>{{ order.title }}</h3>
 
                 <table class="table card-table table-vcenter table-striped text-nowrap">
@@ -506,7 +506,7 @@
             {% endif %}
         </div>
 
-        <div class="tab-pane fade" id="tab-invoices" role="tabpanel">
+        <div class="tab-pane fade overflow-auto" id="tab-invoices" role="tabpanel">
             <div class="help">
                 <h3>{{ 'Order invoices'|trans }}</h3>
             </div>

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_manage.html.twig
@@ -2,27 +2,27 @@
 
 {% set service = admin.order_service({ "id": order.id }) %}
 
-<div class="card-body">
+<div class="card-body overflow-auto">
     <h3>{{ 'Details'|trans }}</h3>
+    <table class="table card-table table-vcenter table-striped text-nowrap">
+        <tbody>
+            <tr>
+                <td class="text-end">{{ 'Key'|trans }}:</td>
+                <td>{{ service.license_key }}</td>
+            </tr>
+            <tr>
+                <td class="text-end">{{ 'Plugin'|trans }}:</td>
+                <td>
+                    {{ service.plugin }}
+                </td>
+            </tr>
+            <tr>
+                <td class="text-end">{{ 'Last ping'|trans }}:</td>
+                <td>{{ service.pinged_at|format_date }} ({{ service.pinged_at|timeago }} ago)</td>
+            </tr>
+        </tbody>
+    </table>
 </div>
-<table class="table card-table table-vcenter table-striped text-nowrap">
-    <tbody>
-        <tr>
-            <td class="text-end">{{ 'Key'|trans }}:</td>
-            <td>{{ service.license_key }}</td>
-        </tr>
-        <tr>
-            <td class="text-end">{{ 'Plugin'|trans }}:</td>
-            <td>
-                {{ service.plugin }}
-            </td>
-        </tr>
-        <tr>
-            <td class="text-end">{{ 'Last ping'|trans }}:</td>
-            <td>{{ service.pinged_at|format_date }} ({{ service.pinged_at|timeago }} ago)</td>
-        </tr>
-    </tbody>
-</table>
 
 <div class="card-footer text-center">
     {{ order_actions }}

--- a/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
@@ -7,7 +7,7 @@
 {% set active_menu = 'activity' %}
 
 {% block content %}
-<div class="card">
+<div class="card overflow-auto">
     <div class="card-body">
         <h5>{{ 'Staff members logins history'|trans }}</h5>
     </div>
@@ -37,7 +37,7 @@
             </td>
             <td>
                 <a href="{{ 'staff/manage'|alink }}/{{ event.staff.id }}">
-                    <span class="avatar avatar-xs" style="background-image: url({{ event.staff.email|gravatar }}&size=24)"></span>
+                    <span class="avatar avatar-xs d-none d-md-inline-block" style="background-image: url({{ event.staff.email|gravatar }}&size=24)"></span>
                 </a>
             </td>
             <td>


### PR DESCRIPTION
Just some minor fixes and improvements to the `admin_default` theme. Mostly focused at the overflow issue on small screens.
I also fixed an issue where the extensions class wasn't using the params passed to `_request` function.
This fixes instances where pages like this were showing all types of extensions, and once we provide a way to call the [update function](https://github.com/FOSSBilling/FOSSBilling/blob/main/src/modules/Extension/Service.php#L324) I believe the change will also allow for that to work as well.
![image](https://user-images.githubusercontent.com/17304943/230540283-678474db-f214-4c25-99b7-94ce1ba6faf5.png)
