### PR TITLE
Various improvements to translatable strings

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -42,7 +42,7 @@ if (!is_null($http_err_code)) {
             break;
         default:
             http_response_code($http_err_code);
-            $e = new Box_Exception('HTTP Error :err_code occured attempting to load :url', [':err_code' => $http_err_code, ':url' => $url], $http_err_code);
+            $e = new Box_Exception('HTTP Error :err_code occured while attempting to load :url', [':err_code' => $http_err_code, ':url' => $url], $http_err_code);
             echo $app->render('error', ['exception' => $e]);
     }
     exit;

--- a/src/library/Box/Crypt.php
+++ b/src/library/Box/Crypt.php
@@ -22,7 +22,7 @@ class Box_Crypt implements \Box\InjectionAwareInterface
     public function __construct()
     {
         if (!extension_loaded('openssl')) {
-            throw new Box_Exception('php openssl extension must be enabled on your server');
+            throw new Box_Exception('The PHP openssl extension must be enabled on your server');
         }
     }
 

--- a/src/library/Box/Extension.php
+++ b/src/library/Box/Extension.php
@@ -94,7 +94,7 @@
             $json = $response->toArray();
 
             if(is_null($json)) {
-                throw new \Box_Exception('Unable to connect to FOSSBilling extensions site.', null, 1545);
+                throw new \Box_Exception('Unable to connect to FOSSBilling extension directory.', null, 1545);
             }
 
             if(isset($json['error']) && is_array($json['error'])) {

--- a/src/library/Box/Period.php
+++ b/src/library/Box/Period.php
@@ -173,7 +173,7 @@ class Box_Period
                 $qty = $this->qty * 12;
                 break;
             default:
-                throw new \Box_Exception('Can not determine months amount from unit');
+                throw new \Box_Exception('Unable to get the number of months for :unit',[':unit' => $this->unit]);
         }
 
         return $qty;

--- a/src/library/Box/Validate.php
+++ b/src/library/Box/Validate.php
@@ -56,7 +56,7 @@ class Box_Validate
     {
         $valid = (filter_var(idn_to_ascii($email), FILTER_VALIDATE_EMAIL)) ? true : false;
         if(!$valid && $throw) {
-            throw new \Box_Exception('Email is not valid');
+            throw new \Box_Exception('Email is invalid');
         }
         return $valid;
     }
@@ -119,7 +119,7 @@ class Box_Validate
     public function isBirthdayValid($birthday = '')
     {
         if (strlen(trim($birthday)) > 0 && strtotime($birthday) === false) {
-            throw new \Box_Exception('Invalid birth date value');
+            throw new \Box_Exception('Birthdate is invalid');
         }
         return true;
     }

--- a/src/library/Box/Zip.php
+++ b/src/library/Box/Zip.php
@@ -40,7 +40,8 @@ class Box_Zip
             }
             catch(\PhpZip\Exception\ZipException $e){
                 $zip->close();
-                throw new \Box_Exception('Failed to extract file! Exception:<br>' . $e);
+                error_log($e->getMessage());
+                throw new \Box_Exception('Failed to extract file, please check file and folder permissions. Further details are available in the error log.');
             }
         }
     }

--- a/src/library/Model/ProductTable.php
+++ b/src/library/Model/ProductTable.php
@@ -115,7 +115,7 @@ class Model_ProductTable implements \Box\InjectionAwareInterface
             return $price;
         }
 
