### PR TITLE
Invalidate existing sessions during PW reset

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -354,6 +354,9 @@ class Admin extends \Api_Abstract
         $client->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($client);
 
+        $profileService = $this->di['mod_service']('profile');
+        $profileService->invalidateSessions('client', $data['id']);
+
         $this->di['events_manager']->fire(['event' => 'onAfterAdminClientPasswordChange', 'params' => ['id' => $client->id, 'password' => $data['password']]]);
 
         $this->di['logger']->info('Changed client #%s password', $client->id);

--- a/src/modules/Profile/Api/Admin.php
+++ b/src/modules/Profile/Api/Admin.php
@@ -116,10 +116,26 @@ class Admin extends \Api_Abstract
 
         $staff = $this->getIdentity();
 
-        if(!$this->di['password']->verify($data['current_password'], $staff->pass)) {
+        if (!$this->di['password']->verify($data['current_password'], $staff->pass)) {
             throw new \Exception('Current password incorrect');
         }
 
+        $this->getService()->invalidateSessions();
         return $this->getService()->changeAdminPassword($staff, $data['new_password']);
+    }
+
+    /**
+     * Used to destroy / invalidate all existing sessions for a given user
+     * @param array $data An array with the options.
+     *                    The array can contain the following sub-keys:
+     *                    - string|null $data['type'] The user type (admin or staff) (optional).
+     *                    - id|null $data['id'] The session ID (optional).
+     * @return bool 
+     */
+    public function destroy_sessions(array $data): bool
+    {
+        $data['type'] ??= null;
+        $data['id'] ??= null;
+        return $this->getService()->invalidateSessions($data['type'], $data['id']);
     }
 }

--- a/src/modules/Profile/Api/Client.php
+++ b/src/modules/Profile/Api/Client.php
@@ -120,10 +120,11 @@ class Client extends \Api_Abstract
 
         $client = $this->getIdentity();
 
-        if(!$this->di['password']->verify($data['current_password'], $client->pass)) {
+        if (!$this->di['password']->verify($data['current_password'], $client->pass)) {
             throw new \Exception('Current password incorrect');
         }
 
+        $this->getService()->invalidateSessions();
         return $this->getService()->changeClientPassword($client, $data['new_password']);
     }
 
@@ -135,5 +136,14 @@ class Client extends \Api_Abstract
     public function logout()
     {
         return $this->getService()->logoutClient();
+    }
+
+    /**
+     * Used to destroy / invalidate all existing sessions for the current client
+     * @return bool 
+     */
+    public function destroy_sessions(array $data): bool
+    {
+        return $this->getService()->invalidateSessions();
     }
 }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -443,6 +443,9 @@ class Service implements InjectionAwareInterface
         $model->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($model);
 
+        $profileService = $this->di['mod_service']('profile');
+        $profileService->invalidateSessions('admin', $model->id);
+
         $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffPasswordChange', 'params' => ['id' => $model->id]]);
 
         $this->di['logger']->info('Changed staff member %s password', $model->id);

--- a/tests/modules/Client/Api/AdminTest.php
+++ b/tests/modules/Client/Api/AdminTest.php
@@ -449,6 +449,8 @@ class AdminTest extends \BBTestCase
             ->method('hashIt')
             ->with($data['password']);
 
+        $profileService = $this->getMockBuilder('\Box\Mod\Profile\Service')->getMock();
+
         $di                   = new \Pimple\Container();
         $di['db']             = $dbMock;
         $di['events_manager'] = $eventMock;
@@ -459,7 +461,9 @@ class AdminTest extends \BBTestCase
             ->method('checkRequiredParamsForArray')
             ->will($this->returnValue(null));
         $di['validator'] = $validatorMock;
-
+        $di['mod_service'] = $di->protect(function () use ($profileService) {
+            return $profileService;
+        });
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -1027,12 +1027,17 @@ class ServiceTest extends \BBTestCase
         $passwordMock->expects($this->atLeastOnce())
             ->method('hashIt')
             ->with($plainTextPassword);
+        
+        $profileService = $this->getMockBuilder('\Box\Mod\Profile\Service')->getMock();
 
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
         $di['db']             = $dbMock;
         $di['password']       = $passwordMock;
+        $di['mod_service'] = $di->protect(function () use ($profileService) {
+            return $profileService;
+        });
 
         $service = new \Box\Mod\Staff\Service();
         $service->setDi($di);


### PR DESCRIPTION
As the tin says. 
The PR introduces new functionality to find and destroy sessions when performing a PW reset.
It'll do so when a client or staff member resets their own password as well as when a staff member performs a reset for someone else.
Also a bit of a happy accident, it's unable to truly delete the current session that's performing the reset as even if it gets trashed, it's instantly re-created while FOSSBilling handles the API request meaning a user won't be force to instantly log back in after changing their password which is nice for QoL.