### PR TITLE
Minor improvements to the locale detection

### DIFF
--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -51,7 +51,11 @@ class FOSSBilling_i18n
             $detectedLocale = '';
         }
 
-        $matchingLocale = Locale::lookup(self::getLocales(), $detectedLocale, false, null);
+        try {
+            $matchingLocale = Locale::lookup(self::getLocales(), $detectedLocale, false, null);
+        } catch (Exception) {
+            $matchingLocale = null;
+        }
 
         /* The system was unable to match the browser locale to one of our local ones.
          * This is most likely because Locale::lookup will not match en with en_US. It will only match en_US with en.
@@ -59,11 +63,17 @@ class FOSSBilling_i18n
          * If it does, return that.
          */
         if (empty($matchingLocale)) {
+            if (strlen($detectedLocale) < 2) {
+                return null;
+            }
             foreach (self::getLocales() as $locale) {
-                if (str_starts_with($locale, $detectedLocale)) {
+                if (str_starts_with($locale, substr($detectedLocale, 0, 2))) {
+                    setcookie("BBLANG", $locale, strtotime("+1 month"));
                     return $locale;
                 }
             }
+        } else {
+            setcookie("BBLANG", $matchingLocale, strtotime("+1 month"));
         }
 
         return $matchingLocale;


### PR DESCRIPTION
Just a handful of minor improvements: 
- The `Locale::lookup` command has been wrapped in a try-catch since the polyfill doesn't include it.
- It will also now set the `BBLANG` cookie to the detected locale so that the locale selector will be set to the detected locale.
- I've also made the fallback to the `Locale::lookup` command use only the first two chars of the detected locale, so that for example `en_GB` will be matched to `en_US`.