-        throw new \Box_Exception('Unknown Period selected for setup price');
+        throw new \Box_Exception('Unknown period selected for setup price');
     }
 
     /**

--- a/src/library/Payment/Adapter/AliPay.php
+++ b/src/library/Payment/Adapter/AliPay.php
@@ -17,15 +17,15 @@ class Payment_Adapter_AliPay extends Payment_AdapterAbstract
     public function init()
     {
         if(!$this->getParam('partner')) {
-            throw new Payment_Exception('Payment gateway "AliPay" is not configured properly. Please update configuration parameter "Partner ID" at "Configuration -> Payment gateways".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'AliPay', ':missing' => 'Partner ID']);
         }
 
         if (!$this->getParam('security_code')) {
-        	throw new Payment_Exception('Payment gateway "AliPay" is not configured properly. Please update configuration parameter "Security Code" at "Configuration -> Payment gateways".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'AliPay', ':missing' => 'Security Code']);
         }
 
         if (!$this->getParam('seller_email')) {
-        	throw new Payment_Exception('Payment gateway "AliPay" is not configured properly. Please update configuration parameter "Seller email" at "Configuration -> Payment gateways".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'AliPay', ':missing' => 'Seller Email']);
         }
 
         $this->_config['charset']       = 'utf-8';

--- a/src/library/Payment/Adapter/ClientBalance.php
+++ b/src/library/Payment/Adapter/ClientBalance.php
@@ -65,7 +65,7 @@ class Payment_Adapter_ClientBalance implements \Box\InjectionAwareInterface
 
         $invoiceService = $this->di['mod_service']('Invoice');
         if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
-            return __trans('Forbidden to pay deposit invoice with this gateway');
+            return __trans('It is forbidden to pay a deposit invoice with this gateway');
         }
 
         $ipnUrl = $this->getServiceUrl($invoice_id);
@@ -94,7 +94,7 @@ class Payment_Adapter_ClientBalance implements \Box\InjectionAwareInterface
 
         $invoiceService = $this->di['mod_service']('Invoice');
         if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
-            throw new Payment_Exception('Forbidden to pay deposit invoice with this gateway', array(), 303);
+            throw new Payment_Exception('It is forbidden to pay a deposit invoice with this gateway', array(), 303);
         }
 
         if($invoice_id) {
@@ -128,7 +128,7 @@ class Payment_Adapter_ClientBalance implements \Box\InjectionAwareInterface
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
         $invoiceService = $this->di['mod_service']('Invoice');
         if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
-            throw new Payment_Exception('Forbidden to pay deposit invoice with this gateway', null, 302);
+            throw new Payment_Exception('It is forbidden to pay a deposit invoice with this gateway', null, 302);
         }
 
         $gatewayService = $this->di['mod_service']('Invoice', 'PayGateway');

--- a/src/library/Payment/Adapter/Interkassa.php
+++ b/src/library/Payment/Adapter/Interkassa.php
@@ -38,10 +38,10 @@ class Payment_Adapter_Interkassa extends Payment_AdapterAbstract implements \Box
     public function init()
     {
         if(!$this->getParam('ik_co_id')) {
-            throw new Payment_Exception('Shop ID is missing in gateway configuration');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Interkassa', ':missing' => 'Shop ID']);
         }
         if(!$this->getParam('ik_secret_key')) {
-            throw new Payment_Exception('Secret key is missing in gateway configuration');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Interkassa', ':missing' => 'Secret key']);
         }
     }
 
@@ -227,7 +227,7 @@ class Payment_Adapter_Interkassa extends Payment_AdapterAbstract implements \Box
             );
 
             if ($this->isIpnDuplicate($ipn)){
-                throw new Payment_Exception('IPN is duplicate');
+                throw new Payment_Exception('Cannot process duplicate IPN');
             }
 
             $clientService = $this->di['mod_service']('Client');

--- a/src/library/Payment/Adapter/Onebip.php
+++ b/src/library/Payment/Adapter/Onebip.php
@@ -114,7 +114,7 @@ class Payment_Adapter_Onebip extends Payment_AdapterAbstract
      */
     public function recurrentPayment(Payment_Invoice $invoice)
     {
-        throw new Payment_Exception('Not implemented yet');
+        throw new Payment_Exception('This feature is unimplemented');
     }
 
     public function isIpnValid($data, Payment_Invoice $invoice)

