### PR TITLE
Renamed phonestate_cc to city in admin/client/update

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -286,7 +286,7 @@ class Admin extends \Api_Abstract
         $client->country = (!empty($data['country']) ? $data['country'] : $client->country);
         $client->postcode = (!empty($data['postcode']) ? $data['postcode'] : $client->postcode);
         $client->state = (!empty($data['state']) ? $data['state'] : $client->state);
-        $client->city = (!empty($data['phonestate_cc']) ? $data['phonestate_cc'] : $client->city);
+        $client->city = (!empty($data['city']) ? $data['city'] : $client->city);
 
         $client->status = (!empty($data['status']) ? $data['status'] : $client->status);
         $client->email_approved = (!empty($data['email_approved']) ? $data['email_approved'] : $client->email_approved);


### PR DESCRIPTION
In the admin/client/update function, when a user requests to update the city for a desired client. 
They have to use the pair as `{"phonestate_cc": "<city_name>"}` instead of `{"city": "<city_name>"}`. 

This issue caused a lot of confusion since the docs mention to update the city for a client, we must use the key: **city**. However, this query won't work since the actual key in the code is **phonestate_cc**. 

I have updated one code line to fix this minor issue.