### PR TITLE
Refactor Box/Tools to remove unnecessary functions

### DIFF
--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -280,32 +280,6 @@ class Box_Tools
         return $result;
     }
 
-    /**
-     * Get either a Gravatar URL or complete image tag for a specified email address.
-     *
-     * @param string $email The email address
-     * @param string $s Size in pixels, defaults to 80px [ 1 - 2048 ]
-     * @param string $d Default imageset to use [ 404 | mp | identicon | monsterid | wavatar ]
-     * @param string $r Maximum rating (inclusive) [ g | pg | r | x ]
-     * @param boole $img True to return a complete IMG tag False for just the URL
-     * @param array $atts Optional, additional key/value attributes to include in the IMG tag
-     * @return String containing either just a URL or a complete image tag
-     * @source https://gravatar.com/site/implement/images/php/
-     */
-    public function get_gravatar($email, $size = 80, $d = 'mp', $r = 'g', $img = false, $atts = array())
-    {
-        $url = 'https://www.gravatar.com/avatar/';
-        $url .= md5(strtolower(trim($email)));
-        $url .= "?s=$size&d=$d&r=$r";
-        if ($img) {
-            $url = '<img src="' . $url . '"';
-            foreach ($atts as $key => $val)
-                $url .= ' ' . $key . '="' . $val . '"';
-            $url .= ' />';
-        }
-        return $url;
-    }
-
     public function getTable($type)
     {
         $class = 'Model_' . ucfirst($type) . 'Table';

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * FOSSBilling
  *
@@ -10,7 +9,7 @@
  * Copyright BoxBilling, Inc 2011-2021
  *
  * This source file is subject to the Apache-2.0 License that is bundled
- * with this source code in the file LICENSE
+ * with this source code in the file LICENSE.
  */
 
 class Box_Tools
@@ -54,15 +53,6 @@ class Box_Tools
                     )
                 )
             );
-        }
-    }
-
-    public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0, $useoffset = true)
-    {
-        if ($useoffset) {
-            return file_get_contents($filename, $use_include_path, $context, $offset);
-        } else {
-            return file_get_contents($filename, $use_include_path, $context);
         }
     }
 
@@ -124,15 +114,6 @@ class Box_Tools
                 $file->isDir() ?  rmdir($file->getRealPath()) : unlink($file->getRealPath());
             }
         }
