### PR TITLE
Fix resetting an ordered API key from admin panel

### DIFF
--- a/src/modules/Serviceapikey/html_admin/mod_serviceapikey_manage.html.twig
+++ b/src/modules/Serviceapikey/html_admin/mod_serviceapikey_manage.html.twig
@@ -17,7 +17,7 @@
 <div class="card-footer text-center">
     {{ order_actions }}
     <a class="btn btn-primary api-link"
-        href="{{ 'api/admin/serviceapikey/reset'|link({ 'id': service.id, 'CSRFToken': CSRFToken }) }}"
+        href="{{ 'api/admin/serviceapikey/reset'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure?'|trans }}"
         data-api-reload="1">
         <svg class="icon" width="24" height="24">


### PR DESCRIPTION
I forgot to update this when I changed the model's API to better match the existing ones. This PR fixes that