### PR TITLE
HestiaCP failed setup if domain already exists on server

### DIFF
--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -203,7 +203,7 @@ class Server_Manager_Hestia extends Server_Manager
         if (0 !== intval($result2)) {
             $postvars3 = [
                 'returncode' => 'yes',
-                'cmd' => 'v-remove-user',
+                'cmd' => 'v-delete-user',
                 'arg1' => $a->getUsername(),
             ];
             $result3 = $this->_makeRequest($postvars3);

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -201,6 +201,16 @@ class Server_Manager_Hestia extends Server_Manager
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
         if (0 !== intval($result2)) {
+            $postvars3 = [
+                'returncode' => 'yes',
+                'cmd' => 'v-remove-user',
+                'arg1' => $a->getUsername(),
+            ];
+            $result3 = $this->_makeRequest($postvars3);
+            if(0 !== intval($result3)) {
+                $placeholders = ['action1' => __trans('delete domain'), 'action2' => __trans('create domain'), 'type' => 'HestiaCP'];
+                throw new Server_Exception('Failed to :action1: on the :type: server after failed to :action2:, check the error logs for further details', $placeholders);
+            }
             $placeholders = ['action' => __trans('create domain'), 'type' => 'HestiaCP'];
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }


### PR DESCRIPTION
When you create a new order with a domain that already exists on the server the setup will fail but it will leave a user on the HestiaCP server. This PR adds a 3rd request for exactly this case. It will clean up after a failed setup.