-    }
-
-    /**
-     * Returns referer url
-     * @return string
-     */
-    public function getReferer($default = '/')
-    {
-        return empty($_SERVER['HTTP_REFERER']) ? $default : $_SERVER['HTTP_REFERER'];
     }
 
     /**
@@ -323,31 +304,6 @@ class Box_Tools
             $url .= ' />';
         }
         return $url;
-    }
-
-    public function fileExists($file)
-    {
-        return file_exists($file);
-    }
-
-    public function rename($old, $new)
-    {
-        return rename($old, $new);
-    }
-
-    public function unlink($file)
-    {
-        return unlink($file);
-    }
-
-    public function mkdir($destination, $perm, $recursive = false)
-    {
-        return mkdir($destination, $perm, $recursive);
-    }
-
-    public function glob($pattern, $flag = 0)
-    {
-        return glob($pattern, $flag);
     }
 
     public function getTable($type)

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -335,63 +335,6 @@ class Box_Tools
         return $result;
     }
 
-    public function updateConfig()
-    {
-        $configPath = PATH_ROOT . '/config.php';
-        $currentConfig = include $configPath;
-
-        if (!is_array($currentConfig)) {
-            throw new \Box_Exception('Unable to load existing configuration. updateConfig() is unable to progress.');
-        }
-        if (!copy($configPath, substr($configPath, 0, -4) . '.old.php')) {
-            throw new \Box_Exception('Unable to create backup of configuration file. Cancelling config migration.');
-        }
-
-        $newConfig = $currentConfig;
-
-        $newConfig['security']['mode'] ??= 'strict';
-        $newConfig['security']['force_https'] ??= true;
-        $newConfig['security']['cookie_lifespan'] ??= '7200';
-
-        $newConfig['update_branch'] ??= 'release';
-        $newConfig['log_stacktrace'] ??= true;
-        $newConfig['stacktrace_length'] ??= 25;
-
-        $newConfig['maintenance_mode']['enabled'] ??= false;
-        $newConfig['maintenance_mode']['allowed_urls'] ??= [];
-        $newConfig['maintenance_mode']['allowed_ips'] ??= [];
-
-        $newConfig['disable_auto_cron'] ??= false;
-
-        $newConfig['i18n']['locale'] = $currentConfig['locale'] ?? 'en_US';
-        $newConfig['i18n']['timezone'] = $currentConfig['timezone'] ?? 'UTC';
-        $newConfig['i18n']['date_format'] ??= 'medium';
-        $newConfig['i18n']['time_format'] ??= 'short';
-
-        $newConfig['db']['port'] ??= '3306';
-
-        $newConfig['api']['throttle_delay'] ??= 2;
-        $newConfig['api']['rate_span_login'] ??= 60;
-        $newConfig['api']['rate_limit_login'] ??= 20;
-        $newConfig['api']['CSRFPrevention'] ??= true;
-
-        // Remove depreciated config keys/subkeys.
-        $depreciatedConfigKeys = [ 'guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone' ];
-        $depreciatedConfigSubkeys = [];
-        $newConfig = array_diff_key($newConfig, array_flip($depreciatedConfigKeys));
-        foreach ($depreciatedConfigSubkeys as $key => $subkey) {
-            unset($newConfig[$key][$subkey]);
-        }
-
-        $output = '<?php ' . PHP_EOL;
-        $output .= 'return ' . var_export($newConfig, true) . ';';
-        if (file_put_contents($configPath, $output)) {
-            return true;
-        } else {
-            throw new \Box_Exception('Error when writing updated configuration file.');
-        }
-    }
-
     public function validateAndSanitizeEmail($email, $throw = true)
     {
         $email = htmlspecialchars($email);

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -223,7 +223,10 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_gravatar_filter($email, $size = 20)
     {
-        return (new Box_Tools())->get_gravatar($email, $size);
+        $url = 'https://www.gravatar.com/avatar/';
+        $url .= md5(strtolower(trim($email)));
+        $url .= "?s=$size&d=mp&r=g";
+        return $url;
     }
 
     public function twig_autolink_filter($text)

--- a/src/library/Box/Update.php
+++ b/src/library/Box/Update.php
@@ -167,7 +167,7 @@ class Box_Update
         $latest_version_archive = PATH_CACHE.DIRECTORY_SEPARATOR.$latest_version.'.zip';
 
         // download latest archive from link
-        $content = $this->di['tools']->file_get_contents($this->getLatestVersionDownloadLink(), false, null, null, false);
+        $content = file_get_contents($this->getLatestVersionDownloadLink(), false, null, null, false);
         $f = fopen($latest_version_archive,'wb');
         fwrite($f,$content,strlen($content));
         fclose($f);
@@ -180,7 +180,7 @@ class Box_Update
 
         if(file_exists(PATH_ROOT.'/foss-update.php')) {
             error_log('Calling foss-update.php script from auto-updater');
-            $this->di['tools']->file_get_contents(BB_URL.'foss-update.php');
+            file_get_contents(BB_URL.'foss-update.php');
         }
 
         // Migrate the configuration file

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -938,9 +938,8 @@ class Service implements InjectionAwareInterface
     {
         if (isset($config['filename'])) {
             $f = $this->getSavePath($config['filename']);
-            if ($this->di['tools']->fileExists($f)) {
-                $this->di['tools']->unlink($f);
-
+            if (file_exists($f)) {
+                unlink($f);
                 return true;
             }
         }

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -263,7 +263,7 @@ class Service implements InjectionAwareInterface
         $info = $this->toApiArray($serviceDownloadable);
         $filename = $info['filename'];
         $path = $info['path'];
-        if (!$this->di['tools']->fileExists($path)) {
+        if (!file_exists($path)) {
             throw new \Box_Exception('File can not be downloaded at the moment. Please contact support', null, 404);
         }
         $this->hitDownload($serviceDownloadable);

--- a/src/modules/Spamchecker/Service.php
+++ b/src/modules/Spamchecker/Service.php
@@ -133,7 +133,7 @@ class Service implements InjectionAwareInterface
     {
         $data['f'] = 'json';
         $url = 'https://www.stopforumspam.com/api?' . http_build_query($data);
-        $file_contents = $this->di['tools']->file_get_contents($url);
+        $file_contents = file_get_contents($url);
 
         $json = json_decode($file_contents);
         if (!is_object($json) || isset($json->success) && !$json->success) {

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -195,8 +195,8 @@ class Service
 
     /**
      * @depricated Please use the \FOSSBilling_i18n::getLocales function, which provides the same functionality.
-     * @param bool $deep 
-     * @return array 
+     * @param bool $deep
+     * @return array
      */
     public function getLanguages($deep = false): array
     {
@@ -264,7 +264,7 @@ class Service
         }
 
         $install = PATH_ROOT . '/install';
