### PR TITLE
Fix / improve flawed email confirmation system

### DIFF
--- a/src/modules/Client/Api/Client.php
+++ b/src/modules/Client/Api/Client.php
@@ -54,4 +54,14 @@ class Client extends \Api_Abstract
     {
         return $this->getService()->isClientTaxable($this->identity);
     }
+
+    public function resend_email_verification()
+    {
+        if($this->identity->email_approved){
+            // Email is already validated, so we don't need to do so again
+            return true;
+        }
+
+        return $this->getService()->sendEmailConfirmationForClient($this->identity);
+    }
 }

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -90,7 +90,7 @@ class Guest extends \Api_Abstract
 
         $client = $service->guestCreateClient($data);
 
-        if (isset($config['require_email_confirmation']) && (int) $config['require_email_confirmation'] && !$client->email_approved) {
+        if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation'] && !$client->email_approved) {
             throw new \Box_Exception('Account has been created. Please check your mailbox and confirm email address.', null, 7777);
         }
 
@@ -280,5 +280,11 @@ class Guest extends \Api_Abstract
         $config = $this->di['mod_config']('client');
 
         return $config['custom_fields'] ?? [];
+    }
+
+    public function is_email_validation_required(): bool
+    {
+        $config = $this->di['mod_config']('client');
+        return (bool) ($config['require_email_confirmation'] ?? false);
     }
 }

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -599,16 +599,6 @@ class Service implements InjectionAwareInterface
             return null;
         }
 
-        if (!$this->di['is_client_email_validated']($model)) {
-            $meta = $this->di['db']->findOne('ExtensionMeta', ' extension = "mod_client" AND meta_key = "confirm_email" AND client_id = :client_id', [':client_id' => $model->id]);
-            if (!is_null($meta)) {
-                throw new \Box_Exception('Please check your mailbox and confirm email address.');
-            } else {
-                $this->sendEmailConfirmationForClient($model);
-                throw new \Box_Exception('Confirmation email was sent to your email address. Please click on link in it in order to verify your email.');
-            }
-        }
-
         return $this->di['auth']->authorizeUser($model, $plainTextPassword);
     }
 

--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -15,6 +15,16 @@
 
 <div class="tab-pane active" id="two">
 
+{% if (guest.client_is_email_validation_required) and (not profile.email_approved) %}
+<div class="alert alert-block alert-danger">
+    <div class="row">
+        <span>You must verify your email address before you may access our services.</span>
+    </div>
+    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+    <a href="{{ 'api/client/client/resend_email_verification'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-alt btn-primary api-link" data-api-msg="{{ 'Verification email has been resent'|trans }}">{{ 'Resend verification email'|trans }}</a>
+</div>
+{% endif %}
+
 <!-- Second level tabs -->
 <div class="tabbable tabs-left">
     <ul class="nav nav-tabs">

--- a/tests/modules/Client/ServiceTest.php
+++ b/tests/modules/Client/ServiceTest.php
@@ -1052,44 +1052,6 @@ class ServiceTest extends \BBTestCase {
         $this->assertInstanceOf('\Model_Client', $result);
     }
 
-    public function testauthorizeClientEmailRequiredNotConfirmed()
-    {
-        $email    = 'example@fossbilling.vm';
-        $password = '123456';
-
-        $clientModel = new \Model_Client();
-        $clientModel->loadBean(new \DummyBean());
-
-        $extensionMetaModel = new \Model_ExtensionMeta();
-        $extensionMetaModel->loadBean(new \DummyBean());
-
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->exactly(2))
-            ->method('findOne')
-            ->withConsecutive(['Client'],['ExtensionMeta'])
-            ->will($this->onConsecutiveCalls($clientModel, $extensionMetaModel));
-
-        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
-        $authMock->expects($this->never())
-            ->method('authorizeUser')
-            ->with($clientModel, $password)
-            ->willReturn($clientModel);
-
-        $di               = new \Pimple\Container();
-        $di['db']         = $dbMock;
-        $di['auth']       = $authMock;
-        $di['mod_config'] = $di->protect(function ($name) use ($di) {
-            return array('require_email_confirmation' => true);
-        });
-        $service          = new \Box\Mod\Client\Service();
-        $service->setDi($di);
-
-        $this->expectException(\Box_Exception::class);
-        $result = $service->authorizeClient($email, $password);
-        $this->assertInstanceOf('\Model_Client', $result);
-    }
-
-
     public function testauthorizeClientEmailRequiredConfirmed()
     {
         $email    = 'example@fossbilling.vm';


### PR DESCRIPTION
This pull request fixes / improves the currently flawed email confirmation system with the following improvements:
1. Rather than checking if an email is validated when attempting to login, it is now checked when a client attempts to load a page.
2. If their email isn't validated, the client is only allowed to make API requests to the `profile` and `client` modules to allow them to change their email address if needed.
3. If the client attempts to load any page, they will be redirect to their profile.
4. There is now a button for a client to resend a verification email.
5. The profile displays this when their email is not yet validated:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/43d93ede-a3c2-4003-a38a-9ccd0449c2e2)

(all of these changes only apply if email verification is turned on)

Closes #1255 (and other large issues that aren't documented as an open issue)