### PR TITLE
Improve .htaccess rules & prevent access to PHP files

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -393,6 +393,7 @@
         "*.config.js",
         "src/modules/Wysiwyg/src/ckeditor.js",
         ".github/**",
-        ".gitignore"
+        ".gitignore",
+        "src/.htaccess"
     ]
 }

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -22,7 +22,7 @@ RewriteRule ^bb-ipn\.php$ /ipn.php [L]
 
 # Block direct access to sensitive files.
 RewriteCond %{REQUEST_URI} /?.+\.(_|htaccess|htpasswd|bak|conf|inc|ini|lock|log|old|sh|sql|twig|yaml) [NC,OR]
-RewriteCond %{REQUEST_URI} /?.*(config.php|di.php|load.php)
+RewriteCond %{REQUEST_URI} /?.*(config.php|di.php|load.php|cron.php|rb.php|composer.json|README.md|CHANGELOG.md)
 RewriteRule ^(.*)$ index.php?_url=/$1&_errcode=404 [L]
 
 # Rewrite non-existent file/directory names to index.php.

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,35 +1,39 @@
 # BEGIN FOSSBilling
 # Read documentation https://fossbilling.org/docs for more information.
-Options     -Indexes    +SymLinksIfOwnerMatch
+Options -Indexes +SymLinksIfOwnerMatch
 <IfModule !mod_rewrite.c>
-DirectoryIndex rewrite-missing.html
-FallbackResource rewrite-missing.html
+    DirectoryIndex rewrite-missing.html
+    FallbackResource rewrite-missing.html
 </IfModule>
 <IfModule mod_rewrite.c>
