### PR TITLE
Allow IPs to be whitelisted from rate limiting

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -183,8 +183,6 @@ return [
          * Any IP address within this list will not be put through the rate-limiter system.
          * This is useful if you have an application with a static IP address that needs to make frequent API requests to FOSSBilling.
          */
-        'rate_limit_whitelist' => [
-
-        ],
+        'rate_limit_whitelist' => [],
     ],
 ];

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -59,24 +59,18 @@ return [
          * Enable or disable the system maintenance mode.
          * Enabling this will block public access to your website, and API endpoints except the allowed ones won't work
          * However, this will not block access to the administrator area.
-         *
-         * @since 4.22.0
          */
         'enabled' => false,
 
         /*
          * Don't block these URLs when the maintenance is going on.
          * Supports wildcard (e.g. '/api/guest/staff/*').
-         *
-         * @since 4.22.0
          */
         'allowed_urls' => [],
 
         /*
          * Don't block these IP/Subnet addresses when the maintenance is going on.
          * Supported formats: 127.0.0.1、127.0.0.1/32.
-         *
-         * @since 4.22.0
          */
         'allowed_ips' => [],
     ],
@@ -163,17 +157,13 @@ return [
         // How many requests allowed per time span
         'rate_limit' => 1000,
 
-        /*
-         * Note about rate-limiting login attempts:
-         * When the limit is reached, a default delay of 2 seconds is added to the request.
-         * This makes brute-forcing a password useless while not outright blocking legitimate traffic.
-         * When calculating, ensure the rate-limited traffic can still make enough requests to stay rate limited
-         * Ex: One request every 2 seconds is more than 20 times in 1 minute, so the IP will remain throttled.
-         *
-         * @since 4.22.0
-         */
-
-        // Throttling delay
+        /**
+          * Note about rate-limiting login attempts:
+          * When the limit is reached, a default delay of 2 seconds is added to the request.
+          * This makes brute-forcing a password useless while not outright blocking legitimate traffic.
+          * When calculating, ensure the rate-limited traffic can still make enough requests to stay rate limited
+          * Ex: One request every 2 seconds is more than 20 times in 1 minute, so the IP will remain throttled.
+          */
         'throttle_delay' => 2,
 
         // Time span login for limit in seconds
@@ -188,5 +178,13 @@ return [
         * This option is only here for backwards compatibility.
         */
         'CSRFPrevention' => true,
+
+        /**
+         * Any IP address within this list will not be put through the rate-limiter system.
+         * This is useful if you have an application with a static IP address that needs to make frequent API requests to FOSSBilling.
+         */
+        'rate_limit_whitelist' => [
+
+        ],
     ],
 ];

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -485,6 +485,7 @@ final class Box_Installer
                 'rate_span_login' => 60,
                 'rate_limit_login' => 20,
                 'CSRFPrevention' => true,
+                'rate_limit_whitelist' => [],
             ],
         ];
         $output = '<?php ' . PHP_EOL;

--- a/src/library/FOSSBilling/Request.php
+++ b/src/library/FOSSBilling/Request.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -28,19 +29,18 @@ class Request implements InjectionAwareInterface
      * Gets most possible client IPv4 Address. This method search in $_SERVER[‘REMOTE_ADDR’] and optionally in $_SERVER[‘HTTP_X_FORWARDED_FOR’]
      * @param bool $trustForwardedHeader - No by default because this can be changed to anything extremely easy, making it unreliable for tracking and adding a potential source for external data to be executed.
      * Please see: https://stackoverflow.com/questions/3003145/how-to-get-the-client-ip-address-in-php
-     * return string
      */
-    public function getClientAddress($trustForwardedHeader = false)
+    public function getClientAddress(bool $trustForwardedHeader = false): null|string|array
     {
         $address = null;
-        if($trustForwardedHeader) {
-            $address = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? null;
-        }
-        if(is_null($address)) {
+        if ($trustForwardedHeader && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            $address = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        } else {
             $address = $_SERVER['REMOTE_ADDR'] ?? null;
         }
-        if(is_string($address)) {
-            if(strpos($address, ',') !== false) {
+
+        if (is_string($address)) {
+            if (strpos($address, ',') !== false) {
                 list($address) = explode(',', $address);
             }
         }
@@ -55,9 +55,9 @@ class Request implements InjectionAwareInterface
     {
         $number_of_files = 0;
         $number_of_successful_files = 0;
-        foreach($_FILES as $file) {
+        foreach ($_FILES as $file) {
             $number_of_files++;
-            if(isset($file['error']) && $file['error'] == 0) {
+            if (isset($file['error']) && $file['error'] == 0) {
                 $number_of_successful_files++;
             }
         }
@@ -71,10 +71,10 @@ class Request implements InjectionAwareInterface
     public function getUploadedFiles($onlySuccessful = true)
     {
         $files = array();
-        foreach($_FILES as $file) {
+        foreach ($_FILES as $file) {
             $f = new \FOSSBilling\RequestFile($file);
-            if($onlySuccessful) {
-                if($file['error'] == 0) {
+            if ($onlySuccessful) {
+                if ($file['error'] == 0) {
                     $files[] = $f;
                 }
             } else {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -71,6 +71,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['api']['rate_span_login'] ??= 60;
         $newConfig['api']['rate_limit_login'] ??= 20;
         $newConfig['api']['CSRFPrevention'] ??= true;
+        $newConfig['api']['rate_limit_whitelist'] ??= [];
 
         // Remove depreciated config keys/subkeys.
         $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone', 'sef_urls'];

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -92,8 +92,12 @@ class Client implements InjectionAwareInterface
 
     private function checkRateLimit($method = null)
     {
+        if (in_array($this->_getIp(), $this->_api_config['rate_limit_whitelist'])) {
+            return true;
+        }
+
         $isLoginMethod = false;
-        if ('staff_login' == $method || 'client_login' == $method) {
+        if ($method == 'staff_login' || $method == 'client_login') {
             $rate_span = $this->_api_config['rate_span_login'];
             $rate_limit = $this->_api_config['rate_limit_login'];
             $isLoginMethod = true;
@@ -104,9 +108,8 @@ class Client implements InjectionAwareInterface
 
         $service = $this->di['mod_service']('api');
         $requests = $service->getRequestCount(time() - $rate_span, $this->_getIp(), $isLoginMethod);
-        $requests_left = $rate_limit - $requests;
-        $this->_requests_left = $requests_left;
-        if ($requests_left < 0) {
+        $this->_requests_left = $rate_limit - $requests;
+        if ($this->_requests_left <= 0) {
             sleep($this->_api_config['throttle_delay']);
         }
 

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -346,6 +346,8 @@ class ServiceTransaction implements InjectionAwareInterface
     /**
      * New simplified transaction processing logic.
      *
+     * @since 2.9.11
+     *
      * @param type $id
      *
      * @return mixed

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -346,8 +346,6 @@ class ServiceTransaction implements InjectionAwareInterface
     /**
      * New simplified transaction processing logic.
      *
-     * @since 2.9.11
-     *
      * @param type $id
      *
      * @return mixed


### PR DESCRIPTION
Minor patch to allow a system administrator to whitelist an IP address from rate-limiting on the API.