### PR TITLE
Fix config migrator using a string instead of an int

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -54,7 +54,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig = $currentConfig;
         $newConfig['security']['mode'] ??= 'strict';
         $newConfig['security']['force_https'] ??= true;
-        $newConfig['security']['cookie_lifespan'] ??= '7200';
+        $newConfig['security']['cookie_lifespan'] ??= 7200;
         $newConfig['update_branch'] ??= 'release';
         $newConfig['log_stacktrace'] ??= true;
         $newConfig['stacktrace_length'] ??= 25;


### PR DESCRIPTION
The config migrator was setting the `cookie_lifespan` config property to a string by mistake if it wasn't already set instead of an int, causing people to get error messages like this:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/a362342c-0559-4886-968a-c24676f02d02)
