### PR TITLE
Fix issues with updating clients

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -272,7 +272,6 @@ class Admin extends \Api_Abstract
         $client->email = (!empty($data['email']) ? $data['email'] : $client->email);
         $client->first_name = (!empty($data['first_name']) ? $data['first_name'] : $client->first_name);
         $client->last_name = (!empty($data['last_name']) ? $data['last_name'] : $client->last_name);
-        $client->last_name = (!empty($data['last_name']) ? $data['last_name'] : $client->last_name);
         $client->aid = (!empty($data['aid']) ? $data['aid'] : $client->aid);
         $client->gender = (!empty($data['gender']) ? $data['gender'] : $client->gender);
         $client->birthday = (!empty($data['birthday']) ? $data['birthday'] : $client->birthday);

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -269,45 +269,46 @@ class Admin extends \Api_Abstract
             $client->phone_cc = intval($phoneCC);
         }
 
-        $client->email = $data['email'] ?? (empty($client->email) ? null : $client->email);
-        $client->first_name = $data['first_name'] ?? (empty($client->first_name) ? null : $client->first_name);
-        $client->last_name = $data['last_name'] ?? (empty($client->last_name) ? null : $client->last_name);
-        $client->aid = $data['aid'] ?? (empty($client->aid) ? null : $client->aid);
-        $client->gender = $data['gender'] ?? (empty($client->gender) ? null : $client->gender);
-        $client->birthday = $data['birthday'] ?? (empty($client->birthday) ? null : $client->birthday);
-        $client->company = $data['company'] ?? (empty($client->company) ? null : $client->company);
-        $client->company_vat = $data['company_vat'] ?? (empty($client->company_vat) ? null : $client->company_vat);
-        $client->address_1 = $data['address_1'] ?? (empty($client->address_1) ? null : $client->address_1);
-        $client->address_2 = $data['address_2'] ?? (empty($client->address_1) ? null : $client->address_1);
-        $client->phone = $data['phone'] ?? (empty($client->phone) ? null : $client->phone);
-        $client->document_type = $data['document_type'] ?? (empty($client->document_type) ? null : $client->document_type);
-        $client->document_nr = $data['document_nr'] ?? (empty($client->document_nr) ? null : $client->document_nr);
-        $client->notes = $data['notes'] ?? (empty($client->notes) ? null : $client->notes);
-        $client->country = $data['country'] ?? (empty($client->country) ? null : $client->country);
-        $client->postcode = $data['postcode'] ?? (empty($client->postcode) ? null : $client->postcode);
-        $client->state = $data['phonestate_cc'] ?? (empty($client->phonestate_cc) ? null : $client->phonestate_cc);
-        $client->city = $data['city'] ?? (empty($client->city) ? null : $client->city);
+        $client->email = (!empty($data['email']) ? $data['email'] : $client->email);
+        $client->first_name = (!empty($data['first_name']) ? $data['first_name'] : $client->first_name);
+        $client->last_name = (!empty($data['last_name']) ? $data['last_name'] : $client->last_name);
+        $client->last_name = (!empty($data['last_name']) ? $data['last_name'] : $client->last_name);
+        $client->aid = (!empty($data['aid']) ? $data['aid'] : $client->aid);
+        $client->gender = (!empty($data['gender']) ? $data['gender'] : $client->gender);
+        $client->birthday = (!empty($data['birthday']) ? $data['birthday'] : $client->birthday);
+        $client->company = (!empty($data['company']) ? $data['company'] : $client->company);
+        $client->company_vat = (!empty($data['company_vat']) ? $data['company_vat'] : $client->company_vat);
+        $client->address_1 = (!empty($data['address_1']) ? $data['address_1'] : $client->address_1);
+        $client->address_2 = (!empty($data['address_2']) ? $data['address_2'] : $client->address_2);
+        $client->phone = (!empty($data['phone']) ? $data['phone'] : $client->phone);
+        $client->document_type = (!empty($data['document_type']) ? $data['document_type'] : $client->document_type);
+        $client->document_nr = (!empty($data['document_nr']) ? $data['document_nr'] : $client->document_nr);
+        $client->notes = (!empty($data['notes']) ? $data['notes'] : $client->notes);
+        $client->country = (!empty($data['country']) ? $data['country'] : $client->country);
+        $client->postcode = (!empty($data['postcode']) ? $data['postcode'] : $client->postcode);
+        $client->state = (!empty($data['state']) ? $data['state'] : $client->state);
+        $client->city = (!empty($data['city']) ? $data['city'] : $client->city);
 
