### PR TITLE
Fix & improve formbuilder layout + update last patch

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -316,7 +316,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','28',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','33',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
+++ b/src/modules/Formbuilder/html_admin/mod_formbuilder_settings.html.twig
@@ -6,8 +6,33 @@
 
 {% set active_menu = 'system' %}
 
+{% block breadcrumbs %}
+    <ul class="breadcrumb">
+        <li class="breadcrumb-item">
+            <a href="{{ '/'|alink }}">
+                <svg class="icon">
+                    <use xlink:href="#home"/>
+                </svg>
+            </a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{{ 'system'|alink }}">{{ 'Settings'|trans }}</a>
+        </li>
+        {% if not request.id %}
+            <li class="breadcrumb-item active" aria-current="page">{{ 'Custom form builder'|trans }}</li>
+        {% else %}
+            {% set form = admin.formbuilder_get_form({ "id": request.id }) %}
+            <li class="breadcrumb-item">
+                <a href="{{ 'extension/settings/formbuilder'|alink }}">{{ 'Custom form builder'|trans }}</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">{{ form.name }}</li>
+        {% endif %}
+    </ul>
+{% endblock %}
+
 {% block content %}
 <div class="card">
+{% if not request.id %}
     <!--<ul class="nav nav-tabs" role="tablist">
         <li class="nav-item" role="presentation">
             <a class="nav-link active" href="#tab-index" data-bs-toggle="tab" role="tab">{{ 'Custom forms'|trans }}</a>
@@ -84,10 +109,9 @@
 {#            </form>#}
 {#        </div>#}
 
-{% if request.id %}
+{% else %}
 {% set form = admin.formbuilder_get_form({ "id": request.id }) %}
-
-    <div class="mt-3 card widget" id="form-options-{{ form.id }}">
+    <div class="tab-pane fade show active" id="form-options-{{ form.id }}" role="tabpanel">
         <div class="card-header">
             <h3 class="card-title">{{ 'Form options'|trans }}</h3>
         </div>
@@ -190,7 +214,7 @@
                 </fieldset>
             </div>
         </div>
-    </div>
+</div>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Closes #1323 by fixing the breadcrumb and slightly improving the layout of the page.
I also updated the `last_patch` number in our SQL to ensure that FOSSBilling won't attempt to run outdated patches on clean installations.

Slightly updated layouts for the form builder:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/33f994e2-98c0-4fd3-b509-e4f0f41b5e8e)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/374f842e-2dd7-483e-b315-e37d07e4edaa)

VS the old one:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/a9482229-a408-4d78-9610-be333819746a)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/951a51fb-5b16-43d5-86a1-c78a0a78f2e9)

If all goes to plan, I intend for this to be the final patch before we release 0.5.0