### PR TITLE
Automatically select locale based on browser info

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -309,7 +309,7 @@ $di['twig'] = $di->factory(function () use ($di) {
 
     // Get internationalisation settings from config, or use sensible defaults for
     // missing required settings.
-    $locale = $_COOKIE['BBLANG'] ?? $config['i18n']['locale'] ?? 'en_US';
+    $locale = \FOSSBilling_i18n::getActiveLocale();
     $timezone = $config['i18n']['timezone'] ?? 'UTC';
     $date_format = !empty($config['i18n']['date_format']) ? strtoupper($config['i18n']['date_format']) : 'MEDIUM';
     $time_format = !empty($config['i18n']['time_format']) ? strtoupper($config['i18n']['time_format']) : 'SHORT';
@@ -338,7 +338,7 @@ $di['twig'] = $di->factory(function () use ($di) {
 
     try {
         $dateFormatter = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
-    } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodArgumentValueNotImplementedException $e) {
+    } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodArgumentValueNotImplementedException) {
         if (($config['i18n']['locale'] ?? 'en_US') == 'en_US') {
             $dateFormatter = new \IntlDateFormatter('en', constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
         } else {
@@ -750,8 +750,7 @@ $di['translate'] = $di->protect(function ($textDomain = '') use ($di) {
         $tr->setDomain($textDomain);
     }
 
-    $cookieBBlang = $di['cookie']->get('BBLANG');
-    $locale = !empty($cookieBBlang) ? $cookieBBlang : ($di['config']['i18n']['locale'] ?? 'en_US');
+    $locale = \FOSSBilling_i18n::getActiveLocale();
 
     $tr->setDi($di);
     $tr->setLocale($locale);

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -51,7 +51,22 @@ class FOSSBilling_i18n
             $detectedLocale = '';
         }
 
-        return Locale::lookup(self::getLocales(), $detectedLocale, false, null);
+        $matchingLocale = Locale::lookup(self::getLocales(), $detectedLocale, false, null);
+
+        /* The system was unable to match the browser locale to one of our local ones.
+         * This is most likely because Locale::lookup will not match en with en_US. It will only match en_US with en.
+         * As a workaround, let's see if one of the available locales starts with the detected locale.
+         * If it does, return that.
+         */
+        if (empty($matchingLocale)) {
+            foreach (self::getLocales() as $locale) {
+                if (str_starts_with($locale, $detectedLocale)) {
+                    return $locale;
+                }
+            }
+        }
+
+        return $matchingLocale;
     }
 
     /**

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * FOSSBilling
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This file may contain code previously used in the BoxBilling project.
+ * Copyright BoxBilling, Inc 2011-2021
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+class FOSSBilling_i18n
+{
+    /**
+     * Attempts to get the correct locale for the current user, or a suitable fallback option if it's unavailable.
+     *
+     * @return string The locale code to use for the system.
+     */
+    public static function getActiveLocale(): string
+    {
+        $config = include PATH_ROOT . '/config.php';
+
+        /* We check in a few different spots for the active locale:
+         * First: The BBLANG locale which will be defined after the end-user changes their locale
+         * Then: If they haven't manually chosen one, we try to detect the browser locale
+         * Next: if that didn't work, try to use the locale in the config file
+         * Finally: As a last resort, default to en_US for the locale
+         */
+        return $_COOKIE['BBLANG'] ?? self::getBrowserLocale() ?? $config['i18n']['locale'] ?? 'en_US';
+    }
+
+    /**
+     * Retrieves the user's preferred language/locale based on the browser's Accept-Language header.
+     *
+     * @return string|null The user's preferred language/locale or null if not found.
+     */
+    private static function getBrowserLocale(): ?string
+    {
+        try {
+            $detectedLocale = @Locale::acceptFromHttp($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+            $detectedLocale = @Locale::canonicalize($detectedLocale . '.utf8');
+        } catch (Exception) {
+            $detectedLocale = '';
+        }
+
+        if (empty($detectedLocale) || !$detectedLocale) {
+            $detectedLocale = '';
+        }
+
+        return Locale::lookup(self::getLocales(), $detectedLocale, false, null);
+    }
+
+    /**
+     * Retrieve a list of available locales, optionally including their details.
+     *
+     * @param bool $includeLocaleDetails (optional) Whether to include locale details or not. Defaults to false.
+     *
+     * @return array An array of locales, sorted alphabetically. If `$includeLocaleDetails` is true, the array will contain
+     *               subarrays with the following keys: `locale` (string), `title` (string), `name` (string).
+     *               If `$includeLocaleDetails` is false, the array will only contain the locale codes (strings).
+     */
+    public static function getLocales($includeLocaleDetails  = false): array
+    {
+        $locales = array_filter(glob(PATH_LANGS . DIRECTORY_SEPARATOR . '*'), 'is_dir');
+        $locales = array_map('basename', $locales); // get only the directory name
+        sort($locales);
+        if (!$includeLocaleDetails) {
+            return $locales;
+        }
+        $details = [];
+        $array = include PATH_LANGS . DIRECTORY_SEPARATOR . 'locales.php';
+        foreach ($locales as $locale) {
+            $title = ($array[$locale] ?? $locale) . "($locale)";
+            $details[] = [
+                'locale' => $locale,
+                'title' => $title,
+                'name' => $array[$locale] ?? $locale,
+            ];
+        }
+        return $details;
+    }
+}

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -78,9 +78,7 @@ class Admin extends \Api_Abstract
      */
     public function languages()
     {
-        $systemService = $this->di['mod_service']('system');
-
-        return $systemService->getLanguages(true);
+        return \FOSSBilling_i18n::getLocales(true);
     }
 
     /**

--- a/src/modules/Extension/Api/Guest.php
+++ b/src/modules/Extension/Api/Guest.php
@@ -81,8 +81,6 @@ class Guest extends \Api_Abstract
      */
     public function languages($deep = false)
     {
-        $service = $this->di['mod_service']('system');
-
-        return $service->getLanguages($deep);
+        return \FOSSBilling_i18n::getLocales($deep);
     }
 }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -193,41 +193,14 @@ class Service
         ];
     }
 
+    /**
+     * @depricated Please use the \FOSSBilling_i18n::getLocales function, which provides the same functionality.
+     * @param bool $deep 
+     * @return array 
+     */
     public function getLanguages($deep = false): array
     {
-        $path = PATH_LANGS;
-        $locales = [];
-        if ($handle = opendir($path)) {
-            while (false !== ($entry = readdir($handle))) {
-                if (!str_starts_with($entry, '.') && is_dir($path . DIRECTORY_SEPARATOR . $entry)) {
-                    $locales[] = $entry;
-                }
-            }
-            closedir($handle);
-        }
-        sort($locales);
-        if (!$deep) {
-            return $locales;
-        }
-        $array = include PATH_ROOT . '/locale/locales.php';
-        $details = [];
-        foreach ($locales as $locale) {
-            if (empty($array[$locale])) {
-                //fall back on locale string
-                $details[] = [
-                    'locale' => $locale,
-                    'title' => $locale . ' (' . $locale . ')',
-                    'name' => $locale,
-                ];
-            } else {
-                $details[] = [
-                    'locale' => $locale,
-                    'title' => $array[$locale] . ' (' . $locale . ')',
-                    'name' => $array[$locale],
-                ];
-            }
-        }
-        return $details;
+        return \FOSSBilling_i18n::getLocales($deep);
     }
 
     public function getParams($data)

--- a/tests/modules/Extension/Api/AdminTest.php
+++ b/tests/modules/Extension/Api/AdminTest.php
@@ -104,17 +104,7 @@ class AdminTest extends \BBTestCase {
 
     public function testlanguages()
     {
-        $systemService = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $systemService->expects($this->atLeastOnce())
-            ->method('getLanguages')
-            ->will($this->returnValue(array()));
-
-        $di = new \Box_Di();
-        $di['mod_service'] = $di->protect(function() use ($systemService) {return $systemService;});
-
-        $this->api->setDi($di);
         $result = $this->api->languages();
-
         $this->assertIsArray($result);
     }
 

--- a/tests/modules/Extension/Api/GuestTest.php
+++ b/tests/modules/Extension/Api/GuestTest.php
@@ -111,14 +111,6 @@ class GuestTest extends \BBTestCase {
 
     public function testlanguages()
     {
-        $systemServiceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $systemServiceMock->expects($this->atLeastOnce())
-            ->method('getLanguages')
-            ->will($this->returnValue(array()));
-
-        $di = new \Box_Di();
-        $di['mod_service'] = $di->protect(function ($name) use($systemServiceMock) { return $systemServiceMock;});
-
         $this->api->setDi($di);
         $result = $this->api->languages();
         $this->assertIsArray($result);

--- a/tests/modules/System/ServiceTest.php
+++ b/tests/modules/System/ServiceTest.php
@@ -76,7 +76,8 @@ class ServiceTest extends \BBTestCase {
     public function testgetLanguages()
     {
         $result = $this->service->getLanguages(true);
-        $this->assertIsArray($result);    }
+        $this->assertIsArray($result);
+    }
 
     public function testgetParams()
     {


### PR DESCRIPTION
This PR enhances our support for i18n by automatically selecting the locale based on the browser's language and also implements some general improvements to how we internally get this info.

The locale will only be detected if the user hasn't manually selected the language, so they can always override it.
If we are unable to detect the locale or it's not one that's supported by the current installation, it then uses the config locale just as the original behavior would have