### PR TITLE
Minor improvements to cron

### DIFF
--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -70,7 +70,7 @@ class Service
         $ss = $this->di['mod_service']('system');
         $ss->setParamValue('last_cron_exec', date('Y-m-d H:i:s'), $create);
 
-        $count = $this->clearOldSessions();
+        $count = $this->clearOldSessions() ?? 0;
         $this->di['logger']->setChannel('cron')->info("Cleared $count outdated sessions from the database");
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
@@ -115,7 +115,7 @@ class Service
         return $t1 < $t2;
     }
 
-    private function clearOldSessions(): int
+    private function clearOldSessions(): ?int
     {
         $maxAge = time() - $this->di['config']['security']['cookie_lifespan'];
         $sql = 'DELETE FROM session WHERE modified_at <= :age';

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -70,8 +70,8 @@ class Service
         $ss = $this->di['mod_service']('system');
         $ss->setParamValue('last_cron_exec', date('Y-m-d H:i:s'), $create);
 
-        $this->clearOldSessions();
-        $this->di['logger']->setChannel('cron')->info('Cleared outdated sessions from the database');
+        $count = $this->clearOldSessions();
+        $this->di['logger']->setChannel('cron')->info("Cleared $count outdated sessions from the database");
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
 
@@ -115,14 +115,10 @@ class Service
         return $t1 < $t2;
     }
 
-    private function clearOldSessions()
+    private function clearOldSessions(): int
     {
-        $sessions = $this->di['db']->findAll('session');
-        foreach ($sessions as $session){
-            $maxAge = time() - $this->di['config']['security']['cookie_lifespan'];
-            if($session->modified_at <= $maxAge){
-                $this->di['db']->trash($session);
-            }
-        }
+        $maxAge = time() - $this->di['config']['security']['cookie_lifespan'];
+        $sql = 'DELETE FROM session WHERE modified_at <= :age';
+        return $this->di['db']->exec($sql, [':age' => $maxAge]);
     }
 }

--- a/src/modules/Cron/html_admin/mod_cron_settings.html.twig
+++ b/src/modules/Cron/html_admin/mod_cron_settings.html.twig
@@ -68,7 +68,7 @@
             </table>
         </div>
         <div class="card-footer text-center">
-            <a href="{{ cron.cron_url }}" class="btn btn-primary" target="_blank">
+            <a href="{{'api/admin/cron/run'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" target="_blank" data-api-msg="{{ 'Cron executed'|trans }}">
                 <svg class="icon icon-tabler">
                     <use xlink:href="#play"/>
                 </svg>

--- a/tests/modules/Cron/ServiceTest.php
+++ b/tests/modules/Cron/ServiceTest.php
@@ -64,8 +64,7 @@ class ServiceTest extends \BBTestCase {
         
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('findAll')
-            ->will($this->returnValue([]));
+            ->method('exec');
 
         $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();

--- a/tests/modules/Cron/ServiceTest.php
+++ b/tests/modules/Cron/ServiceTest.php
@@ -74,6 +74,13 @@ class ServiceTest extends \BBTestCase {
         $di['mod_service'] = $di->protect(function() use($systemServiceMock) {return $systemServiceMock;});
         $serviceMock->setDi($di);
         $di['db'] = $dbMock;
+        $di['config'] = [
+            'security' => [
+                'mode' => 'strict',
+                'force_https' => true,
+                'cookie_lifespan' => 7200,
+            ],
+        ];
 
         $result = $serviceMock->runCrons();
         $this->assertTrue($result);


### PR DESCRIPTION
Two minor improvements to cron:
1. The "execute now" button has been changed to call the `run` API endpoint rather than attempting to open the file in the browser
2. The session cleaning job will now log how many outdated sessions were cleared and it's been cleaned up to be much more efficient. Something to note is that due to #1335, this function doesn't 100% behave as expected since the timestamps are off, but that's not something I am fixing in this PR. Edit: the two are unrelated