### PR TITLE
Prevent exceptions from being interpreted as HTML

### DIFF
--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -137,7 +137,7 @@ class ErrorPage
     public function generatePage(int $code, string $message)
     {
         $error = $this->getCodeInfo($code);
-        $error['message'] ??= __trans('Uh-oh! You\'ve received a generic error message: :errorMessage', [':errorMessage' => '<code>' . $message . '</code>']);
+        $error['message'] ??= __trans('You\'ve received a generic error message: :errorMessage', [':errorMessage' => '<code>' . $message . '</code>']);
 
         $page = '
         <!DOCTYPE html>

--- a/src/load.php
+++ b/src/load.php
@@ -152,16 +152,17 @@ function errorHandler(int $number, string $message, string $file, int $line)
  */
 function exceptionHandler($e)
 {
+    $message = htmlspecialchars($e->getMessage());
     if (APPLICATION_ENV === 'testing') {
-        echo $e->getMessage() . PHP_EOL;
+        echo $message . PHP_EOL;
 
         return;
     }
-    error_log($e->getMessage());
+    error_log($message);
 
     if (defined('BB_MODE_API')) {
         $code = $e->getCode() ?: 9998;
-        $result = ['result' => null, 'error' => ['message' => $e->getMessage(), 'code' => $code]];
+        $result = ['result' => null, 'error' => ['message' => $message, 'code' => $code]];
         echo json_encode($result);
 
         return false;
@@ -187,7 +188,7 @@ function exceptionHandler($e)
     } else {
         include PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'ErrorPage.php';
         $errorPage = new \FOSSBilling\ErrorPage();
-        $errorPage->generatePage($e->getCode(), $e->getMessage());
+        $errorPage->generatePage($e->getCode(), $message);
     }
 }
 


### PR DESCRIPTION
This change is just to prevent exceptions that contain HTML from being interpreted as such within the browser.
I think there is a few places where we actually intentionally do this, which needs to change, but finding and updating those is outside the scope of this PR.

Oh yeah: I removed the "Uh-oh!" part from the "generic" error message because I just decided I didn't at all like it.