### PR TITLE
Update Dependabot config to ignore incorrect PHPUnit action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "php-actions/phpunit"
+        versions: ["5", "6", "7", "8", "9"]
 
   - package-ecosystem: "composer"
     directory: "/"


### PR DESCRIPTION
Update Dependabot workflow config to ignore incorrect PHPUnit action versions due to php-actions/phpunit#49.