### PR TITLE
Fix order popup breaking Huraga layout

### DIFF
--- a/src/modules/Invoice/html_client/mod_invoice_print.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_print.html.twig
@@ -6,8 +6,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <link rel='stylesheet' type='text/css' href="{{ ('css/bootstrap.css') | asset_url }}" media="screen">
-        <link rel='stylesheet' type='text/css' href="{{ ('css/bootstrap.css') | asset_url }}" media="print">
+        <link rel='stylesheet' type='text/css' href="{{ ('css/bootstrap.css') | asset_url }}">
 
         <link rel="shortcut icon" href="{{ guest.system_company.favicon_url }}">
 

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
@@ -14,7 +14,6 @@
 
     <meta charset="utf-8">
     <title>Order</title>
-    {{ 'css/bootstrap.css' | asset_url | stylesheet_tag }}
     {{ 'css/font-awesome.css' | asset_url | stylesheet_tag }}
     {{ 'css/huraga-main.css' | asset_url | stylesheet_tag }}
     {{ theme_color | asset_url | stylesheet_tag }}


### PR DESCRIPTION
Closes #1330 by removing the reference to the Huraga bootstrap CSS.
The CSS isn't needed and it was breaking the page layout. Even without it, everything loads fine & the order screen functions correctly.
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/2fb5932b-e3b1-49ca-9b8b-e00d51b8c5a6)
