### PR TITLE
Avoid HTML interpretation of the company's "signature".

### DIFF
--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -293,7 +293,7 @@
 
 {% if settings.footer_enabled %}
 <footer id="footer" class="container">
-    <p>&copy; {{ now|format_date(pattern='yyyy') }} {{ settings.footer_signature | default(company.signature) | raw }}</p>
+    <p>&copy; {{ now|format_date(pattern='yyyy') }} {{ settings.footer_signature | default(company.signature) }}</p>
     <ul>
         {% if settings.footer_link_1_enabled %}
         <li>


### PR DESCRIPTION
This prevents the "signature" (added to the footer of the Huraga theme) from being interpreted as HTML / JS.