### PR TITLE
Fix issue with the locale selector

### DIFF
--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -27,7 +27,7 @@ class i18n
          * Next: if that didn't work, try to use the locale in the config file
          * Finally: As a last resort, default to en_US for the locale
          */
-        return $_COOKIE['BBLANG'] ?? self::getBrowserLocale() ?? $config['i18n']['locale'] ?? 'en_US';
+        return $_COOKIE['BBLANG'] ?: self::getBrowserLocale() ?: $config['i18n']['locale'] ?: 'en_US';
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where certain setups could get the error message "Unable to setup FOSSBilling translation functionality, locale was undefined"

Fix originally created by @evrifaessa 