### PR TITLE
Fix some malformed search statements

### DIFF
--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -35,8 +35,8 @@ class ServicePayGateway implements InjectionAwareInterface
         $search = $data['search'] ?? null;
         $params = [];
         if ($search) {
-            $sql .= 'AND m.name LIKE :search';
-            $params['search'] = "%$search%";
+            $sql .= 'AND name LIKE :search';
+            $params[':search'] = "%$search%";
         }
 
         $sql .= ' ORDER by gateway ASC';

--- a/src/modules/Invoice/ServiceSubscription.php
+++ b/src/modules/Invoice/ServiceSubscription.php
@@ -128,7 +128,7 @@ class ServiceSubscription implements InjectionAwareInterface
         $params = [];
         if ($status) {
             $sql .= ' AND status = :status';
-            $params['status'] = $status;
+            $params[':status'] = $status;
         }
 
         if ($invoice_id) {
@@ -138,43 +138,43 @@ class ServiceSubscription implements InjectionAwareInterface
 
         if ($gateway_id) {
             $sql .= ' AND gateway_id = :gateway_id';
-            $params['gateway_id'] = $gateway_id;
+            $params[':gateway_id'] = $gateway_id;
         }
 
         if ($client_id) {
-            $sql .= ' AMD client_id  = :client_id';
-            $params['client_id'] = $client_id;
+            $sql .= ' AND client_id  = :client_id';
+            $params[':client_id'] = $client_id;
         }
 
         if ($currency) {
             $sql .= ' AND currency =  :currency ';
-            $params['currency'] = $currency;
+            $params[':currency'] = $currency;
         }
 
         if ($date_from) {
-            $sql .= ' AND UNIX_TIMESTAMP(m.created_at) >= :date_from';
-            $params['date_from'] = $date_from;
+            $sql .= ' AND UNIX_TIMESTAMP(created_at) >= :date_from';
+            $params[':date_from'] = $date_from;
         }
 
         if ($date_to) {
-            $sql .= ' AND UNIX_TIMESTAMP(m.created_at) <= :date_to';
-            $params['date_to'] = $date_to;
+            $sql .= ' AND UNIX_TIMESTAMP(created_at) <= :date_to';
+            $params[':date_to'] = $date_to;
         }
 
         if ($search) {
-            $sql .= ' AND sid = :sid OR m.id = :mid ';
-            $params['sid'] = $search;
-            $params['mid'] = $search;
+            $sql .= ' AND sid = :sid OR id = :mid ';
+            $params[':sid'] = $search;
+            $params[':mid'] = $search;
         }
 
         if ($id) {
             $sql .= ' AND id = :id';
-            $params['id'] = $id;
+            $params[':id'] = $id;
         }
 
         if ($sid) {
             $sql .= ' AND sid = :sid';
-            $params['sid'] = $sid;
+            $params[':sid'] = $sid;
         }
 
         $sql .= ' ORDER BY id DESC';

--- a/src/modules/News/Service.php
+++ b/src/modules/News/Service.php
@@ -59,12 +59,12 @@ class Service
 
         if (null !== $status) {
             $sql .= ' AND status = :status';
-            $params['status'] = $status;
+            $params[':status'] = $status;
         }
 
         if (null !== $search) {
-            $sql .= ' AND (m.title LIKE :search OR m.content LIKE :search)';
-            $params['search'] = '%' . $search . '%';
+            $sql .= ' AND (title LIKE :search OR content LIKE :search)';
+            $params[':search'] = '%' . $search . '%';
         }
 
         $sql .= ' ORDER BY created_at DESC';

--- a/tests/modules/Invoice/ServicePayGatewayTest.php
+++ b/tests/modules/Invoice/ServicePayGatewayTest.php
@@ -43,12 +43,12 @@ class ServicePayGatewayTest extends \BBTestCase {
 
         $this->service->setDi($di);
         $data = array('search' => 'keyword');
-        $expectedParams = array('search' => "%$data[search]%");
+        $expectedParams = array(':search' => "%$data[search]%");
 
         $result = $this->service->getSearchQuery($data);
         $this->assertIsArray($result);
         $this->assertIsString($result[0]);
-        $this->assertTrue(strpos($result[0], 'AND m.name LIKE :search') > 0);
+        $this->assertTrue(strpos($result[0], 'AND name LIKE :search') > 0);
         $this->assertIsArray($result[1]);
         $this->assertEquals($expectedParams, $result[1]);
     }

--- a/tests/modules/Invoice/ServiceSubscriptionTest.php
+++ b/tests/modules/Invoice/ServiceSubscriptionTest.php
@@ -180,31 +180,31 @@ class ServiceSubscriptionTest extends \BBTestCase
                 array(), 'FROM subscription', array(),
             ),
             array(
-                array('status' => 'active'), 'AND status = :status', array('status' => 'active'),
+                array('status' => 'active'), 'AND status = :status', array(':status' => 'active'),
             ),
             array(
                 array('invoice_id' => '1'), 'AND invoice_id = :invoice_id', array('invoice_id' => '1'),
             ),
             array(
-                array('gateway_id' => '2'), 'AND gateway_id = :gateway_id', array('gateway_id' => '2'),
+                array('gateway_id' => '2'), 'AND gateway_id = :gateway_id', array(':gateway_id' => '2'),
             ),
             array(
-                array('client_id' => '3'), 'AMD client_id  = :client_id', array('client_id' => '3'),
+                array('client_id' => '3'), 'AND client_id  = :client_id', array(':client_id' => '3'),
             ),
             array(
-                array('currency' => 'EUR'), 'AND currency =  :currency', array('currency' => 'EUR'),
+                array('currency' => 'EUR'), 'AND currency =  :currency', array(':currency' => 'EUR'),
             ),
             array(
-                array('date_from' => '1234567'), 'AND UNIX_TIMESTAMP(m.created_at) >= :date_from', array('date_from' => '1234567'),
+                array('date_from' => '1234567'), 'AND UNIX_TIMESTAMP(created_at) >= :date_from', array(':date_from' => '1234567'),
             ),
             array(
-                array('date_to' => '1234567'), 'AND UNIX_TIMESTAMP(m.created_at) <= :date_to', array('date_to' => '1234567'),
+                array('date_to' => '1234567'), 'AND UNIX_TIMESTAMP(created_at) <= :date_to', array(':date_to' => '1234567'),
             ),
             array(
-                array('id' => '10'), 'AND id = :id', array('id' => '10'),
+                array('id' => '10'), 'AND id = :id', array(':id' => '10'),
             ),
             array(
-                array('sid' => '10'), 'AND sid = :sid', array('sid' => '10'),
+                array('sid' => '10'), 'AND sid = :sid', array(':sid' => '10'),
             ),
         );
     }

--- a/tests/modules/Invoice/ServiceTransactionTest.php
+++ b/tests/modules/Invoice/ServiceTransactionTest.php
@@ -290,7 +290,7 @@ class ServiceTransactionTest extends \BBTestCase
      */
     public function testgetSearchQuery($data, $expectedParams, $expectedStringPart)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
         $result = $this->service->getSearchQuery($data);


### PR DESCRIPTION
These search query functions were creating incorrect SQL statements which resulted in errors like this:
```PHP
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'm.id' in 'where clause'
```

This pull request corrects them so that they now function