-        if ($this->di['tools']->fileExists(PATH_ROOT . '/install')) {
+        if (file_exists(PATH_ROOT . '/install')) {
             $msgs['danger'][] = sprintf('Install module "%s" still exists. Please remove it for security reasons.', $install);
         }
 
@@ -289,7 +289,7 @@ class Service
         $themeService = $this->di['mod_service']('theme');
         $theme = $themeService->getThemeConfig($client);
         foreach ($theme['paths'] as $path) {
-            if ($this->di['tools']->fileExists($path . DIRECTORY_SEPARATOR . $file)) {
+            if (file_exists($path . DIRECTORY_SEPARATOR . $file)) {
                 return true;
             }
         }

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -234,8 +234,8 @@ class Service implements InjectionAwareInterface
     {
         $assets = $theme->getPathAssets() . DIRECTORY_SEPARATOR;
 
-        $css_files = $this->di['tools']->glob($assets . '*.css.html.twig');
-        $js_files = $this->di['tools']->glob($assets . '*.js.html.twig');
+        $css_files = glob($assets . '*.css.html.twig');
+        $js_files = glob($assets . '*.js.html.twig');
         $files = array_merge($css_files, $js_files);
 
         foreach ($files as $file) {
@@ -245,7 +245,7 @@ class Service implements InjectionAwareInterface
             $vars = [];
 
             $vars['settings'] = $settings;
-            $vars['_tpl'] = $this->di['tools']->file_get_contents($file);
+            $vars['_tpl'] = file_get_contents($file);
             $systemService = $this->di['mod_service']('system');
             $data = $systemService->renderString($vars['_tpl'], false, $vars);
 

--- a/src/themes/huraga/assets/css/font-awesome.css
+++ b/src/themes/huraga/assets/css/font-awesome.css
@@ -37,7 +37,7 @@
     text-decoration: inherit;
     -webkit-font-smoothing: antialiased;
     /* sprites.less reset */
-  
+
     display: inline;
     width: auto;
     height: auto;
@@ -86,7 +86,7 @@
   .nav [class*=" awe-"] {
     display: inline;
     /* keeps button heights with and without icons the same */
-  
+
   }
   .btn [class^="awe-"].awe-large,
   .nav [class^="awe-"].awe-large,
@@ -105,7 +105,7 @@
   .nav-tabs [class*=" awe-"],
   .nav-pills [class*=" awe-"] {
     /* keeps button heights with and without icons the same */
-  
+
   }
   .nav-tabs [class^="awe-"],
   .nav-pills [class^="awe-"],
@@ -130,7 +130,7 @@
   li [class*=" awe-"].awe-large,
   .nav li [class*=" awe-"].awe-large {
     /* increased font size for awe-large */
-  
+
     width: 1.5625em;
   }
   ul.icons {

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -621,11 +621,11 @@ class ServiceTest extends \BBTestCase {
             ->will($this->returnValue(array('download_url' => 'www.fossbilling.com')));
 
         $httpClientMock = new MockHttpClient();
-        
+
         $di = new \Box_Di();
         $di['extension'] = $extensionMock;
         $di['http_client'] = $httpClientMock;
-        
+
         $this->service->setDi($di);
         $this->expectException(\Box_Exception::class);
         $this->expectExceptionMessage('Extension type (notDefinedType) cannot be automatically installed.');

--- a/tests/modules/Product/ServiceTest.php
+++ b/tests/modules/Product/ServiceTest.php
@@ -1074,46 +1074,6 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testremoveOldFile()
-    {
-        $config = array('filename' => 'test.cfg');
-
-        $toolMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(true));
-        $toolMock->expects($this->atLeastOnce())
-            ->method('unlink');
-
-        $di           = new \Box_Di();
-        $di['tools']  = $toolMock;
-        $di['config'] = array('path_data' => '/home');
-
-        $this->service->setDi($di);
-        $result = $this->service->removeOldFile($config);
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
-    public function testremoveOldFileFileNotFound()
-    {
-        $config = array('filename' => 'test.cfg');
-
-        $toolMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(false));
-
-        $di           = new \Box_Di();
-        $di['tools']  = $toolMock;
-        $di['config'] = array('path_data' => '/home');
-
-        $this->service->setDi($di);
-        $result = $this->service->removeOldFile($config);
-        $this->assertIsBool($result);
-        $this->assertFalse($result);
-    }
-
     public function testcanUpgradeTo_returnsTrue()
     {
         $serviceMock = $this->getMockBuilder('\Box\Mod\Product\Service')
@@ -1210,4 +1170,3 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals((double) $amount, $result);
     }
 }
- 

--- a/tests/modules/Servicecustom/ServiceTest.php
+++ b/tests/modules/Servicecustom/ServiceTest.php
@@ -128,7 +128,7 @@ class ServiceTest extends \BBTestCase
         $data    = array(
             'field_name' => 'field_name'
         );
-        
+
         $this->expectException(\Exception::class);
         $result  = $this->service->validateCustomForm($data, $product);
         $this->assertNull($result);
@@ -599,4 +599,3 @@ class ServiceTest extends \BBTestCase
         $serviceMock->updateConfig(rand(1, 100), $config);
     }
 }
- 

--- a/tests/modules/Servicedownloadable/ServiceTest.php
+++ b/tests/modules/Servicedownloadable/ServiceTest.php
@@ -273,42 +273,6 @@ class ServiceTest extends \BBTestCase
         $this->service->updateProductFile($serviceDownloadableModel, $orderModel);
     }
 
-    public function testsendFile()
-    {
-        $serviceDownloadableModel = new \Model_ServiceDownloadable();
-        $serviceDownloadableModel->loadBean(new \DummyBean());
-        $serviceDownloadableModel->filename  = 'config.cfg';
-        $serviceDownloadableModel->downloads = 1;
-
-        $filePath = 'path/to/location' . md5($serviceDownloadableModel->filename);
-
-        $productServiceMock = $this->getMockBuilder('\Box\Mod\Product\Service')->getMock();
-        $productServiceMock->expects($this->atLeastOnce())
-            ->method('getSavePath')
-            ->will($this->returnValue($filePath));
-
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(true));
-
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('store');
-
-        $di                = new \Box_Di();
-        $di['db']          = $dbMock;
-        $di['tools']       = $toolsMock;
-        $di['logger']      = new \Box_Log();
-        $di['mod_service'] = $di->protect(function () use ($productServiceMock) { return $productServiceMock; });
-
-        $this->service->setDi($di);
-
-        $result = $this->service->sendFile($serviceDownloadableModel);
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
     public function testsendFileFileDoesNotExists()
     {
         $serviceDownloadableModel = new \Model_ServiceDownloadable();
@@ -322,11 +286,6 @@ class ServiceTest extends \BBTestCase
         $productServiceMock->expects($this->atLeastOnce())
             ->method('getSavePath')
             ->will($this->returnValue($filePath));
-
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists');
-
 
         $di                = new \Box_Di();
         $di['tools']       = $toolsMock;
@@ -342,4 +301,3 @@ class ServiceTest extends \BBTestCase
 
 
 }
- 

--- a/tests/modules/Spamchecker/ServiceTest.php
+++ b/tests/modules/Spamchecker/ServiceTest.php
@@ -153,22 +153,6 @@ class ServiceTest extends \BBTestCase {
         $this->service->isBlockedIp($boxEventMock);
     }
 
-    public function testisInStopForumSpamDatabase_InvalidResponse()
-    {
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('file_get_contents')
-            ->willReturn('{}');
-
-        $di = new \Box_Di();
-        $di['tools'] = $toolsMock;
-
-        $data = array();
-        $this->service->setDi($di);
-        $result = $this->service->isInStopForumSpamDatabase($data);
-        $this->assertFalse($result);
-    }
-
     public function dataProviderSpamResponses()
     {
         return array(
@@ -183,43 +167,4 @@ class ServiceTest extends \BBTestCase {
             ),
         );
     }
-
-    /**
-     * @dataProvider dataProviderSpamResponses
-     */
-    public function testisInStopForumSpamDatabase_UserNameBlackListed($json, $exceptionMessage)
-    {
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('file_get_contents')
-            ->willReturn($json);
-
-        $di = new \Box_Di();
-        $di['tools'] = $toolsMock;
-
-        $data = array();
-        $this->service->setDi($di);
-        $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage($exceptionMessage);
-        $this->service->isInStopForumSpamDatabase($data);
-    }
-
-    public function testisInStopForumSpamDatabase_NotExists()
-    {
-        $json = '{"success" : "true", "username" : {}}';
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('file_get_contents')
-            ->willReturn($json);
-
-        $di = new \Box_Di();
-        $di['tools'] = $toolsMock;
-
-        $data = array();
-        $this->service->setDi($di);
-        $result = $this->service->isInStopForumSpamDatabase($data);
-        $this->assertFalse($result);
-    }
-
-
 }

