### PR TITLE
Make system version & company info visibility through the guest API configurable

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -345,6 +345,7 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addGlobal('CSRFToken', $token);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);
+    $twig->addGlobal('FOSSBillingVersion', FOSSBilling\Version::VERSION);
 
     return $twig;
 });

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -345,8 +345,8 @@ VALUES
 	(27,'funds_min_amount','10',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(28,'funds_max_amount','200',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(29,'company_favicon','themes/huraga/assets/favicon.ico',0,NULL,NULL,'2023-01-08 12:00:00','2023-01-08 12:00:00');
-    (30,'show_version_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
-    (31,'show_company_public',0,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
+    (30,'hide_version_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
+    (31,'hide_company_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
 
 /*!40000 ALTER TABLE `setting` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -345,6 +345,8 @@ VALUES
 	(27,'funds_min_amount','10',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(28,'funds_max_amount','200',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(29,'company_favicon','themes/huraga/assets/favicon.ico',0,NULL,NULL,'2023-01-08 12:00:00','2023-01-08 12:00:00');
+    (30,'show_version_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
+    (31,'show_company_public',0,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
 
 /*!40000 ALTER TABLE `setting` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -69,7 +69,8 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             'money_without_currency' => new TwigFilter('money_without_currency', [$this, 'twig_money_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert' => new TwigFilter('money_convert', [$this, 'twig_money_convert'], ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert_without_currency' => new TwigFilter('money_convert_without_currency', [$this, 'money_convert_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
-
+            // Twig filter to provide FOSSBilling Version
+            'fb_version' => new TwigFilter('fb_version', [$this, 'twig_fb_version'], ['needs_environment' => true, 'is_safe' => ['html']]),
             // We override these default twig filters so we can explicitly disable it from calling certain functions that may leak data or allow commands to be executed on the system.
             'filter' => new TwigFilter('filter', [$this, 'filteredFilter']),
             'map' => new TwigFilter('map', [$this, 'filteredMap']),
@@ -204,7 +205,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         if(empty($email)){
             return '';
         }
-    
+
         $url = 'https://www.gravatar.com/avatar/';
         $url .= md5(strtolower(trim($email)));
         $url .= "?s=$size&d=mp&r=g";
@@ -310,6 +311,12 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         }
 
         return $value;
+    }
+
+    // Function to provide Version
+    public function twig_fb_version(Twig\Environment $env, $data)
+    {
+        return $data . \FOSSBilling\Version::VERSION;
     }
 
     public function filteredFilter($array, $arrow)

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -69,8 +69,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             'money_without_currency' => new TwigFilter('money_without_currency', [$this, 'twig_money_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert' => new TwigFilter('money_convert', [$this, 'twig_money_convert'], ['needs_environment' => true, 'is_safe' => ['html']]),
             'money_convert_without_currency' => new TwigFilter('money_convert_without_currency', [$this, 'money_convert_without_currency'], ['needs_environment' => true, 'is_safe' => ['html']]),
-            // Twig filter to provide FOSSBilling Version
-            'fb_version' => new TwigFilter('fb_version', [$this, 'twig_fb_version'], ['needs_environment' => true, 'is_safe' => ['html']]),
+
             // We override these default twig filters so we can explicitly disable it from calling certain functions that may leak data or allow commands to be executed on the system.
             'filter' => new TwigFilter('filter', [$this, 'filteredFilter']),
             'map' => new TwigFilter('map', [$this, 'filteredMap']),
@@ -311,12 +310,6 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         }
 
         return $value;
-    }
-
-    // Function to provide Version
-    public function twig_fb_version(Twig\Environment $env, $data)
-    {
-        return $data . \FOSSBilling\Version::VERSION;
     }
 
     public function filteredFilter($array, $arrow)

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -291,7 +291,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $str .= 'Email template is just like FOSSBilling theme file.   ' . PHP_EOL;
         $str .= 'Use **admin** and **guest** API calls to get additional information using variables passed to template.' . PHP_EOL . PHP_EOL;
         $str .= 'Example API usage in email template:' . PHP_EOL . PHP_EOL;
-        $str .= '{{ guest.system_version }}' . PHP_EOL . PHP_EOL;
+        $str .= '{{ FOSSBillingVersion }}' . PHP_EOL . PHP_EOL;
         $str .= "{{ now|date('Y-m-d') }}" . PHP_EOL . PHP_EOL;
         $str .= '{% endapply %}';
 

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -23,20 +23,15 @@ class Guest extends \Api_Abstract
      */
     public function version()
     {
-        // check if the user is logged in as admin and if so, return the version
-        if ($this->di['auth']->isAdminLoggedIn()) {
-            return $this->getService()->getVersion();
-        }
+        $hideVersionGuest = $this->getService()->getParamValue('hide_version_public');
 
-        // check if the "show_version_public" parameter is set to true
-        $showVersionPublic = $this->getService()->getParamValue('show_version_public');
-        if ($showVersionPublic) {
+        // Only provide the FOSSBilling version if configured to do so or if the request is being made by an admistrator.
+        if ($this->di['auth']->isAdminLoggedIn() || !$hideVersionGuest) {
             return $this->getService()->getVersion();
         } else {
-            // return empty array
-            return [];
+            // return an empty string
+            return "";
         }
-        return $this->getService()->getVersion();
     }
 
     /**
@@ -48,9 +43,9 @@ class Guest extends \Api_Abstract
     {
         $companyInfo = $this->getService()->getCompany();
         $auth = $this->di['auth'];
-        $showCompanyPublic = $this->getService()->getParamValue('show_company_public');
+        $hideExtraCompanyInfoFromGuest = $this->getService()->getParamValue('hide_company_public');
 
-        if(!$auth->isAdminLoggedIn() && !$auth->isClientLoggedIn() && !$showCompanyPublic){
+        if(!$auth->isAdminLoggedIn() && !$auth->isClientLoggedIn() && $hideExtraCompanyInfoFromGuest){
             unset($companyInfo['vat_number']);
             unset($companyInfo['email']);
             unset($companyInfo['tel']);

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -33,8 +33,8 @@ class Guest extends \Api_Abstract
         if ($showVersionPublic == 1) {
             return $this->getService()->getVersion();
         } else {
-            // return 0.0.0
-            return '0.0.0';
+            // return empty array
+            return [];
         }
         return $this->getService()->getVersion();
     }

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -30,7 +30,7 @@ class Guest extends \Api_Abstract
 
         // check if the "show_version_public" parameter is set to true
         $showVersionPublic = $this->getService()->getParamValue('show_version_public');
-        if ($showVersionPublic == 1) {
+        if ($showVersionPublic) {
             return $this->getService()->getVersion();
         } else {
             // return empty array
@@ -48,7 +48,7 @@ class Guest extends \Api_Abstract
     {
         // check if the "show_company_public" parameter is set to true
         $showCompanyPublic = $this->getService()->getParamValue('show_company_public');
-        if ($showCompanyPublic == 1) {
+        if ($showCompanyPublic) {
             return $this->getService()->getCompany();
         } else {
             // return empty array

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -46,14 +46,23 @@ class Guest extends \Api_Abstract
      */
     public function company()
     {
-        // check if the "show_company_public" parameter is set to true
+        $companyInfo = $this->getService()->getCompany();
+        $auth = $this->di['auth'];
         $showCompanyPublic = $this->getService()->getParamValue('show_company_public');
-        if ($showCompanyPublic) {
-            return $this->getService()->getCompany();
-        } else {
-            // return empty array
-            return [];
+
+        if(!$auth->isAdminLoggedIn() && !$auth->isClientLoggedIn() && !$showCompanyPublic){
+            unset($companyInfo['vat_number']);
+            unset($companyInfo['email']);
+            unset($companyInfo['tel']);
+            unset($companyInfo['account_number']);
+            unset($companyInfo['number']);
+
+            unset($companyInfo['address_1']);
+            unset($companyInfo['address_2']);
+            unset($companyInfo['address_3']);
         }
+
+        return $companyInfo;
     }
 
     /**

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -25,7 +25,7 @@ class Guest extends \Api_Abstract
     {
         $hideVersionGuest = $this->getService()->getParamValue('hide_version_public');
 
-        // Only provide the FOSSBilling version if configured to do so or if the request is being made by an admistrator.
+        // Only provide the FOSSBilling version if configured to do so or if the request is being made by an administrator.
         if ($this->di['auth']->isAdminLoggedIn() || !$hideVersionGuest) {
             return $this->getService()->getVersion();
         } else {

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -23,6 +23,19 @@ class Guest extends \Api_Abstract
      */
     public function version()
     {
+        // check if the user is logged in as admin and if so, return the version
+        if ($this->di['auth']->isAdminLoggedIn()) {
+            return $this->getService()->getVersion();
+        }
+
+        // check if the "show_version_public" parameter is set to true
+        $showVersionPublic = $this->getService()->getParamValue('show_version_public');
+        if ($showVersionPublic == 1) {
+            return $this->getService()->getVersion();
+        } else {
+            // return 0.0.0
+            return '0.0.0';
+        }
         return $this->getService()->getVersion();
     }
 
@@ -33,7 +46,14 @@ class Guest extends \Api_Abstract
      */
     public function company()
     {
-        return $this->getService()->getCompany();
+        // check if the "show_company_public" parameter is set to true
+        $showCompanyPublic = $this->getService()->getParamValue('show_company_public');
+        if ($showCompanyPublic == 1) {
+            return $this->getService()->getCompany();
+        } else {
+            // return empty array
+            return [];
+        }
     }
 
     /**

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -50,7 +50,8 @@ class Service
     public function setParamValue($param, $value, $createIfNotExists = true)
     {
         $pdo = $this->di['pdo'];
-
+        // log param and value to the logfile
+        $this->di['logger']->info('Setting parameter value', ['param' => $param, 'value' => $value]);
         if ($this->paramExists($param)) {
             $query = 'UPDATE setting SET value = :value WHERE param = :param';
             $stmt = $pdo->prepare($query);

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -50,8 +50,6 @@ class Service
     public function setParamValue($param, $value, $createIfNotExists = true)
     {
         $pdo = $this->di['pdo'];
-        // log param and value to the logfile
-        $this->di['logger']->info('Setting parameter value', ['param' => $param, 'value' => $value]);
         if ($this->paramExists($param)) {
             $query = 'UPDATE setting SET value = :value WHERE param = :param';
             $stmt = $pdo->prepare($query);

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -114,19 +114,19 @@
                             </div>
                             <div class="mb-3 row">
                                 <label class="form-label col-3 col-form-label">
-                                    {{ 'Show Version information Publicly ' | trans }}:
-                                    <br & >
-                                    {{'(Disabling Might break older Modules)' | trans }}
+                                    {{ 'Disallow guest API to fetch FOSSBilling version' | trans }}
+                                    <br/>
+                                    <small class="text-muted">{{'Enabling this functionality may effect modules that depend on it.' | trans }}</small>
                                 </label>
                                 <div class="col">
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showPublicYes" type="radio" name="show_version_public" value="1" {% if params.show_version_public == "1" %}checked{% endif %}>
+                                        <input class="form-check-input" id="radio_showPublicYes" type="radio" name="hide_version_public" value="1" {% if params.hide_version_public == "1" %}checked{% endif %}>
                                         <label class="form-check-label" for="radio_showPublicYes">
                                             {{ 'Yes' | trans }}
                                         </label>
                                     </div>
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showPublicNo" type="radio" name="show_version_public" value="0" {% if params.show_version_public == "0" %}checked{% endif %}>
+                                        <input class="form-check-input" id="radio_showPublicNo" type="radio" name="hide_version_public" value="0" {% if params.hide_version_public == "0" %}checked{% endif %}>
                                         <label class="form-check-label" for="radio_showPublicNo">
                                             {{ 'No' | trans }}
                                         </label>
@@ -135,17 +135,19 @@
                             </div>
                             <div class="mb-3 row">
                                 <label class="form-label col-3 col-form-label">
-                                    {{ 'Show Company Information Publicly' | trans }}:
+                                    {{ 'Hide some company information in the guest API' | trans }}
+                                    <br/>
+                                    <small class="text-muted">{{'Enabling this will hide some information from the "company" guest API endpoint such as the address, phone number, email, VAT number, and more.' | trans }}</small>
                                 </label>
                                 <div class="col">
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showCompanyPublicYes" type="radio" name="show_company_public" value="1" {% if params.show_company_public == "1" %}checked{% endif %}>
+                                        <input class="form-check-input" id="radio_showCompanyPublicYes" type="radio" name="hide_company_public" value="1" {% if params.hide_company_public == "1" %}checked{% endif %}>
                                         <label class="form-check-label" for="radio_showCompanyublicYes">
                                             {{ 'Yes' | trans }}
                                         </label>
                                     </div>
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showCompanyPublicNo" type="radio" name="show_company_public" value="0" {% if params.show_company_public == "0" %}checked{% endif %}>
+                                        <input class="form-check-input" id="radio_showCompanyPublicNo" type="radio" name="hide_company_public" value="0" {% if params.hide_company_public == "0" %}checked{% endif %}>
                                         <label class="form-check-label" for="radio_showCompanyPublicNo">
                                             {{ 'No' | trans }}
                                         </label>
@@ -473,7 +475,7 @@ ZW=Zimbabwe
                         <div class="datagrid">
                             <div class="datagrid-item">
                                 <div class="datagrid-title">FOSSBilling version</div>
-                                <div class="datagrid-content">{{ FOSSBilling |fb_version }}</div>
+                                <div class="datagrid-content">{{ FOSSBillingVersion }}</div>
                             </div>
                             <div class="datagrid-item">
                                 <div class="datagrid-title">PHP version</div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -471,7 +471,7 @@ ZW=Zimbabwe
                         <div class="datagrid">
                             <div class="datagrid-item">
                                 <div class="datagrid-title">FOSSBilling version</div>
-                                <div class="datagrid-content">{{ guest.system_version }}</div>
+                                <div class="datagrid-content">{{ FOSSBilling |fb_version }}</div>
                             </div>
                             <div class="datagrid-item">
                                 <div class="datagrid-title">PHP version</div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -114,7 +114,9 @@
                             </div>
                             <div class="mb-3 row">
                                 <label class="form-label col-3 col-form-label">
-                                    {{ 'Show Version information Publicly' | trans }}:
+                                    {{ 'Show Version information Publicly ' | trans }}:
+                                    <br & >
+                                    {{'(Disabling Might break older Modules)' | trans }}
                                 </label>
                                 <div class="col">
                                     <div class="form-check form-check-inline">

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -113,6 +113,44 @@
                                 </div>
                             </div>
                             <div class="mb-3 row">
+                                <label class="form-label col-3 col-form-label">
+                                    {{ 'Show Version information Publicly' | trans }}:
+                                </label>
+                                <div class="col">
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" id="radio_showPublicYes" type="radio" name="show_version_public" value="1" {% if params.show_version_public == "1" %}checked{% endif %}>
+                                        <label class="form-check-label" for="radio_showPublicYes">
+                                            {{ 'Yes' | trans }}
+                                        </label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" id="radio_showPublicNo" type="radio" name="show_version_public" value="0" {% if params.show_version_public == "0" %}checked{% endif %}>
+                                        <label class="form-check-label" for="radio_showPublicNo">
+                                            {{ 'No' | trans }}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="mb-3 row">
+                                <label class="form-label col-3 col-form-label">
+                                    {{ 'Show Company Information Publicly' | trans }}:
+                                </label>
+                                <div class="col">
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" id="radio_showCompanyPublicYes" type="radio" name="show_company_public" value="1" {% if params.show_company_public == "1" %}checked{% endif %}>
+                                        <label class="form-check-label" for="radio_showCompanyublicYes">
+                                            {{ 'Yes' | trans }}
+                                        </label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" id="radio_showCompanyPublicNo" type="radio" name="show_company_public" value="0" {% if params.show_company_public == "0" %}checked{% endif %}>
+                                        <label class="form-check-label" for="radio_showCompanyPublicNo">
+                                            {{ 'No' | trans }}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Signature'|trans }}</label>
                                 <div class="col-md-6">
                                     <textarea class="form-control" name="company_signature" rows="2">{{ params.company_signature }}</textarea>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -213,7 +213,7 @@
 
             <footer class="footer footer-transparent d-print-none">
                 <div class="container-xl">
-                    <div>Copyright &copy; {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener"> {{ FOSSBilling |fb_version }}</a></div>
+                    <div>Copyright &copy; {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener">FOSSBilling {{ FOSSBillingVersion }}</a></div>
                 </div>
             </footer>
         </div>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -213,7 +213,7 @@
 
             <footer class="footer footer-transparent d-print-none">
                 <div class="container-xl">
-                    <div>Copyright &copy; {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener">FOSSBilling {{ guest.system_version }}</a></div>
+                    <div>Copyright &copy; {{ now|format_date(pattern='yyyy') }}. All rights reserved. Powered by <a href="https://fossbilling.org" title="Billing system" target="_blank" rel="noopener"> {{ FOSSBilling |fb_version }}</a></div>
                 </div>
             </footer>
         </div>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -18,7 +18,7 @@
     {% include 'partial_bb_meta.html.twig' %}
 
     {{ encore_entry_link_tags('fossbilling') }}
-    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
+    {{ "Api/API.js" | library_url | script_tag }}
     {{ encore_entry_script_tags('fossbilling') }}
 
     {% block head %}{% endblock %}

--- a/src/themes/admin_default/html/layout_login.html.twig
+++ b/src/themes/admin_default/html/layout_login.html.twig
@@ -12,7 +12,7 @@
     {% include "partial_bb_meta.html.twig" %}
 
     {{ encore_entry_link_tags('fossbilling') }}
-    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
+    {{ "Api/API.js" | library_url | script_tag }}
     {{ encore_entry_script_tags('fossbilling') }}
 </head>
 

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -17,7 +17,7 @@
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
-    <meta name="generator" content="FOSSBilling {{ guest.system_version }}">
+    <meta name="generator" content=" {{ FOSSBilling |fb_version }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block opengraph %}{% endblock %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -30,7 +30,7 @@
 
     <link rel="shortcut icon" href="{{ guest.system_company.favicon_url }}">
 
-    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
+    {{ "Api/API.js" | library_url | script_tag }}
     <script src="{{ 'js/libs/jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/bb-jquery.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'js/bootstrap/bootstrap.min.js' | asset_url}}" defer="defer"></script>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -17,7 +17,7 @@
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
-    <meta name="generator" content=" {{ FOSSBilling |fb_version }}">
+    <meta name="generator" content="FOSSBilling {{ FOSSBillingVersion }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block opengraph %}{% endblock %}

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -17,7 +17,7 @@
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
-    <meta name="generator" content="FOSSBilling {{ guest.system_version }}">
+    <meta name="generator" content=" {{ FOSSBilling |fb_version }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block opengraph %}{% endblock %}

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -29,7 +29,7 @@
 
     <link rel="shortcut icon" href="{{ guest.system_company.favicon_url }}">
 
-    <script src="{{ "Api/API.js?v=#{guest.system_version}" | library_url }}"></script>
+    {{ "Api/API.js" | library_url | script_tag }}
     <script src="{{ 'js/libs/jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/bb-jquery.js' | asset_url }}"></script>
     <script src="{{ 'js/bootstrap/bootstrap.min.js' | asset_url}}"></script>

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -17,7 +17,7 @@
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
-    <meta name="generator" content=" {{ FOSSBilling |fb_version }}">
+    <meta name="generator" content="FOSSBilling {{ FOSSBillingVersion }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block opengraph %}{% endblock %}

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -22,35 +22,100 @@ class GuestTest extends \BBTestCase {
         $getDi = $this->api->getDi();
         $this->assertEquals($di, $getDi);
     }
-
-    public function testversion()
+    public function testVersionAdmin()
     {
-        $servuceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $servuceMock->expects($this->atLeastOnce())
-            ->method('getVersion')
-            ->will($this->returnValue(\FOSSBilling\Version::VERSION));
+        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock->method('isAdminLoggedIn')->willReturn(true);
 
-        $this->api->setService($servuceMock);
+        $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getVersion')
+            ->willReturn(\FOSSBilling\Version::VERSION);
+
+        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setService($serviceMock);
         $result = $this->api->version();
+
         $this->assertIsString($result);
         $this->assertNotEmpty($result);
     }
 
-    public function testcompany()
+    public function testVersionShowPublicOn()
     {
-        $data = array(
+        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock->method('isAdminLoggedIn')->willReturn(false);
 
-        );
-        $servuceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
-        $servuceMock->expects($this->atLeastOnce())
-            ->method('getCompany')
-            ->will($this->returnValue(array()));
+        $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getVersion')
+            ->willReturn(\FOSSBilling\Version::VERSION);
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getParamValue')
+            ->with('show_version_public')
+            ->willReturn(1);
 
-        $this->api->setService($servuceMock);
+        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setService($serviceMock);
+        $result = $this->api->version();
 
-        $result = $this->api->company($data);
-        $this->assertIsArray($result);
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
     }
+
+    public function testVersionShowPublicOff()
+    {
+        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock->method('isAdminLoggedIn')->willReturn(false);
+
+        $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getParamValue')
+            ->with('show_version_public')
+            ->willReturn(0);
+
+        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setService($serviceMock);
+        $result = $this->api->version();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function testCompanyShowPublicOn()
+    {
+        $companyData = array('companyName' => 'TestCo');
+
+        $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getCompany')
+            ->willReturn($companyData);
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getParamValue')
+            ->with('show_company_public')
+            ->willReturn(1);
+
+        $this->api->setService($serviceMock);
+        $result = $this->api->company();
+
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+    }
+
+    public function testCompanyShowPublicOff()
+    {
+        $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getParamValue')
+            ->with('show_company_public')
+            ->willReturn(0);
+
+        $this->api->setService($serviceMock);
+        $result = $this->api->company();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
 
     public function testphone_codes()
     {

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -24,7 +24,7 @@ class GuestTest extends \BBTestCase {
     }
     public function testVersionAdmin()
     {
-        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
         $authMock->method('isAdminLoggedIn')->willReturn(true);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
@@ -42,7 +42,7 @@ class GuestTest extends \BBTestCase {
 
     public function testVersionShowPublicOn()
     {
-        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
         $authMock->method('isAdminLoggedIn')->willReturn(false);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
@@ -64,7 +64,7 @@ class GuestTest extends \BBTestCase {
 
     public function testVersionShowPublicOff()
     {
-        $authMock = $this->getMockBuilder('\Box\Auth')->getMock();
+        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
         $authMock->method('isAdminLoggedIn')->willReturn(false);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -100,6 +100,10 @@ class GuestTest extends \BBTestCase {
     {
         $companyData = array('companyName' => 'TestCo');
 
+        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authMock->method('isAdminLoggedIn')->willReturn(false);
+        $authMock->method('isClientLoggedIn')->willReturn(false);
+
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCompany')
@@ -108,28 +112,60 @@ class GuestTest extends \BBTestCase {
             ->method('getParamValue')
             ->with('show_company_public')
             ->willReturn(1);
-
+        $di = new \Pimple\Container();
+        $di['auth'] = $authMock;
+        $this->api->setDi($di);
         $this->api->setService($serviceMock);
         $result = $this->api->company();
 
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
     }
-
     public function testCompanyShowPublicOff()
     {
+        $companyData = array(
+            'companyName' => 'TestCo',
+            'vat_number' => 'Test VAT',
+            'email' => 'test@email.com',
+            'tel' => '123456789',
+            'account_number' => '987654321',
+            'number' => '123456',
+            'address_1' => 'Test Address 1',
+            'address_2' => 'Test Address 2',
+            'address_3' => 'Test Address 3',
+        );
+
+        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authMock->method('isAdminLoggedIn')->willReturn(false);
+        $authMock->method('isClientLoggedIn')->willReturn(false);
+
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getCompany')
+            ->willReturn($companyData);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
             ->with('show_company_public')
             ->willReturn(0);
 
+        $di = new \Pimple\Container();
+        $di['auth'] = $authMock;
+        $this->api->setDi($di);
         $this->api->setService($serviceMock);
         $result = $this->api->company();
 
         $this->assertIsArray($result);
-        $this->assertEmpty($result);
+        $this->assertArrayNotHasKey('vat_number', $result);
+        $this->assertArrayNotHasKey('email', $result);
+        $this->assertArrayNotHasKey('tel', $result);
+        $this->assertArrayNotHasKey('account_number', $result);
+        $this->assertArrayNotHasKey('number', $result);
+        $this->assertArrayNotHasKey('address_1', $result);
+        $this->assertArrayNotHasKey('address_2', $result);
+        $this->assertArrayNotHasKey('address_3', $result);
     }
+
+
 
 
     public function testphone_codes()

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -92,7 +92,7 @@ class GuestTest extends \BBTestCase {
         $this->api->setService($serviceMock);
         $result = $this->api->version();
 
-        $this->assertIsArray($result);
+        $this->assertIsString($result);
         $this->assertEmpty($result);
     }
 

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -61,8 +61,8 @@ class GuestTest extends \BBTestCase {
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->with('show_version_public')
-            ->willReturn(1);
+            ->with('hide_version_public')
+            ->willReturn(0);
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -85,8 +85,8 @@ class GuestTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->with('show_version_public')
-            ->willReturn(0);
+            ->with('hide_version_public')
+            ->willReturn(1);
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -110,8 +110,9 @@ class GuestTest extends \BBTestCase {
             ->willReturn($companyData);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->with('show_company_public')
-            ->willReturn(1);
+            ->with('hide_company_public')
+            ->willReturn(0);
+
         $di = new \Pimple\Container();
         $di['auth'] = $authMock;
         $this->api->setDi($di);
@@ -145,8 +146,8 @@ class GuestTest extends \BBTestCase {
             ->willReturn($companyData);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->with('show_company_public')
-            ->willReturn(0);
+            ->with('hide_company_public')
+            ->willReturn(1);
 
         $di = new \Pimple\Container();
         $di['auth'] = $authMock;

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -24,15 +24,20 @@ class GuestTest extends \BBTestCase {
     }
     public function testVersionAdmin()
     {
-        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
-        $authMock->method('isAdminLoggedIn')->willReturn(true);
+        $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authorizationMock->expects($this->atLeastOnce())
+            ->method("isAdminLoggedIn")
+            ->willReturn(true);
+
+        $di = new \Pimple\Container();
+        $di['auth'] = $authorizationMock;
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getVersion')
             ->willReturn(\FOSSBilling\Version::VERSION);
 
-        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setDi($di);
         $this->api->setService($serviceMock);
         $result = $this->api->version();
 
@@ -42,19 +47,24 @@ class GuestTest extends \BBTestCase {
 
     public function testVersionShowPublicOn()
     {
-        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
-        $authMock->method('isAdminLoggedIn')->willReturn(false);
+        $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authorizationMock->expects($this->atLeastOnce())
+            ->method("isAdminLoggedIn")
+            ->willReturn(false);
 
+        $di = new \Pimple\Container();
+        $di['auth'] = $authorizationMock;
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getVersion')
             ->willReturn(\FOSSBilling\Version::VERSION);
+
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
             ->with('show_version_public')
             ->willReturn(1);
 
-        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setDi($di);
         $this->api->setService($serviceMock);
         $result = $this->api->version();
 
@@ -64,8 +74,13 @@ class GuestTest extends \BBTestCase {
 
     public function testVersionShowPublicOff()
     {
-        $authMock = $this->getMockBuilder('\Box\Authorization')->getMock();
-        $authMock->method('isAdminLoggedIn')->willReturn(false);
+        $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authorizationMock->expects($this->atLeastOnce())
+            ->method("isAdminLoggedIn")
+            ->willReturn(false);
+
+        $di = new \Pimple\Container();
+        $di['auth'] = $authorizationMock;
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\System\Service')->getMock();
         $serviceMock->expects($this->atLeastOnce())
@@ -73,7 +88,7 @@ class GuestTest extends \BBTestCase {
             ->with('show_version_public')
             ->willReturn(0);
 
-        $this->api->setDi(['auth' => $authMock]);
+        $this->api->setDi($di);
         $this->api->setService($serviceMock);
         $result = $this->api->version();
 


### PR DESCRIPTION
Discord-User Pielgrzym mentioned that he'd like to hide the version number from the public. 

I also found that the api/guest/system/company endpoint returned the company data. 

AFAIK only the version endpoint is used in the admin area. The company endpoint isn't - and to be honest, I also like the idea of being able to disable this. 

I've added the settings to Admin -> Company, and added checks to getVersion & getCompany. 

Version now checks if the request comes from a logged in Admin, and returns the version (no matter the setting). 
After that, both functions check for the setting in the database. 

