### PR TITLE
Fix HTTP response error code bug

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
 
 $url = $_GET['_url'] ?? '';
-$http_err_code = $_GET['_errcode'] ?? '';
+$http_err_code = $_GET['_errcode'] ?? null;
 
 $admin_prefix = $di['config']['admin_area_prefix'];
 if (0 === strncasecmp($url, $admin_prefix, strlen($admin_prefix))) {
@@ -40,6 +40,7 @@ if (!is_null($http_err_code)) {
             echo $app->show404($e);
             break;
         default:
+            $http_err_code = intval($http_err_code);
             http_response_code($http_err_code);
             $e = new Box_Exception('HTTP Error :err_code occured while attempting to load :url', [':err_code' => $http_err_code, ':url' => $url], $http_err_code);
             echo $app->render('error', ['exception' => $e]);


### PR DESCRIPTION
Update index to fix bug in error code handling introduced in #1122 by restoring default $_GET value for errcode to null.