### PR TITLE
Fix update patcher overring locale / timezone config

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -70,8 +70,8 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['maintenance_mode']['allowed_urls'] ??= [];
         $newConfig['maintenance_mode']['allowed_ips'] ??= [];
         $newConfig['disable_auto_cron'] ??= false;
-        $newConfig['i18n']['locale'] = $currentConfig['locale'] ?? 'en_US';
-        $newConfig['i18n']['timezone'] = $currentConfig['timezone'] ?? 'UTC';
+        $newConfig['i18n']['locale'] ??= $currentConfig['locale'] ?? 'en_US';
+        $newConfig['i18n']['timezone'] ??= $currentConfig['timezone'] ?? 'UTC';
         $newConfig['i18n']['date_format'] ??= 'medium';
         $newConfig['i18n']['time_format'] ??= 'short';
         $newConfig['db']['port'] ??= '3306';


### PR DESCRIPTION
Minor bug-fix. 
Before it would always re-assigning these values to the default, now it only does so if they are not already set.