-        $client->status = $data['status'] ?? (empty($client->status) ? null : $client->status);
-        $client->email_approved = $data['email_approved'] ?? (empty($client->email_approved) ? null : $client->email_approved);
-        $client->tax_exempt = $data['tax_exempt'] ?? (empty($client->tax_exempt) ? null : $client->tax_exempt);
-        $client->created_at = $data['created_at'] ?? (empty($client->created_at) ? null : $client->created_at);
+        $client->status = (!empty($data['status']) ? $data['status'] : $client->status);
+        $client->email_approved = (!empty($data['email_approved']) ? $data['email_approved'] : $client->email_approved);
+        $client->tax_exempt = (!empty($data['tax_exempt']) ? $data['tax_exempt'] : $client->tax_exempt);
+        $client->created_at = (!empty($data['created_at']) ? $data['created_at'] : $client->created_at);
 
-        $client->custom_1 = $data['custom_1'] ?? (empty($client->custom_1) ? null : $client->custom_1);
-        $client->custom_2 = $data['custom_2'] ?? (empty($client->custom_2) ? null : $client->custom_2);
-        $client->custom_3 = $data['custom_3'] ?? (empty($client->custom_3) ? null : $client->custom_3);
-        $client->custom_4 = $data['custom_4'] ?? (empty($client->custom_4) ? null : $client->custom_4);
-        $client->custom_5 = $data['custom_5'] ?? (empty($client->custom_5) ? null : $client->custom_5);
-        $client->custom_6 = $data['custom_6'] ?? (empty($client->custom_6) ? null : $client->custom_6);
-        $client->custom_7 = $data['custom_7'] ?? (empty($client->custom_7) ? null : $client->custom_7);
-        $client->custom_8 = $data['custom_8'] ?? (empty($client->custom_8) ? null : $client->custom_8);
-        $client->custom_9 = $data['custom_9'] ?? (empty($client->custom_9) ? null : $client->custom_9);
-        $client->custom_10 = $data['custom_10'] ?? (empty($client->custom_10) ? null : $client->custom_10);
+        $client->custom_1 = (!empty($data['custom_1']) ? $data['custom_1'] : $client->custom_1);
+        $client->custom_2 = (!empty($data['custom_2']) ? $data['custom_2'] : $client->custom_2);
+        $client->custom_3 = (!empty($data['custom_3']) ? $data['custom_3'] : $client->custom_3);
+        $client->custom_4 = (!empty($data['custom_4']) ? $data['custom_4'] : $client->custom_4);
+        $client->custom_5 = (!empty($data['custom_5']) ? $data['custom_5'] : $client->custom_5);
+        $client->custom_6 = (!empty($data['custom_6']) ? $data['custom_6'] : $client->custom_6);
+        $client->custom_7 = (!empty($data['custom_7']) ? $data['custom_7'] : $client->custom_7);
+        $client->custom_8 = (!empty($data['custom_8']) ? $data['custom_8'] : $client->custom_8);
+        $client->custom_9 = (!empty($data['custom_9']) ? $data['custom_9'] : $client->custom_9);
+        $client->custom_10 = (!empty($data['custom_10']) ? $data['custom_10'] : $client->custom_10);
 
-        $client->client_group_id = $data['group_id'] ?? (empty($client->group_id) ? null : $client->group_id);
-        $client->company_number = $data['company_number'] ?? (empty($client->company_number) ? null : $client->company_number);
-        $client->type = $data['type'] ?? (empty($client->type) ? null : $client->type);
-        $client->lang = $data['lang'] ?? (empty($client->lang) ? null : $client->lang);
+        $client->client_group_id = (!empty($data['client_group_id']) ? $data['client_group_id'] : $client->client_group_id);
+        $client->company_number = (!empty($data['company_number']) ? $data['company_number'] : $client->company_number);
+        $client->type = (!empty($data['type']) ? $data['type'] : $client->type);
+        $client->lang = (!empty($data['lang']) ? $data['lang'] : $client->lang);
 
         $client->updated_at = date('Y-m-d H:i:s');
 


### PR DESCRIPTION
Closes #1241 by fixing the logic that checks to see if the posted data is empty or not.
Old logic was checking if it was null, not if it was empty, thus causing the fallback to use the info from the database to not work (as the API wrapper will still send an empty string for those)