### PR TITLE
Fixes dark mode system toast

### DIFF
--- a/src/themes/admin_default/assets/scss/fossbilling.scss
+++ b/src/themes/admin_default/assets/scss/fossbilling.scss
@@ -82,3 +82,14 @@
 #script-code {
     resize: none;
 }
+
+[data-bs-theme=dark] 
+{ 
+  .toast {
+    background: var(--tblr-bg-surface);
+    border: var(--tblr-border-width) var(--tblr-border-style) var(--tblr-secondary);
+    }
+  .toast-header {
+    color: var(--tblr-secondary);
+   }
+}


### PR DESCRIPTION
In dark mode system alerts (using Bootstrap toast) were not visible. This commit changes the toast background, border and font color when in dark mode so the alerts are visible. This bug was mentioned in #1438

Before this commit
![pr-before-fix-dark-mode](https://github.com/FOSSBilling/FOSSBilling/assets/8171442/29c75ab4-5c79-4d2f-8a88-9aab833decee)

After this commit
![pr-fix-dark-mode-toast](https://github.com/FOSSBilling/FOSSBilling/assets/8171442/794eb20e-2e9f-4e8a-9e42-4831e7d47610)
