### PR TITLE
Display a user-friendly error message if proc_open is disabled.

### DIFF
--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -162,6 +162,9 @@ class FOSSBilling_Mail
         switch ($this->transport) {
             case 'sendmail':
                 $dsn = 'sendmail://default';
+                if (!function_exists('proc_open')) {
+                    throw new \Box_Exception("FOSSBilling requires the proc_open PHP function to be enabled when using the sendmail transport");
+                }
                 break;
             case 'smtp':
                 $dsn = $this->__smtpDsn($options);
@@ -172,7 +175,6 @@ class FOSSBilling_Mail
                 }
                 $dsn = 'sendgrid://' . $options['sendgrid_key'] . '@default';
                 break;
-            case null:
             case 'custom':
                 if (empty($this->dsn)) {
                     throw new \Box_Exception("Unable to send email: 'Custom' transport method was selected without a custom DSN");


### PR DESCRIPTION
Just a small change so that users get a more helpful error message if they are trying to use the `sendmail` transport option when `proc_open` is disabled. Right now, they'd get a message like this: `Call to undefined function Symfony\Component\Mailer\Transport\Smtp\Stream\proc_open()`.

I also changed it so that `null` no longer fell back to the custom DSN transport option, as the more I thought about it the less it made sense to me