-RewriteEngine On
-RewriteBase /
-RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteEngine On
+    RewriteBase /
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-# Rewrite rules to block out some common exploits.
-RewriteCond %{QUERY_STRING} base64_encode[^(]*\([^)]*\) [OR]
-RewriteCond %{QUERY_STRING} (<|%3C)([^s]*s)+cript.*(>|%3E) [NC,OR]
-RewriteCond %{QUERY_STRING} GLOBALS(=|\[|\%[0-9A-Z]{0,2}) [OR]
-RewriteCond %{QUERY_STRING} _REQUEST(=|\[|\%[0-9A-Z]{0,2})
-RewriteRule .* index.php [F]
+    # Rewrite rules to block out some common exploits.
+    RewriteCond %{QUERY_STRING} base64_encode[^(]*\([^)]*\) [OR]
+    RewriteCond %{QUERY_STRING} (<|%3C)([^s]*s)+cript.*(>|%3E) [NC,OR]
+    RewriteCond %{QUERY_STRING} (GLOBALS|_REQUEST)(=|\[|\%[0-9A-Z]{0,2})
+    RewriteRule .* index.php [F]
 
-# Alias from bb-ipn.php to ipn.php for those who have upgraded from BoxBilling.
-RewriteRule ^bb-ipn\.php$ /ipn.php [L]
+    # Alias from bb-ipn.php to ipn.php for those who have upgraded from BoxBilling.
+    RewriteRule ^bb-ipn\.php$ /ipn.php [L]
 
-# Block direct access to sensitive files.
-RewriteCond %{REQUEST_URI} /?.+\.(_|htaccess|htpasswd|bak|conf|inc|ini|lock|log|old|sh|sql|twig|yaml) [NC,OR]
-RewriteCond %{REQUEST_URI} /?.*(config.php|di.php|load.php|cron.php|rb.php|composer.json|README.md|CHANGELOG.md)
-RewriteRule ^(.*)$ index.php?_url=/$1&_errcode=404 [L]
+    # Allow access to the index.php and ipn.php files.
+    RewriteCond %{REQUEST_URI} ^/(index|ipn)\.php [NC]
+    RewriteRule ^ - [L]
 
-# Rewrite non-existent file/directory names to index.php.
-RewriteCond %{REQUEST_FILENAME} -f [OR]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^.*$ - [NC,L]
-RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
-RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
+    # Block direct access to sensitive files and file types.
+    RewriteCond %{REQUEST_URI} /?.+\.(htaccess|htpasswd|bak|conf|inc|ini|lock|log|old|sh|sql|twig|yaml|php) [NC,OR]
+    RewriteCond %{REQUEST_URI} /?.*(composer.json|README.md|CHANGELOG.md) [NC]
+    RewriteRule ^(.*)$ index.php?_url=/$1&_errcode=404 [L]
+
+    # Rewrite to allow custom pages to function correctly
+    RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
+
+    # Rewrite non-existent file/directory names to index.php.
+    RewriteCond %{REQUEST_FILENAME} !-f [OR]
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
 </IfModule>
 # END FOSSBilling

--- a/src/cron.php
+++ b/src/cron.php
@@ -13,24 +13,19 @@ $di = include __DIR__ . '/di.php';
 $di['translate']();
 
 try {
-    if ('cli' === PHP_SAPI) {
-        echo "\e[33m- Welcome to FOSSBilling.\n";
-    }
     $interval = $argv[1] ?? null;
     $service = $di['mod_service']('cron');
+
     if ('cli' === PHP_SAPI) {
+        echo "\e[33m- Welcome to FOSSBilling.\n";
         echo "\e[34mLast executed: " . $service->getLastExecutionTime() . ".\e[0m";
     }
+
     $service->runCrons($interval);
 } catch (Exception $exception) {
     throw new Exception($exception);
 } finally {
     if ('cli' === PHP_SAPI) {
         echo "\e[32mSuccessfully ran the cron jobs.\e[0m";
-    } else {
-        $admin_prefix = $di['config']['admin_area_prefix'];
-        $login_url = $di['url']->link($admin_prefix);
-        unset($service, $interval, $di);
-        header("Location: $login_url");
     }
 }

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -29,7 +29,6 @@ class Service
         $service = $this->di['mod_service']('system');
 
         $result = [
-            'cron_url' => BB_URL . 'cron.php',
             'cron_path' => PATH_ROOT . DIRECTORY_SEPARATOR . 'cron.php',
             'last_cron_exec' => $service->getParamValue('last_cron_exec'),
         ];

--- a/src/modules/Cron/html_admin/mod_cron_settings.html.twig
+++ b/src/modules/Cron/html_admin/mod_cron_settings.html.twig
@@ -60,10 +60,6 @@
                     <td class="text-end">{{ 'Unix crontab setup'|trans }}:</td>
                     <td>*/5 * * * * php {{ cron.cron_path }}</td>
                 </tr>
-                <tr>
-                    <td class="text-end">{{ 'Execute scheduled tasks from browser'|trans }}:</td>
-                    <td>{{ cron.cron_url }}</td>
-                </tr>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
This PR updates our `.htaccess` to slightly cleanup + improve a few of the default rules, but more significantly it changes what files we prevent access to and adds to the list.

## Additional files that are now prevented from being loaded via the browser
 - `composer.json` - Prevents people from seeing what deps are being used on the instance & (roughly) what version. The lock-file was already prevented as the old rules included all `.lock` files.
 - `README.md` - Doesn't need to be publicly visible
 - `CHANGELOG.md` - Doesn't need to be publicly visible
 - All `php` files, **except** `index.php` and `ipn.php` as we no longer heavily rely on this functionality.
    - With 0.5.0, we replaced the `foss-update.php` script & the fallback patching method that it used is entirely a virtual path embedded in our `index.php` file.
    - The cron settings page was recently changed to call cron via the API instead opening via the browser. This PR finally removes the direct browser URL from this settings page.
       - The ability to call cron via the browser isn't really useful & is obsolete, so there's no issue with blocking access to it.
    - I verified the `bb-ipn.php` rewrite rule still correctly forwards to the `ipn.php` file, so this change also doesn't cause issues there.


The result is a slightly more secure default config that makes it less likely for a sensitive file to be accessible via the browser