### PR TITLE
Fix product order not respecting configured priority

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_choose_product.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_choose_product.html.twig
@@ -12,7 +12,7 @@
                 <h2 style="margin-bottom: -5px;">{{ category.title }}</h2>
                 <span>{{ category.description|markdown }}</span>
                 <ul class="nav nav-list">
-                    {% for i, product in category.products %}
+                    {% for i, product in category.products|sort((a, b) => a.priority <=> b.priority) %}
                     <li>
                         <a href="{{ 'orderbutton'|link({ 'order': product.id, 'show_custom_form_values': request.show_custom_form_values }) }}">{{ product.title }} <span class="awe-arrow-right pull-right"><span></a>
                     </li>


### PR DESCRIPTION
Closes #1038 by making the orderbutton module sort by priority.
Screenshot with the product priority displayed on screen to show they are in the right order:
![image](https://user-images.githubusercontent.com/17304943/235387245-0d61d2b5-e2ce-4782-b761-a8b75147e5f4.png)

Edit:
I had a screenshot showing the order they were listed in the admin panel because I thought it was the creation order, but that actually was using the priority as well, so I removed it since it didn't show anything different to the main screenshot
