### PR TITLE
Validate add-on configs before adding to cart

### DIFF
--- a/src/modules/Cart/Api/Guest.php
+++ b/src/modules/Cart/Api/Guest.php
@@ -167,7 +167,7 @@ class Guest extends \Api_Abstract
         $product = $this->di['db']->getExistingModelById('Product', $data['id'], 'Product not found');
 
         if ($product->is_addon) {
-            throw new \Box_Exception('Addon products cannot be added seperately.');
+            throw new \Box_Exception('Addon products cannot be added separately.');
         }
 
         $validAddons = json_decode($product->addons ?? '');

--- a/src/modules/Cart/Api/Guest.php
+++ b/src/modules/Cart/Api/Guest.php
@@ -159,11 +159,27 @@ class Guest extends \Api_Abstract
         $required = [
             'id' => 'Product id not passed',
         ];
+
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
 
         $cart = $this->getService()->getSessionCart();
 
         $product = $this->di['db']->getExistingModelById('Product', $data['id'], 'Product not found');
+
+        if ($product->is_addon) {
+            throw new \Box_Exception('Addon products cannot be added seperately.');
+        }
+
+        $validAddons = json_decode($product->addons ?? '');
+        if(empty($validAddons)){
+            $validAddons = [];
+        }
+
+        foreach ($data['addons'] as $addon => $properties) {
+            if($properties['selected'] && !in_array($addon, $validAddons)){
+                throw new \Box_Exception('One or more of your selected addons are not valid for the associated product.');
+            }
+        }
 
         // reset cart by default
         if (!isset($data['multiple']) || !$data['multiple']) {


### PR DESCRIPTION
The API endpoint both allowed an add-ons to be added separately (without an associated product) and it also didn't validate that a provided add-on was valid for the associated product. This PR fixes that