### PR TITLE
Fix owndomain TLD handling to include period

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -519,6 +519,9 @@ class Service implements InjectionAwareInterface
             $item['domain']['register_sld'] = (isset($item['domain']['register_sld'])) ? strtolower($item['domain']['register_sld']) : null;
             $item['domain']['transfer_sld'] = (isset($item['domain']['transfer_sld'])) ? strtolower($item['domain']['transfer_sld']) : null;
 
+            // Domain TLD must begin with a period - add if not present for owndomain.
+            $item['domain']['owndomain_tld'] = (isset( $item['domain']['owndomain_tld'])) ? (str_contains($item['domain']['owndomain_tld'], '.') ? $item['domain']['owndomain_tld'] : '.' . $item['domain']['owndomain_tld']) : null;
+
             $order = $this->di['db']->dispense('ClientOrder');
             $order->client_id = $client->id;
             $order->promo_id = $cart->promo_id;

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -628,7 +628,7 @@ class Service implements \Box\InjectionAwareInterface
 
         if ('owndomain' == $action) {
             $sld = $data['owndomain_sld'];
-            $tld = $data['owndomain_tld'];
+            $tld = str_contains($data['domain']['owndomain_tld'], '.') ? $data['domain']['owndomain_tld'] : '.' . $data['domain']['owndomain_tld'];
         }
 
         if ('transfer' == $action) {

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -529,7 +529,7 @@ class Service implements InjectionAwareInterface
 
         if ('owndomain' == $data['domain']['action']) {
             $sld = $data['domain']['owndomain_sld'];
-            $tld = $data['domain']['owndomain_tld'];
+            $tld = str_contains($data['domain']['owndomain_tld'], '.') ? $data['domain']['owndomain_tld'] : '.' . $data['domain']['owndomain_tld'];
         }
 
         if ('register' == $data['domain']['action']) {


### PR DESCRIPTION
Fix handling of owndomain TLDs to always include the leading period (.), as is required. Resolves #1085. 