### PR TITLE
Update Currency service to check for no API key

### DIFF
--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -355,7 +355,7 @@ class Service implements InjectionAwareInterface
 
         $pairs = $db->getAssoc($sql);
 
-        return $pairs['currencylayer'];
+        return $pairs['currencylayer'] ?? '';
     }
 
     /**


### PR DESCRIPTION
Update the Currency service to check if Currencylayer API key null to prevent undefined array key error.