### PR TITLE
Add check for null value in isBirthdayValid invocation

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -256,7 +256,10 @@ class Admin extends \Api_Abstract
                 throw new \Box_Exception('Can not change email. It is already registered.');
             }
         }
-        $this->di['validator']->isBirthdayValid($data['birthday'] ?? null);
+
+        if (!is_null($data['birthday'] ?? null)) {
+            $this->di['validator']->isBirthdayValid($data['birthday'] ?? null);
+        }
 
         if (($data['currency'] ?? null) && $service->canChangeCurrency($client, ($data['currency'] ?? null))) {
             $client->currency = $data['currency'] ?? $client->currency;

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -257,8 +257,8 @@ class Admin extends \Api_Abstract
             }
         }
 
-        if (!is_null($data['birthday'] ?? null)) {
-            $this->di['validator']->isBirthdayValid($data['birthday'] ?? null);
+        if (!empty($data['birthday'])) {
+            $this->di['validator']->isBirthdayValid($data['birthday']);
         }
 
         if (($data['currency'] ?? null) && $service->canChangeCurrency($client, ($data['currency'] ?? null))) {


### PR DESCRIPTION
This pull request adds a check to prevent the execution of the isBirthdayValid() method when the $data['birthday'] field is null, as it is an optional field. The modified code ensures that the method is only called if the value is not null.

If the following change is not made, the request may give the following error every time the birthday is not specified:
```
trim(): argument #1 ($string) must be of type string, null given
```

Unless the developer specifies the date of birth in every POST request, this error will not stop.