### PR TITLE
Fixed renderJSON in App.php not loaded

### DIFF
--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -269,6 +269,8 @@ class Box_App
         $adminApiPrefixes = [
             '/api/guest/staff/login',
             '/api/admin',
+            'api/admin',
+            '/index.php?_url=/api/admin/',
         ];
 
         foreach ($adminApiPrefixes as $adminApiPrefix) {
@@ -348,8 +350,7 @@ class Box_App
 
                 if ('api' == $this->mod) {
                     $exc = new \Box_Exception('The system is undergoing maintenance. Please try again later', [], 503);
-
-                    return (new \Box\Mod\Api\Controller\Client())->renderJson(null, $exc);
+                    return $this->renderJson(null, $exc);
                 } else {
                     return $this->render('mod_system_maintenance');
                 }
@@ -379,4 +380,41 @@ class Box_App
 
         return $this->show404($e);
     }
+
+    public function renderJson($data = null, \Exception $e = null)
+    {
+
+        // do not emit response if headers already sent
+        if (headers_sent()) {
+            return;
+        }
+        $this->_api_config = null;
+        if (is_null($this->_api_config)) {
+            $this->_api_config = $this->di['config']['api'];
+        }
+        header('Cache-Control: no-cache, must-revalidate');
+        header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+        header('Content-type: application/json; charset=utf-8');
+        header('X-FOSSBilling-Version: ' . \FOSSBilling\Version::VERSION);
+        header('X-RateLimit-Span: ' . $this->_api_config['rate_span']);
+        header('X-RateLimit-Limit: ' . $this->_api_config['rate_limit']);
+        header('X-RateLimit-Remaining: ' . '9999');
+        if (null !== $e) {
+            error_log($e->getMessage() . ' ' . $e->getCode());
+            $code = $e->getCode() ? $e->getCode() : 9999;
+            $result = ['result' => null, 'error' => ['message' => $e->getMessage(), 'code' => $code]];
+            $authFailed = array(201, 202, 206, 204, 205, 203, 403, 1004, 1002);
+
+            if (in_array($code, $authFailed)) {
+                header('HTTP/1.1 401 Unauthorized');
+            } elseif ($code == 701 || $code == 879) {
+                header('HTTP/1.1 400 Bad Request');
+            }
+        } else {
+            $result = ['result' => $data, 'error' => null];
+        }
+        echo json_encode($result);
+        exit;
+    }
+
 }

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -21,7 +21,6 @@ class Box_App
     protected $ext = 'html.twig';
     protected $mod = 'index';
     protected $url = '/';
-    private $_api_config = null;
 
     public $uri = null;
 

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -388,17 +388,14 @@ class Box_App
         if (headers_sent()) {
             return;
         }
-        $this->_api_config = null;
-        if (is_null($this->_api_config)) {
-            $this->_api_config = $this->di['config']['api'];
-        }
+        $this->_api_config = $this->di['config']['api'];
         header('Cache-Control: no-cache, must-revalidate');
         header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
         header('Content-type: application/json; charset=utf-8');
         header('X-FOSSBilling-Version: ' . \FOSSBilling\Version::VERSION);
         header('X-RateLimit-Span: ' . $this->_api_config['rate_span']);
         header('X-RateLimit-Limit: ' . $this->_api_config['rate_limit']);
-        header('X-RateLimit-Remaining: ' . '9999');
+        header('X-RateLimit-Remaining: 9999');
         if (null !== $e) {
             error_log($e->getMessage() . ' ' . $e->getCode());
             $code = $e->getCode() ? $e->getCode() : 9999;

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -21,6 +21,7 @@ class Box_App
     protected $ext = 'html.twig';
     protected $mod = 'index';
     protected $url = '/';
+    private $_api_config = null;
 
     public $uri = null;
 


### PR DESCRIPTION
Fixes #1374 

Because the app was not yet completely loaded when the dependency injector was used, there was an error.

I had to replicate the function renderJson from the Client instance within App.php.