--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -34,12 +34,8 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \Bo
     {
         $this->config = $config;
 
-        if(!function_exists('curl_exec')) {
-            throw new Payment_Exception('PHP Curl extension must be enabled in order to use PayPal gateway');
-        }
-
         if(!isset($this->config['email'])) {
-            throw new Payment_Exception('Payment gateway "PayPal" is not configured properly. Please update configuration parameter "PayPal Email address" at "Configuration -> Payments".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'PayPal', ':missing' => 'PayPal Email address']);
         }
     }
 
@@ -130,7 +126,7 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \Bo
                         'rel_id'        =>  $ipn['txn_id'],
                     );
                     if ($this->isIpnDuplicate($ipn)){
-                        throw new Payment_Exception('IPN is duplicate');
+                        throw new Payment_Exception('Cannot process duplicate IPN');
                     }
                     $api_admin->client_balance_add_funds($bd);
                     if($tx['invoice_id']) {

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -36,11 +36,11 @@ class Payment_Adapter_Stripe implements \Box\InjectionAwareInterface
         $this->config = $config;
 
         if (!isset($this->config['api_key'])) {
-            throw new Payment_Exception('Payment gateway "Stripe" is not configured properly. Please update configuration parameter "api_key" at "Configuration -> Payments".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'API key']);
         }
 
         if (!isset($this->config['pub_key'])) {
-            throw new Payment_Exception('Payment gateway "Stripe" is not configured properly. Please update configuration parameter "pub_key" at "Configuration -> Payments".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'Publishable key']);
         }
 
         $api_key = $this->config['test_mode'] ? $this->get_test_api_key() : $this->config['api_key'];

--- a/src/library/Payment/Adapter/TwoCheckout.php
+++ b/src/library/Payment/Adapter/TwoCheckout.php
@@ -31,11 +31,11 @@ class Payment_Adapter_TwoCheckout implements \Box\InjectionAwareInterface
     public function __construct($config)
     {
         if(!$config['vendor_nr']) {
-            throw new Payment_Exception('Payment gateway "2Checkout" is not configured properly. Please update configuration parameter "Vendor account number" at "Configuration -> Payments".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => '2Checkout', ':missing' => 'Vendor account number']);
         }
 
         if(!$config['secret']) {
-            throw new Payment_Exception('Payment gateway "2Checkout" is not configured properly. Please update configuration parameter "Secret word" at "Configuration -> Payments".');
+            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => '2Checkout', ':missing' => 'Secret word']);
         }
 
         $this->config = $config;
@@ -172,7 +172,7 @@ class Payment_Adapter_TwoCheckout implements \Box\InjectionAwareInterface
             );
 
             if ($this->isIpnDuplicate($ipn)){
-                throw new Payment_Exception('IPN is duplicate');
+                throw new Payment_Exception('Cannot process duplicate IPN');
             }
 
             $api_admin->client_balance_add_funds($bd);

--- a/src/library/Payment/Adapter/WebMoney.php
+++ b/src/library/Payment/Adapter/WebMoney.php
@@ -53,7 +53,7 @@ class Payment_Adapter_WebMoney implements \Box\InjectionAwareInterface
 		$this->testMode = (isset($config['test_mode']) && $config['test_mode']) ? true : false;
 
         if(!$this->config['purse']) {
-            throw new Payment_Exception('Payment gateway "WebMoney" is not configured properly. Please update configuration parameter "Purse" at "Configuration -> Payment gateways > WebMoney".');
+			throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'WebMoney', ':missing' => 'Purse']);
         }
     }
 
@@ -146,7 +146,7 @@ class Payment_Adapter_WebMoney implements \Box\InjectionAwareInterface
 		$clientService = $this->di['mod_service']('client');
 
         if ($this->isIpnDuplicate($ipn)){
-            throw new Payment_Exception('IPN is duplicate');
+            throw new Payment_Exception('Cannot process duplicate IPN');
         }
 		$clientService->addFunds($client, $bd['amount'], $bd['description'], $bd);
 

