### PR TITLE
Remove broken and poorly implemented feature

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -86,13 +86,6 @@ return [
      */
     'disable_auto_cron' => false,
 
-    /*
-     * Enable or disable search engine friendly URLs.
-     * Configure .htaccess file before enabling this feature
-     * Set to TRUE if using nginx.
-     */
-    'sef_urls' => true,
-
     /* 
      * These configuration options allow you to configure the default localisation.
      */

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -459,7 +459,6 @@ final class Box_Installer
             'url' => BB_URL,
             'admin_area_prefix' => '/admin',
             'disable_auto_cron' => false,
-            'sef_urls' => true,
 
             'i18n' => [
                 'locale' => 'en_US',

--- a/src/library/Box/Tools.php
+++ b/src/library/Box/Tools.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -63,11 +64,7 @@ class Box_Tools
     public function url($link = null)
     {
         $link = trim($link, '/');
-        if (BB_SEF_URLS) {
-            return BB_URL . $link;
-        }
-
-        return BB_URL . 'index.php?_url=/' . $link;
+        return BB_URL . $link;
     }
 
     public function hasService($type)

--- a/src/library/Box/Update.php
+++ b/src/library/Box/Update.php
@@ -275,7 +275,7 @@ class Box_Update
         $newConfig['api']['CSRFPrevention'] ??= true;
 
         // Remove depreciated config keys/subkeys.
-        $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone'];
+        $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone', 'sef_urls'];
         $depreciatedConfigSubkeys = [];
         $newConfig = array_diff_key($newConfig, array_flip($depreciatedConfigKeys));
         foreach ($depreciatedConfigSubkeys as $key => $subkey) {

--- a/src/library/Box/Url.php
+++ b/src/library/Box/Url.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling
  *
@@ -36,7 +37,7 @@ class Box_Url implements Box\InjectionAwareInterface
     /**
      * Generates a URL
      */
-    public function get ($uri)
+    public function get($uri)
     {
         return $this->baseUri . $uri;
     }
@@ -47,16 +48,11 @@ class Box_Url implements Box\InjectionAwareInterface
     public function link($uri = null, $params = array())
     {
         $uri = trim($uri, '/');
-        $link = BB_SEF_URLS ? $this->baseUri . $uri : $this->baseUri .'index.php?_url=/' . $uri;
-        if(BB_SEF_URLS) {
-            if (!empty($params)){
-                $link .= '?' . http_build_query($params);
-            }
-        } else {
-            if (!empty($params)){
-                $link .= '&' . http_build_query($params);
-            }
+        $link = $this->baseUri . $uri;
+        if (!empty($params)) {
+            $link .= '?' . http_build_query($params);
         }
+
 
         return $link;
     }

--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -71,7 +71,6 @@ class FOSSBilling_Requirements implements \Box\InjectionAwareInterface
 
         $data['FOSSBilling']    = array(
             'BB_LOCALE'     =>  $this->di['config']['i18n']['locale'],
-            'BB_SEF_URLS'   =>  BB_SEF_URLS,
             'version'       =>  FOSSBilling_Version::VERSION,
         );
 

--- a/src/load.php
+++ b/src/load.php
@@ -229,16 +229,11 @@ $config = require PATH_CONFIG;
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', $config['debug']);
 define('BB_URL', $config['url']);
-define('BB_SEF_URLS', $config['sef_urls']);
 define('PATH_CACHE', $config['path_data'] . '/cache');
 define('PATH_LOG', $config['path_data'] . '/log');
 define('BB_SSL', str_starts_with($config['url'], 'https'));
 define('ADMIN_PREFIX', $config['admin_area_prefix']);
-if ($config['sef_urls']) {
-    define('BB_URL_API', $config['url'] . 'api/');
-} else {
-    define('BB_URL_API', $config['url'] . 'index.php?_url=/api/');
-}
+define('BB_URL_API', $config['url'] . 'api/');
 
 // Check if SSL required, and enforce if so.
 checkSSL();


### PR DESCRIPTION
This PR removes the functionality for non-search engine friendly URLs because it was poorly implemented and didn't actually work correctly. It has also been entirely broken for a month without a single person commenting on it. 