### PR TITLE
Prevent actions on hosting services with bad order status

### DIFF
--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -379,9 +379,17 @@ class Service implements InjectionAwareInterface
         return null;
     }
 
-    private function _performOnService(\Model_ClientOrder $order)
+    private function _performOnService(\Model_ClientOrder $order): bool
     {
-        return $order->status != \Model_ClientOrder::STATUS_FAILED_SETUP;
+        // If the order matches any of the following status, we should prevent actions such as PW resets or username changes from being performed
+        $badStatus = [
+            \Model_ClientOrder::STATUS_FAILED_SETUP,
+            \Model_ClientOrder::STATUS_PENDING_SETUP,
+            \Model_ClientOrder::STATUS_SUSPENDED,
+            \Model_ClientOrder::STATUS_CANCELED,
+        ];
+
+        return !in_array($order->status, $badStatus);
     }
 
     private function _getServerMangerForOrder($model)


### PR DESCRIPTION
When performing any of the following actions on a hosting service, FOSSBilling checks if the status of the order isn't `STATUS_FAILED_SETUP`.
 - Changing the plan
 - Changing the account username
 - Changing the account IP
 - Changing the domain
 - Changing the password

This logic is flawed / incomplete as there are more statuses where actions should not be performed on the web-server.
This PR adds in the missing status where actions should also be prevented.