### PR TITLE
A few small fixes

### DIFF
--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -40,8 +40,9 @@ class FOSSBilling_i18n
      */
     private static function getBrowserLocale(): ?string
     {
+        $header = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
         try {
-            $detectedLocale = @Locale::acceptFromHttp($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+            $detectedLocale = @Locale::acceptFromHttp($header);
             $detectedLocale = @Locale::canonicalize($detectedLocale . '.utf8');
         } catch (Exception) {
             $detectedLocale = '';
@@ -68,12 +69,12 @@ class FOSSBilling_i18n
             }
             foreach (self::getLocales() as $locale) {
                 if (str_starts_with($locale, substr($detectedLocale, 0, 2))) {
-                    setcookie("BBLANG", $locale, strtotime("+1 month"));
+                    setcookie("BBLANG", $locale, strtotime("+1 month"), "/");
                     return $locale;
                 }
             }
         } else {
-            setcookie("BBLANG", $matchingLocale, strtotime("+1 month"));
+            setcookie("BBLANG", $matchingLocale, strtotime("+1 month"), "/");
         }
 
         return $matchingLocale;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -802,7 +802,7 @@ class Service implements InjectionAwareInterface
         $model->status = $data['status'] ?? (empty($model->status) ? null : $model->status);
         $model->taxrate = $data['taxrate'] ?? (empty($model->taxrate) ? null : $model->taxrate);
         $model->taxname = $data['taxname'] ?? (empty($model->taxname) ? null : $model->taxname);
-        $model->approved = (int) $data['approved'] ?? (empty($model->approved) ? null : $model->approved);
+        $model->approved = (int) ($data['approved'] ?? (empty($model->approved) ? null : $model->approved));
         $model->notes = $data['notes'] ?? (empty($model->notes) ? null : $model->notes);
 
         $created_at = $data['created_at'] ?? '';


### PR DESCRIPTION
This PR fixes a few small issues:
1) I fixed an issue that caused the API to return an invalid response when updating an invoice when the `approved` status was not set. This caused the API wrapper to throw and error an not handle the response correctly, so it appeared as if the task was never completed.
2) Implemented a ternary operator to prevent an undefined array key error if the `HTTP_ACCEPT_LANGUAGE` headers isn't provided.
3) Explicitly setting the path to `/` when setting the cookie in the `getBrowserLocale` check. It was creating a new cookie for each page URL. This fixes that, which will prevent cookies from being spammed and also saves some processing since it won't have to process this check for every single page you visit