### PR TITLE
Re-check promo code validity during checkout

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -432,10 +432,6 @@ class Service implements InjectionAwareInterface
             if (!$this->isPromoAvailableForClientGroup($promo)) {
                 throw new \Box_Exception('Promo can not be applied to your account');
             }
-    
-            if (!$this->promoCanBeApplied($promo)) {
-                throw new \Box_Exception('Promo code is expired or does not exist');
-            }
         }
 
         $this->di['events_manager']->fire(

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -424,6 +424,18 @@ class Service implements InjectionAwareInterface
             if (!$this->isClientAbleToUsePromo($client, $promo)) {
                 throw new \Box_Exception('You have already used this promo code. Please remove promo code and checkout again.', null, 9874);
             }
+
+            if (!$promo instanceof \Model_Promo) {
+                throw new \Box_Exception('Promo code is expired or does not exist');
+            }
+    
+            if (!$this->isPromoAvailableForClientGroup($promo)) {
+                throw new \Box_Exception('Promo can not be applied to your account');
+            }
+    
+            if (!$this->promoCanBeApplied($promo)) {
+                throw new \Box_Exception('Promo code is expired or does not exist');
+            }
         }
 
         $this->di['events_manager']->fire(

--- a/tests/modules/Cart/ServiceTest.php
+++ b/tests/modules/Cart/ServiceTest.php
@@ -654,12 +654,14 @@ class ServiceTest extends \BBTestCase
         $order->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Cart\Service')
-            ->setMethods(array('createFromCart', 'isClientAbleToUsePromo', 'rm'))->getMock();
+            ->setMethods(array('createFromCart', 'isClientAbleToUsePromo', 'rm', 'isPromoAvailableForClientGroup'))->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('createFromCart')
             ->will($this->returnValue(array($order, rand(1, 100), array(rand(1, 100)))));
         $serviceMock->expects($this->atLeastOnce())->method('isClientAbleToUsePromo')
             ->will($this->returnValue(true));
         $serviceMock->expects($this->atLeastOnce())->method('rm')
+            ->will($this->returnValue(true));
+        $serviceMock->expects($this->atLeastOnce())->method('isPromoAvailableForClientGroup')
             ->will($this->returnValue(true));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
@@ -670,8 +672,6 @@ class ServiceTest extends \BBTestCase
         $requestMock->expects($this->atLeastOnce())
             ->method('getClientAddress')
             ->will($this->returnValue('1.1.1.1'));
-
-        $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
 
         $invoice = new \Model_Invoice();
         $invoice->loadBean(new \DummyBean());
@@ -693,7 +693,6 @@ class ServiceTest extends \BBTestCase
         $di['db']             = $dbMock;
         $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
         $di['request']        = $requestMock;
-        $di['tools']          = $toolsMock;
         $serviceMock->setDi($di);
 
         $result = $serviceMock->checkoutCart($cart, $client);

--- a/tests/modules/Cart/ServiceTest.php
+++ b/tests/modules/Cart/ServiceTest.php
@@ -671,6 +671,7 @@ class ServiceTest extends \BBTestCase
             ->method('getClientAddress')
             ->will($this->returnValue('1.1.1.1'));
 
+        $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
 
         $invoice = new \Model_Invoice();
         $invoice->loadBean(new \DummyBean());
@@ -692,6 +693,7 @@ class ServiceTest extends \BBTestCase
         $di['db']             = $dbMock;
         $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
         $di['request']        = $requestMock;
+        $di['tools']          = $toolsMock;
         $serviceMock->setDi($di);
 
         $result = $serviceMock->checkoutCart($cart, $client);


### PR DESCRIPTION
This PR applies an additional check during the cart checkout process, which prevents an issue where a client could add a promo code to their cart while it was still valid and then still use it once the promo code is no longer valid for them