### PR TITLE
Keep same invoice id

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -371,7 +371,6 @@ class Service implements InjectionAwareInterface
         $ctable = $this->di['mod_service']('Currency');
 
         $invoice->serie = $systemService->getParamValue('invoice_series_paid');
-        $invoice->nr = $this->getNextInvoiceNumber($invoice);
         $invoice->approved = true;
         $invoice->currency_rate = $ctable->getRateByCode($invoice->currency);
         $invoice->status = \Model_Invoice::STATUS_PAID;

--- a/tests/modules/Invoice/ServiceTest.php
+++ b/tests/modules/Invoice/ServiceTest.php
@@ -444,13 +444,11 @@ class ServiceTest extends \BBTestCase
     public function testmarkAsPaid()
     {
         $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\Service')
-            ->setMethods(array('countIncome', 'getNextInvoiceNumber'))
+            ->setMethods(array('countIncome'))
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('countIncome');
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getNextInvoiceNumber');
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -534,9 +532,7 @@ class ServiceTest extends \BBTestCase
 
         $this->service->setDi($di);
 
-        $result = $this->service->getNextInvoiceNumber($invoiceModel);
-        $this->assertIsInt($result);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $invoiceModel -> nr);
     }
 
     public function testcountIncome()
@@ -815,8 +811,6 @@ class ServiceTest extends \BBTestCase
             ->method('countIncome');
         $serviceMock->expects($this->exactly(3))
             ->method('addNote');
-        $serviceMock->expects($this->once())
-            ->method('getNextInvoiceNumber');
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -824,10 +818,6 @@ class ServiceTest extends \BBTestCase
 
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
-
-        $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventManagerMock->expects($this->atLeastOnce())
-            ->method('fire');
 
 
         $systemService = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();

--- a/tests/modules/Invoice/ServiceTest.php
+++ b/tests/modules/Invoice/ServiceTest.php
@@ -819,6 +819,10 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
+        $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
+        $eventManagerMock->expects($this->atLeastOnce())
+            ->method('fire');
+
 
         $systemService = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $systemService->expects($this->atLeastOnce())


### PR DESCRIPTION
I  don't know why it was made like this in the past but with in Europe it is illegal

I don't know if we want to keep a option in the settings as backup? for Existing setups