### PR TITLE
Fixed Password Reset handling 

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -169,7 +169,7 @@ class Guest extends \Api_Abstract
 
         $c = $this->di['db']->findOne('Client', 'email = ?', [$data['email']]);
         if (!$c instanceof \Model_Client) {
-            throw new \Box_Exception('If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent');
+            return true;
         }
 
         $hash = hash('sha256', time() . random_bytes(13));

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -169,7 +169,7 @@ class Guest extends \Api_Abstract
 
         $c = $this->di['db']->findOne('Client', 'email = ?', [$data['email']]);
         if (!$c instanceof \Model_Client) {
-            throw new \Box_Exception('If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent');
+            throw new \Box_Exception('If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent');
         }
 
         $hash = hash('sha256', time() . random_bytes(13));

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -169,7 +169,7 @@ class Guest extends \Api_Abstract
 
         $c = $this->di['db']->findOne('Client', 'email = ?', [$data['email']]);
         if (!$c instanceof \Model_Client) {
-            throw new \Box_Exception('Email not found in our database');
+            throw new \Box_Exception('If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent');
         }
 
         $hash = hash('sha256', time() . random_bytes(13));

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -59,7 +59,7 @@ $(function() {
             'guest/client/reset_password',
             $(this).serialize(),
             function(result) {
-                bb.msg("{{ 'If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent.'|trans }}");
+                bb.msg("{{ 'If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent.'|trans }}");
             }
         );
 

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -59,7 +59,7 @@ $(function() {
             'guest/client/reset_password',
             $(this).serialize(),
             function(result) {
-                bb.msg("{{ 'Password reset confirmation email was sent'|trans }}");
+                bb.msg("{{ 'If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent.'|trans }}");
             }
         );
 

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -59,7 +59,7 @@ $(function() {
             'guest/client/reset_password',
             $(this).serialize(),
             function(result) {
-                bb.msg("{{ 'If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent.'|trans }}");
+                bb.msg("{{ 'A password reset confirmation email will be sent to you if we found an account with that email address.'|trans }}");
             }
         );
 

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -151,7 +151,7 @@ class Guest extends \Api_Abstract
         $c = $this->di['db']->findOne('Admin', 'email = ?', [$data['email']]);
 
         if (!$c instanceof \Model_Admin) {
-            throw new \Box_Exception('Email not found in our database');
+            return true;
         }
         $hash = hash('sha256', time().random_bytes(13));
 

--- a/src/modules/Staff/html_admin/mod_staff_password_reset.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_password_reset.html.twig
@@ -15,7 +15,7 @@
             <div class="card-body">
                 <h2 class="h2 text-center mb-4">{{ 'Reset your password' | trans }}</h2>
                 <p class="text-muted mb-4">{{ 'Enter your email address. You will receive a confirmation link if your account exists.' | trans }}</p>
-                <form class="api-form" action="{{ 'api/guest/staff/passwordreset'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
+                <form class="api-form" action="{{ 'api/guest/staff/passwordreset'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}" data-api-msg="{{ 'If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent.'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3">
                         <label class="form-label" for="inputEmail">{{ 'Email address' | trans }}</label>

--- a/src/modules/Staff/html_admin/mod_staff_password_reset.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_password_reset.html.twig
@@ -15,7 +15,7 @@
             <div class="card-body">
                 <h2 class="h2 text-center mb-4">{{ 'Reset your password' | trans }}</h2>
                 <p class="text-muted mb-4">{{ 'Enter your email address. You will receive a confirmation link if your account exists.' | trans }}</p>
-                <form class="api-form" action="{{ 'api/guest/staff/passwordreset'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}" data-api-msg="{{ 'If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent.'|trans }}">
+                <form class="api-form" action="{{ 'api/guest/staff/passwordreset'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}" data-api-msg="{{ 'A password reset confirmation email will be sent to you if we found an account with that email address.'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3">
                         <label class="form-label" for="inputEmail">{{ 'Email address' | trans }}</label>

--- a/tests/modules/Client/Api/GuestTest.php
+++ b/tests/modules/Client/Api/GuestTest.php
@@ -296,9 +296,9 @@ class GuestTest extends \BBTestCase {
         $client = new \Box\Mod\Client\Api\Guest();
         $client->setDi($di);
 
-        $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent');
-        $client->reset_password($data);
+        // expects true because we don't want to give away if the email exists or not
+        $result = $client->reset_password($data);
+        $this->assertTrue($result);
     }
 
     public function testconfirm_reset()

--- a/tests/modules/Client/Api/GuestTest.php
+++ b/tests/modules/Client/Api/GuestTest.php
@@ -297,7 +297,7 @@ class GuestTest extends \BBTestCase {
         $client->setDi($di);
 
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('Email not found in our database');
+        $this->expectExceptionMessage('If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent');
         $client->reset_password($data);
     }
 

--- a/tests/modules/Client/Api/GuestTest.php
+++ b/tests/modules/Client/Api/GuestTest.php
@@ -297,7 +297,7 @@ class GuestTest extends \BBTestCase {
         $client->setDi($di);
 
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('If you have entered an E-Mail adress that is associated with an Account, a Password reset confirmation email was sent');
+        $this->expectExceptionMessage('If you have entered an E-Mail address that is associated with an Account, a Password reset confirmation email was sent');
         $client->reset_password($data);
     }
 


### PR DESCRIPTION
Small Security Issue with the Error Message. 
I fixed it so the message is the same whether the E-Mail address exists or not. Needs PR in the locale Repo to be completely fixed. 