### PR TITLE
Fix locale date/time formatting issue

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -327,7 +327,7 @@ $di['twig'] = $di->factory(function () use ($di) {
         $dateFormatter = new \IntlDateFormatter($locale, constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
     } catch (\Symfony\Polyfill\Intl\Icu\Exception\MethodArgumentValueNotImplementedException) {
         if (($config['i18n']['locale'] ?? 'en_US') == 'en_US') {
-            $dateFormatter = new \IntlDateFormatter('en', constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
+            $dateFormatter = new \IntlDateFormatter('en_US', constant("\IntlDateFormatter::$date_format"), constant("\IntlDateFormatter::$time_format"), $timezone, null, $datetime_pattern);
         } else {
             throw new \Box_Exception("It appears you are trying to use FOSSBilling without the php intl extension enabled. FOSSBilling includes a polyfill for the intl extension, however it does not support :locale. Please enable the intl extension.", [':locale' => $config['i18n']['locale']]);
         }


### PR DESCRIPTION
Update locale handling to fix minor issue introduced by #1060 when specifying default/fallback locale.

Specifically, the locale requires both a language and country to be specified; without the latter the date appears to be displayed incorrectly.