### PR TITLE
(WIP) Initial Work to per-currency rounding feature.

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -112,9 +112,9 @@ UNLOCK TABLES;
 LOCK TABLES `currency` WRITE;
 /*!40000 ALTER TABLE `currency` DISABLE KEYS */;
 
-INSERT INTO `currency` (`id`, `title`, `code`, `is_default`, `conversion_rate`, `format`, `price_format`, `created_at`, `updated_at`)
+INSERT INTO `currency` (`id`, `title`, `code`, `is_default`, `conversion_rate`, `format`, `price_format`, `rounding_precision`, `created_at`, `updated_at`)
 VALUES
-	(1,'US Dollar','USD',1,1.000000,'${{price}}','1','2022-12-01 12:00:00','2022-12-01 12:00:00');
+	(1,'US Dollar','USD',1,1.000000,'${{price}}','1','1','2022-12-01 12:00:00','2022-12-01 12:00:00');
 
 /*!40000 ALTER TABLE `currency` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/install/sql/content_test.sql
+++ b/src/install/sql/content_test.sql
@@ -141,9 +141,10 @@ LOCK TABLES `currency` WRITE;
 
 INSERT INTO `currency` (`id`, `title`, `code`, `is_default`, `conversion_rate`, `format`, `price_format`, `created_at`, `updated_at`)
 VALUES
-	(1,'US Dollar','USD',1,1.000000,'${{price}}','1','2022-12-01 12:00:00','2022-12-01 12:00:00'),
-	(2,'Euro','EUR',0,0.600000,'€{{price}}','1','2022-12-01 12:00:00','2022-12-01 12:00:00'),
-	(3,'Pound Sterling','GBP',0,0.600000,'{{price}} ₤','1','2022-12-01 12:00:00','2022-12-01 12:00:00');
+	(1,'US Dollar','USD',1,1.000000,'${{price}}','1','1','2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(2,'Euro','EUR',0,0.600000,'€{{price}}','1','1','2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(3,'Pound Sterling','GBP',0,0.600000,'{{price}} ₤','1','1','2022-12-01 12:00:00','2022-12-01 12:00:00');
+    (4,'Swiss Francs','CHF',0,1.1500000,'{{price}} CHF','1','0.05','2022-12-01 12:00:00','2022-12-01 12:00:00');
 
 /*!40000 ALTER TABLE `currency` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -415,6 +415,7 @@ CREATE TABLE `currency` (
   `conversion_rate` decimal(13,6) DEFAULT '1.000000',
   `format` varchar(30) DEFAULT NULL,
   `price_format` varchar(50) DEFAULT '1',
+  `rounding_precision` decimal(13,6) DEFAULT '1.000000',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -291,6 +291,11 @@ class UpdatePatcher implements InjectionAwareInterface
                 $q = "ALTER TABLE session ADD fingerprint TEXT;";
                 $this->executeSql($q);
             },
+            35 => function () {
+                // Adds the new "fingerprint" to the session table, to allow us to fingerprint devices and help prevent against attacks such as session hijacking.
+                $q = "ALTER TABLE currency ADD `rounding_precision` int(11) DEFAULT '1' AFTER `price_format`;";
+                $this->executeSql($q);
+            },
         ];
         ksort($patches, SORT_NATURAL);
 

--- a/src/modules/Currency/Api/Admin.php
+++ b/src/modules/Currency/Api/Admin.php
@@ -117,8 +117,8 @@ class Admin extends \Api_Abstract
 
         $title = $data['title'] ?? null;
         $conversionRate = $data['conversion_rate'] ?? 1;
-
-        return $service->createCurrency($data['code'] ?? null, $data['format'] ?? null, $title, $conversionRate);
+        $roundingprecision = $data['rounding_precision'] ?? 1;
+        return $service->createCurrency($data['code'] ?? null, $data['format'] ?? null, $title, $conversionRate, $roundingprecision);
     }
 
     /**
@@ -145,8 +145,9 @@ class Admin extends \Api_Abstract
         $title = $data['title'] ?? null;
         $priceFormat = $data['price_format'] ?? null;
         $conversionRate = $data['conversion_rate'] ?? null;
+        $roundingprecision = $data['rounding_precision'] ?? null;
 
-        return $this->getService()->updateCurrency($data['code'], $format, $title, $priceFormat, $conversionRate);
+        return $this->getService()->updateCurrency($data['code'], $format, $title, $priceFormat, $conversionRate, $roundingprecision);
     }
 
     /**

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -81,6 +81,7 @@ class Guest extends \Api_Abstract
             3 => number_format($p, 2, ',', '.'),
             4 => number_format($p, 0, '', ','),
             5 => number_format($p, 0, '', ''),
+            6 => number_format($p, 2, '\''),
             default => number_format($p, 2, '.', ''),
         };
 

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -420,13 +420,14 @@ class Service implements InjectionAwareInterface
             'code' => $model->code,
             'title' => $model->title,
             'conversion_rate' => (float) $model->conversion_rate,
+            'rounding_precision' => (float) $model->rounding_precision,
             'format' => $model->format,
             'price_format' => $model->price_format,
             'default' => $model->is_default,
         ];
     }
 
-    public function createCurrency($code, $format, $title = null, $conversionRate = 1)
+    public function createCurrency($code, $format, $title = null, $conversionRate = 1, $roundingprecision = 1)
     {
         $systemService = $this->di['mod_service']('system');
         $systemService->checkLimits('Model_Currency', 2);
@@ -438,6 +439,7 @@ class Service implements InjectionAwareInterface
         $model->title = $title;
         $model->format = $format;
         $model->conversion_rate = $conversionRate;
+        $model->rounding_precision = $roundingprecision;
         $model->created_at = date('Y-m-d H:i:s');
         $model->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($model);
@@ -454,7 +456,7 @@ class Service implements InjectionAwareInterface
         }
     }
 
-    public function updateCurrency($code, $format = null, $title = null, $priceFormat = null, $conversionRate = null)
+    public function updateCurrency($code, $format = null, $title = null, $priceFormat = null, $conversionRate = null, $roundingprecision = 1)
     {
         $db = $this->di['db'];
 
@@ -481,6 +483,14 @@ class Service implements InjectionAwareInterface
                 throw new \Box_Exception('Currency rate is invalid', null, 151);
             }
             $model->conversion_rate = $conversionRate;
+        }
+
+        // update rounding_precision
+        if (isset($roundingprecision)) {
+            if (!is_numeric($roundingprecision) || $roundingprecision < 0) {
+                throw new \Box_Exception('Currency rounding precision is invalid', null, 151);
+            }
+            $model->rounding_precision = $roundingprecision;
         }
 
         $model->updated_at = date('Y-m-d H:i:s');

--- a/src/modules/Currency/html_admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_manage.html.twig
@@ -45,6 +45,12 @@
                 </div>
             </div>
             <div class="mb-3 row">
+                <label class="col-md-3 col-form-label">{{ 'Rounding Precision'|trans }}</label>
+                <div class="col-md-6">
+                    <input class="form-control" type="text" name="rounding_precision" value="{{ currency.rounding_precision }}" required>
+                </div>
+            </div>
+            <div class="mb-3 row">
                 <label class="col-md-3 col-form-label">{{ 'Format'|trans }}</label>
                 <div class="col-md-6">
                     <input class="form-control" type="text" name="format" value="{{ currency.format }}" required placeholder="$ {{ price|raw }}">
@@ -66,6 +72,10 @@
                         <label class="form-check-label" for="radioPriceFormat3">1.234,56</label>
                     </div>
                     <div class="form-check form-check-inline">
+                        <input class="form-check-input" id="radioPriceFormat5" type="radio" name="price_format" value="6"{% if currency.price_format == 6 %} checked{% endif %}>
+                        <label class="form-check-label" for="radioPriceFormat5">1'234.00</label>
+                    </div>
+                    <div class="form-check form-check-inline">
                         <input class="form-check-input" id="radioPriceFormat4" type="radio" name="price_format" value="4"{% if currency.price_format == 4 %} checked{% endif %}>
                         <label class="form-check-label" for="radioPriceFormat4">1,234</label>
                     </div>
@@ -73,6 +83,7 @@
                         <input class="form-check-input" id="radioPriceFormat5" type="radio" name="price_format" value="5"{% if currency.price_format == 5 %} checked{% endif %}>
                         <label class="form-check-label" for="radioPriceFormat5">1234</label>
                     </div>
+
                 </div>
             </div>
         </div>

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -57,6 +57,7 @@
                                 <th>{{ 'ISO code'|trans }}</th>
                                 <th>{{ 'Title'|trans }}</th>
                                 <th>{{ 'Conversion rate'|trans }}</th>
+                                <th>{{ 'Rounding Precision'|trans }}</th>
                                 <th>{{ 'Example price'|trans }}</th>
                                 <th class="w-1"></th>
                             </tr>
@@ -69,6 +70,7 @@
                                         <a href="{{ '/currency/manage'|alink }}/{{ currency.code }}">{{ currency.title }}</a>
                                     </td>
                                     <td>{{ currency.conversion_rate }}</td>
+                                    <td>{{ currency.rounding_precision }}</td>
                                     <td>{{ mf.currency_format(1) }} = {{ mf.currency(1, currency.code) }}</td>
                                     <td>
                                         <a class="btn btn-icon" href="{{ '/currency/manage'|alink }}/{{ currency.code }}"

--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -248,7 +248,15 @@ class ServiceInvoiceItem implements InjectionAwareInterface
 
     public function getTotalWithTax(\Model_InvoiceItem $item)
     {
-        return $this->getTotal($item) + $this->getTax($item) * $item->quantity;
+        $currencyService = $this->di['mod_service']('Currency');
+
+        // Calculate total with tax
+        $total_with_tax = $this->getTotal($item) + $this->getTax($item) * $item->quantity;
+        // Round according to currencies rounding precision
+        $currency_rounding_precision = $currencyService->getByCode($item->currency)->rounding_precision;
+        $total_with_tax = floor($total_with_tax/$currency_rounding_precision)*$currency_rounding_precision;
+
+        return $total_with_tax;
     }
 
     public function getOrderId(\Model_InvoiceItem $item)


### PR DESCRIPTION
This implements a "rounding precision" for currencies that don't round to two decimals. (Specifically, CHF) 

In the field "Rounding precision", you can set the next decimal the program should round to. 

Currently, only rounding down works, but implementing "bank" rounding is also on the to-do list.

I've decided to pause working on this and instead clean up the cart / order button functionality before, as currently, rounding not only happens in `ServiceInvoiceItem.php` (in the function `getTotalWithTax`), but also in the twig template of the checkout process.

It's important to have a set of core functionalities to process business logic, and the checkout process needs rewriting to make use of that. Before that isn't done, rounding isn't a pressing issue.