### PR TITLE
Fix load.php and minor error handler issues

### DIFF
--- a/src/library/Error/ErrorPage.php
+++ b/src/library/Error/ErrorPage.php
@@ -30,7 +30,7 @@ class FOSSBillingErrorPage
         return [
             '1' => [
                 'title' => __trans('Unable to find Composer Packages'),
-                'message' => 'The composer packages appear to be missing. This shouldn\'t happen if you are using a release version of FOSSBilling. If you are developer, you will need to install dependencies using :code', [':code' => '<code>composer install</code>'],
+                'message' => 'The composer packages appear to be missing. This shouldn\'t happen if you are using a release version of FOSSBilling. If you are developer, you will need to install dependencies using :code.', [':code' => '<code>composer install</code>'],
                 'link' => [
                     'label' => __trans('View more info on the composer website'),
                     'href' => 'https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies',
@@ -45,7 +45,7 @@ class FOSSBillingErrorPage
             ],
             '3' => [
                 'title' => __trans('Your Configuration is Empty'),
-                'message' => __trans('Your FOSSBilling configuration seems to either be empty or non-existient. You may need to re-install FOSSBilling, or re-create the :code file based on the example config' . [':code' => '<code>config.php</code>']),
+                'message' => __trans('Your FOSSBilling configuration seems to either be empty or non-existient. You may need to re-install FOSSBilling, or re-create the :code file based on the example config.', [':code' => '<code>config.php</code>']),
                 'link' => [
                     'label' => __trans('See the example config.'),
                     'href' => 'https://github.com/FOSSBilling/FOSSBilling/blob/main/src/config-sample.php',
@@ -127,7 +127,7 @@ class FOSSBillingErrorPage
     public function generatePage(int $code, string $message)
     {
         $error = $this->getCodeInfo($code);
-        $error['message'] ??= __trans('Uh-oh! You\'ve received a generic error message: :errorMessage', ['errorMessage' => $message]);
+        $error['message'] ??= __trans('Uh-oh! You\'ve received a generic error message: :errorMessage', [':errorMessage' => '<code>' . $message . '</code>']);
 
         $page = '
         <!DOCTYPE html>

--- a/src/load.php
+++ b/src/load.php
@@ -57,7 +57,7 @@ function checkInstaller()
     $filesystem = new Filesystem();
 
     // Check if /install directory still exists after installation has been completed.
-    if ($filesystem->exists('config.php') && $filesystem->exists('install/index.php')) {
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install/index.php')) {
         throw new Exception('For security reasons, you have to delete the install directory before you can use FOSSBilling.', 2);
     }
 }
@@ -222,8 +222,11 @@ checkLegacyFiles();
 // Check config exists.
 checkConfig();
 
-//All seems good, so load the config file
+//All seems good, so load the config file.
 $config = require PATH_CONFIG;
+
+// Verify the installer was removed.
+checkInstaller();
 
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');

--- a/src/load.php
+++ b/src/load.php
@@ -41,8 +41,8 @@ function checkConfig()
 
     // Check if configuration is available, and redirect to installer if not.
     if (!$filesystem->exists(PATH_CONFIG)) {
-        if ($filesystem->exists('/install/index.php')) {
-            header("Location: " . $base_url . '/install', true, 301);
+        if ($filesystem->exists('install/index.php')) {
+            header("Location: " . $base_url . '/install', true, 307);
         } else {
             throw new Exception("The FOSSBilling configuration file is empty or invalid.", 3);
         }
@@ -57,7 +57,7 @@ function checkInstaller()
     $filesystem = new Filesystem();
 
     // Check if /install directory still exists after installation has been completed.
-    if ($filesystem->exists('config.php') && $filesystem->exists('/install/index.php')) {
+    if ($filesystem->exists('config.php') && $filesystem->exists('install/index.php')) {
         throw new Exception('For security reasons, you have to delete the install directory before you can use FOSSBilling.', 2);
     }
 }

--- a/src/load.php
+++ b/src/load.php
@@ -27,7 +27,7 @@ const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
 const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
 const PATH_UPLOADS = PATH_ROOT . DIRECTORY_SEPARATOR . 'uploads';
 const PATH_DATA = PATH_ROOT . DIRECTORY_SEPARATOR . 'data';
-const PATH_CONFIG = PATH_ROOT . '/config.php';
+const PATH_CONFIG = PATH_ROOT . DIRECTORY_SEPARATOR . 'config.php';
 
 /*
  * Check configuration exists, and is valid.
@@ -42,7 +42,7 @@ function checkConfig()
     // Check if configuration is available, and redirect to installer if not.
     if (!$filesystem->exists(PATH_CONFIG)) {
         if ($filesystem->exists('install/index.php')) {
-            header("Location: " . $base_url . '/install', true, 307);
+            header("Location: " . $base_url . '/install/index.php', true, 307);
         } else {
             throw new Exception("The FOSSBilling configuration file is empty or invalid.", 3);
         }
@@ -203,9 +203,13 @@ function exceptionHandler($e)
  *
  */
 
-// Define custom error handlers
+// Define custom error handlers.
 set_exception_handler('exceptionHandler');
 set_error_handler('errorHandler');
+
+//Enabled during setup, is then overridden once we have loaded the config.
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
 
 // Check hard requirements.
 checkRequirements();
@@ -233,8 +237,8 @@ date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', $config['debug']);
 define('BB_URL', $config['url']);
 define('BB_SEF_URLS', $config['sef_urls']);
-define('PATH_CACHE', $config['path_data'] . '/cache');
-define('PATH_LOG', $config['path_data'] . '/log');
+define('PATH_CACHE', $config['path_data'] . DIRECTORY_SEPARATOR . 'cache');
+define('PATH_LOG', $config['path_data'] . DIRECTORY_SEPARATOR . 'log');
 define('BB_SSL', str_starts_with($config['url'], 'https'));
 define('ADMIN_PREFIX', $config['admin_area_prefix']);
 if ($config['sef_urls']) {
@@ -249,7 +253,7 @@ checkSSL();
 // Set error and exception handlers, and default logging settings.
 ini_set('log_errors', '1');
 ini_set('html_errors', false);
-ini_set('error_log', PATH_LOG . '/php_error.log');
+ini_set('error_log', PATH_LOG . DIRECTORY_SEPARATOR . 'php_error.log');
 if ($config['debug']) {
     error_reporting(E_ALL);
     ini_set('display_errors', '1');


### PR DESCRIPTION
This PR fixes two issues with #1006 and #1177
Namely:
 - I fixed some issues with the strings in our error handler
 - Fixed a problem where `load.php` was checking for the wrong file path for the installer, which caused it to try and load an empty config problem. I also changed the 301 redirect to 307, since it is temporary and not permanent. 