### PR TITLE
Allow server manager-defined username generation

### DIFF
--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -11,8 +12,6 @@
  * This source file is subject to the Apache-2.0 License that is bundled
  * with this source code in the file LICENSE
  */
-
-use Symfony\Component\HttpClient\HttpClient;
 
 abstract class Server_Manager
 {
@@ -83,6 +82,21 @@ abstract class Server_Manager
     }
 
     /**
+     * Generates a username for an account based on the provided domain name.
+     * Server managers may define this function to provide their own method for username generation depending on the specifics of the server they are integrated with.
+     *
+     * @param mixed $domain_name The domain name used to generate the username.
+     * @return string The generated username.
+     */
+    public function generateUsername($domain_name)
+    {
+        $username = preg_replace('/[^A-Za-z0-9]/', '', $domain_name);
+        $username = substr($username, 0, 7);
+        $randnum = random_int(0, 9);
+        return $username . $randnum;
+    }
+
+    /**
      * Sets the logger object.
      *
      * @param Box_Log $value The logger object.
@@ -117,7 +131,7 @@ abstract class Server_Manager
     public function getHttpClient()
     {
         return \Symfony\Component\HttpClient\HttpClient::create();
-    }  
+    }
 
     /**
      * Initializes the object after construction.

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -118,7 +118,8 @@ class Service implements InjectionAwareInterface
         if (isset($c['username']) && !empty($c['username'])) {
             $username = $c['username'];
         } else {
-            $username = $this->_generateUsername($model->sld . $model->tld);
+            $serverManager = $this->_getServerMangerForOrder($model);
+            $username = $serverManager->generateUsername($model->sld . $model->tld);
         }
 
         $model->username = $username;
@@ -398,17 +399,10 @@ class Service implements InjectionAwareInterface
         return \Model_ClientOrder::STATUS_FAILED_SETUP != $order->status;
     }
 
-    /**
-     * Generate username by domain.
-     */
-    private function _generateUsername($domain_name)
+    private function _getServerMangerForOrder($model)
     {
-        $username = preg_replace('/[^A-Za-z0-9]/', '', $domain_name);
-        $username = substr($username, 0, 7);
-        $randnum = random_int(0, 9);
-        $username = $username . $randnum;
-
-        return $username;
+        $server = $this->di['db']->getExistingModelById('ServiceHostingServer', $model->service_hosting_server_id, 'Server not found');
+        return $this->getServerManager($server);
     }
 
     public function _getAM(\Model_ServiceHosting $model, \Model_ServiceHostingHp $hp = null)
@@ -887,7 +881,7 @@ class Service implements InjectionAwareInterface
 
     public function getServerPackage(\Model_ServiceHostingHp $model)
     {
-        $config = json_decode($model->config, 1);
+        $config = json_decode(($model->config ?? ''), 1);
         if (!is_array($config)) {
             $config = [];
         }


### PR DESCRIPTION
This small change allows server managers to define a custom `generateUsername` function. While the default method works fine in most cases, some control panels or custom integrations may have specific limitations for the username, so this allows them to handle such situations.