### PR TITLE
Quiet down our automated PRs

### DIFF
--- a/.github/workflows/ckeditor.yml
+++ b/.github/workflows/ckeditor.yml
@@ -2,7 +2,7 @@ name: Check for CKEditor updates
 
 on:
   schedule:
-    - cron: '0 12 * * *'  # Runs once per day
+    - cron: '0 12 * * 2' # Runs once every Tuesday
 
 jobs:
   update-dependencies:
@@ -35,3 +35,4 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           committer: FOSSBilling Bot <fossbilling-bot>
           author: FOSSBilling Bot <fossbilling-bot>
+          labels: skip-changelog, dependencies

--- a/.github/workflows/rectorAndCs.yml
+++ b/.github/workflows/rectorAndCs.yml
@@ -1,8 +1,8 @@
 name: Rector and Code Styling
 
 on:
-  push:
-    branches: main
+  schedule:
+    - cron: '0 12 * * 2,4' # Runs once every Tuesday and Thursday
 
 jobs:
   php-cs-fixer:
@@ -54,3 +54,4 @@ jobs:
         token: ${{ secrets.BOT_TOKEN }}
         committer: FOSSBilling Bot <fossbilling-bot>
         author: FOSSBilling Bot <fossbilling-bot>
+        labels: skip-changelog


### PR DESCRIPTION
These were admittedly more noisy than I (and likely everyone else) would have liked.
- CKEditor updates are now limited to once per week as the updates are usually just translations which are unimportant (and they will sometimes do multiple releases in a few days).
- Rector and CS will be run twice per week: every Tuesday and every Thursday. Enough to prevent lots of noise from it, but still runs fairly frequently to help prevent CS issues from building up.

I also added labels to them as those were previously missing.