### PR TITLE
Apply the EscapeFormula CSV formatter

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -775,8 +775,8 @@ $di['table_export_csv'] = $di->protect(function (string $table, string $outputNa
         $headers = array_keys(reset($rows));
     }
 
-    $csv = League\Csv\Writer::createFromFileObject(new SplTempFileObject());
-
+    $csv = League\Csv\Writer::createFromFileObject(new SplTempFileObject);
+    $csv->addFormatter(new League\Csv\EscapeFormula);
     $csv->insertOne($headers);
     $csv->insertAll($rows);
 


### PR DESCRIPTION
Minor change to apply a formatter to the CSV generator that just escapes any formulas as this function should never be sending a CSV with formulas