### PR TITLE
Fix issue with the sessions during installation

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -30,7 +30,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 0);
 ini_set('display_startup_errors', 1);
 ini_set('log_errors', '1');
-ini_set('error_log', __DIR__ . '/logs/php_error.log');
+ini_set('error_log', 'php_error.log');
 
 // If not connected via SSL, try and detect a valid SSL certificate on the server and then redirect to HTTPs.
 if(!isSSL()){

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -118,7 +118,7 @@ class Session implements \FOSSBilling\InjectionAwareInterface
      * Checks both the fingerprint and age of the current session to see if it can be used.
      * If the session can't be used, it's destroyed from the database, forcing a new one to be created.
      */
-    private function canUseSession():void
+    private function canUseSession(): void
     {
         if (empty($_COOKIE['PHPSESSID'])) {
             return;
@@ -143,13 +143,16 @@ class Session implements \FOSSBilling\InjectionAwareInterface
     /**
      * Depending on the specifics, this will either set or update the fingerprint associated with the current session.
      */
-    private function updateFingerprint():void
+    private function updateFingerprint(): void
     {
         $sessionID = $_COOKIE['PHPSESSID'] ?? session_id();
         $session = $this->di['db']->findOne('session', 'id = :id', [':id' => $sessionID]);
 
-        $fingerprint = new \FOSSBilling\Fingerprint;
-        $session->fingerprint = json_encode($fingerprint->fingerprint());
-        $this->di['db']->store($session);
+        // Fix for the installer which temporarily uses FS sessions before FOSSBilling is completely setup.
+        if (!is_null($session)) {
+            $fingerprint = new \FOSSBilling\Fingerprint;
+            $session->fingerprint = json_encode($fingerprint->fingerprint());
+            $this->di['db']->store($session);
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug that prevents a fresh installation.
The installer uses filesystem sessions since the DB schema isn't completely setup, and that causes issues with the FOSSBilling session handler as it uses the existing session and then tries to write a fingerprint to it in the DB, but it doesn't actually exist int the DB.

To fix it, I just made it skip that step if the session doesn't exist in the DB.
I also modified the error log location so it could actually write one as no "logs" folder exists under `/installer`