### PR TITLE
Beef up invoice & ticket hash generation

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -511,7 +511,7 @@ class Service implements InjectionAwareInterface
 
         $model->serie = $systemService->getParamValue('invoice_series');
         $model->nr = $model->id;
-        $model->hash = hash('sha256', random_bytes(13));
+        $model->hash = bin2hex(random_bytes(random_int(100, 127)));;
 
         $taxtitle = '';
         $taxService = $this->di['mod_service']('Invoice', 'Tax');
@@ -628,7 +628,7 @@ class Service implements InjectionAwareInterface
 
                 $new = $this->di['db']->dispense('Invoice');
                 $new->client_id = $invoice->client_id;
-                $new->hash = hash('sha256', random_bytes(13));
+                $new->hash = bin2hex(random_bytes(random_int(100, 127)));;
                 $new->status = \Model_Invoice::STATUS_REFUNDED;
                 $new->currency = $invoice->currency;
                 $new->approved = true;

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -815,7 +815,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
 
         $ticket = $this->di['db']->dispense('SupportPTicket');
-        $ticket->hash = hash('sha256', random_bytes(13));
+        $ticket->hash = bin2hex(random_bytes(random_int(100, 127)));;
         $ticket->author_name = $data['name'];
         $ticket->author_email = $data['email'];
         $ticket->subject = $subject;
@@ -1202,7 +1202,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminPublicTicketOpen', 'params' => $data]);
 
         $ticket = $this->di['db']->dispense('SupportPTicket');
-        $ticket->hash = hash('sha256', random_bytes(13));
+        $ticket->hash = bin2hex(random_bytes(random_int(100, 127)));;
         $ticket->author_name = $data['name'];
         $ticket->author_email = $data['email'];
         $ticket->subject = $data['subject'];

--- a/tests/modules/Support/ServiceTest.php
+++ b/tests/modules/Support/ServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Box\Tests\Mod\Support;
 
 use \RedBeanPHP\OODBBean;
@@ -446,19 +447,20 @@ class ServiceTest extends \BBTestCase
     {
         return array(
             array(
-                array('search'              => 'query',
-                      'id'                  => rand(1, 100),
-                      'status'              => 'open',
-                      'client_id'           => rand(1, 100),
-                      'client'              => 'Client name',
-                      'order_id'            => rand(1, 100),
-                      'subject'             => 'subject',
-                      'content'             => 'Content',
-                      'support_helpdesk_id' => rand(1, 100),
-                      'created_at'          => date('Y-m-d H:i:s'),
-                      'date_from'           => date('Y-m-d H:i:s'),
-                      'date_to'             => date('Y-m-d H:i:s'),
-                      'priority'            => rand(1, 100),
+                array(
+                    'search'              => 'query',
+                    'id'                  => rand(1, 100),
+                    'status'              => 'open',
+                    'client_id'           => rand(1, 100),
+                    'client'              => 'Client name',
+                    'order_id'            => rand(1, 100),
+                    'subject'             => 'subject',
+                    'content'             => 'Content',
+                    'support_helpdesk_id' => rand(1, 100),
+                    'created_at'          => date('Y-m-d H:i:s'),
+                    'date_from'           => date('Y-m-d H:i:s'),
+                    'date_to'             => date('Y-m-d H:i:s'),
+                    'priority'            => rand(1, 100),
                 )
             ),
             array(
@@ -643,8 +645,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(rand(1, 100)));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
@@ -680,7 +681,7 @@ class ServiceTest extends \BBTestCase
 
     public function testCanBeReopenedNotClosed()
     {
-        $helpdesk = New \Model_SupportHelpdesk();
+        $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
@@ -701,7 +702,7 @@ class ServiceTest extends \BBTestCase
 
     public function testCanBeReopened()
     {
-        $helpdesk = New \Model_SupportHelpdesk();
+        $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
         $helpdesk->support_helpdesk_id = rand(1, 100);
         $helpdesk->can_reopen          = true;
@@ -758,8 +759,8 @@ class ServiceTest extends \BBTestCase
             ->method('find')
             ->withConsecutive(['SupportTicketNote'], ['SupportTicketMessage'])
             ->willReturnOnConsecutiveCalls(
-                    [new \Model_SupportTicketNote(), new \Model_SupportTicketNote()],
-                    [new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage()]
+                [new \Model_SupportTicketNote(), new \Model_SupportTicketNote()],
+                [new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage()]
             );
 
         $dbMock->expects($this->atLeastOnce())
@@ -782,7 +783,7 @@ class ServiceTest extends \BBTestCase
     {
         $supportTicketMessageModel = new \Model_SupportTicketMessage();
         $supportTicketMessageModel->loadBean(new \DummyBean());
-        $helpdesk = New \Model_SupportHelpdesk();
+        $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
@@ -1312,8 +1313,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($randId));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
@@ -1346,8 +1346,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($randId));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
@@ -1421,8 +1420,8 @@ class ServiceTest extends \BBTestCase
 
         $result = $this->service->ticketCreateForGuest($data);
         $this->assertIsString($result);
-        $this->assertGreaterThanOrEqual(strlen($result), 200);
-        $this->assertLessThanOrEqual(strlen($result), 255);
+        $this->assertGreaterThanOrEqual(200, strlen($result));
+        $this->assertLessThanOrEqual(255, strlen($result));
     }
 
     public function testTicketCreateForClient()
@@ -1803,8 +1802,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(rand(1, 100)));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
@@ -2007,8 +2005,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($randId));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
@@ -2080,8 +2077,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($randId));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-        method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
@@ -2238,9 +2234,9 @@ class ServiceTest extends \BBTestCase
 
         $expected = array(
             'General' =>
-                array(
-                    1 => 'R  Title',
-                ),
+            array(
+                1 => 'R  Title',
+            ),
         );
 
         $result = $this->service->cannedGetGroupedPairs();
