### PR TITLE
Fix email verification behavior oddities

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -387,8 +387,6 @@ $di['is_client_email_validated'] = $di->protect(function ($model) use ($di) {
     $config = $di['mod_config']('client');
     if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation']) {
         return (bool) $model->email_approved;
-    } else {
-        return true;
     }
 
     return true;
@@ -519,7 +517,7 @@ $di['api'] = $di->protect(function ($role) use ($di) {
             if (strncasecmp($url, '/api/client/client/', strlen('/api/client/client/')) !== 0 && strncasecmp($url, '/api/client/profile/', strlen('/api/client/profile/')) !== 0) {
                 throw new Exception('Please check your mailbox and confirm email address.');
             }
-        } elseif (strncasecmp($url, '/client/profile', strlen('/client/profile')) !== 0) {
+        } elseif (strncasecmp($url, '/client', strlen('/client')) !== 0) {
             // If they aren't attempting to access their profile, redirect them to it.
             $login_url = $di['url']->link('client/profile');
             header("Location: $login_url");

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -85,8 +85,8 @@ class Guest extends \Api_Abstract
 
         $client = $service->guestCreateClient($data);
 
-        if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation'] && !$client->email_approved) {
-            throw new \Box_Exception('Account has been created. Please check your mailbox and confirm email address.', null, 7777);
+        if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation']) {
+            $service->sendEmailConfirmationForClient($client);
         }
 
         if ($data['auto_login'] ?? 0) {


### PR DESCRIPTION
This PR fixes two issues with the confirmation system:
1. Idiotically when BoxBilling added this functionality, they never set it up to even send the confirmation email. It literally just told the user to verify using it and then never sent it. I've fixed this
2. I've changed the allowed URLs to include everything under `/client` as right now it prevents access to the `/client/logout` page.

Closes #1525 (I can't replicate the issue with the resend button that's mentioned in that issue. It is most likely an issue specific to their browser)