### PR TITLE
Prevent deprecation errors when adding products to cart

### DIFF
--- a/src/modules/Cart/Api/Guest.php
+++ b/src/modules/Cart/Api/Guest.php
@@ -170,14 +170,20 @@ class Guest extends \Api_Abstract
             throw new \Box_Exception('Addon products cannot be added separately.');
         }
 
-        $validAddons = json_decode($product->addons ?? '');
-        if(empty($validAddons)){
-            $validAddons = [];
-        }
+        if (is_array($data['addons'] ?? '')) {
+            $validAddons = json_decode($product->addons ?? '');
+            if (empty($validAddons)) {
+                $validAddons = [];
+            }
 
-        foreach ($data['addons'] as $addon => $properties) {
-            if($properties['selected'] && !in_array($addon, $validAddons)){
-                throw new \Box_Exception('One or more of your selected addons are not valid for the associated product.');
+            foreach ($data['addons'] as $addon => $properties) {
+                if ($properties['selected']) {
+                    $addon = $this->di['db']->getExistingModelById('Product', $addon, 'Addon not found');
+
+                    if ($addon->status !== 'enabled' || !in_array($addon, $validAddons)) {
+                        throw new \Box_Exception('One or more of your selected addons are not valid for the associated product.');
+                    }
+                }
             }
         }
 

--- a/src/modules/Cart/Api/Guest.php
+++ b/src/modules/Cart/Api/Guest.php
@@ -178,9 +178,9 @@ class Guest extends \Api_Abstract
 
             foreach ($data['addons'] as $addon => $properties) {
                 if ($properties['selected']) {
-                    $addon = $this->di['db']->getExistingModelById('Product', $addon, 'Addon not found');
+                    $addonModel = $this->di['db']->getExistingModelById('Product', $addon, 'Addon not found');
 
-                    if ($addon->status !== 'enabled' || !in_array($addon, $validAddons)) {
+                    if ($addonModel->status !== 'enabled' || !in_array($addon, $validAddons)) {
                         throw new \Box_Exception('One or more of your selected addons are not valid for the associated product.');
                     }
                 }


### PR DESCRIPTION
Minor improvement to prevent it from trying reference an array key that was unset (`$data['addons']`) if the client didn't select any add-ons.
Also added an extra check to verify the add-on is actually enabled. 