--- a/tests/modules/System/ServiceTest.php
+++ b/tests/modules/System/ServiceTest.php
@@ -155,11 +155,6 @@ class ServiceTest extends \BBTestCase {
             ->method('getLatestVersion')
             ->will($this->returnValue($latestVersion));
 
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->returnValue(true));
-
         $di = new \Box_Di();
         $di['updater'] = $updaterMock;
         $di['mod_service'] = $di->protect(function () use($systemServiceMock) {return $systemServiceMock;});
@@ -170,37 +165,6 @@ class ServiceTest extends \BBTestCase {
 
         $result = $systemServiceMock->getMessages($type, true);
         $this->assertIsArray($result);
-    }
-
-    public function testtemplateExists()
-    {
-
-        $getThemeResults = array(
-            'paths' => array(
-                '\home',
-                '\var',
-            ),
-        );
-        $systemServiceMock = $this->getMockBuilder('\Box\Mod\Theme\Service')->setMethods(array('getThemeConfig'))->getMock();
-        $systemServiceMock->expects($this->atLeastOnce())
-            ->method('getThemeConfig')
-            ->will($this->returnValue($getThemeResults));
-
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('fileExists')
-            ->will($this->onConsecutiveCalls(false, true));
-
-        $di = new \Box_Di();
-        $di['tools'] = $toolsMock;
-        $di['mod_service'] = $di->protect(function () use($systemServiceMock) {return $systemServiceMock;});
-
-        $this->service->setDi($di);
-
-        $result =  $this->service->templateExists('defaultFile.cp');
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-
     }
 
     public function testtemplateExistsEmptyPaths()
