### PR TITLE
Fix admin theme brief flash

### DIFF
--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -25,12 +25,6 @@ coloris({
 
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (localStorage.getItem('theme') === 'dark') {
-    document.body.setAttribute("data-bs-theme", localStorage.getItem('theme'))
-  } else {
-    document.body.removeAttribute("data-bs-theme")
-  }
-
   document.querySelectorAll('.js-theme-toggler').forEach(element => {
     element.addEventListener('click', event => {
       event.preventDefault();

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -25,13 +25,19 @@
 </head>
 
 <body data-bs-theme="dark">
-    {% if not admin %}
     <script>
-        $(function () {
-            bb.redirect("{{ 'staff/login'|alink }}");
-        });
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.setAttribute("data-bs-theme", localStorage.getItem('theme'));
+        } else {
+            document.body.removeAttribute("data-bs-theme");
+        }
+
+        {% if not admin %}
+            $(function () {
+                bb.redirect("{{ 'staff/login'|alink }}");
+            });
+        {% else %}
     </script>
-    {% else %}
     {% if hide_menu %}
     {% block content_wide %}{% endblock %}
     {% else %}

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -603,9 +603,12 @@
                     labels: {
                         show: false,
                     },
-                    colors: ["#206bc4"],
-                    tooltip: {
-                        theme: (localStorage.getItem('theme') === 'dark') ? 'dark' : 'light'
+                    colors:  (localStorage.getItem('theme') === 'dark') ? ["#91bbed"] : ["#206bc4"] ,
+                    theme : {
+                        mode: (localStorage.getItem('theme') === 'dark') ? 'dark' : 'light',
+                        monochrome: {
+                            enabled: false,
+                        }
                     }
                 }).render();
             }


### PR DESCRIPTION
I've moved the step where we set the correct theme attribute so that it's one of the very first things that are performed during a page load. For me, this appears to completely resolve any issues with the page flashing the "dark" theme state that's in the template.
I've also update the code that sets up the charts so it correctly applies dark mode

Before:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/91db9aec-b6c0-4aa6-a122-2967230a0c2c)

After:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/27f161e6-9aa2-4e6f-82b0-4b5e15a1b3c5)


I tried and managed to change the background color by overriding it with JS, but ApexCharts re-draws the chart when you drag it which caused the changes to be reverted. They don't seem to provide any way to change the background color, leaving overriding it in the CSS pretty much the only option, which isn't that practical since we have both a light and dark mode. See: https://github.com/apexcharts/apexcharts.js/issues/218