### PR TITLE
Prevent twig from calling unsafe functions

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -17,6 +17,17 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 {
     protected ?\Pimple\Container $di;
 
+    /**
+     * A list of functions we want to precent Twig code from being able to call.
+     * Primarily based on https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Server%20Side%20Template%20Injection/README.md#twig---code-execution
+     * With some additions from https://stackoverflow.com/questions/3115559/exploitable-php-functions/3697776#3697776
+     */
+    private array $protectedFunctions = [
+        'escapeshellarg', 'escapeshellcmd', 'exec', 'passthru', 'proc_close', 'proc_get_status', 'proc_nice', 'proc_open', 'proc_terminate', 'shell_exec', 'system', 'pcntl_exec', 'php_info', 'popen',
+        'eval', 'assert', 'preg_replace', 'create_function', 'include', 'include_once', 'require', 'require_once', 'posix_mkfifo', 'posix_getlogin', 'posix_ttyname', 'getenv', 'get_current_user', 'proc_get_status',
+        'get_cfg_var', 'disk_free_space', 'disk_total_space', 'diskfreespace', 'getcwd', 'getlastmo', 'getmygid', 'getmyinode', 'getmypid', 'getmyuid'
+    ];
+
     public function setDi(\Pimple\Container $di): void
     {
         $this->di = $di;
@@ -35,17 +46,11 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
     public function getFilters()
     {
         return [
-            /**
-             * 'trans' filter rewrite same filter from Symfony\Bridge\Twig\Extension\TranslationExtension
-             * for compatible with outdated php-gettext library.
-             *
-             * TODO: Use Symfony\Component\Translation\Loader\MoFileLoader and remove php-gettext hardcoded library.
-             */
             'trans' => new TwigFilter('trans', '__trans'),
 
             'alink' => new TwigFilter('alink', [$this, 'twig_bb_admin_link_filter'], ['is_safe' => ['html']]),
-
             'link' => new TwigFilter('link', [$this, 'twig_bb_client_link_filter'], ['is_safe' => ['html']]),
+            'autolink' => new TwigFilter('autolink', [$this, 'twig_autolink_filter']),
 
             'gravatar' => new TwigFilter('gravatar', [$this, 'twig_gravatar_filter']),
 
@@ -54,7 +59,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             'truncate' => new TwigFilter('truncate', [$this, 'twig_truncate_filter'], ['needs_environment' => true]),
 
             'timeago' => new TwigFilter('timeago', [$this, 'twig_timeago_filter']),
-
             'daysleft' => new TwigFilter('daysleft', [$this, 'twig_daysleft_filter']),
 
             'size' => new TwigFilter('size', [$this, 'twig_size_filter']),
@@ -65,27 +69,23 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
             'period_title' => new TwigFilter('period_title', [$this, 'twig_period_title'], ['needs_environment' => true, 'is_safe' => ['html']]),
 
-            'autolink' => new TwigFilter('autolink', [$this, 'twig_autolink_filter']),
-
             'img_tag' => new TwigFilter('img_tag', [$this, 'twig_img_tag'], ['needs_environment' => false, 'is_safe' => ['html']]),
-
             'script_tag' => new TwigFilter('script_tag', [$this, 'twig_script_tag'], ['needs_environment' => false, 'is_safe' => ['html']]),
-
             'stylesheet_tag' => new TwigFilter('stylesheet_tag', [$this, 'twig_stylesheet_tag'], ['needs_environment' => false, 'is_safe' => ['html']]),
-
             'mod_asset_url' => new TwigFilter('mod_asset_url', [$this, 'twig_mod_asset_url']),
-
             'asset_url' => new TwigFilter('asset_url', [$this, 'twig_asset_url'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
             'library_url' => new TwigFilter('library_url', [$this, 'twig_library_url'], ['is_safe' => ['html']]),
 
             'money' => new TwigFilter('money', [$this, 'twig_money'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
             'money_without_currency' => new TwigFilter('money_without_currency', [$this, 'twig_money_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
             'money_convert' => new TwigFilter('money_convert', [$this, 'twig_money_convert'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
             'money_convert_without_currency' => new TwigFilter('money_convert_without_currency', [$this, 'money_convert_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
+
+            // We override these default twig filters so we can explicitly disable it from calling certain functions that may leak data or allow commands to be executed on the system.
+            'filter' => new TwigFilter('filter', [$this, 'filteredFilter']),
+            'map' => new TwigFilter('map', [$this, 'filteredMap']),
+            'reduce' => new TwigFilter('reduce', [$this, 'filteredReduce']),
+            'sort' => new TwigFilter('sort', [$this, 'filteredSort']),
         ];
     }
 
@@ -317,5 +317,63 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         }
 
         return $value;
+    }
+
+    public function filteredFilter($array, $arrow)
+    {
+        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
+            return $array;
+        }
+
+        return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);
+    }
+
+    public function filteredMap($array, $arrow)
+    {
+        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
+            return $array;
+        }
+
+        $r = [];
+        foreach ($array as $k => $v) {
+            $r[$k] = $arrow($v, $k);
+        }
+
+        return $r;
+    }
+
+    public function filteredReduce($array, $arrow, $initial = null)
+    {
+        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
+            return $array;
+        }
+
+        $accumulator = $initial;
+        foreach ($array as $key => $value) {
+            $accumulator = $arrow($accumulator, $value, $key);
+        }
+
+        return $accumulator;
+    }
+
+    public function filteredSort($array, $arrow)
+    {
+        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
+            return $array;
+        }
+
+        if ($array instanceof \Traversable) {
+            $array = iterator_to_array($array);
+        } elseif (!\is_array($array)) {
+            return $array;
+        }
+
+        if (null !== $arrow) {
+            uasort($array, $arrow);
+        } else {
+            asort($array);
+        }
+
+        return $array;
     }
 }

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -310,7 +310,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredFilter($array, $arrow)
     {
-        if(!$arrow instanceof Closure){
+        if (!$arrow instanceof Closure) {
             return;
         }
 
@@ -319,7 +319,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredMap($array, $arrow)
     {
-        if(!$arrow instanceof Closure){
+        if (!$arrow instanceof Closure) {
             return;
         }
 
@@ -333,7 +333,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredReduce($array, $arrow, $initial = null)
     {
-        if(!$arrow instanceof Closure){
+        if (!$arrow instanceof Closure) {
             return;
         }
 
@@ -347,7 +347,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredSort($array, $arrow)
     {
-        if(!$arrow instanceof Closure){
+        if (!$arrow instanceof Closure) {
             return;
         }
 

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -17,17 +17,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 {
     protected ?\Pimple\Container $di;
 
-    /**
-     * A list of functions we want to precent Twig code from being able to call.
-     * Primarily based on https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Server%20Side%20Template%20Injection/README.md#twig---code-execution
-     * With some additions from https://stackoverflow.com/questions/3115559/exploitable-php-functions/3697776#3697776
-     */
-    private array $protectedFunctions = [
-        'escapeshellarg', 'escapeshellcmd', 'exec', 'passthru', 'proc_close', 'proc_get_status', 'proc_nice', 'proc_open', 'proc_terminate', 'shell_exec', 'system', 'pcntl_exec', 'php_info', 'popen',
-        'eval', 'assert', 'preg_replace', 'create_function', 'include', 'include_once', 'require', 'require_once', 'posix_mkfifo', 'posix_getlogin', 'posix_ttyname', 'getenv', 'get_current_user', 'proc_get_status',
-        'get_cfg_var', 'disk_free_space', 'disk_total_space', 'diskfreespace', 'getcwd', 'getlastmo', 'getmygid', 'getmyinode', 'getmypid', 'getmyuid'
-    ];
-
     public function setDi(\Pimple\Container $di): void
     {
         $this->di = $di;
@@ -321,8 +310,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredFilter($array, $arrow)
     {
-        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
-            return $array;
+        if(!$arrow instanceof Closure){
+            return;
         }
 
         return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);
@@ -330,8 +319,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredMap($array, $arrow)
     {
-        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
-            return $array;
+        if(!$arrow instanceof Closure){
+            return;
         }
 
         $r = [];
@@ -344,8 +333,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredReduce($array, $arrow, $initial = null)
     {
-        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
-            return $array;
+        if(!$arrow instanceof Closure){
+            return;
         }
 
         $accumulator = $initial;
@@ -358,8 +347,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function filteredSort($array, $arrow)
     {
-        if (is_string($arrow) && in_array(strtolower($arrow), $this->protectedFunctions)) {
-            return $array;
+        if(!$arrow instanceof Closure){
+            return;
         }
 
         if ($array instanceof \Traversable) {


### PR DESCRIPTION
This overrides the twig `filter`, `map`, `reduce`, and `sort` filters to prevent anything other than a closure being used for the "arrow" in them. This matches the behavior of the sandbox extension that twig created, except doing it this way means we don't need to setup the extension, configure the allowed list of filters (which would be most if not all of them), and then find a way to wrap things in a `{% sandbox %}` block when we don't trust them.