### PR TITLE
Make tables sortable in the admin panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12866,6 +12866,11 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sortable-tablesort": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sortable-tablesort/-/sortable-tablesort-2.2.0.tgz",
+      "integrity": "sha512-ScmWIQnYWCSUOPl8Kv/oQMf/h5RL68YWFKm9p86YWrVvv8v+o644b6ixFxagrobkh18M8JKYFS9uHh8a5MLJnQ=="
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15177,6 +15182,7 @@
         "jquery": "^3.7.0",
         "litepicker": "^2.0.12",
         "select2": "^4.0.13",
+        "sortable-tablesort": "^2.2.0",
         "tom-select": "^2.2.2"
       }
     }

--- a/src/modules/Activity/html_admin/mod_activity_index.html.twig
+++ b/src/modules/Activity/html_admin/mod_activity_index.html.twig
@@ -13,13 +13,13 @@
     </div>
 
     {% include 'partial_search.html.twig' %}
-    <table class="table card-table table-vcenter table-striped text-nowrap">
+    <table class="table card-table table-vcenter table-striped text-nowrap sortable">
         <thead>
             <tr>
-                <th class="w-1">
+                <th class="w-1 no-sort">
                     <input class="form-check-input m-0 align-middle batch-delete-master-checkbox" type="checkbox">
                 </th>
-                <th class="w-1"></th>
+                <th class="w-1 no-sort"></th>
                 <th>{{ 'User'|trans }}</th>
                 <th>{{ 'Message'|trans }}</th>
                 <th>{{ 'IP'|trans }}</th>

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -200,10 +200,10 @@
             <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
                 {% include 'partial_search.html.twig' %}
                 <div class="table-responsive">
-                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                    <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                         <thead>
                             <tr>
-                                <th class="w-1">
+                                <th class="w-1 no-sort">
                                     <input class="form-check-input m-0 align-middle batch-delete-master-checkbox" type="checkbox">
                                 </th>
                                 <th>{{ 'Name'|trans }}</th>

--- a/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
@@ -25,7 +25,7 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             {% include 'partial_search.html.twig' %}
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th>{{ 'Title'|trans }}</th>

--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -199,10 +199,10 @@
             <div class="tab-pane show active" id="tab-index" role="tabpanel">
                 {% include 'partial_search.html.twig' %}
               <div class="table-responsive">
-                <table class="table card-table table-vcenter table-striped text-nowrap">
+                <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                     <thead>
                         <tr>
-                            <th class="w-1">
+                            <th class="w-1 no-sort">
                                 <input type="checkbox" class="form-check-input m-0 align-middle batch-delete-master-checkbox">
                             </th>
                             <th class="w-1">#</th>

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -32,7 +32,7 @@
 <div class="card">
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th class="w-1">

--- a/src/modules/Kb/html_admin/mod_kb_index.html.twig
+++ b/src/modules/Kb/html_admin/mod_kb_index.html.twig
@@ -36,7 +36,7 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             {% include 'partial_search.html.twig' %}
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th>{{ 'Title'|trans }}</th>

--- a/src/modules/News/html_admin/mod_news_index.html.twig
+++ b/src/modules/News/html_admin/mod_news_index.html.twig
@@ -25,10 +25,10 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             {% include 'partial_search.html.twig' %}
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
-                        <th class="w-1">
+                        <th class="w-1 no-sort">
                             <input type="checkbox" class="form-check-input m-0 align-middle batch-delete-master-checkbox">
                         </th>
                         <th class="w-1">#</th>

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -173,10 +173,10 @@
             <div class="tab-pane fade show active" id="tab-index" role="tabpanel" aria-labelledby="index-tab">
                 {% include 'partial_search.html.twig' %}
                 <div class="table-responsive">
-                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                    <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                         <thead>
                             <tr>
-                                <th class="w-1">
+                                <th class="w-1 no-sort">
                                     <input class="form-check-input m-0 align-middle batch-delete-master-checkbox" type="checkbox">
                                 </th>
                                 <th class="w-1">#</th>

--- a/src/modules/Product/html_admin/mod_product_index.html.twig
+++ b/src/modules/Product/html_admin/mod_product_index.html.twig
@@ -39,7 +39,7 @@
             <div class="table-responsive">
                 <form method="post" action="{{ 'api/admin/product/update_priority'|link }}" class="api-form" data-api-reload="1">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
