### PR TITLE
Apply discount credits to account balance

### DIFF
--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -228,9 +228,6 @@ class ServiceInvoiceItem implements InjectionAwareInterface
     public function creditInvoiceItem(\Model_InvoiceItem $item)
     {
         $total = $this->getTotalWithTax($item);
-        if ($total <= 0) {
-            return true;
-        }
 
         $invoice = $this->di['db']->getExistingModelById('Invoice', $item->invoice_id, 'Invoice not found');
         $client = $this->di['db']->getExistingModelById('Client', $invoice->client_id, 'Client not found');


### PR DESCRIPTION
This PR closes #1238 by allowing the discount credits to be applied to the account balance when previously this was prevented.

I can't find anything that we (FOSSBilling) changed since we forked BoxBilling to introduce the issue, however having looked at their changes, I suspect the problem was introduced in this [pull request](https://github.com/boxbilling/boxbilling/pull/617).

That pull request changed the behavior of discounts to be applied as individual line items. When an invoice is processed, FOSSBilling processes each line item individually and applies it to the account balance, but the original behavior of this function blocked positive changes to the account balance, meaning the discount was never actually applied to the final account balance.

Since the change happened right around the time BoxBilling died (for the first time), I suspect that's why the issue hadn't been noticed until now.