### PR TITLE
Replace default email templats with HTML ones

### DIFF
--- a/src/modules/Client/html_email/mod_client_confirm.html.twig
+++ b/src/modules/Client/html_email/mod_client_confirm.html.twig
@@ -1,16 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] Please confirm your email address {% endblock %}
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Please verify your email by clicking on the link below:
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-{{email_confirmation_link}}
+		p {
+			margin: 0 0 10px;
+		}
 
-To login, visit {{'login'|link({'email' : c.email }) }}
-Edit your profile at {{'client/profile'|link}}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Email confirmation</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Please verify your email by clicking on the link below:</p>
+    <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    <p>You may also <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Client/html_email/mod_client_password_reset_approve.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_approve.html.twig
@@ -1,22 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] Password Changed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-As you requested, your password for our client area has now been reset. 
-Your new login details are as follows:
+		p {
+			margin: 0 0 10px;
+		}
 
-Login at: {{'login'|link({'email' : c.email }) }}
-Email: {{ c.email }}
-Password: {{ password }}
+		strong {
+			font-weight: bold;
+		}
 
-To change your password to something more memorable, after logging in go to 
-Profile &gt; Change Password.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Password reset</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>As you requested, your password for our client area has now been reset.</p>
+    <p>Your new login details are as follows:</p>
+    <ul>
+        <li><strong>Email:</strong> {{ c.email }}</li>
+        <li><strong>Password:</strong> {{ password }}</li>
+    </ul>
+    <p>Once you have logged in, feel free to go to the edit profile page to change your password to be more memorable.</p>
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-Edit your profile at {{ 'client/profile'|link }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
@@ -40,10 +40,10 @@
 	<p>Recently a request was submitted to reset your password for the client area.</p>
     <p>If you did not request this, please ignore this email. It will expire and will not work in 2 hours time.</p>
 
-    <p>To reset your password, pleae visit the link below:</p>
+    <p>To reset your password, please visit the link below:</p>
     <a href="{{'client/reset-password-confirm'|link}}/{{ hash }}" target="_blank">{{'client/reset-password-confirm'|link}}/{{ hash }}</a>
 
-    <p>Once visting the link above, you will be emailed a new password that you may login with.</p>
+    <p>Once visiting the link above, you will be emailed a new password that you may login with.</p>
 
     <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 

--- a/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
@@ -1,23 +1,53 @@
 {% block subject %}[{{ guest.system_company.name }}] Confirm Password Reset{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Recently a request was submitted to reset your password for the client area.
-If you did not request this, please ignore this email. It will expire and will not work in 2 hours time.
+		p {
+			margin: 0 0 10px;
+		}
 
-To reset your password, please visit the url below:    
-{{'client/reset-password-confirm'|link}}/{{ hash }}
+		strong {
+			font-weight: bold;
+		}
 
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Password reset</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Recently a request was submitted to reset your password for the client area.</p>
+    <p>If you did not request this, please ignore this email. It will expire and will not work in 2 hours time.</p>
 
-When you visit the link above, your password will be reset and a new 
-password will be emailed to you.
+    <p>To reset your password, pleae visit the link below:</p>
+    <a href="{{'client/reset-password-confirm'|link}}/{{ hash }}" target="_blank">{{'client/reset-password-confirm'|link}}/{{ hash }}</a>
 
-To login, visit {{'login'|link({'email' : c.email }) }}
-Edit your profile at {{'client/profile'|link}}
+    <p>Once visting the link above, you will be emailed a new password that you may login with.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Client/html_email/mod_client_signup.html.twig
+++ b/src/modules/Client/html_email/mod_client_signup.html.twig
@@ -1,26 +1,55 @@
 {% block subject %}[{{ guest.system_company.name }}] Welcome {{ c.first_name }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Thank you for signing up with us. Your new account has been setup and you can now login to our client area using the details below.
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
+		p {
+			margin: 0 0 10px;
+		}
 
-Email: {{c.email}}    
-Password: {{password}}
+		strong {
+			font-weight: bold;
+		}
 
-{% if require_email_confirmation %}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Welcome</h1>
+	<p>Thank you for signing up with us. Your new account has been setup and you can now login to our client area using the details below:</p>
+    <ul>
+        <li><strong>Email:</strong> {{ c.email }}</li>
+        <li><strong>Password:</strong> {{ password }}</li>
+    </ul>
 
-Approve your email by clicking on the link below:
+    {% if require_email_confirmation %}
+        <p>Please verify your email by clicking on the link below:</p>
+        <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    {% endif %}
+    
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-{{email_confirmation_link}}
-
-{% endif %}
-
-To login, visit {{'login'|link({'email' : c.email }) }}
-Edit your profile at {{'client/profile'|link}}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Email/html_email/mod_email_test.html.twig
+++ b/src/modules/Email/html_email/mod_email_test.html.twig
@@ -1,12 +1,44 @@
 {% block subject %}[{{ guest.system_company.name }}] FOSSBilling Email Test{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-If you are reading this email, FOSSBilling is **configured properly** 
-and is **able to send emails**.
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-{{ guest.system_company.signature }}
+		p {
+			margin: 0 0 10px;
+		}
 
-{% endapply %}
+		strong {
+			font-weight: bold;
+		}
+
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Test email from [{{ guest.system_company.name }}]</h1>
+	<p>Hi {{ staff.name }},</p>
+	<p>If you are reading this email, FOSSBilling is <strong>configured properly</strong> and is <strong>able to send emails</strong>.</p>
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Invoice/html_email/mod_invoice_created.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_created.html.twig
@@ -1,17 +1,53 @@
 {% block subject %}[{{ guest.system_company.name }}] Invoice Created{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-This is to notify that proforma invoice {{ invoice.id }} was generated on {{ invoice.created_at|format_date }}.
-Amount Due: {{ invoice.total | money(invoice.currency) }}
-Due Date: {{ invoice.due_at|format_date }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Invoice created</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>This is to notify that invoice {{ invoice.id }} was generated on {{ invoice.created_at|format_date }}.</p>
+    <ul>
+        <li><strong>Amount Due:</strong> {{ invoice.total | money(invoice.currency) }}</li>
+        <li><strong>Due Date:</strong>  {{ invoice.due_at|format_date }}</li>
+    </ul>
 
-{% endapply %}
+    <p>You may view and pay the invoice <a href="{{'invoice'|link}}/{{invoice.hash}}" target="_blank">here.</a>
+    <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    <p>You may also <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_due_after.html.twig
@@ -1,23 +1,53 @@
 {% block subject %}[{{ guest.system_company.name }}] Invoice Due{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-This is a payment reminder that your proforma invoice **{{ invoice.serie_nr }}** is already
-due for {{ days_passed }} days.   
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Amount Due: {{ invoice.total | money(invoice.currency) }}
-Due Date: {{ invoice.due_at|format_date }}
+		p {
+			margin: 0 0 10px;
+		}
 
-You can view and pay the invoice at: {{'invoice'|link}}/{{invoice.hash}}
+		strong {
+			font-weight: bold;
+		}
 
-You may review your invoice history at any time by logging in to your client area.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Invoice past-due</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>This is a payment reminder that your invoice <strong>{{ invoice.serie_nr }}</strong> is past-due by {{ days_passed }} days.</p>
+    <ul>
+        <li><strong>Amount Due:</strong> {{ invoice.total | money(invoice.currency) }}</li>
+        <li><strong>Due Date:</strong>  {{ invoice.due_at|format_date }}</li>
+    </ul>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-View and manage invoices: {{'invoice'|link}}  
+    <p>You may view and pay the invoice <a href="{{'invoice'|link}}/{{invoice.hash}}" target="_blank">here.</a>
+    <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    <p>You may also <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Invoice/html_email/mod_invoice_paid.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_paid.html.twig
@@ -1,20 +1,53 @@
 {% block subject %}[{{ guest.system_company.name }}] Payment Received{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-This is a payment receipt for Invoice **{{ invoice.serie_nr }}** issued on
-{{ invoice.created_at|format_date }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Total Paid: {{ invoice.total | money(invoice.currency) }}
+		p {
+			margin: 0 0 10px;
+		}
 
-You may review your invoice history at any time by logging in to your client area.
-Note: This email serves as an official receipt for this payment.
+		strong {
+			font-weight: bold;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-View invoice: {{'invoice'|link}}/{{invoice.hash}}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Invoice paid</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>This is a payment receipt for invoice <strong>{{ invoice.serie_nr }}</strong> issued on {{ invoice.created_at|format_date }}</p>
+    <ul>
+        <li><strong>Total Paid:</strong> {{ invoice.total|money(invoice.currency) }}</li>
+        <li><strong>Date Paid:</strong>  {{ invoice.paid_at|format_date }}</li>
+    </ul>
 
-{{ guest.system_company.signature }}
+    <p>You may view the invoice <a href="{{'invoice'|link}}/{{invoice.hash}}" target="_blank">here.</a>
+    <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    <p>You may also <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
+++ b/src/modules/Invoice/html_email/mod_invoice_payment_reminder.html.twig
@@ -1,23 +1,54 @@
 {% block subject %}[{{ guest.system_company.name }}] Payment Reminder{% endblock %}
 
 {% block content %}
-{% apply markdown %}
-Hello {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-This is to remind that your proforma invoice **{{ invoice.serie_nr }}** is due
-in {{ invoice.due_at|daysleft }} days.   
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Amount Due: {{ invoice.total|money(invoice.currency) }}
-Due Date: {{ invoice.due_at|format_date }}
+		p {
+			margin: 0 0 10px;
+		}
 
-You can view and pay the invoice at: {{ 'invoice'|link }}/{{ invoice.hash }}
+		strong {
+			font-weight: bold;
+		}
 
-You may review your invoice history at any time by logging in to your client area.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Invoice payment reminder</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>This is to remind that your invoice <strong>{{ invoice.serie_nr }}</strong> is due in {{ invoice.due_at|daysleft }} days.</p>
+    <ul>
+        <li><strong>Amount Due:</strong> {{ invoice.total | money(invoice.currency) }}</li>
+        <li><strong>Due Date:</strong>  {{ invoice.due_at|format_date }}</li>
+    </ul>
 
-Login to members area: {{ 'login'|link({ 'email': c.email }) }}
-View and manage invoices: {{ 'invoice'|link }}
+    <p>You may view and pay the invoice <a href="{{'invoice'|link}}/{{invoice.hash}}" target="_blank">here.</a>
+    <a href="{{email_confirmation_link}}" target="_blank">{{email_confirmation_link}}</a>
+    <p>You may also <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
-
-{{ guest.system_company.signature }}
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
@@ -37,7 +37,7 @@
 <body>
 	<h1>Order is now active</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> is now actived.</p>
+	<p>Your <strong>{{ order.title }}</strong> is now activated.</p>
 
     <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
@@ -37,7 +37,7 @@
 <body>
 	<h1>Order is now active</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> is now active.</p>
+	<p>Your <strong>{{ order.title }}</strong> is now actived.</p>
 
     <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_activated.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Activated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** is now active.
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order is now active</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now active.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_canceled.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_canceled.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Canceled{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now canceled
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order canceled</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now canceled.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_renewed.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_renewed.html.twig
@@ -1,21 +1,50 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** has been renewed.
+		p {
+			margin: 0 0 10px;
+		}
 
-{% if order.expires_at %}
+		strong {
+			font-weight: bold;
+		}
 
-Next renewal date: {{ order.expires_at|format_date }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order renewed</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
+    {% if order.expires_at %}
+        <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
+    {% endif %}
 
-{% endif %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_suspended.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_suspended.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was activated at *{{ order.activated_at|format_date }}* is now suspended
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order suspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicecustom/html_email/mod_servicecustom_unsuspended.html.twig
+++ b/src/modules/Servicecustom/html_email/mod_servicecustom_unsuspended.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated {% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* has been reactivated. 
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order unsuspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now unsuspended.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
@@ -37,7 +37,7 @@
 <body>
 	<h1>Order activated</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> is now actived.</p>
+	<p>Your <strong>{{ order.title }}</strong> is now activated.</p>
     <p>Please keep in mind that your domain name may not be visible on the internet instantly due to the propagation process which may take up to 48 hours.</p>
     <p>Your website and email will not function until the domain has propagated.</p>
 

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_activated.html.twig
@@ -1,43 +1,66 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-This message is to confirm that your **{{ order.title }}** has been successful. 
+		p {
+			margin: 0 0 10px;
+		}
 
-Please keep in mind that your domain name will not be visible  on the internet 
-instantly. This process is called propagation and can take up to 48 hours. 
-Your website and  email will not function until the domain has propagated.
+		strong {
+			font-weight: bold;
+		}
 
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order activated</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now actived.</p>
+    <p>Please keep in mind that your domain name may not be visible on the internet instantly due to the propagation process which may take up to 48 hours.</p>
+    <p>Your website and email will not function until the domain has propagated.</p>
 
-**Domain details:**
+    <p>Domain details:</p>
+    <ul>
+        <li><strong>Domain:</strong> {{ service.domain }}</li>
+        <li><strong>Registration date:</strong> {{order.created_at|format_date}}</li>
+        <li><strong>Registration period:</strong> {{service.period}} Year(s)</li>
+        {% if order.expires_at %}<li><strong>Expires on:</strong> {{ order.expires_at|format_date }}</li>{% endif %}
+        {% if order.period %}<li><strong>Billing period:</strong> {{ order.total | money(order.currency) }} every {{ order.period | period_title }}</li>{% endif %}
+    </ul>
 
+    <p>Nameserver details:</p>
+    <ul>
+        <li><strong>Nameserver 1:</strong> {{ service.server.ns1 }}</li>
+        <li><strong>Nameserver 2:</strong> {{ service.server.ns2 }}</li>
+        {% if  service.server.ns3 %}<li><strong>Nameserver 4:</strong> {{ service.server.ns3 }}</li>{% endif %}
+        {% if  service.server.ns3 %}<li><strong>Nameserver 4:</strong> {{ service.server.ns4 }}</li>{% endif %}
+    </ul>
 
-Domain: {{ service.domain }}     
-Registration date: {{order.created_at|format_date}}
-Registration period: {{service.period}} Year(s)   
-{% if order.expires_at %}Expires on: {{ order.expires_at|format_date }} {% endif %}
-{% if order.period %}
-Billing period:
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-{{ order.total | money(order.currency) }}
-{{ order.period | period_title }}
-
-{% endif %}       
-
-
-**Domain nameservers**
-
-Nameserver 1: {{ service.ns1 }}   
-Nameserver 2: {{ service.ns2 }}   
-{% if  service.server.ns3 %}Nameserver 3: {{ service.ns3 }}   {% endif %}
-{% if  service.server.ns4 %}Nameserver 4: {{ service.ns4 }}   {% endif %}
-
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_renewed.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_renewed.html.twig
@@ -1,22 +1,50 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** has been renewed.
+		p {
+			margin: 0 0 10px;
+		}
 
-{% if order.expires_at %}
+		strong {
+			font-weight: bold;
+		}
 
-Next renewal date: {{ order.expires_at|format_date }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order renewed</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
+    {% if order.expires_at %}
+        <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
+    {% endif %}
 
-{% endif %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_suspended.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_suspended.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now suspended.
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order suspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicedomain/html_email/mod_servicedomain_unsuspended.html.twig
+++ b/src/modules/Servicedomain/html_email/mod_servicedomain_unsuspended.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* has been reactivated. 
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order unsuspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now unsuspended.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicedownloadable/html_email/mod_servicedownloadable_activated.html.twig
+++ b/src/modules/Servicedownloadable/html_email/mod_servicedownloadable_activated.html.twig
@@ -37,7 +37,7 @@
 <body>
 	<h1>Order activated</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>Your <strong>{{ order.title }}</strong> is now actived and ready for download.</p>
+	<p>Your <strong>{{ order.title }}</strong> is now activated and ready for download.</p>
 
     <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'servicedownloadable/get-file'|link }}/{{ order.id }}" target="_blank">download your order now.</a>
 

--- a/src/modules/Servicedownloadable/html_email/mod_servicedownloadable_activated.html.twig
+++ b/src/modules/Servicedownloadable/html_email/mod_servicedownloadable_activated.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Ready to Download{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** is now active and ready for download.
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{ 'login'|link({ 'email': c.email }) }}
-Download URL: {{ 'servicedownloadable/get-file'|link }}/{{ order.id }}     
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order activated</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now actived and ready for download.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'servicedownloadable/get-file'|link }}/{{ order.id }}" target="_blank">download your order now.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
@@ -44,7 +44,7 @@
 	<h1>Order activated</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
 	<p>Thank you for ordering with us! Your hosting account has now been set up. This email contains all the information you will need in order to begin using your service.</p>
-    <p>Pleae keep in mind that if you ordered a domain, it may not be visible online instantly due to the propagation process which can take up to 48 hours. </p>
+    <p>Please keep in mind that if you ordered a domain, it may not be visible online instantly due to the propagation process which can take up to 48 hours. </p>
 
     <h2>{{ order.title }}</h2>
 

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_activated.html.twig
@@ -1,75 +1,95 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Activated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Thank you for ordering with us! Your hosting account has now been set up. This email contains all the information you will need in order to begin using your service.
+        h2 {
+			font-size: 20px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-If you have requested a domain name during the signup, please keep in mind that 
-your domain name will not be visible  on the internet instantly. 
-This process is called propagation and can take up to 48 hours. 
-Your website and email will not function until your domain has propagated.
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.title }}**
+		strong {
+			font-weight: bold;
+		}
 
-Activated: {{ order.activated_at|format_date }}
-{% if order.expires_at %}Expires: {{ order.expires_at|format_date }} {% endif %}
-{% if order.period %}
-Billing period:
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order activated</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Thank you for ordering with us! Your hosting account has now been set up. This email contains all the information you will need in order to begin using your service.</p>
+    <p>Pleae keep in mind that if you ordered a domain, it may not be visible online instantly due to the propagation process which can take up to 48 hours. </p>
 
-{{ order.total | money(order.currency) }}
-{{ order.period | period_title }}
+    <h2>{{ order.title }}</h2>
 
-{% endif %}       
+    <ul>
+        <li><strong>Activated:</strong> {{ order.activated_at|format_date }}</li>
+        {% if order.expires_at %}<li><strong>Expires:</strong> {{ order.expires_at|format_date }}</li>{% endif %}
+        {% if order.period %}<li><strong>Billing period:</strong> {{ order.total | money(order.currency) }} every {{ order.period | period_title }}</li>{% endif %}
+    </ul>
 
-**New Account Information**
+    <p>Account information:<p>
+    <ul>
+        <li><strong>Hosting package:</strong> {{ service.hosting_plan.name }}</li>
+        <li><strong>Domain:</strong> {{ service.domain }}</li>
+        <li><strong>IP address:</strong> {{ service.server.ip }}</li>
+    </ul>
 
+    <p>Control panel login details:<p>
+    <ul>
+        <li><strong>Username:</strong> {{ service.username }}</li>
+        <li><strong>Password:</strong> {{ password }}</li>
+        <li><strong>Control panel URL:</strong> {{ service.server.cpanel_url }}</li>
+    </ul>
 
-Hosting Package: {{ service.hosting_plan.name }}    
-Domain: {{ service.domain }}    
-IP Address: {{ service.server.ip }}
+    <p>Server information:<p>
+    <ul>
+        <li><strong>Server Name:</strong> {{ service.server.name }}</li>
+        <li><strong>Server IP:</strong> {{ service.server.ip }}</li>
+        <li><strong>Control panel URL:</strong> {{ service.server.cpanel_url }}</li>
+        <li><strong>Nameserver 1:</strong> {{ service.server.ns1 }}</li>
+        <li><strong>Nameserver 2:</strong> {{ service.server.ns2 }}</li>
+        {% if  service.server.ns3 %}<li><strong>Nameserver 4:</strong> {{ service.server.ns3 }}</li>{% endif %}
+        {% if  service.server.ns3 %}<li><strong>Nameserver 4:</strong> {{ service.server.ns4 }}</li>{% endif %}
+    </ul>
 
+    <p>FTP information:<p>
+    <ul>
+        <li><strong>Temporary FTP Hostname:</strong> {{ service.server.ip }}  </li>
+        <li><strong>Full FTP Hostname:</strong> {{ service.domain }}</li>
+        <li><strong>FTP Username:</strong> {{ service.username }}</li>
+        <li><strong>FTP Password:</strong> {{ password }}</li>
+    </ul>
 
-**Control Panel Login Details**
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'servicedownloadable/get-file'|link }}/{{ order.id }}" target="_blank">download your order now.</a>
 
-Username: {{ service.username }}    
-Password: {{ password }}     
-Control Panel URL: {{ service.server.cpanel_url }}
-
-
-**Server Information**
-
-Server Name: {{ service.server.name }}     
-Server IP: {{ service.server.ip }}
-
-If you are using an existing domain with your new hosting account, you  will 
-need to update the domain settings to point it to the nameservers listed below.
-
-Nameserver 1: {{ service.server.ns1 }}   
-Nameserver 2: {{ service.server.ns2 }}   
-{% if  service.server.ns3 %}Nameserver 3: {{ service.server.ns3 }}   {% endif %}
-{% if  service.server.ns4 %}Nameserver 4: {{ service.server.ns4 }}   {% endif %}
-
-**Uploading Your Website**
-
-
-You may use one of the addresses given below to manage your web site:
-
-
-Temporary FTP Hostname: {{ service.server.ip }}    
-Full FTP Hostname: {{ service.domain }}    
-FTP Username: {{ service.username }}    
-FTP Password: {{ password }}    
-
-You must upload files to the **public_html** folder!
-Thank you for choosing us.
-
-
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_canceled.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_canceled.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Canceled{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now canceled.
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order canceled</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now canceled.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_renewed.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_renewed.html.twig
@@ -1,21 +1,50 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** has been renewed.
+		p {
+			margin: 0 0 10px;
+		}
 
-{% if order.expires_at %}
+		strong {
+			font-weight: bold;
+		}
 
-Next renewal date: {{ order.expires_at|format_date }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order renewed</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
+    {% if order.expires_at %}
+        <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
+    {% endif %}
 
-{% endif %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_suspended.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_suspended.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now suspended.
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order suspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicehosting/html_email/mod_servicehosting_unsuspended.html.twig
+++ b/src/modules/Servicehosting/html_email/mod_servicehosting_unsuspended.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* has been reactivated.
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order unsuspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now unsuspended.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_activated.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_activated.html.twig
@@ -1,17 +1,49 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Activated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** is now active.
+		p {
+			margin: 0 0 10px;
+		}
 
-License key: **{{ service.license_key }}**
+		strong {
+			font-weight: bold;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order is now active</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now activated.</p>
 
-{{ guest.system_company.signature }}
+    <p><strong>License key:</strong> {{ service.license_key }}</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_canceled.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_canceled.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Canceled{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now canceled.
-{% if order.reason %} due to reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order canceled</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now canceled.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_renewed.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_renewed.html.twig
@@ -1,21 +1,50 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** has been renewed.
+		p {
+			margin: 0 0 10px;
+		}
 
-{% if order.expires_at %}
+		strong {
+			font-weight: bold;
+		}
 
-Next renewal date: {{ order.expires_at|format_date }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order renewed</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
+    {% if order.expires_at %}
+        <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
+    {% endif %}
 
-{% endif %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_suspended.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_suspended.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was issued on *{{ order.activated_at|format_date }}* is now suspended.
-{% if order.reason %} due to reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order suspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicelicense/html_email/mod_servicelicense_unsuspended.html.twig
+++ b/src/modules/Servicelicense/html_email/mod_servicelicense_unsuspended.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* has been reactivated. 
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order unsuspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now unsuspended.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_activated.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_activated.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Activated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** is now active.
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order is now active</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now activated.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_canceled.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_canceled.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Canceled{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now canceled.
-{% if order.reason %} Reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order canceled</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now canceled.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_renewed.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_renewed.html.twig
@@ -1,21 +1,50 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Renewed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your **{{ order.title }}** has been renewed.
+		p {
+			margin: 0 0 10px;
+		}
 
-{% if order.expires_at %}
+		strong {
+			font-weight: bold;
+		}
 
-Next renewal date: {{ order.expires_at|format_date }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order renewed</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> has been renewed.</p>
+    {% if order.expires_at %}
+        <p><strong>Next renewal date:</strong> {{ order.expires_at|format_date }}</p>
+    {% endif %}
 
-{% endif %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_suspended.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_suspended.html.twig
@@ -1,20 +1,52 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Suspended{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* that was activated on *{{ order.activated_at|format_date }}* is now suspended.
-{% if order.reason %} due to reason:     
+		p {
+			margin: 0 0 10px;
+		}
 
-**{{ order.reason }}** {% endif %}   
+		strong {
+			font-weight: bold;
+		}
 
-If you have any questions regarding this message please login to the members area and submit a support ticket.
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order suspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> that was activated on <strong>{{ order.activated_at|format_date }}</strong> is now suspended.</p>
+    {% if order.reason %}
+        <p><strong>Reason:</strong> {{ order.reason }}</p>
+    {% endif %}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Submit support ticket: {{ 'support'|link({'ticket' : 1}) }}
+    <p>If you have any questions regarding this, please login to the members area and submit a support ticket.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'support'|link({'ticket' : 1}) }}" target="_blank">submit a ticket.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Servicemembership/html_email/mod_servicemembership_unsuspended.html.twig
+++ b/src/modules/Servicemembership/html_email/mod_servicemembership_unsuspended.html.twig
@@ -1,15 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ order.title }} Reactivated{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Your *{{ order.title }}* has been reactivated. 
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Manage order: {{ 'order/service/manage'|link }}/{{ order.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Order unsuspended</h1>
+	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
+	<p>Your <strong>{{ order.title }}</strong> is now unsuspended.</p>
 
-{% endapply %}
+    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{ 'order/service/manage'|link }}/{{ order.id }}" target="_blank">manage your order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_client_order.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_client_order.html.twig
@@ -1,12 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] New Order Placed{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Client **{{ order.client.first_name }} {{ order.client.last_name }}** placed a new order for **{{ order.title }}** on {{ order.created_at|format_date }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Manage order {{ 'order/manage'|alink }}/{{ order.id }}
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ guest.system_company.signature }}
-{% endapply %}
+		strong {
+			font-weight: bold;
+		}
+
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>New order placed</h1>
+	<p>Hello {{ staff.name }},</p>
+	<p>Client <strong>{{ order.client.first_name }} {{ order.client.last_name }}</strong> placed a new order for <strong>{{ order.title }}</strong> on {{ order.created_at|format_date }}</p>
+
+    <p><a href="{{ 'order/manage'|alink }}/{{ order.id }}" target="_blank">Manage order.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_client_signup.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_client_signup.html.twig
@@ -1,13 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] New Client Signed Up{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
- *{{ c.first_name }} {{ c.last_name }}* has just signed up with {{ guest.system_company.name }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Manage client at {{'client/manage'|alink}}/{{c.id}}
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ guest.system_company.signature }}
+		strong {
+			font-weight: bold;
+		}
 
-{% endapply %}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>New client signed up</h1>
+	<p>Hello {{ staff.name }},</p>
+	<p><strong>{{ c.first_name }} {{ c.last_name }}</strong> has just signed up with {{ guest.system_company.name }}</p>
+
+    <p><a href="{{'client/manage'|alink}}/{{c.id}}" target="_blank">Manage client.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_password_reset_approve.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_password_reset_approve.html.twig
@@ -1,17 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] Password Changed{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style type="text/css">
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 14px;
+            color: #333333;
+        }
 
-Hello {{ c.name }},
-
-Your password has been changed.
-
-Login at: {{'admin/staff/login'|link({'email' : c.email }) }}
-Email: {{ c.email }}
-
-Edit your profile at {{ 'admin/staff/profile'|link }}
-
-{{ guest.system_company.signature }}
-
-{% endapply %}
+        h1 {
+            font-size: 24px;
+            font-weight: bold;
+            margin: 0 0 20px;
+        }
+        
+        p {
+            margin: 0 0 10px;
+        }
+        
+        strong {
+            font-weight: bold;
+        }
+        
+        .signature {
+            font-style: italic;
+            color: #999999;
+            margin-top: 20px;
+            border-top: 1px solid #cccccc;
+            padding-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Password reset</h1>
+    <p>Hello {{ staff.name }},</p>
+    <p>Your password has been changed.</p>
+    
+    <p><a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">Click here to login.</a>
+    
+    <p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_password_reset_request.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_password_reset_request.html.twig
@@ -1,23 +1,53 @@
 {% block subject %}[{{ guest.system_company.name }}] Confirm Password Reset{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hello {{ c.name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Recently a request was submitted to reset your password for the staff area.
-If you did not request this, please ignore this email. It will expire and will not work in 2 hours time.
+		p {
+			margin: 0 0 10px;
+		}
 
-To reset your password, please visit the url below:
-{{'admin/staff/email'|link}}/{{ hash }}
+		strong {
+			font-weight: bold;
+		}
 
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Password reset</h1>
+	<p>Hello {{ c.name }},</p>
+	<p>Recently a request was submitted to reset your password for the client area.</p>
+    <p>If you did not request this, please ignore this email. It will expire and will not work in 2 hours time.</p>
 
-When you visit the link above, your password will be reset and a new
-password will be emailed to you.
+    <p>To reset your password, please visit the link below:</p>
+    <a href="{{'admin/staff/email'|link}}/{{ hash }}" target="_blank">{{'admin/staff/email'|link}}/{{ hash }}</a>
 
-To login, visit {{'admin/staff/login'|link({'email' : c.email }) }}
-Edit your profile at {{'admin/staff/profile'|link}}
+    <p>Once visiting the link above, you will be emailed a new password that you may login with.</p>
 
-{{ guest.system_company.signature }}
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
 
-{% endapply %}
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_pticket_close.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_pticket_close.html.twig
@@ -1,12 +1,47 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}} [closed]{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ staff.name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Public ticket {{ 'support/public-ticket/'|alink }}/{{ticket.id}} was closed by client.
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ guest.system_company.signature }}
+		strong {
+			font-weight: bold;
+		}
 
-{% endapply %}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket closed</h1>
+	<p>Hello {{ c.name }},</p>
+	<p>Public ticket <a href="{{ 'support/public-ticket/'|alink }}/{{ticket.id}}" target="_blank">{{ 'support/public-ticket/'|alink }}/{{ticket.id}}</a> was closed by the client.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_pticket_open.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_pticket_open.html.twig
@@ -1,15 +1,49 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-New public ticket received. 
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Reply at {{'support/public-ticket'|alink }}/{{ ticket.id }}
+		p {
+			margin: 0 0 10px;
+		}
 
-Track conversation at:  {{'support/contact-us/conversation'|link }}/{{ ticket.hash }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket opended</h1>
+	<p>Hello {{ c.name }},</p>
+    <p>New public ticket received.</p>
+	<p>Reply at <a href="{{'support/public-ticket'|alink }}/{{ ticket.id }}" target="_blank">{{'support/public-ticket'|alink }}/{{ ticket.id }}</a></p>
+    <p>Track the conversation at <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}</a></p>
 
-{% endapply %}
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_pticket_open.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_pticket_open.html.twig
@@ -35,7 +35,7 @@
 	</style>
 </head>
 <body>
-	<h1>Ticket opended</h1>
+	<h1>Ticket opened</h1>
 	<p>Hello {{ c.name }},</p>
     <p>New public ticket received.</p>
 	<p>Reply at <a href="{{'support/public-ticket'|alink }}/{{ ticket.id }}" target="_blank">{{'support/public-ticket'|alink }}/{{ ticket.id }}</a></p>

--- a/src/modules/Staff/html_email/mod_staff_pticket_reply.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_pticket_reply.html.twig
@@ -1,12 +1,49 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ staff.name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-New reply posted on ticket {{ 'support/public-ticket/'|alink }}/{{ticket.id}}
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ guest.system_company.signature }}
+		strong {
+			font-weight: bold;
+		}
 
-{% endapply %}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>New ticket reply</h1>
+	<p>Hello {{ c.name }},</p>
+
+    <p>Public ticket {{ticket.id}} has a new reply.</p>
+	<p>Reply at <a href="{{ 'support/public-ticket/'|alink }}/{{ticket.id}}" target="_blank">{{ 'support/public-ticket/'|alink }}/{{ticket.id}}</a></p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_ticket_close.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_ticket_close.html.twig
@@ -1,13 +1,49 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
- **{{ ticket.client.first_name }} {{ ticket.client.last_name }}** closed support ticket #{{ ticket.id }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Review the ticket at {{'support/ticket'|alink }}/{{ ticket.id }}
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ guest.system_company.signature }}
+		strong {
+			font-weight: bold;
+		}
 
-{% endapply %}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket closed</h1>
+	<p>Hello {{ c.name }},</p>
+
+    <p><strong>{{ ticket.client.first_name }} {{ ticket.client.last_name }}</strong> closed support ticket #{{ ticket.id }}</p>
+	<a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Review the ticket</a>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_ticket_open.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_ticket_open.html.twig
@@ -1,23 +1,61 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
- **{{ ticket.client.first_name }} {{ ticket.client.last_name }}** opened a new support ticket #{{ ticket.id }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-***
+		p {
+			margin: 0 0 10px;
+		}
 
-{{ ticket.messages[0].content }}
+		strong {
+			font-weight: bold;
+		}
 
-***
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket opended</h1>
+	<p>Hello {{ c.name }},</p>
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}
+    <p><strong>{{ ticket.client.first_name }} {{ ticket.client.last_name }}</strong>  opened a new support ticket #{{ ticket.id }}</p>
+	<a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Review the ticket</a>
 
-Reply at {{'support/ticket'|alink }}/{{ ticket.id }}
+    <h2>Ticket contents<h2>
+    <p>{{ ticket.messages[0].content }}</p>
 
-{{ guest.system_company.signature }}
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
 
-{% endapply %}
+    <a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Reply<a>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Staff/html_email/mod_staff_ticket_open.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_ticket_open.html.twig
@@ -35,13 +35,13 @@
 	</style>
 </head>
 <body>
-	<h1>Ticket opended</h1>
+	<h1>Ticket opened</h1>
 	<p>Hello {{ c.name }},</p>
 
     <p><strong>{{ ticket.client.first_name }} {{ ticket.client.last_name }}</strong>  opened a new support ticket #{{ ticket.id }}</p>
 	<a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Review the ticket</a>
 
-    <h2>Ticket contents<h2>
+    opened<h2>Ticket contents</h2>
     <p>{{ ticket.messages[0].content }}</p>
 
     <p>Ticket info</p>

--- a/src/modules/Staff/html_email/mod_staff_ticket_reply.html.twig
+++ b/src/modules/Staff/html_email/mod_staff_ticket_reply.html.twig
@@ -1,17 +1,58 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ staff.name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
- **{{ ticket.client.first_name }} {{ ticket.client.last_name }}** replied to support ticket #{{ ticket.id }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}
+		p {
+			margin: 0 0 10px;
+		}
 
-Reply at {{'support/ticket'|alink }}/{{ ticket.id }}
+		strong {
+			font-weight: bold;
+		}
 
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket reply</h1>
+	<p>Hello {{ c.name }},</p>
 
-{% endapply %}
+    <p><strong>{{ ticket.client.first_name }} {{ ticket.client.last_name }}</strong> replied to support ticket #{{ ticket.id }}</p>
+	<a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Review the ticket</a>
+
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
+
+    <a href="{{'support/ticket'|alink }}/{{ ticket.id }}" target="_blank">Reply<a>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_helpdesk_ticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_helpdesk_ticket_open.html.twig
@@ -35,7 +35,7 @@
 	</style>
 </head>
 <body>
-	<h1>Ticket opended</h1>
+	<h1>Ticket opened</h1>
 
     <h2>Ticket contents</h2>
     <p>{{ ticket.messages[0].content }}</p>

--- a/src/modules/Support/html_email/mod_support_helpdesk_ticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_helpdesk_ticket_open.html.twig
@@ -1,22 +1,59 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-{{ticket.messages[0].content}}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-***
+		p {
+			margin: 0 0 10px;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}   
+		strong {
+			font-weight: bold;
+		}
 
-Reply Ticket at: {{'support/ticket'|link}}/{{ ticket.id }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket opended</h1>
 
+    <h2>Ticket contents</h2>
+    <p>{{ ticket.messages[0].content }}</p>
 
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
 
-{% endapply %}
+    <a href="{{'support/ticket'|link}}/{{ ticket.id }}" target="_blank">Reply<a>
+    
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
 
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_pticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_pticket_open.html.twig
@@ -1,14 +1,51 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ ticket.author_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Thank You for Your request. We will reply in 24 hours.
-You can track and respond to this conversation at {{'support/contact-us/conversation'|link }}/{{ ticket.hash }}
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+		p {
+			margin: 0 0 10px;
+		}
 
-{% endapply %}
+		strong {
+			font-weight: bold;
+		}
+
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Public ticket opened</h1>
+
+    <p>Hi {{ ticket.author_name }},</p>
+
+    <p>Thank You for Your request. We will reply wthin 24 hours.</p>
+    <p>You can track and respond to this conversation <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">here</a></p>
+
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_pticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_pticket_open.html.twig
@@ -39,7 +39,7 @@
 
     <p>Hi {{ ticket.author_name }},</p>
 
-    <p>Thank You for Your request. We will reply wthin 24 hours.</p>
+    <p>Thank You for Your request. We will reply within 24 hours.</p>
     <p>You can track and respond to this conversation <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">here</a></p>
 
     <p>Please do not reply to this email directly. Use the link provided above.</p>

--- a/src/modules/Support/html_email/mod_support_pticket_staff_close.html.twig
+++ b/src/modules/Support/html_email/mod_support_pticket_staff_close.html.twig
@@ -1,18 +1,51 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}} [closed]{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ ticket.author_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-This is a confirmation email to inform you that your ticket was closed.
+		p {
+			margin: 0 0 10px;
+		}
 
-You can track conversation at   
+		strong {
+			font-weight: bold;
+		}
 
-{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}
-      
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Public ticket opened</h1>
 
-{% endapply %}
+    <p>Hi {{ ticket.author_name }},</p>
+
+    <p>This is a confirmation email to inform you that your ticket was closed.</p>
+    <p>You can track conversation <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">here</a></p>
+
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_pticket_staff_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_pticket_staff_open.html.twig
@@ -1,20 +1,51 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ ticket.author_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-{{ticket.messages[0].content}}
+		p {
+			margin: 0 0 10px;
+		}
 
-***
+		strong {
+			font-weight: bold;
+		}
 
-You can track and respond to this conversation at:
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Public ticket opened</h1>
 
-{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}
-      
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+    <p>Hi {{ ticket.author_name }},</p>
 
-{% endapply %}
+    <p>{{ticket.messages[0].content}}</p>
+
+    <p>You can track and respond to this conversation <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">here</a></p>
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_pticket_staff_reply.html.twig
+++ b/src/modules/Support/html_email/mod_support_pticket_staff_reply.html.twig
@@ -1,18 +1,51 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ ticket.author_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-New reply was posted to request **{{ticket.subject}}**
+		p {
+			margin: 0 0 10px;
+		}
 
-You can track and respond to this conversation at:
+		strong {
+			font-weight: bold;
+		}
 
-{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}
-      
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Public ticket reply</h1>
 
-{% endapply %}
+    <p>Hi {{ ticket.author_name }},</p>
+
+    <p>A new reply was posted to ticket <strong>{{ticket.subject}}</strong></p>
+
+    <p>You can track and respond to this conversation <a href="{{'support/contact-us/conversation'|link }}/{{ ticket.hash }}" target="_blank">here</a></p>
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_ticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_ticket_open.html.twig
@@ -35,7 +35,7 @@
 	</style>
 </head>
 <body>
-	<h1>Ticket opended</h1>
+	<h1>Ticket opened</h1>
 
     <p>Thank you for contacting our support team. A support ticket has now been opened for your request.</p>
     <p>You will be notified by email when your ticket receives a response. The details of your ticket are shown below.</p>

--- a/src/modules/Support/html_email/mod_support_ticket_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_ticket_open.html.twig
@@ -1,22 +1,59 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ ticket.subject }}{% endblock %}
 {% block content %}
-{% apply markdown %}
-Hi {{ c.first_name }} {{ c.last_name }},
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Thank you for contacting our support team. 
-A support ticket has now been opened for your request. You will be notified when 
-a response is made by email. The details of your ticket are shown below.
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}
+		p {
+			margin: 0 0 10px;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Reply Ticket at: {{'support/ticket'|link}}/{{ ticket.id }}
+		strong {
+			font-weight: bold;
+		}
 
-Please do not reply to this email directly.
-      
-{{ guest.system_company.signature }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket opended</h1>
 
-{% endapply %}
+    <p>Thank you for contacting our support team. A support ticket has now been opened for your request.</p>
+    <p>You will be notified by email when your ticket receives a response. The details of your ticket are shown below.</p>
+
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
+
+    <a href="{{'support/ticket'|link}}/{{ ticket.id }}" target="_blank">Reply<a>
+    
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_ticket_staff_close.html.twig
+++ b/src/modules/Support/html_email/mod_support_ticket_staff_close.html.twig
@@ -1,23 +1,60 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-This a notification message to inform you that ticket **{{ticket.subject}}**
-is now closed.
+		p {
+			margin: 0 0 10px;
+		}
 
+		strong {
+			font-weight: bold;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}   
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket closed</h1>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Reply Ticket at: {{'support/ticket'|link}}/{{ ticket.id }}
+    <p>Hi {{ c.first_name }} {{ c.last_name }},</p>
 
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+    <p>This a notification message to inform you that ticket <strong>{{ticket.subject}}</strong> is now closed.</p>
 
-{% endapply %}
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
+
+    <a href="{{'support/ticket'|link}}/{{ ticket.id }}" target="_blank">Reply<a>
+    
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_ticket_staff_open.html.twig
+++ b/src/modules/Support/html_email/mod_support_ticket_staff_open.html.twig
@@ -1,25 +1,60 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-{{ticket.messages[0].content}}
+		p {
+			margin: 0 0 10px;
+		}
 
-***
+		strong {
+			font-weight: bold;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}   
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket opened</h1>
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Reply Ticket at: {{'support/ticket'|link}}/{{ ticket.id }}
+    <p>Hi {{ c.first_name }} {{ c.last_name }},</p>
 
+    <p>{{ticket.messages[0].content}}</p>
 
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
 
-{% endapply %}
+    <a href="{{'support/ticket'|link}}/{{ ticket.id }}" target="_blank">Reply<a>
+    
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
 
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}

--- a/src/modules/Support/html_email/mod_support_ticket_staff_reply.html.twig
+++ b/src/modules/Support/html_email/mod_support_ticket_staff_reply.html.twig
@@ -1,22 +1,60 @@
 {% block subject %}[{{ guest.system_company.name }}] {{ticket.subject}}{% endblock %}
 {% block content %}
-{% apply markdown %}
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<style type="text/css">
+		body {
+			font-family: Arial, sans-serif;
+			font-size: 14px;
+			color: #333333;
+		}
 
-Hi {{ c.first_name }} {{ c.last_name }},
+		h1 {
+			font-size: 24px;
+			font-weight: bold;
+			margin: 0 0 20px;
+		}
 
-New reply was posted to request **{{ticket.subject}}**
+		p {
+			margin: 0 0 10px;
+		}
 
-Ticket ID: #{{ticket.id}}   
-Department: {{ticket.helpdesk.name}}   
-Status: {{ticket.status|title}}  
+		strong {
+			font-weight: bold;
+		}
 
-Login to members area: {{'login'|link({'email' : c.email }) }}
-Reply Ticket at: {{'support/ticket'|link}}/{{ ticket.id }}
+		.signature {
+			font-style: italic;
+			color: #999999;
+			margin-top: 20px;
+			border-top: 1px solid #cccccc;
+			padding-top: 10px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Ticket replied</h1>
 
+    <p>Hi {{ c.first_name }} {{ c.last_name }},</p>
 
-Please do not reply to this email directly. Use the link provided above.
-      
-{{ guest.system_company.signature }}
+    <p>A new reply was posted to ticket <strong>{{ticket.subject}}</strong></p>
 
-{% endapply %}
+    <p>Ticket info</p>
+    <ul>
+        <li><strong>Ticket ID:</strong> #{{ticket.id}}</li>
+        <li><strong>Department:</strong> {{ticket.helpdesk.name}}</li>
+        <li><strong>Status:</strong> {{ticket.status|title}}</li>
+    </ul>
+
+    <a href="{{'support/ticket'|link}}/{{ ticket.id }}" target="_blank">Reply<a>
+    
+    <p>Please do not reply to this email directly. Use the link provided above.</p>
+
+    <p>You may <a href="{{'admin/staff/login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'admin/staff/profile'|link}}" target="_blank">edit your profile.</a>
+
+	<p class="signature">{{ guest.system_company.signature }}</p>
+</body>
+</html>
 {% endblock %}


### PR DESCRIPTION
This PR replaces the default markdown emails with ones that are styled using some simple HTML.
The templates are still very simple, but they are much more visually appealing than the otherwise plain-text templates.
Here's a few examples of the new ones:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/7d58a07c-7115-4226-affe-2a02680d8743)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/4459b3ae-1a59-4cef-b4fc-c5945c8321cf)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/9c2bcd5c-9acc-4925-ae07-edce9fd98ef4)
