### PR TITLE
Very minor bugfix

### DIFF
--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -27,7 +27,7 @@ class i18n
          * Next: if that didn't work, try to use the locale in the config file
          * Finally: As a last resort, default to en_US for the locale
          */
-        return $_COOKIE['BBLANG'] ?: self::getBrowserLocale() ?: $config['i18n']['locale'] ?: 'en_US';
+        return $_COOKIE['BBLANG'] ?? self::getBrowserLocale() ?: $config['i18n']['locale'] ?? 'en_US';
     }
 
     /**
@@ -70,10 +70,9 @@ class i18n
                     return $locale;
                 }
             }
-        } else {
-            setcookie("BBLANG", $matchingLocale, strtotime("+1 month"), "/");
         }
 
+        setcookie("BBLANG", $matchingLocale, strtotime("+1 month"), "/");
         return $matchingLocale;
     }
 


### PR DESCRIPTION
Followup to #1329
Unfortunately, `?:` will cause an undefined array key message if something isn't set meaning the code as-is will cause constant `Undefined array key "BBLANG"` errors in the error log.
As such, I've changed it so that it uses the `??` ternary operator for the cookie and config file as we only care if those are actually defined.

For the `self::getBrowserLocale()`, I've left it with the new operator as that function will always give a return & it won't cause errors to be logged.