### PR TITLE
Fix changelog link when preview update branches are enabled

### DIFF
--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -81,8 +81,8 @@ class Update implements InjectionAwareInterface
         $branch = (in_array($branch, ['release', 'preview'])) ? $branch : 'release';
 
         if ($branch === 'preview') {
-            $latestReleaseVersion = $this->getLatestVersionInfo('release')['version'];
-            $compareLink = "https://github.com/FOSSBilling/FOSSBilling/compare/{$latestReleaseVersion}...main";
+            $currentVersion = Version::VERSION;
+            $compareLink = "https://github.com/FOSSBilling/FOSSBilling/compare/{$currentVersion}...main";
             $downloadUrl = 'https://fossbilling.org/downloads/preview/';
 
             return [


### PR DESCRIPTION
This PR fixes an issue that was introduced with PR #1252.
When FOSSBilling is configured to run preview releases, the compare link is supposed to be created with the version that is currently being run so that you can see what's been changed compared to the version you are currently running and that PR changed it to compare against the most recent release instead.