### PR TITLE
Fix admin panel dark mode

### DIFF
--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -25,15 +25,17 @@ coloris({
 
 
 document.addEventListener('DOMContentLoaded', () => {
-
   if (localStorage.getItem('theme') === 'dark') {
-    document.body.classList.add('theme-dark');
+    document.body.setAttribute("data-bs-theme", localStorage.getItem('theme'))
+  } else {
+    document.body.removeAttribute("data-bs-theme")
   }
+
   document.querySelectorAll('.js-theme-toggler').forEach(element => {
     element.addEventListener('click', event => {
       event.preventDefault();
-      document.body.classList.toggle('theme-dark');
       localStorage.setItem('theme', element.getAttribute('href').split('=')[1]);
+      document.body.setAttribute("data-bs-theme", localStorage.getItem('theme'))
     });
   });
 

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -24,7 +24,7 @@
     {% block head %}{% endblock %}
 </head>
 
-<body class="theme-light">
+<body data-bs-theme="dark">
     {% if not admin %}
     <script>
         $(function () {


### PR DESCRIPTION
Tabler changed their dark mode to use the bootstrap `data-bs-theme` attribute so it was unified and this change broke the dark mode for the admin panel.

This PR corrects the behavior of the dark mode selector to correctly work once again, and also changes the default attribute to being dark instead of white.

I changed the default attribute to dark mode because it often takes a little bit of time before the correct mode is applied. If you are working in the dark using dark mode and the page flashes white for a brief moment, it can actually be painful at worst and very distracting at best. Comparatively, if you are expecting it to be bright and there's a very brief moment of it being dark you won't be hurting your eyes even if it is still a bit distracting.