--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -24,7 +24,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
             $this->config['email'] = $options['email'];
             unset($options['email']);
         } else {
-            throw new Registrar_Exception('Email Registrar config requires param "email"');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Email', ':missing' => 'email']);
         }
 
         if(isset($options['use_whois'])) {

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -15,14 +15,14 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
             $this->config['apikey'] = $options['apikey'];
             unset($options['apikey']);
         } else {
-            throw new Registrar_Exception('Domain registrar "Internetbs" is not configured properly. Please update configuration parameter "Internetbs API key" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Internetbs', ':missing' => 'Internetbs API key']);
         }
 
         if(isset($options['password']) && !empty($options['password'])) {
             $this->config['password'] = $options['password'];
             unset($options['password']);
         } else {
-            throw new Registrar_Exception('Domain registrar "Internetbs" is not configured properly. Please update configuration parameter "Internetbs API password" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Internetbs', ':missing' => 'Internetbs API password']);
         }
     }
 

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -26,13 +26,13 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
         if (isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
         } else {
-            throw new Registrar_Exception('Domain registrar "Namecheap" is not configured properly. Please update configuration parameter "API Key" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Namecheap', ':missing' => 'API Key']);
         }
 
         if (isset($options['username']) && !empty($options['username'])) {
             $this->config['username'] = $options['username'];
         } else {
-            throw new Registrar_Exception('Domain registrar "Namecheap" is not configured properly. Please update configuration parameter "Username" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Namecheap', ':missing' => 'Username']);
         }
 
         if (!isset($options['api-user-id']) || empty(trim($options['api-user-id']))) {
@@ -42,7 +42,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
         if (isset($options['ip']) && !empty($options['ip'])) {
             $this->config['ip'] = $options['ip'];
         } else {
-            throw new Registrar_Exception('Domain registrar "Namecheap" is not configured properly. Please update configuration parameter "Server IP Address" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Namecheap', ':missing' => 'server IP address']);
         }
     }
 
@@ -244,7 +244,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
         // problem here: FOSSBilling doesn't display our error and will display 'nameservers updates' evern when this fails
 
         if (!isset($result->CommandResponse->DomainDNSSetCustomResult['Updated']) && $result->CommandResponse->DomainDNSSetCustomResult['Updated'] != 'true') {
-            throw new Registrar_Exception($message = 'Could not update NameServers');
+            throw new Registrar_Exception($message = 'Could not update name servers');
         }
         return True;
     }

--- a/src/library/Registrar/Adapter/Netearthone.php
+++ b/src/library/Registrar/Adapter/Netearthone.php
@@ -8,14 +8,14 @@ class Registrar_Adapter_Netearthone extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne Reseller ID" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'NetEarthOne', ':missing' => 'NetEarthOne Reseller ID']);
         }
 
         if(isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne API Key" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'NetEarthOne', ':missing' => 'NetEarthOne API Key']);
         }
     }
 

