### PR TITLE
Fix / change invoice incrementation logic

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -510,7 +510,7 @@ class Service implements InjectionAwareInterface
 
         $model->serie = $systemService->getParamValue('invoice_series');
         $model->nr = $this->getNextInvoiceNumber();
-        $model->hash = bin2hex(random_bytes(random_int(100, 127)));;
+        $model->hash = bin2hex(random_bytes(random_int(100, 127)));
 
         $taxtitle = '';
         $taxService = $this->di['mod_service']('Invoice', 'Tax');

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -372,7 +372,6 @@ class Service implements InjectionAwareInterface
         $ctable = $this->di['mod_service']('Currency');
 
         $invoice->serie = $systemService->getParamValue('invoice_series_paid');
-        $invoice->nr = $this->getNextInvoiceNumber($invoice);
         $invoice->approved = true;
         $invoice->currency_rate = $ctable->getRateByCode($invoice->currency);
         $invoice->status = \Model_Invoice::STATUS_PAID;
@@ -399,23 +398,22 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
-    public function getNextInvoiceNumber(\Model_Invoice $model)
+    public function getNextInvoiceNumber()
     {
-        $p = 'invoice_starting_number';
         $systemService = $this->di['mod_service']('system');
-        $next_nr = $systemService->getParamValue($p);
+        $next_nr = $systemService->getParamValue('invoice_starting_number');
+
         if (empty($next_nr)) {
-            $next_nr = $model->id;
-
-            // get last invoice number
-
+            // In theory this code should never need to be called, but is provided as a fallback
             $r = $this->di['db']->findOne('Invoice', 'nr is not null order by id desc');
             if ($r instanceof \Model_Invoice && is_numeric($r->nr)) {
                 $next_nr = intval($r->nr) + 1;
+            } else {
+                throw new \Box_Exception("Unable to determine the next invoice number");
             }
         }
-        $systemService->setParamValue($p, intval($next_nr) + 1);
 
+        $systemService->setParamValue('invoice_starting_number', intval($next_nr) + 1);
         return $next_nr;
     }
 
@@ -511,8 +509,8 @@ class Service implements InjectionAwareInterface
         $model->due_at = date('Y-m-d H:i:s', $due_time);
 
         $model->serie = $systemService->getParamValue('invoice_series');
-        $model->nr = $model->id;
-        $model->hash = bin2hex(random_bytes(random_int(100, 127)));
+        $model->nr = $this->getNextInvoiceNumber();
+        $model->hash = bin2hex(random_bytes(random_int(100, 127)));;
 
         $taxtitle = '';
         $taxService = $this->di['mod_service']('Invoice', 'Tax');
@@ -687,7 +685,6 @@ class Service implements InjectionAwareInterface
 
                 if ($logic == 'negative_invoice') {
                     $new->serie = $systemService->getParamValue('invoice_series_paid');
-                    $new->nr = $this->getNextInvoiceNumber($new);
                     $this->di['db']->store($new);
                 }
 

--- a/tests/modules/Invoice/ServiceTest.php
+++ b/tests/modules/Invoice/ServiceTest.php
@@ -504,39 +504,6 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testgetNextInvoiceNumber()
-    {
-        $invoiceModel = new \Model_Invoice();
-        $invoiceModel->loadBean(new \DummyBean());
-        $invoiceModel->id = 2;
-        $invoiceModel->nr = 2;
-
-        $expected = $invoiceModel->id + 1;
-
-        $systemService = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $systemService->expects($this->atLeastOnce())
-            ->method('getParamValue');
-        $systemService->expects($this->atLeastOnce())
-            ->method('setParamValue');
-
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('findOne')
-            ->will($this->returnValue($invoiceModel));
-
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(function () use ($systemService) {
-            return $systemService;
-        });
-
-        $this->service->setDi($di);
-
-        $result = $this->service->getNextInvoiceNumber($invoiceModel);
-        $this->assertIsInt($result);
-        $this->assertEquals($expected, $result);
-    }
-
     public function testcountIncome()
     {
         $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\Service')
@@ -675,7 +642,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($seller));
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue(0));
+            ->will($this->returnValue(1));
 
         $serviceTaxMock = $this->getMockBuilder('\Box\Mod\Invoice\ServiceTax')->getMock();
         $serviceTaxMock->expects($this->atLeastOnce())

--- a/tests/modules/Invoice/ServiceTest.php
+++ b/tests/modules/Invoice/ServiceTest.php
@@ -444,13 +444,11 @@ class ServiceTest extends \BBTestCase
     public function testmarkAsPaid()
     {
         $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\Service')
-            ->setMethods(array('countIncome', 'getNextInvoiceNumber'))
+            ->setMethods(array('countIncome'))
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('countIncome');
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getNextInvoiceNumber');
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -802,7 +800,7 @@ class ServiceTest extends \BBTestCase
         $total       = 10;
         $tax         = 2.2;
         $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\Service')
-            ->setMethods(array('getTotal', 'getTax', 'countIncome', 'addNote', 'getNextInvoiceNumber'))
+            ->setMethods(array('getTotal', 'getTax', 'countIncome', 'addNote'))
             ->getMock();
 
         $serviceMock->expects($this->once())
@@ -815,8 +813,6 @@ class ServiceTest extends \BBTestCase
             ->method('countIncome');
         $serviceMock->expects($this->exactly(3))
             ->method('addNote');
-        $serviceMock->expects($this->once())
-            ->method('getNextInvoiceNumber');
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());


### PR DESCRIPTION
Based on the work done in PR #1473, however it accounts for a few minor oversights and changes that were missed + corrects the base logic for invoice numbering.

## Old Logic
1. During the `prepareInvoice` function, `setInvoiceDefaults` was called. This function would assign the invoice a number based off the invoice ID in the DB
2. When paying an invoice, it would use the `getNextInvoiceNumber` function to increment the invoice's number to whatever the next one is.
3. If an invoice is *refunded*, the `negative_invoice` would also use `getNextInvoiceNumber` to increment the invoice number.

## New logic
1. When preparing an invoice, the `setInvoiceDefaults` now uses the `getNextInvoiceNumber` to get the next invoice number and correctly updates what the next invoice number will be.
2. The instances where the invoice number was changed have been removed.

Closes #131 and closes #1473