@@ -2603,6 +2599,5 @@ class ServiceTest extends \BBTestCase
 
         $result = $this->service->canClientSubmitNewTicket($client, $config);
         $this->assertTrue($result);
-
     }
 }

--- a/tests/modules/Support/ServiceTest.php
+++ b/tests/modules/Support/ServiceTest.php
@@ -1421,7 +1421,8 @@ class ServiceTest extends \BBTestCase
 
         $result = $this->service->ticketCreateForGuest($data);
         $this->assertIsString($result);
-        $this->assertEquals(strlen($result), 64);
+        $this->assertGreaterThanOrEqual(strlen($result), 200);
+        $this->assertLessThanOrEqual(strlen($result), 255);
     }
 
     public function testTicketCreateForClient()


### PR DESCRIPTION
This PR replaces the existing method for creating access hashes for public tickets and invoices.

While the old method did use `random_bytes` to generate cryptographically secure random bytes and then convert that into a hash, the overall length was still *relatively* short at 64 char and a lot of that was made up by the final step where it then created a sha256 hash of the random bytes, the bytes that were created only have a length of 26 chars (as a hexadecimal string).

This version improves on it in a couple of ways:
 - Length is now between 200 and 254 chars to further utilize the 255 char length that the DB schema assigns for them.
 - Length is randomly chosen using `random_int`. which is cryptographically secure.
 - To create the final hash, it simply uses `bin2hex` to convert the random bytes to a hexadecimal string, rather than creating a hash that represents the random bytes.

By doing this, the resulting access hashes are considerably longer **and** have an unpredictable length, effectively eliminating any possibility of an attacker guessing the hash.

Example hash created with the current method:
`cb5e1620db29646c4a955c41af3135f5b228b9dd3e0d8f507c20f4cf74e422c8`

Example hash with the new method:
`5e1b28394c850164bf5cf358e7ae7fd1a19c3cdc55f75f96869be7bb735e87264bdb09dcb2b447fb1febe030e75b440ee6d616f83f277633396c57f1f0d3a13dab141db68cdeeca84830569f63bb7392e361dfd8dfab1534960da624fa746eb00f15b91e73e1cf8e08d040bcb8353f504ae621c48e1c`