--- a/src/library/Registrar/Adapter/Resellbiz.php
+++ b/src/library/Registrar/Adapter/Resellbiz.php
@@ -8,14 +8,14 @@ class Registrar_Adapter_Resellbiz extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "Resell.biz" is not configured properly. Please update configuration parameter "Resell.biz Reseller ID" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Resell.biz', ':missing' => 'Resell.biz Reseller ID']);
         }
 
         if(isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "Resell.biz" is not configured properly. Please update configuration parameter "Resell.biz API Key" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Resell.biz', ':missing' => 'Resell.biz API Key']);
         }
     }
 

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -834,7 +834,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
         if($tld == '.es') {
             if(strlen(trim($client->getDocumentNr())) == 0 ) {
-                throw new Registrar_Exception('Valid contact Passport information is required while registering ES domain name');
+                throw new Registrar_Exception('Valid contact passport information is required while registering ES domain name');
             }
 
             //@see http://manage.directi.com/kb/answer/790
@@ -854,7 +854,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
         if($tld == '.asia') {
             if(strlen(trim($client->getDocumentNr())) == 0 ) {
-                throw new Registrar_Exception('Valid contact Passport information is required while registering ASIA domain name');
+                throw new Registrar_Exception('Valid contact passport information is required while registering ASIA domain name');
             }
 
             $contact['attr-name1'] =   'locality';
@@ -878,11 +878,11 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
         if($tld == '.ru' || $tld == '.com.ru' || $tld == '.org.ru' || $tld == '.net.ru') {
             if(strlen(trim($client->getBirthday())) === 0 || strtotime($client->getBirthday()) === false) {
-                throw new Registrar_Exception('Valid contact Birth Date is required while registering RU domain name');
+                throw new Registrar_Exception('Valid contact birth date is required while registering RU domain name');
             }
 
             if(strlen(trim($client->getDocumentNr())) === 0 ) {
-                throw new Registrar_Exception('Valid contact Passport information is required while registering RU domain name');
+                throw new Registrar_Exception('Valid contact passport information is required while registering RU domain name');
             }
 
             if(str_word_count($contact['company']) < 2) {

--- a/src/library/Registrar/Adapter/Resellerid.php
+++ b/src/library/Registrar/Adapter/Resellerid.php
@@ -8,14 +8,14 @@ class Registrar_Adapter_Resellerid extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID Reseller ID" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'ResellerID', ':missing' => 'ResellerID Reseller ID']);
         }
 
         if(isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID API Key" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'ResellerID', ':missing' => 'ResellerID API Key']);
         }
     }
 

--- a/src/library/Server/Manager/CWP.php
+++ b/src/library/Server/Manager/CWP.php
@@ -22,15 +22,15 @@ class Server_Manager_CWP extends Server_Manager
 	public function init()
 	{
 		if (empty($this->_config['ip'])) {
-			throw new Server_Exception('Server manager "CWP" is not configured properly. IP address is not set!');
+			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'IP address']);
 		}
 
 		if (empty($this->_config['host'])) {
-			throw new Server_Exception('Server manager "CWP" is not configured properly. Hostname is not set!');
+			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'Hostname']);
 		}
 
 		if (empty($this->_config['accesshash'])) {
-			throw new Server_Exception('Server manager "CWP" is not configured properly. API Key / Access Hash is not set!');
+			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'API Key / Access Hash']);
 		} else {
 			$this->_config['accesshash'] = preg_replace("'(\r|\n)'", "", $this->_config['accesshash']);
 		}

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -19,15 +19,15 @@ class Server_Manager_Directadmin extends Server_Manager
     public function init()
     {
         if(empty($this->_config['host'])) {
-            throw new Server_Exception('Server manager "DirectAdmin" is not configured properly. Hostname is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'hostname']);
         }
         
         if(empty($this->_config['username'])) {
-            throw new Server_Exception('Server manager "DirectAdmin" is not configured properly. Username is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'username']);
         }
         
         if(empty($this->_config['password'])) {
-            throw new Server_Exception('Server manager "DirectAdmin" is not configured properly. Password is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'password']);
         }
     }
     
@@ -67,7 +67,7 @@ class Server_Manager_Directadmin extends Server_Manager
     {
         $ips = $this->getIps();
         if(empty($ips)) {
-            throw new Server_Exception('Server Manager DirectAdmin Error: "There are no IPs on DirectAdmin server"');
+            throw new Server_Exception('There are no available IPs on this server.');
         }
         $ip = $ips[array_rand($ips)];
         
@@ -172,7 +172,7 @@ class Server_Manager_Directadmin extends Server_Manager
         }
         
         if(strpos(implode('', $results), 'Error Creating User') !== false) {
-            throw new Server_Exception('Error Creating User');
+            throw new Server_Exception('Error creating user');
         }
         
         return true;

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -23,15 +23,15 @@ class Server_Manager_Whm extends Server_Manager
 	public function init()
     {
         if(empty($this->_config['host'])) {
-            throw new Server_Exception('Server manager "cPanel WHM" is not configured properly. Hostname is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'cPanel WHM', ':missing' => 'hostname']);
         }
 
         if(empty($this->_config['username'])) {
-            throw new Server_Exception('Server manager "cPanel WHM" is not configured properly. Username is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'cPanel WHM', ':missing' => 'username']);
         }
 
         if(empty($this->_config['password']) && empty($this->_config['accesshash'])) {
-            throw new Server_Exception('Server manager "cPanel WHM" is not configured properly. Authentication is not set');
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'cPanel WHM', ':missing' => 'authentication credentials']);
         }
 	}
 

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -94,7 +94,7 @@ class Service implements InjectionAwareInterface
         $qty = $data['quantity'] ?? 1;
         // check stock
         if (!$this->isStockAvailable($product, $qty)) {
-            throw new \Box_Exception("I'm afraid we are out of stock.");
+            throw new \Box_Exception("This item is currently out of stock");
         }
 
         $addons = $data['addons'] ?? [];
@@ -127,7 +127,7 @@ class Service implements InjectionAwareInterface
                         $this->di['validator']->checkRequiredParamsForArray($required, $ac);
 
                         if (!$this->isPeriodEnabledForProduct($addon, $ac['period'])) {
-                            throw new \Box_Exception('Selected billing period is not valid for addon');
+                            throw new \Box_Exception('Selected billing period is not valid for the selected addon');
                         }
                     }
                     $ac['parent_id'] = $product->id;

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -682,7 +682,7 @@ class Service implements InjectionAwareInterface
         foreach ($required as $field) {
             if (!isset($checkArr[$field]) || empty($checkArr[$field])) {
                 $name = ucwords(str_replace('_', ' ', $field));
-                throw new \Box_Exception('It is required that you provide details for field ":field"', [':field' => $name]);
+                throw new \Box_Exception('Field :field cannot be empty', [':field' => $name]);
             }
         }
     }
@@ -697,7 +697,7 @@ class Service implements InjectionAwareInterface
             if ($active && $required) {
                 if (!isset($checkArr[$cFieldName]) || empty($checkArr[$cFieldName])) {
                     $name = isset($cField['title']) && !empty($cField['title']) ? $cField['title'] : ucwords(str_replace('_', ' ', $cFieldName));
-                    throw new \Box_Exception('It is required that you provide details for field ":field"', [':field' => $name]);
+                    throw new \Box_Exception('Field :field cannot be empty', [':field' => $name]);
                 }
             }
         }

