### PR TITLE
Fix logical error in Servicedownloadable module

### DIFF
--- a/src/modules/Servicedownloadable/Api/Admin.php
+++ b/src/modules/Servicedownloadable/Api/Admin.php
@@ -29,6 +29,7 @@ class Admin extends \Api_Abstract
         $required = [
             'id' => 'Product ID is missing',
         ];
+
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
 
         $model = $this->di['db']->getExistingModelById('Product', $data['id'], 'Product not found');

--- a/src/modules/Servicedownloadable/Api/Client.php
+++ b/src/modules/Servicedownloadable/Api/Client.php
@@ -36,7 +36,7 @@ class Client extends \Api_Abstract
 
         $orderService = $this->di['mod_service']('order');
         $s = $orderService->getOrderService($order);
-        if (!$s instanceof \Model_ServiceDownloadable) {
+        if (!$s instanceof \Model_ServiceDownloadable || $order->status !== 'active') {
             throw new \Box_Exception('Order is not activated');
         }
 

--- a/tests/modules/Servicedownloadable/Api/ClientTest.php
+++ b/tests/modules/Servicedownloadable/Api/ClientTest.php
@@ -105,10 +105,14 @@ class ClientTest extends \BBTestCase {
             ->method('getOrderService')
             ->will($this->returnValue(new \Model_ServiceDownloadable()));
 
+        $mockOrder = new \Model_ClientOrder();
+        $mockOrder->loadBean(New \DummyBean());
+        $mockOrder->status = "active";
+
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->will($this->returnValue($mockOrder));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;


### PR DESCRIPTION
This PR closes #877 by resolving an issue where the module wasn't correctly checking if an order was active before sending the file to download.

Additionally, I was unable to replicate the issue where uploading an new file would case a 404 error when a client tries to download the file. In my testing, updating the product correctly updates the file name for it and although the file name isn't updated for orders, the order fetches the download through the product's configuration itself and not from the order config, so it's actually unused.
We could update the file name as well, but that would require us to loop through each `downloadable` order type, decode the config from JSON to an array, check if it needed to be updated, and then update it which is a lot of added complexity and wasted resources for a value that's not necessary to update.