### PR TITLE
Provide a fallback method to perform patches

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -11,7 +11,7 @@
 require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
 
-$url = $_GET['_url'] ?? ($_SERVER['PATH_INFO'] ?? '');
+$url = $_GET['_url'] ?? $_SERVER['PATH_INFO'] ?? '';
 $http_err_code = $_GET['_errcode'] ?? null;
 
 $admin_prefix = $di['config']['admin_area_prefix'];
@@ -21,6 +21,23 @@ if (0 === strncasecmp($url, $admin_prefix, strlen($admin_prefix))) {
 } else {
     $appUrl = $url;
     $app = new Box_AppClient();
+}
+
+if($url === '/run-patcher'){
+    $patcher = new FOSSBilling\UpdatePatcher;
+    $patcher->setDi($di);
+
+    if(!$patcher->isOutdated()){
+        die("There are no patches to apply");
+    }
+
+    try {
+        $patcher->applyConfigPatches();
+        $patcher->applyCorePatches();
+        die("Patches have been applied");
+    } catch(\Exception $e) {
+        die("An error occured while attempting to apply patches: <br>" . $e->getMessage());
+    }
 }
 
 $app->setUrl($appUrl);

--- a/src/index.php
+++ b/src/index.php
@@ -36,7 +36,7 @@ if($url === '/run-patcher'){
         $patcher->applyCorePatches();
         die("Patches have been applied");
     } catch(\Exception $e) {
-        die("An error occured while attempting to apply patches: <br>" . $e->getMessage());
+        die("An error occurred while attempting to apply patches: <br>" . $e->getMessage());
     }
 }
 


### PR DESCRIPTION
Right now an administrator needs to be able to login to the admin panel to perform patches, however this is problematic for cases where updates are being manually performed or if something didn't work right in the patching step.

So, this PR adds a workaround way to call the patcher by simply navigating to `example.com/run-patcher`.
It'll only run if the DB is actually behind on patches and gives some feedback on if the process went okay or if there were any errors.