### PR TITLE
Implement a custom autoloader

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -63,3 +63,4 @@ jobs:
       with:
         configuration: phpstan.neon
         memory_limit: 512M
+        version: latest

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ FOSSBilling is designed to be extensible and to integrate easily with your favor
 
 The following environment is highly recommended for running FOSSBilling. It *may* be possible to install and run the software in other environments, but it will be untested and unsupported.
 
-- A suitable web server (Apache/nginx/LSWS/Lighttpd)
+- A suitable web server (Apache/nginx/LSWS)
 - PHP 8.0, 8.1 or 8.2
 - MySQL 8 (or higher), or MariaDB 10.3 (or higher) *Other direct MySQL compatible DBs should also work but are not supported.*
 - The Following PHP extensions:
-      - curl (optional, but recommended)
-      - intl
-      - mbstring (optional, but recommended)
-      - openssl
-      - pdo_mysql
-      - xml
-      - zlib
+  - curl (optional, but recommended)
+  - intl
+  - mbstring (optional, but recommended)
+  - openssl
+  - pdo_mysql
+  - xml
+  - zlib
 
 ## Installation
 
@@ -85,7 +85,7 @@ Your [pull requests](https://github.com/FOSSBilling/FOSSBilling/pulls) will be h
 
 Don't hesitate to create an [issue](https://github.com/FOSSBilling/FOSSBilling/issues), start a discussion in the [FOSSBilling Forum](https://forum.fossbilling.org/), or join us on [Discord](https://fossbilling.org/discord) to say hi.
 
-⭐ Not a developer? Feel free to help by starring the repository. It helps us catch the attention of new developers who'd like to contribute. 
+⭐ Not a developer? Feel free to help by starring the repository. It helps us catch the attention of new developers who'd like to contribute.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,7 @@ FOSSBilling is designed to be extensible and to integrate easily with your favor
 
 - [Contents](#contents)
 - [Requirements](#requirements)
-- [Example Configurations](#example-configurations)
 - [Installation](#installation)
-  - [Download the latest preview build](#download-the-latest-preview-build)
-  - [Install from latest source code](#install-from-latest-source-code)
-  - [Installing with Docker](#installing-with-docker)
 - [Contributing](#contributing)
 - [Star History](#star-history)
 - [Licensing](#licensing)
@@ -54,85 +50,23 @@ FOSSBilling is designed to be extensible and to integrate easily with your favor
 The following environment is highly recommended for running FOSSBilling. It *may* be possible to install and run the software in other environments, but it will be untested and unsupported.
 
 - A suitable web server (Apache/nginx/LSWS/Lighttpd)
-- PHP 8.0, 8.1 or 8.2 
+- PHP 8.0, 8.1 or 8.2
 - MySQL 8 (or higher), or MariaDB 10.3 (or higher) *Other direct MySQL compatible DBs should also work but are not supported.*
 - The Following PHP extensions:
-    - curl (optional, but recommended)
-    - intl
-    - mbstring (optional, but recommended)
-    - openssl
-    - pdo_mysql
-    - xml
-    - zlib
+      - curl (optional, but recommended)
+      - intl
+      - mbstring (optional, but recommended)
+      - openssl
+      - pdo_mysql
+      - xml
+      - zlib
 
 ## Installation
-Installing FOSSBilling is pretty easy. Depending on how you plan to use it there are three different ways to install it:
 
-1. If you are using shared hosting, or are installing FOSSBilling to use on a live production site (which is not currently recommended and comes with absolutely no guarantees), then you should probably download and install the **[latest preview build](#download-the-latest-preview-build)**.
-3. If you're planning to contribute to FOSSBilling's development, and wanting to make pull requests in the future, please directly **[install from latest source code](#install-from-latest-source-code)** instead.
-4. If you are familiar with Docker, you can also choose to install **[FOSSBilling in a Docker container](#installing-with-docker)**.
-
-### Download the latest preview build
-If you're planning to use FOSSBilling in a production environment (see the disclaimers above) then this will likely be the best option for you. They are not actual releases, but the preview builds are the most secure and stable versions currently available.
-
-First, you should download the [latest preview build](https://fossbilling.org/downloads/preview). Unlike the source code, these preview builds already include the Composer packages, so you won't need to run Composer to install PHP packages. This is perfect if you are using shared hosting as you might not have the ability to run Composer yourself.
-
-You can either download the .tar file to your local computer and then upload it to your server using FTP, or download it directly to your web server using wget or git clone. In either case, you will need to extract the contents into the public folder of your site (usually, that's called **"htdocs"** or **"public_html"**).
-
-Your web directory's structure should now look like this:
-- htdocs
-    - data
-    - library
-    - modules
-    - **...**
-
-Next, you will also need to create a new empty MySQL database using the command line, or from your server control panel. Make a note of the database name, database user, and password, you will need them in the next step. 
-
-Now, you have everything ready to start the installation of FOSSBilling, navigate to your domain using a web browser, and simply follow the on-screen instructions to complete the installation using the web installer. Ta-da, you've done it! 🎉
-
-### Install from latest source code
-To install the latest development version of FOSSBilling, you will need to get the [latest up-to-date ZIP archive](https://github.com/FOSSBilling/FOSSBilling/archive/master.zip) from the Github repository.
-
-You can either download the .zip file to your local computer and then upload it to your server using FTP, or download it directly to your web server using wget or git clone. In either case, you will need to unzip it and make sure that the files contained in the archive are in the public folder of your site (usually, that's called **"htdocs"** or **"public_html"**).
-
-Your web directory's structure should now look like this:
-- htdocs
-    - data
-    - library
-    - modules
-    - **...**
-
-Next, you will also need to create a new empty MySQL database using the command line, or from your server control panel. Make a note of the database name, database user, and password, you will need them later. 
-
-We do not store the Composer packages in our GitHub repository, we use [Composer](https://getcomposer.org/) for that. Composer is a dependency manager for PHP, just like the NPM of Node.js, or PIP of Python.
-
-If you don't have Composer installed, or it's your first time using it, you probably should read Composer's [getting started guide](https://getcomposer.org/doc/00-intro.md).
-
-If you've already installed Composer, head over to the folder where you copied the content of the **"src"** folder, and run the following command to download the required packages to your web server:
-
-```bash
-$ composer install
-```
-
-Just as with Composer (see above) we do not store the final artifacts in our source repo. To build them make sure you have [Node.js](https://nodejs.org/en/download/) installed. 
-
-Head over to your root directory and run
-
-```bash
-$ npm install
-$ npm run build
-```
-
-Now, you have everything ready to start the installation of FOSSBilling,. Navigate to your domain using a web browser, and simply follow the on-screen instructions to complete the installation using the web installer. Ta-da, you've done it! 🎉
-
-### Installing with Docker
-<a href="https://www.docker.com/"><img align="right" src="https://www.docker.com/wp-content/uploads/2022/03/horizontal-logo-monochromatic-white.png" alt="Docker logo" width="125"></a>
-
-We have developed an official Docker image, however, it should be noted that both the image and FOSSBilling are currently undergoing significant development and should not be considered production ready.
-
-The image and install instructions can be found **[here](https://github.com/FOSSBilling/Docker)**.
+For instructions on installing FOSSBilling, check out our [getting started guide](https://fossbilling.org/docs/getting-started).  
 
 ## Contributing
+
 🖥️ Welcome, fellow developer! 🙂
 
 First of all, thank you for your interest, and for taking your time to contribute to FOSSBilling.
@@ -147,7 +81,6 @@ Your [pull requests](https://github.com/FOSSBilling/FOSSBilling/pulls) will be h
 
 [![Star History Chart](https://api.star-history.com/svg?repos=FOSSBilling/FOSSBilling&type=Date)](https://star-history.com/#FOSSBilling/FOSSBilling&Date)
 
-
 **Got questions? Found a bug? Ideas for improvements?**
 
 Don't hesitate to create an [issue](https://github.com/FOSSBilling/FOSSBilling/issues), start a discussion in the [FOSSBilling Forum](https://forum.fossbilling.org/), or join us on [Discord](https://fossbilling.org/discord) to say hi.
@@ -159,13 +92,14 @@ Don't hesitate to create an [issue](https://github.com/FOSSBilling/FOSSBilling/i
 FOSSBilling is open source software and is released under the Apache v2.0 license. See [LICENSE](https://github.com/FOSSBilling/FOSSBilling/blob/master/LICENSE) for the full license terms.
 
 This product includes the following third party work:
+
 - GeoLite2 data created by MaxMind, available from [https://www.maxmind.com](https://www.maxmind.com).
 - Open Source Iconography by [Pictogrammers](https://pictogrammers.com/) licensed under the [Pictogrammers Free License](https://pictogrammers.com/docs/general/license/).
 
 ## Links
 
-* [Website](https://www.fossbilling.org/)
-* [Documentation](https://fossbilling.org/docs)
-* [Forum](https://forum.fossbilling.org)
-* [Twitter](https://twitter.com/FOSSBilling)
-* [Discord](https://fossbilling.org/discord)
+- [Website](https://www.fossbilling.org/)
+- [Documentation](https://fossbilling.org/docs)
+- [Forum](https://forum.fossbilling.org)
+- [Twitter](https://twitter.com/FOSSBilling)
+- [Discord](https://fossbilling.org/discord)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,11 @@
     "readme": "https://github.com/FOSSBilling/FOSSBilling/blob/master/README.md",
     "type": "project",
     "license": "Apache-2.0",
-    "keywords": ["billing", "invoice", "client management"],
+    "keywords": [
+        "billing",
+        "invoice",
+        "client management"
+    ],
     "homepage": "https://fossbilling.org",
     "require": {
         "php": ">=8.0",
@@ -22,7 +26,7 @@
         "gabordemooij/redbean": "^5.7",
         "geoip2/geoip2": "^2.10.0",
         "io-developer/php-whois": "^4.1",
-        "lcharette/webpack-encore-twig": "1.1.0",
+        "lcharette/webpack-encore-twig": "^1.1.0",
         "league/commonmark": "^2.3",
         "league/csv": "^9.8",
         "nelexa/zip": "^4.0.2",
@@ -58,12 +62,10 @@
         "ext-gettext": "*",
         "ext-intl": "*"
     },
-    "autoload": {
-        "psr-0": {"": "src/library"},
-        "psr-4": {"Box\\Mod\\": "src/modules"}
-    },
     "autoload-dev": {
-        "psr-0": { "": "tests/library" }
+        "psr-0": {
+            "": "tests/library"
+        }
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "ext-zlib": "*",
+        "composer/class-map-generator": "^1.0",
         "dompdf/dompdf": "^2.0.1",
         "filp/whoops": "^2.14",
         "gabordemooij/redbean": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f428e654195f8d981f63dcbd97343bb",
+    "content-hash": "1b133687a858810b86e31326e71c0fd5",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -81,6 +81,150 @@
                 }
             ],
             "time": "2023-01-11T08:27:00+00:00"
+        },
+        {
+            "name": "composer/class-map-generator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "1e1cb2b791facb2dfe32932a7718cf2571187513"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/1e1cb2b791facb2dfe32932a7718cf2571187513",
+                "reference": "1e1cb2b791facb2dfe32932a7718cf2571187513",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2 || ^3",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.6",
+                "phpstan/phpstan-deprecation-rules": "^1",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/filesystem": "^5.4 || ^6",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-19T11:31:27+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-17T09:50:14+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4963,77 +5107,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "composer/pcre",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.3",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-17T09:50:14+00:00"
-        },
         {
             "name": "composer/semver",
             "version": "3.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2a14e448f71117efb4f84e8775a4cca",
+    "content-hash": "8f428e654195f8d981f63dcbd97343bb",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/cspell.json
+++ b/cspell.json
@@ -331,7 +331,9 @@
         "Coudn\\'t",
         "updatepassword",
         "datatable",
-        "FileCacheExcption"
+        "FileCacheExcption",
+        "Autoloader",
+        "autoloader"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -77,6 +77,8 @@ const PATH_CONFIG = PATH_ROOT . DIRECTORY_SEPARATOR . 'config.php';
 const PATH_CRON = PATH_ROOT . DIRECTORY_SEPARATOR . 'cron.php';
 const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
 const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
+const PATH_CACHE = PATH_ROOT . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'cache';
+
 
 /*
   Config paths & templates
@@ -100,6 +102,7 @@ require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Autoload.php';
 $loader = new \FOSSBillingAutoloader();
 $loader->addPrefix('', PATH_LIBRARY, 'psr0');
 $loader->addPrefix('Box\\Mod\\', PATH_MODS, 'psr4');
+$loader->checkClassMap();
 $loader->register();
 
 final class Box_Installer

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -76,6 +76,7 @@ const PATH_INSTALL = PATH_ROOT . DIRECTORY_SEPARATOR . 'install';
 const PATH_CONFIG = PATH_ROOT . DIRECTORY_SEPARATOR . 'config.php';
 const PATH_CRON = PATH_ROOT . DIRECTORY_SEPARATOR . 'cron.php';
 const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
+const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
 
 /*
   Config paths & templates
@@ -95,6 +96,11 @@ set_include_path(implode(PATH_SEPARATOR, [
 ]));
 
 require PATH_VENDOR . DIRECTORY_SEPARATOR . 'autoload.php';
+require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Autoload.php';
+$loader = new \FOSSBillingAutoloader();
+$loader->addPrefix('', PATH_LIBRARY, 'psr0');
+$loader->addPrefix('Box\\Mod\\', PATH_MODS, 'psr4');
+$loader->register();
 
 final class Box_Installer
 {
@@ -517,8 +523,6 @@ final class Box_Installer
 
     private function generateEmailTemplates(): bool
     {
-        define('PATH_MODS', PATH_ROOT . '/modules');
-
         $emailService = new Service();
         $di = include PATH_ROOT . '/di.php';
         $di['translate']();

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -13,14 +13,14 @@ class FOSSBillingAutoloader
     }
 
     /**
-     * @param string $prefix Class prefix. Use an empty prefix to allow this prefix to work with any path. Paths must already have directory seperators normalized for the current system.
-     * @param string $path Base path associaded with the class prefix
+     * @param string $prefix Class prefix. Use an empty prefix to allow this prefix to work with any path. Paths must already have directory separators normalized for the current system.
+     * @param string $path Base path associated with the class prefix
      * @param string $type The type of PSR autoloader the prefix is associated with. EX: psr4
      * @return void 
      */
     public function addPrefix(string $prefix, string $path, string $type): void
     {
-        //The loader assumes the path does NOT end in a directory seperator, so let's remove it now.
+        //The loader assumes the path does NOT end in a directory separator, so let's remove it now.
         if (str_ends_with($path, DIRECTORY_SEPARATOR)) {
             $path = substr($path, 0, -1);
         }
@@ -48,7 +48,7 @@ class FOSSBillingAutoloader
         //Remove the "prefix" so we get just the classname
         $classname = substr($class, strlen($prefix));
 
-        //Now convert it to a path and ensure it has a directory seperator at the start, since our paths won't.
+        //Now convert it to a path and ensure it has a directory separator at the start, since our paths won't.
         $classname = str_replace('\\', DIRECTORY_SEPARATOR, $classname) . '.php';
         if (!str_starts_with($classname, DIRECTORY_SEPARATOR)) {
             $classname = DIRECTORY_SEPARATOR . $classname;

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -13,7 +13,7 @@ class FOSSBillingAutoloader
     private string $typePsr4 = 'psr4';
 
     /** 
-     * Checks for the existance of the classMap file. Will generate a new one if it doesn't exist.
+     * Checks for the existence of the classMap file. Will generate a new one if it doesn't exist.
      * After generating one / if it exists, the map is loaded to the classMap array to be used to speed up loading later.
      * @return void  
      */
@@ -38,7 +38,6 @@ class FOSSBillingAutoloader
             return;
         }
         $this->classMap = include self::$classMapPath;
-        return;
     }
 
     /** 

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -1,0 +1,94 @@
+<?php
+class FOSSBillingAutoloader
+{
+    private array $psr0 = [];
+    private array $psr4 = [];
+
+    private string $typePsr0 = 'psr0';
+    private string $typePsr4 = 'psr4';
+
+    public function register()
+    {
+        spl_autoload_register(array($this, 'autoload'));
+    }
+
+    /**
+     * @param string $prefix Class prefix. Use an empty prefix to allow this prefix to work with any path. Paths must already have directory seperators normalized for the current system.
+     * @param string $path Base path associaded with the class prefix
+     * @param string $type The type of PSR autoloader the prefix is associated with. EX: psr4
+     * @return void 
+     */
+    public function addPrefix(string $prefix, string $path, string $type): void
+    {
+        //The loader assumes the path does NOT end in a directory seperator, so let's remove it now.
+        if (str_ends_with($path, DIRECTORY_SEPARATOR)) {
+            $path = substr($path, 0, -1);
+        }
+
+        switch ($type) {
+            case $this->typePsr0:
+                $this->psr0[$prefix] = $path;
+                break;
+            case $this->typePsr4:
+                $this->psr4[$prefix] = $path;
+                break;
+            default:
+                throw new \Exception("Unknown PSR autoloader type: {$type}");
+                break;
+        }
+    }
+
+    /**
+     * @param string $class Classname, after having and specialzed handling performed
+     * @param string $path The path associated with the prefix
+     * @param mixed $prefix The prefix matching the classname.
+     * @return string The completed file path.
+     */
+    private function getFile(string $class, string $path, $prefix): string
+    {
+        //Remove the "prefix" so we get just the classname
+        $classname = substr($class, strlen($prefix));
+
+        //Now convert it to a path and ensure it has a directory seperator at the start, since our paths won't.
+        $classname = str_replace('\\', DIRECTORY_SEPARATOR, $classname) . '.php';
+        if (!str_starts_with($classname, DIRECTORY_SEPARATOR)) {
+            $classname = DIRECTORY_SEPARATOR . $classname;
+        }
+
+        return $path . $classname;
+    }
+
+    /**
+     * @param string $class Classname to load. If found, file will be included and execution will be completed.
+     * @return void 
+     */
+    public function autoload(string $class): void
+    {
+        /* PSR-0 Loader.
+         * @see https://www.php-fig.org/psr/psr-0/
+         */
+        foreach ($this->psr0 as $prefix => $path) {
+            if (empty($prefix) || strpos($class, $prefix) === 0) {
+                $class = str_replace('_', DIRECTORY_SEPARATOR, $class);
+                $file = $this->getFile($class, $path, $prefix);
+                if (file_exists($file)) {
+                    require $file;
+                    return;
+                }
+            }
+        }
+
+        /* PSR-4 Loader.
+         * @see https://www.php-fig.org/psr/psr-4/
+         */
+        foreach ($this->psr4 as $prefix => $path) {
+            if (empty($prefix) || strpos($class, $prefix) === 0) {
+                $file = $this->getFile($class, $path, $prefix);
+                if (file_exists($file)) {
+                    require $file;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -38,7 +38,7 @@ class FOSSBillingAutoloader
     }
 
     /**
-     * @param string $class Classname, after having and specialzed handling performed
+     * @param string $class Classname, after having and specialized handling performed
      * @param string $path The path associated with the prefix
      * @param mixed $prefix The prefix matching the classname.
      * @return string The completed file path.

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -34,7 +34,6 @@ class FOSSBillingAutoloader
                 break;
             default:
                 throw new \Exception("Unknown PSR autoloader type: {$type}");
-                break;
         }
     }
 

--- a/src/library/Autoload.php
+++ b/src/library/Autoload.php
@@ -12,7 +12,12 @@ class FOSSBillingAutoloader
     private string $typePsr0 = 'psr0';
     private string $typePsr4 = 'psr4';
 
-    public function checkClassMap()
+    /** 
+     * Checks for the existance of the classMap file. Will generate a new one if it doesn't exist.
+     * After generating one / if it exists, the map is loaded to the classMap array to be used to speed up loading later.
+     * @return void  
+     */
+    public function checkClassMap(): void
     {
         if (!file_exists(self::$classMapPath)) {
             $generator = new Composer\ClassMapGenerator\ClassMapGenerator;
@@ -33,9 +38,14 @@ class FOSSBillingAutoloader
             return;
         }
         $this->classMap = include self::$classMapPath;
+        return;
     }
 
-    public function register()
+    /** 
+     * Registers the autoloader.
+     * @return void
+     * */
+    public function register(): void
     {
         spl_autoload_register(array($this, 'autoload'));
     }
@@ -74,7 +84,6 @@ class FOSSBillingAutoloader
         //Check if the class exists in the classMap array and then use that to require it, rather than searching for it.
         $file = $this->classMap[$class] ?? '';
         if (file_exists($file)) {
-            error_log("Loaded $class from classmap.");
             require $file;
             return;
         }
@@ -137,7 +146,11 @@ class FOSSBillingAutoloader
         return $path . $classname;
     }
 
-    private function saveMap()
+    /**
+     * Saves the current classMap array to the cache folder for later access.
+     * @return void 
+     */
+    private function saveMap(): void
     {
         $output = '<?php ' . PHP_EOL;
         $output .= 'return ' . var_export($this->classMap, true) . ';';

--- a/src/load.php
+++ b/src/load.php
@@ -232,6 +232,13 @@ $config = require PATH_CONFIG;
 // Verify the installer was removed.
 checkInstaller();
 
+//Initial setup and checks passed, now we setup our custom autoloader.
+require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Autoload.php';
+$loader = new \FOSSBillingAutoloader();
+$loader->addPrefix('', PATH_LIBRARY, 'psr0');
+$loader->addPrefix('Box\\Mod\\', PATH_MODS, 'psr4');
+$loader->register();
+
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', $config['debug']);

--- a/src/load.php
+++ b/src/load.php
@@ -232,13 +232,6 @@ $config = require PATH_CONFIG;
 // Verify the installer was removed.
 checkInstaller();
 
-//Initial setup and checks passed, now we setup our custom autoloader.
-require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Autoload.php';
-$loader = new \FOSSBillingAutoloader();
-$loader->addPrefix('', PATH_LIBRARY, 'psr0');
-$loader->addPrefix('Box\\Mod\\', PATH_MODS, 'psr4');
-$loader->register();
-
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', $config['debug']);
@@ -248,6 +241,14 @@ define('PATH_LOG', $config['path_data'] . DIRECTORY_SEPARATOR . 'log');
 define('BB_SSL', str_starts_with($config['url'], 'https'));
 define('ADMIN_PREFIX', $config['admin_area_prefix']);
 define('BB_URL_API', $config['url'] . 'api/');
+
+//Initial setup and checks passed, now we setup our custom autoloader.
+require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Autoload.php';
+$loader = new \FOSSBillingAutoloader();
+$loader->addPrefix('', PATH_LIBRARY, 'psr0');
+$loader->addPrefix('Box\\Mod\\', PATH_MODS, 'psr4');
+$loader->checkClassMap();
+$loader->register();
 
 // Check if SSL required, and enforce if so.
 checkSSL();


### PR DESCRIPTION
This PR implements a custom auto loader which allows us to workaround issues introduced in PR https://github.com/FOSSBilling/FOSSBilling/pull/1191. Unfortunately, composer [doesn't seem interested](https://github.com/composer/composer/issues/5198) in providing the ability to define a custom document root, so it's always going to be tied to the location of the manifest file, which causes issues for the autoloader functionality when you move the manifest outside of your application's release folder.

For me, this PR fixes that issue. It would probably be ideal for other's to test as well before we merge.
![image](https://user-images.githubusercontent.com/17304943/235382063-7fbb358c-1d7f-49b1-b67f-48dfaaede2f8.png)
