### PR TITLE
fix/do-not-translate-product_title

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -715,7 +715,7 @@ class Service implements InjectionAwareInterface
         if (method_exists($service, 'getCartProductTitle')) {
             return $service->getCartProductTitle($product, $config);
         } else {
-            return __trans(':product_title', [':product_title' => $product->title]);
+            return $product->title;
         }
     }
 


### PR DESCRIPTION
 return __trans(':product_title', [':product_title' => $product->title]);

is the same as 

 return $product->title);

And prevent users from making mistakes

Unless we support multiple translations for product titles.. 