@@ -225,7 +189,7 @@ class ServiceTest extends \BBTestCase {
         $vars = array(
             '_client_id' => 1
         );
-        
+
 
         $this
         ->getMockBuilder('Drupal\Core\Template\TwigEnvironment')
@@ -259,11 +223,11 @@ class ServiceTest extends \BBTestCase {
         $vars = array(
             '_client_id' => 1
         );
-        
+
         $twigMock = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
             ->getMock();
-        
+
         $twigMock->expects($this->atLeastOnce())
             ->method('addGlobal');
         // $twigMock->method('createTemplate')
@@ -272,7 +236,7 @@ class ServiceTest extends \BBTestCase {
         //     ->willReturn(new \FakeTemplateWrapper('test'));
         $twigMock->method('render')
             ->willReturn('');
-                 
+
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')

--- a/tests/modules/Theme/ServiceTest.php
+++ b/tests/modules/Theme/ServiceTest.php
@@ -306,11 +306,6 @@ class ServiceTest extends \BBTestCase {
 
     public function testregenerateThemeCssAndJsFiles_EmptyFiles()
     {
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('glob')
-            ->will($this->returnValue(array()));
-
         $themeMock = $this->getMockBuilder('\Box\Mod\Theme\Model\Theme')->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getPathAssets')
@@ -321,47 +316,6 @@ class ServiceTest extends \BBTestCase {
         $this->service->setDi($di);
 
         $result = $this->service->regenerateThemeCssAndJsFiles($themeMock, 'default', new \Model_Admin());
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
-    public function testregenerateThemeCssAndJsFiles()
-    {
-        $serviceMock = $this->getMockBuilder('\Box\Mod\Theme\Service')
-            ->setMethods(array('getThemeSettings'))
-            ->getMock();
-
-        $presets = array(
-            'default' => 'Defaults',
-            'red_black' => 'Red Black',
-        );
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getThemeSettings')
-            ->will($this->returnValue($presets));
-
-        $toolsMock = $this->getMockBuilder('\Box_Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('glob')
-            ->will($this->onConsecutiveCalls(array('css.css'), array('js.js')));
-        $toolsMock->expects($this->atLeastOnce())
-            ->method('file_put_contents');
-
-        $systemServiceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $systemServiceMock->expects($this->atLeastOnce())
-            ->method('renderString')
-            ->will($this->returnValue('renderedString'));
-
-        $themeMock = $this->getMockBuilder('\Box\Mod\Theme\Model\Theme')->disableOriginalConstructor()->getMock();
-        $themeMock->expects($this->atLeastOnce())
-            ->method('getPathAssets')
-            ->will($this->returnValue('location/Of/'));
-
-        $di = new \Box_Di();
-        $di['tools'] = $toolsMock;
-        $di['mod_service'] = $di->protect(function() use($systemServiceMock) {return $systemServiceMock;});
-        $serviceMock->setDi($di);
-
-        $result = $serviceMock->regenerateThemeCssAndJsFiles($themeMock, 'default', new \Model_Admin());
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
@@ -454,4 +408,3 @@ class ServiceTest extends \BBTestCase {
     }
 
 }
- 


### PR DESCRIPTION
Refactor Box/Tools to remove functions which essentially duplicate PHP functionality, or provide a thin wrapper around such functions.

This is a relatively tame refactoring, and no doubt it could go much further, but none of the changes should be breaking. 🙂 