### PR TITLE
Prevent float to int conversion warning

### DIFF
--- a/src/modules/Queue/Api/Admin.php
+++ b/src/modules/Queue/Api/Admin.php
@@ -183,9 +183,9 @@ class Admin extends \Api_Abstract
 
         $iterate = true;
         while ($iterate) {
-            $start = (float) array_sum(explode(' ', microtime()));
+            $start = (int) array_sum(explode(' ', microtime()));
             $r = $this->_execute($q, $max, $interval);
-            $end = (float) array_sum(explode(' ', microtime()));
+            $end = (int) array_sum(explode(' ', microtime()));
 
             $wait_for = $interval - ($end - $start);
 


### PR DESCRIPTION
In recent versions of PHP, converting from a float to an int causes deprecation warnings. This PR cleans up a situation I came across where that was happing.