--- a/tests/integration/bb-modules/mod_cart/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_cart/Api_GuestTest.php
@@ -82,7 +82,7 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
         );
 
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('Selected billing period is not valid for addon');
+        $this->expectExceptionMessage('Selected billing period is not valid for the selected addon');
 
         $bool = $this->api_guest->cart_add_item($data);
     }

--- a/tests/integration/bb-modules/mod_invoice/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_invoice/ServiceTest.php
@@ -73,7 +73,7 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
         );
 
         $this->expectException(Payment_Exception::class);
-        $this->expectExceptionMessage('IPN is duplicate');
+        $this->expectExceptionMessage('Cannot process duplicate IPN');
 
         $newId = $service->createAndProcess($ipn);
 

--- a/tests/modules/Cart/ServiceTest.php
+++ b/tests/modules/Cart/ServiceTest.php
@@ -899,7 +899,7 @@ class ServiceTest extends \BBTestCase
         $productModel->setDi($di);
 
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage("I'm afraid we are out of stock.");
+        $this->expectExceptionMessage("This item is currently out of stock");
         $serviceMock->addItem($cartModel, $productModel, $data);
     }
 

--- a/tests/modules/Client/ServiceTest.php
+++ b/tests/modules/Client/ServiceTest.php
@@ -1223,7 +1223,7 @@ class ServiceTest extends \BBTestCase {
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('It is required that you provide details for field "Id"');
+        $this->expectExceptionMessage('Field Id cannot be empty');
         $service->checkExtraRequiredFields($data);
     }
 
@@ -1246,7 +1246,7 @@ class ServiceTest extends \BBTestCase {
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('It is required that you provide details for field "custom_field_title"');
+        $this->expectExceptionMessage('Field custom_field_title cannot be empty');
         $service->checkCustomFields($data);
 
     }


### PR DESCRIPTION
Most of these changes are just improving / fixing how things are worded.

The more noteworthy change is that I've changed the initialization / construct exceptions for payment gateways. server managers, and domain registrars.
They now use a standardized message with two placeholders so that translators don't need to translate a unique message for each one. Before they'd have to do different translations for every payment gateways. server managers, or domain registrars PLUS additional strings for each parameter they required.

Now there should only be 3 unique strings for that style of exception. 