### PR TITLE
Fix incorrect logic in the .htaccess

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -32,8 +32,9 @@ Options -Indexes +SymLinksIfOwnerMatch
     RewriteRule ^page/(.*)$ index.php?_url=/custompages/$1
 
     # Rewrite non-existent file/directory names to index.php.
-    RewriteCond %{REQUEST_FILENAME} !-f [OR]
+    RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
+
 </IfModule>
 # END FOSSBilling


### PR DESCRIPTION
This wasn't supposed to have the `[or]`. Not sure why it worked when I originally write that into the `.htaccess`, however when testing on a new web-server I noticed it wasn't working. This PR fixes that