-                    <table class="table card-table table-vcenter table-striped text-nowrap">
+                    <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                         <thead>
                             <tr>
                                 <th>{{ 'Type'|trans }}</th>

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -43,7 +43,7 @@
                 <p class="text-muted">{{ 'Setup domain pricing and allowed operations. Assign specific domain registrars for each Top Level Domain (TLD)'|trans }}</p>
             </div>
 
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th>{{ 'TLD'|trans }}</th>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -35,7 +35,7 @@
             <div class="card-body">
                 <h5>{{ 'Servers'|trans }}</h5>
             </div>
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th>{{ 'Title'|trans }}</th>
@@ -90,7 +90,7 @@
             <div class="card-body">
                 <h5>{{ 'Hosting plans'|trans }}</h5>
             </div>
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <td>{{ 'Title'|trans }}</td>

--- a/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_responses.html.twig
@@ -51,12 +51,12 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
             {% include 'partial_search.html.twig' %}
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
                         <th>{{ 'Title'|trans }}</th>
                         <th class="text-center">{{ 'Category'|trans }}</th>
-                        <th class="w-1"></th>
+                        <th class="w-1 no-sort"></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/modules/Support/html_admin/mod_support_public_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_public_tickets.html.twig
@@ -73,10 +73,10 @@
         </div>
 
         {% include 'partial_search.html.twig' %}
-        <table class="table card-table table-vcenter table-striped text-nowrap">
+        <table class="table card-table table-vcenter table-striped text-nowrap sortable">
             <thead>
                 <tr>
-                    <th class="w-1">
+                    <th class="w-1 no-sort">
                         <input type="checkbox" class="form-check-input m-0 align-middle batch-delete-master-checkbox">
                     </th>
                     <th>{{ 'Subject'|trans }}</th>

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -182,10 +182,10 @@
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-index" role="tabpanel" aria-labelledby="index-tab">
             {% include 'partial_search.html.twig' %}
-            <table class="table card-table table-vcenter table-striped text-nowrap">
+            <table class="table card-table table-vcenter table-striped text-nowrap sortable">
                 <thead>
                     <tr>
-                        <th class="w-1">
+                        <th class="w-1 no-sort">
                             <input class="form-check-input m-0 align-middle batch-delete-master-checkbox" type="checkbox">
                         </th>
                         <th>{{ 'Client'|trans }}</th>

--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -12,6 +12,7 @@ import './js/datepicker'
 import ApexCharts from 'apexcharts';
 import './js/ui/theme_settings';
 import './js/fossbilling';
+import 'sortable-tablesort/sortable.min.js';
 
 globalThis.ApexCharts = ApexCharts;
 globalThis.$ = globalThis.jQuery = $;

--- a/src/themes/admin_default/assets/scss/fossbilling.scss
+++ b/src/themes/admin_default/assets/scss/fossbilling.scss
@@ -3,6 +3,7 @@
 @import "flags";
 @import "~tom-select/dist/css/tom-select.bootstrap5.css";
 @import "theme_settings";
+@import 'sortable-tablesort/sortable-base.css';
 
 .page {
     min-height: calc(100vh - 2px);

--- a/src/themes/admin_default/html/partial_extensions.html.twig
+++ b/src/themes/admin_default/html/partial_extensions.html.twig
@@ -5,10 +5,10 @@
 {% endif %}
 
 <div class="table-responsive">
-    <table class="table card-table table-vcenter table-striped text-nowrap">
+    <table class="table card-table table-vcenter table-striped text-nowrap sortable">
         <thead>
         <tr>
-            <th></th>
+            <th class="no-sort"></th>
             <th>{{ 'Extension'|trans }}</th>
             <th>{{ 'Description'|trans }}</th>
             <th class="w-1"></th>

--- a/src/themes/admin_default/package.json
+++ b/src/themes/admin_default/package.json
@@ -21,6 +21,7 @@
     "jquery": "^3.7.0",
     "litepicker": "^2.0.12",
     "select2": "^4.0.13",
+    "sortable-tablesort": "^2.2.0",
     "tom-select": "^2.2.2"
   }
 }


### PR DESCRIPTION
This PR ships [sortable-tablesort](https://www.npmjs.com/package/sortable-tablesort#non-sortable-field) within FOSSBilling and adds it to all of the tables in the admin panel where I thought it would be helpful to sort tables. It's a fully native JS solution that's small, fast, and doesn't need external dependencies which is great.
Closes #1057
![Animation](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/4c87dacb-5ac8-40ed-aee2-96b3c1a68e1e)

