### PR TITLE
Begin reworking permission management

### DIFF
--- a/src/library/Api/Handler.php
+++ b/src/library/Api/Handler.php
@@ -70,7 +70,7 @@ final class Api_Handler implements InjectionAwareInterface
         // permissions check
         if($this->type == 'admin') {
             $staff_service = $this->di['mod_service']('Staff');
-            if(!$staff_service->hasPermission($this->identity, $mod, $method_name)) {
+            if(!$staff_service->hasPermission($this->identity, $mod)) {
                 if($this->_acl_exception) {
                     throw new \FOSSBilling\Exception('You do not have access to :mod module', array(':mod'=>$mod), 725);
                 } else {

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -67,6 +67,10 @@ class Box_App
     {
     }
 
+    protected function checkPermission(){
+
+    }
+
     public function show404(Exception $e)
     {
         error_log($e->getMessage());
@@ -149,6 +153,7 @@ class Box_App
     {
         $this->registerModule();
         $this->init();
+        $this->checkPermission();
 
         return $this->processRequest();
     }

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -23,7 +23,7 @@ class Box_AppAdmin extends Box_App
     {
         $service = $this->di['mod_service']('Staff');
         
-        if($this->di['auth']->isAdminLoggedIn() && !$service->hasPermission(null, $this->mod)){
+        if($this->mod !== 'extension' && $this->di['auth']->isAdminLoggedIn() && !$service->hasPermission(null, $this->mod)){
             http_response_code(403);
             $e = new \Box_Exception('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
             echo $this->render('error', ['exception' => $e]);

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -19,6 +19,18 @@ class Box_AppAdmin extends Box_App
         }
     }
 
+    protected function checkPermission()
+    {
+        $service = $this->di['mod_service']('Staff');
+        
+        if(!$service->hasPermission(null, $this->mod)){
+            http_response_code(403);
+            $e = new \Box_Exception('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
+            echo $this->render('error', ['exception' => $e]);
+            exit;
+        }
+    }
+
     public function render($fileName, $variableArray = [])
     {
         $template = $this->getTwig()->load($fileName . '.html.twig');

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -23,7 +23,7 @@ class Box_AppAdmin extends Box_App
     {
         $service = $this->di['mod_service']('Staff');
         
-        if(!$service->hasPermission(null, $this->mod)){
+        if($this->di['auth']->isAdminLoggedIn() && !$service->hasPermission(null, $this->mod)){
             http_response_code(403);
             $e = new \Box_Exception('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
             echo $this->render('error', ['exception' => $e]);

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -25,7 +25,7 @@ class Box_AppAdmin extends Box_App
         
         if($this->mod !== 'extension' && $this->di['auth']->isAdminLoggedIn() && !$service->hasPermission(null, $this->mod)){
             http_response_code(403);
-            $e = new \Box_Exception('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
+            $e = new \FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
             echo $this->render('error', ['exception' => $e]);
             exit;
         }

--- a/src/modules/Activity/Api/Admin.php
+++ b/src/modules/Activity/Api/Admin.php
@@ -115,10 +115,7 @@ class Admin extends \Api_Abstract
 
         $model = $this->di['db']->getExistingModelById('ActivitySystem', $data['id'], 'Event not found');
 
-        $staff_service = $this->di['mod_service']('Staff');
-        if (!$staff_service->hasPermission(null, 'activity', 'delete_activity')) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
-        }
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('activity', 'delete_activity');
 
         $this->di['db']->trash($model);
 

--- a/src/modules/Activity/Api/Admin.php
+++ b/src/modules/Activity/Api/Admin.php
@@ -115,6 +115,11 @@ class Admin extends \Api_Abstract
 
         $model = $this->di['db']->getExistingModelById('ActivitySystem', $data['id'], 'Event not found');
 
+        $staff_service = $this->di['mod_service']('Staff');
+        if (!$staff_service->hasPermission(null, 'activity', 'delete_activity')) {
+            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
+        }
+
         $this->di['db']->trash($model);
 
         return true;

--- a/src/modules/Activity/Service.php
+++ b/src/modules/Activity/Service.php
@@ -26,6 +26,17 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'delete_activity' => [
+                'type' => 'bool',
+                'display_name' => __trans('Delete activity'),
+                'description' => __trans('Allows the staff member to delete recorded activity.'),
+            ],
+        ];
+    }
+
     public function logEvent($data)
     {
         $extensionService = $this->di['mod_service']('extension');

--- a/src/modules/Api/Service.php
+++ b/src/modules/Api/Service.php
@@ -24,6 +24,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'hide_permissions' => true,
+        ];
+    }
+
     /**
      * @return int - 1
      */

--- a/src/modules/Branding/Service.php
+++ b/src/modules/Branding/Service.php
@@ -24,6 +24,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'hide_permissions' => true,
+        ];
+    }
+
     public function uninstall()
     {
         return true;

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -26,6 +26,13 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'hide_permissions' => true,
+        ];
+    }
+
     public function getSearchQuery($data)
     {
         $sql = '

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -31,11 +31,7 @@ class Service implements InjectionAwareInterface
     {
         return [
             'can_always_access' => true,
-            'manage_settings' => [
-                'type' => 'bool',
-                'display_name' => __trans('Manage settings'),
-                'description' => __trans('Allows the staff member to edit settings for this module.'),
-            ],
+            'manage_settings',
         ];
     }
 

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -31,7 +31,7 @@ class Service implements InjectionAwareInterface
     {
         return [
             'can_always_access' => true,
-            'manage_settings',
+            'manage_settings' => []
         ];
     }
 

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -27,6 +27,18 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'can_always_access' => true,
+            'manage_settings' => [
+                'type' => 'bool',
+                'display_name' => __trans('Manage settings'),
+                'description' => __trans('Allows the staff member to edit settings for this module.'),
+            ],
+        ];
+    }
+
     public function getSearchQuery()
     {
         $sql = 'SELECT * FROM currency WHERE 1';

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -26,6 +26,17 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'edit_settings' => [
+                'type' => 'bool',
+                'display_name' => __trans('Edit settings'),
+                'description' => __trans('Allows the staff member to edit setttings for this module.'),
+            ],
+        ];
+    }
+
     public function getSearchQuery($data)
     {
         $query = 'SELECT * FROM activity_client_email';

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -29,7 +29,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
-            'manage_settings',
+            'manage_settings' => []
         ];
     }
 

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -29,6 +29,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
+            'can_always_access' => true,
             'manage_settings' => []
         ];
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -29,9 +29,9 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
-            'edit_settings' => [
+            'manage_settings' => [
                 'type' => 'bool',
-                'display_name' => __trans('Edit settings'),
+                'display_name' => __trans('Manage settings'),
                 'description' => __trans('Allows the staff member to edit settings for this module.'),
             ],
         ];

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -32,7 +32,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             'edit_settings' => [
                 'type' => 'bool',
                 'display_name' => __trans('Edit settings'),
-                'description' => __trans('Allows the staff member to edit setttings for this module.'),
+                'description' => __trans('Allows the staff member to edit settings for this module.'),
             ],
         ];
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -29,11 +29,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
-            'manage_settings' => [
-                'type' => 'bool',
-                'display_name' => __trans('Manage settings'),
-                'description' => __trans('Allows the staff member to edit settings for this module.'),
-            ],
+            'manage_settings',
         ];
     }
 

--- a/src/modules/Extension/Controller/Admin.php
+++ b/src/modules/Extension/Controller/Admin.php
@@ -77,6 +77,9 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     public function get_settings(\Box_App $app, $mod)
     {
         $this->di['is_admin_logged'];
+        $extensionService = $this->di['mod_service']('Extension');
+        $extensionService->checkPermission($mod, $app);
+
         $file = 'mod_' . $mod . '_settings';
 
         return $app->render($file);

--- a/src/modules/Extension/Controller/Admin.php
+++ b/src/modules/Extension/Controller/Admin.php
@@ -78,7 +78,7 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         $this->di['is_admin_logged'];
         $extensionService = $this->di['mod_service']('Extension');
-        $extensionService->checkPermission($mod, $app);
+        $extensionService->hasManagePermission($mod, $app);
 
         $file = 'mod_' . $mod . '_settings';
 

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -675,7 +675,7 @@ class Service implements InjectionAwareInterface
         return $modules;
     }
 
-    public function getSpecificModulePermissions(string $module, bool $buildingCompleteList = false): array
+    public function getSpecificModulePermissions(string $module, bool $buildingCompleteList = false): array|false
     {
         $class = 'Box\Mod\\' . ucfirst($module) . '\Service';
         if (class_exists($class) && method_exists($class, 'getModulePermissions')) {
@@ -727,7 +727,7 @@ class Service implements InjectionAwareInterface
         $module_permissions = $this->getSpecificModulePermissions($module);
 
         // If they have access, let's see if that module has a permission specifically for managing settings and check if they have that permission.
-        if (array_key_exists('manage_settings', $module_permissions['permissions']) && !$staff_service->hasPermission(null, $module, 'manage_settings')) {
+        if (array_key_exists('manage_settings', $module_permissions) && !$staff_service->hasPermission(null, $module, 'manage_settings')) {
             http_response_code(403);
             $e = new \Box_Exception('You do not have permission to perform this action', [], 403);
             if (!is_null($app)) {

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -596,7 +596,7 @@ class Service implements InjectionAwareInterface
 
     public function setConfig($data)
     {
-        $this->checkPermission($data['ext']);
+        $this->hasManagePermission($data['ext']);
         $this->getConfig($data['ext']); // Creates new config if it does not exist in DB
 
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminExtensionConfigSave', 'params' => $data]);
@@ -698,7 +698,7 @@ class Service implements InjectionAwareInterface
     }
 
     // Checks if the current user has permission to edit a module's settings
-    public function checkPermission(string $module, \Box_App|null $app = null): void
+    public function hasManagePermission(string $module, \Box_App|null $app = null): void
     {
         $staff_service = $this->di['mod_service']('Staff');
         $modules = $this->getCoreAndActiveModulesAndPermissions();

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -701,10 +701,9 @@ class Service implements InjectionAwareInterface
     public function hasManagePermission(string $module, \Box_App|null $app = null): void
     {
         $staff_service = $this->di['mod_service']('Staff');
-        $modules = $this->getCoreAndActiveModulesAndPermissions();
 
         // The module isn't active or has no permissions if this is the case, so continue as normal 
-        if (!array_key_exists($module, $modules)) {
+        if (!$this->isExtensionActive('mod', $module)) {
             return;
         }
 
@@ -720,8 +719,10 @@ class Service implements InjectionAwareInterface
             }
         }
 
+        $module_permissions = $this->getSpecificModulePermissions($module);
+
         // If they have access, let's see if that module has a permission specifically for managing settings and check if they have that permission.
-        if (array_key_exists('manage_settings', $modules[$module]['permissions']) && !$staff_service->hasPermission(null, $module, 'manage_settings')) {
+        if (array_key_exists('manage_settings', $module_permissions['permissions']) && !$staff_service->hasPermission(null, $module, 'manage_settings')) {
             http_response_code(403);
             $e = new \Box_Exception('You do not have permission to perform this action', [], 403);
             if (!is_null($app)) {

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -728,7 +728,7 @@ class Service implements InjectionAwareInterface
         // First check if any access is allowed to the module for this person
         if (!$staff_service->hasPermission(null, $module)) {
             http_response_code(403);
-            $e = new \Box_Exception('You do not have permission to access the :mod: module', [':mod:' => $module], 403);
+            $e = new \FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $module], 403);
             if (!is_null($app)) {
                 echo $app->render('error', ['exception' => $e]);
                 exit;
@@ -742,7 +742,7 @@ class Service implements InjectionAwareInterface
         // If they have access, let's see if that module has a permission specifically for managing settings and check if they have that permission.
         if (array_key_exists('manage_settings', $module_permissions) && !$staff_service->hasPermission(null, $module, 'manage_settings')) {
             http_response_code(403);
-            $e = new \Box_Exception('You do not have permission to perform this action', [], 403);
+            $e = new \FOSSBilling\InformationException('You do not have permission to perform this action', [], 403);
             if (!is_null($app)) {
                 echo $app->render('error', ['exception' => $e]);
                 exit;

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -329,13 +329,13 @@ class Service implements InjectionAwareInterface
 
     public function update(\Model_Extension $model): never
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
         throw new \FOSSBilling\InformationException('Visit the extension directory for more information on updating this extension.', null, 252);
     }
 
     public function activate(\Model_Extension $ext)
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
 
         $result = [
             'id' => $ext->name,
@@ -368,7 +368,7 @@ class Service implements InjectionAwareInterface
 
     public function deactivate(\Model_Extension $ext)
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
 
         switch ($ext->type) {
             case \FOSSBilling\ExtensionManager::TYPE_HOOK:
@@ -408,7 +408,7 @@ class Service implements InjectionAwareInterface
 
     public function uninstall(\Model_Extension $ext)
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
 
         $this->deactivate($ext);
 
@@ -427,7 +427,7 @@ class Service implements InjectionAwareInterface
 
     public function downloadAndExtract($type, $id)
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
 
         $latest = $this->di['extension_manager']->getLatestExtensionRelease($id);
 
@@ -527,7 +527,7 @@ class Service implements InjectionAwareInterface
 
     private function installModule(\Model_Extension $ext)
     {
-        $this->canManageModules();
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'manage_extensions');
 
         $mod = $this->di['mod']($ext->name);
 
@@ -749,20 +749,6 @@ class Service implements InjectionAwareInterface
             } else {
                 throw $e;
             }
-        }
-    }
-
-    /**
-     * Used to check if a staff member has permission to manage extensions.
-     * 
-     * @throws \Box_Exception If they do not have permission
-     */
-    private function canManageModules(): void
-    {
-        $staff_service = $this->di['mod_service']('Staff');
-
-        if (!$staff_service->hasPermission(null, 'extension', 'manage_extensions')) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
         }
     }
 }

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -659,27 +659,23 @@ class Service implements InjectionAwareInterface
         $modules = [];
 
         foreach ($enabledModules as $module) {
-            $class = 'Box\Mod\\' . ucfirst($module) . '\Service';
-            if (class_exists($class) && method_exists($class, 'getModulePermissions')) {
-                $moduleService = new $class;
-                $moduleService->setDi($this->di);
-                $permissions = $moduleService->getModulePermissions();
+            if ($module == 'index' || $module == 'dashboard') {
+                continue;
+            }
 
-                if (isset($permissions['hide_permissions']) && $permissions['hide_permissions']) {
-                    continue;
-                } else {
-                    unset($permissions['hide_permissions']);
-                    $modules[$module]['permissions'] = $permissions;
-                }
-            } elseif ($module !== 'index' && $module !== 'dashboard') {
-                $modules[$module]['permissions'] = [];
+            // If getSpecificModulePermissions returns false, we need to skip that module and not include it in the permissions list
+            $permissions = $this->getSpecificModulePermissions($module, true);
+            if ($permissions === false) {
+                continue;
+            } else {
+                $modules[$module]['permissions'] = $permissions;
             }
         }
 
         return $modules;
     }
 
-    public function getSpecificModulePermissions(string $module): array
+    public function getSpecificModulePermissions(string $module, bool $buildingCompleteList = false): array
     {
         $class = 'Box\Mod\\' . ucfirst($module) . '\Service';
         if (class_exists($class) && method_exists($class, 'getModulePermissions')) {
@@ -688,9 +684,18 @@ class Service implements InjectionAwareInterface
             $permissions = $moduleService->getModulePermissions();
 
             if (isset($permissions['hide_permissions']) && $permissions['hide_permissions']) {
-                return [];
+                return ($buildingCompleteList ? false : []);
             } else {
                 unset($permissions['hide_permissions']);
+
+                // Fill in the manage_settings permission as it will always be the same
+                if (isset($permissions['manage_settings'])) {
+                    $permissions['manage_settings'] = [
+                        'type' => 'bool',
+                        'display_name' => __trans('Manage settings'),
+                        'description' => __trans('Allows the staff member to edit settings for this module.'),
+                    ];
+                }
                 return $permissions;
             }
         }

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -680,7 +680,9 @@ class Service implements InjectionAwareInterface
         $class = 'Box\Mod\\' . ucfirst($module) . '\Service';
         if (class_exists($class) && method_exists($class, 'getModulePermissions')) {
             $moduleService = new $class;
-            $moduleService->setDi($this->di);
+            if (method_exists($moduleService, 'setDi')) {
+                $moduleService->setDi($this->di);
+            }
             $permissions = $moduleService->getModulePermissions();
 
             if (isset($permissions['hide_permissions']) && $permissions['hide_permissions']) {

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -26,6 +26,13 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'hide_permissions' => true,
+        ];
+    }
+
     public function getSearchQuery($filter)
     {
         $q = "SELECT id, rel_type, rel_id, meta_value as event, created_at, updated_at

--- a/src/modules/Page/Service.php
+++ b/src/modules/Page/Service.php
@@ -29,6 +29,7 @@ class Service implements InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
+            'can_always_access' => true,
             'hide_permissions' => true,
         ];
     }

--- a/src/modules/Page/Service.php
+++ b/src/modules/Page/Service.php
@@ -26,6 +26,13 @@ class Service implements InjectionAwareInterface
         return $this->di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'hide_permissions' => true,
+        ];
+    }
+
     public function getPairs()
     {
         $themeService = $this->di['mod_service']('theme');

--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -16,6 +16,14 @@ class Service implements InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
+    public function getModulePermissions(): array
+    {
+        return[
+            'can_always_access' => true,
+            'hide_permissions' => true,
+        ];
+    }
+
     public function setDi(\Pimple\Container $di): void
     {
         $this->di = $di;

--- a/src/modules/Staff/Controller/Admin.php
+++ b/src/modules/Staff/Controller/Admin.php
@@ -83,7 +83,7 @@ class Admin implements InjectionAwareInterface
         $staff = $api->staff_get(['id' => $id]);
 
         $extensionService = $this->di['mod_service']('Extension');
-        $mods = $extensionService->getCoreAndActiveModules();
+        $mods = $extensionService->getCoreAndActiveModulesAndPermissions();
 
         return $app->render('mod_staff_manage', ['staff' => $staff, 'mods' => $mods]);
     }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -44,9 +44,9 @@ class Service implements InjectionAwareInterface
                 'display_name' => __trans('Manage groups'),
                 'description' => __trans('Allows the staff member to manage staff member groups.'),
             ],
-            'edit_settings' => [
+            'manage_settings' => [
                 'type' => 'bool',
-                'display_name' => __trans('Edit settings'),
+                'display_name' => __trans('Manage settings'),
                 'description' => __trans('Allows the staff member to edit settings for this module.'),
             ],
         ];

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -131,7 +131,7 @@ class Service implements InjectionAwareInterface
     {
         $alwaysAllowed = ['index', 'dashboard'];
 
-        if(is_null($member)){
+        if (is_null($member)) {
             $member = $this->di['loggedin_admin'];
         }
 
@@ -139,15 +139,17 @@ class Service implements InjectionAwareInterface
             return true;
         }
 
+        $extensionService = $this->di['mod_service']('Extension');
+        $modulePermissions = $extensionService->getSpecificModulePermissions($module);
         $permissions = $this->getPermissions($member->id);
 
         // They have no permissions or don't have any access to that module
-        if (empty($permissions) || !array_key_exists($module, $permissions) || !is_array($permissions[$module]) || !($permissions[$module]['access'] ?? false)) {
+        if (empty($permissions) || !array_key_exists($module, $permissions) || !is_array($permissions[$module]) || !($permissions[$module]['access'] ?? $modulePermissions['can_always_access'] ?? false)) {
             return false;
         }
 
         // If this passes, the permission key isn't assigned to them and they therefore don't have permission
-        if((!is_null($key) && !is_array($permissions[$module])) || (!is_null($key) && !array_key_exists($key, $permissions[$module]))){
+        if ((!is_null($key) && !is_array($permissions[$module])) || (!is_null($key) && !array_key_exists($key, $permissions[$module]))) {
             return false;
         }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -147,7 +147,7 @@ class Service implements InjectionAwareInterface
         }
 
         // If this passes, the permission key isn't assigned to them and they therefore don't have permission
-        if((!is_null($key) && !is_array($permissions[$module])) || (!is_null($key) && !in_array($key, $permissions[$module]))){
+        if((!is_null($key) && !is_array($permissions[$module])) || (!is_null($key) && !array_key_exists($key, $permissions[$module]))){
             return false;
         }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -44,11 +44,7 @@ class Service implements InjectionAwareInterface
                 'display_name' => __trans('Manage groups'),
                 'description' => __trans('Allows the staff member to manage staff member groups.'),
             ],
-            'manage_settings' => [
-                'type' => 'bool',
-                'display_name' => __trans('Manage settings'),
-                'description' => __trans('Allows the staff member to edit settings for this module.'),
-            ],
+            'manage_settings',
         ];
     }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -44,7 +44,7 @@ class Service implements InjectionAwareInterface
                 'display_name' => __trans('Manage groups'),
                 'description' => __trans('Allows the staff member to manage staff member groups.'),
             ],
-            'manage_settings',
+            'manage_settings' => []
         ];
     }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -47,7 +47,7 @@ class Service implements InjectionAwareInterface
             'edit_settings' => [
                 'type' => 'bool',
                 'display_name' => __trans('Edit settings'),
-                'description' => __trans('Allows the staff member to edit setttings for this module.'),
+                'description' => __trans('Allows the staff member to edit settings for this module.'),
             ],
         ];
     }
@@ -123,7 +123,7 @@ class Service implements InjectionAwareInterface
      * Determines  if a staff member has the required permissions
      * @param \Model_Admin|null $member The model for the staff member to check. If you pass null, FOSSBilling will automatically get the currently authenticated staff member.
      * @param string $module What module to check permission for.
-     * @param string|null $key The permission key for the assocaited module.
+     * @param string|null $key The permission key for the associated module.
      * @param mixed $constraint If the permission key allows for multiple options, specify the one you want to use as a constraint here.
      * @return bool 
      */

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -29,15 +29,35 @@ class Service implements InjectionAwareInterface
     public function getModulePermissions(): array
     {
         return [
-            'manage_admin' => [
+            'create_and_edit_admin' => [
                 'type' => 'bool',
-                'display_name' => __trans('Manage administrators'),
-                'description' => __trans('Allows the staff member to create, edit, delete, and perform password resets on :type: accounts.', [':type:' => __trans('administrator')]),
+                'display_name' => __trans('Create and edit administrators'),
+                'description' => __trans('Allows the staff member to create and edit :type: accounts.', [':type:' => __trans('administrator')]),
             ],
-            'manage_staff' => [
+            'delete_admin' => [
                 'type' => 'bool',
-                'display_name' => __trans('Manage staff members'),
-                'description' => __trans('Allows the staff member to create, edit, delete, and perform password resets on :type: accounts.', [':type:' => __trans('staff')]),
+                'display_name' => __trans('Delete administrators'),
+                'description' => __trans('Allows the staff member to delete :type: accounts.', [':type:' => __trans('administrator')]),
+            ],
+            'reset_admin_password' => [
+                'type' => 'bool',
+                'display_name' => __trans('Reset administrator passwords'),
+                'description' => __trans('Allows the staff member to perform password resets on :type: accounts.', [':type:' => __trans('administrator')]),
+            ],
+            'create_and_edit_staff' => [
+                'type' => 'bool',
+                'display_name' => __trans('Create and edit staff members'),
+                'description' => __trans('Allows the staff member to create and edit :type: accounts.', [':type:' => __trans('staff')]),
+            ],
+            'delete_staff' => [
+                'type' => 'bool',
+                'display_name' => __trans('Delete staff members'),
+                'description' => __trans('Allows the staff member to delete :type: accounts.', [':type:' => __trans('staff')]),
+            ],
+            'reset_staff_password' => [
+                'type' => 'bool',
+                'display_name' => __trans('Reset staff passwords'),
+                'description' => __trans('Allows the staff member to perform password resets on :type: accounts.', [':type:' => __trans('staff')]),
             ],
             'manage_groups' => [
                 'type' => 'bool',
@@ -89,6 +109,8 @@ class Service implements InjectionAwareInterface
 
     public function setPermissions($member_id, $array)
     {
+        $this->checkPermissionsAndThrowException('staff', 'create_and_edit_staff');
+
         $array = array_filter($array);
         $sql = 'UPDATE admin SET permissions = :p WHERE id = :id';
         $pdo = $this->di['pdo'];
@@ -159,6 +181,22 @@ class Service implements InjectionAwareInterface
         }
 
         return true;
+    }
+
+    /**
+     * Acts as an alias to `hasPermission`, but it'll also throw an exception stating the staff member doesn't have permission if they don't
+     * 
+     * @param string $module What module to check permission for.
+     * @param string|null $key The permission key for the associated module.
+     * @param mixed $constraint If the permission key allows for multiple options, specify the one you want to use as a constraint here.
+     * 
+     * @return void 
+     */
+    public function checkPermissionsAndThrowException(string $module, string $key = null, mixed $constraint = null): void
+    {
+        if (!$this->hasPermission(null, $module, $key, $constraint)) {
+            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
+        }
     }
 
     public static function onAfterClientOrderCreate(\Box_Event $event)
@@ -445,6 +483,12 @@ class Service implements InjectionAwareInterface
     {
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffUpdate', 'params' => ['id' => $model->id]]);
 
+        if($model->role === 'admin'){
+            $this->checkPermissionsAndThrowException('staff', 'create_and_edit_admin');
+        } else {
+            $this->checkPermissionsAndThrowException('staff', 'create_and_edit_staff');
+        }
+
         $model->email = $data['email'] ?? $model->email;
         $model->admin_group_id = $data['admin_group_id'] ?? $model->admin_group_id;
         $model->name = $data['name'] ?? $model->name;
@@ -465,6 +509,13 @@ class Service implements InjectionAwareInterface
         if ($model->protected) {
             throw new \FOSSBilling\InformationException('This administrator account is protected and can not be removed');
         }
+
+        if($model->role === 'admin'){
+            $this->checkPermissionsAndThrowException('staff', 'delete_admin');
+        } else {
+            $this->checkPermissionsAndThrowException('staff', 'delete_staff');
+        }
+
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffDelete', 'params' => ['id' => $model->id]]);
 
         $id = $model->id;
@@ -479,6 +530,12 @@ class Service implements InjectionAwareInterface
 
     public function changePassword(\Model_Admin $model, $password)
     {
+        if($model->role === 'admin'){
+            $this->checkPermissionsAndThrowException('staff', 'reset_admin_password');
+        } else {
+            $this->checkPermissionsAndThrowException('staff', 'reset_staff_password');
+        }
+
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffPasswordChange', 'params' => ['id' => $model->id]]);
 
         $model->pass = $this->di['password']->hashIt($password);
@@ -497,6 +554,9 @@ class Service implements InjectionAwareInterface
 
     public function create(array $data)
     {
+        // TODO: When it becomes possible to create other super admins, add a check for that here,
+        $this->checkPermissionsAndThrowException('staff', 'create_and_edit_staff');
+
         $systemService = $this->di['mod_service']('system');
         $systemService->checkLimits('Model_Admin', 3);
 
@@ -528,6 +588,9 @@ class Service implements InjectionAwareInterface
         return (int) $newId;
     }
 
+    /**
+     * Used to create the initial admin account and then goes unused.
+     */
     public function createAdmin(array $data)
     {
         $admin = $this->di['db']->dispense('Admin');
@@ -573,6 +636,8 @@ class Service implements InjectionAwareInterface
 
     public function createGroup($name)
     {
+        $this->checkPermissionsAndThrowException('staff', 'manage_groups');
+
         $systemService = $this->di['mod_service']('system');
         $systemService->checkLimits('Model_AdminGroup', 2);
 
@@ -601,6 +666,8 @@ class Service implements InjectionAwareInterface
 
     public function deleteGroup(\Model_AdminGroup $model)
     {
+        $this->checkPermissionsAndThrowException('staff', 'manage_groups');
+
         $id = $model->id;
         if ($model->id == 1) {
             throw new \FOSSBilling\InformationException('Administrators group can not be removed');
@@ -623,6 +690,8 @@ class Service implements InjectionAwareInterface
 
     public function updateGroup(\Model_AdminGroup $model, $data)
     {
+        $this->checkPermissionsAndThrowException('staff', 'manage_groups');
+
         if (isset($data['name'])) {
             $model->name = $data['name'];
         }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -139,9 +139,12 @@ class Service implements InjectionAwareInterface
         $modulePermissions = $extensionService->getSpecificModulePermissions($module);
         $permissions = $this->getPermissions($member->id);
 
-        // They have no permissions or don't have any access to that module
-        if (empty($permissions) || !array_key_exists($module, $permissions) || !is_array($permissions[$module]) || !($permissions[$module]['access'] ?? $modulePermissions['can_always_access'] ?? false)) {
-            return false;
+        $canAlwaysAccess = $modulePermissions['can_always_access'] ?? false;
+        if (!$canAlwaysAccess) {
+            // They have no permissions or don't have any access to that module
+            if (empty($permissions) || !array_key_exists($module, $permissions) || !is_array($permissions[$module]) || !($permissions[$module]['access'] ?? false)) {
+                return false;
+            }
         }
 
         // If this passes, the permission key isn't assigned to them and they therefore don't have permission

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -131,12 +131,12 @@ class Service implements InjectionAwareInterface
     {
         $alwaysAllowed = ['index', 'dashboard'];
 
-        if ($member->role == \Model_Admin::ROLE_CRON || $member->role == \Model_Admin::ROLE_ADMIN || in_array($module, $alwaysAllowed)) {
-            return true;
-        }
-
         if(is_null($member)){
             $member = $this->di['loggedin_admin'];
+        }
+
+        if ($member->role == \Model_Admin::ROLE_CRON || $member->role == \Model_Admin::ROLE_ADMIN || in_array($module, $alwaysAllowed)) {
+            return true;
         }
 
         $permissions = $this->getPermissions($member->id);

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -195,7 +195,7 @@ class Service implements InjectionAwareInterface
     public function checkPermissionsAndThrowException(string $module, string $key = null, mixed $constraint = null): void
     {
         if (!$this->hasPermission(null, $module, $key, $constraint)) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
+            throw new \FOSSBilling\InformationException('You do not have permission to perform this action', [], 403);
         }
     }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -125,7 +125,7 @@ class Service implements InjectionAwareInterface
      */
     public function hasPermission(\Model_Admin|null $member, string $module, string $key = null, mixed $constraint = null): bool
     {
-        $alwaysAllowed = ['index', 'dashboard'];
+        $alwaysAllowed = ['index', 'dashboard', 'profile'];
 
         if (is_null($member)) {
             $member = $this->di['loggedin_admin'];

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -99,6 +99,8 @@
         <div class="tab-pane fade" id="tab-permissions" role="tabpanel">
             <div class="card-body">
                 <h3>{{ staff.name }} {{ 'permissions'|trans }}</h3>
+                <button class="btn btn-primary" onclick="toggleAll(true);">{{ 'Give all permissions'|trans }}</button>
+                <button class="btn btn-primary" onclick="toggleAll(false);">{{ 'Revoke all permissions'|trans }}</button>
 
                 {% if staff.role == 'admin' %}
                 <p>{{ 'This administrator is allowed to do everything'|trans }}</p>
@@ -112,14 +114,14 @@
 
                 {% for modName, mod in mods %}
                     <h2 class="text-capitalize">{{ modName }}</h2>
-                    <input class="form-check-input" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                    <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
                     <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
                     <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
 
                     {% for permissionName, permission in mod.permissions %}
                         <div class="form-group">
                             {% if permission.type == 'bool' %}
-                                <input class="form-check-input" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
+                                <input class="form-check-input permission-box" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
                                 <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
                                 <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
                             {% endif %}
@@ -168,10 +170,11 @@
 
 {% block js%}
 <script>
-    $(function() {
-        $('.js-permission-check-master').on('click', function() {
-            $('.js-permission-check').prop('checked', this.checked);
+    function toggleAll(check){
+        const  elements = document.getElementsByClassName('permission-box');
+        Array.from(elements).forEach( (element) => {
+            element.checked = check;
         });
-    });
+    }
 </script>
 {% endblock %}

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -99,11 +99,11 @@
         <div class="tab-pane fade" id="tab-permissions" role="tabpanel">
             <div class="card-body">
                 <div class="d-flex justify-content-between align-items-center">
-                    <h3>{{ staff.name }} {{ 'permissions'|trans }}</h3>
+                    <h1>{{ 'Permissions for: '|trans }} {{ staff.name }}</h1>
                     <div>
                         {% if staff.role != 'admin' %}
-                            <button class="btn btn-secondary btn-sm d-inline" onclick="toggleAll(true);">{{ 'Give all permissions'|trans }}</button>
-                            <button class="btn btn-danger btn-sm d-inline" onclick="toggleAll(false);">{{ 'Revoke all permissions'|trans }}</button>
+                            <button class="btn btn-secondary btn-md d-inline" onclick="toggleAll(true);">{{ 'Give all permissions'|trans }}</button>
+                            <button class="btn btn-danger btn-md d-inline" onclick="toggleAll(false);">{{ 'Revoke all permissions'|trans }}</button>
                         {% endif %}
                     </div>
                 </div>
@@ -116,62 +116,64 @@
                 <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
                 <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">
                 <input type="hidden" name="permissions[default]" value="">
-            
+
                 {% for modName, mod in mods %}
-                <div class="card mb-3">
-                    <div class="card-header text-capitalize">
-                        {{ modName }}
-                    </div>
-                    <div class="card-body">
-                        {% if not mod.permissions.can_always_access %}
-                        <div class="mb-3 form-check">
-                            <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
-                            <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
-                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                            </label>
+                    <div class="row">
+                        <div class="col-1"></div>
+                        <div class="col-2">
+                            <h3 class="float-right text-capitalize mt-1">{{ modName }}</h3>
                         </div>
-                        {% else %}
-                        <div class="mb-3 form-check">
-                            <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
-                            <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
-                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                            </label>
-                        </div>
-                        {% endif %}
-            
-                        {% for permissionName, permission in mod.permissions %}
-                        <div class="form-group">
-                            {% if permission.type == 'bool' %}
-                            <div class="mb-3 form-check">
-                                <input class="form-check-input permission-box" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
-                                <label class="form-check-label" for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}
-                                    <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                                </label>
-                            </div>
-                            {% endif %}
-            
-                            {% if permission.type == 'select' %}
-                                <div class="row">
-                                    <div class="col-3">
-                                        <div class="d-flex align-items-center">
-                                            <label for="input-{{ modName }}-{{ permissionName }}" class="mb-3 text-nowrap" style="margin-right: 10px; margin-left: 5px;">{{ permission.display_name }}</label>
-                                            <select class="form-control mb-3 permission-select" name="permissions[{{ modName }}][{{ permissionName }}]" style="margin-right: 5px;">
-                                                <option value="">{{ 'None'|trans }}</option>
-                                                {% for optionName, option in permission.options %}
-                                                    <option value="{{ optionName }}" {% if prms[modName][permissionName] == optionName %} selected {% endif %}>{{ option }}</option>
-                                                {% endfor %}
-                                            </select>
-                                            <svg class="icon mb-3" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right" style="width: 32px; height: 32px;"><use xlink:href="#info"/></svg>
-                                        </div>
-                                    </div>
+                        <div class="col-4">
+                            {% if not mod.permissions.can_always_access %}
+                                <div class="mt-2 form-check">
+                                    <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                                    <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
+                                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                                    </label>
                                 </div>
-                            {% endif %}
+                            {% else %}
+                                <div class="mt-2 form-check">
+                                    <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
+                                    <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
+                                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                                </label>
+                                </div>
+                             {% endif %}
+                        
+                            {% for permissionName, permission in mod.permissions %}
+                                <div class="form-group">
+                                    {% if permission.type == 'bool' %}
+                                        <div class="mt-2 form-check">
+                                            <input class="form-check-input permission-box" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
+                                            <label class="form-check-label" for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}
+                                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                                            </label>
+                                        </div>
+                                    {% endif %}
+                        
+                                    {% if permission.type == 'select' %}
+                                        <div class="row">
+                                            <div class="col-3">
+                                                <div class="d-flex align-items-center">
+                                                    <label for="input-{{ modName }}-{{ permissionName }}" class="mt-2 text-nowrap" style="margin-right: 10px; margin-left: 5px;">{{ permission.display_name }}</label>
+                                                    <select class="form-control mt-2 permission-select" name="permissions[{{ modName }}][{{ permissionName }}]" style="margin-right: 5px;">
+                                                    <option value="">{{ 'None'|trans }}</option>
+                                                        {% for optionName, option in permission.options %}
+                                                            <option value="{{ optionName }}" {% if prms[modName][permissionName] == optionName %} selected {% endif %}>{{ option }}</option>
+                                                        {% endfor %}
+                                                    </select>
+                                                    <svg class="icon mt-2" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right" style="width: 32px; height: 32px;"><use xlink:href="#info"/></svg>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                            <hr class="mt-4 mb-4"/>
                         </div>
-                        {% endfor %}
                     </div>
-                </div>
                 {% endfor %}
-            
+
                 <input type="hidden" name="id" value="{{ staff.id }}">
             
                 <div class="card-footer">

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -115,11 +115,11 @@
                 {% for modName, mod in mods %}
                     <h2 class="text-capitalize">{{ modName }}</h2>
                     {% if not mod.permissions.can_always_access %}
-                        <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                        <input class="form-check-input permission-box mb-1" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
                         <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
                         <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
                     {% else %}
-                        <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
+                        <input data-always-given="1" class="form-check-input permission-box mb-1" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
                         <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
                         <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
                     {% endif %}
@@ -127,9 +127,20 @@
                     {% for permissionName, permission in mod.permissions %}
                         <div class="form-group">
                             {% if permission.type == 'bool' %}
-                                <input class="form-check-input permission-box" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
+                                <input class="form-check-input permission-box mb-1" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
                                 <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
                                 <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                            {% endif %}
+
+                            {% if permission.type == 'select' %}
+                                <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
+                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                                <select  class="form-control permission-select mb-1 w-25" name="permissions[{{ modName }}][{{ permissionName }}]">
+                                    <option value="">{{ 'None'|trans }}</option>
+                                    {% for optionName, option in permission.options %}
+                                    <option value="{{ optionName }}" {% if prms[modName][permissionName] == optionName %} selected {% endif %}>{{ option }}</option>
+                                    {% endfor %}
+                                </select>
                             {% endif %}
                         </div>
                     {% endfor %}

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -98,61 +98,87 @@
 
         <div class="tab-pane fade" id="tab-permissions" role="tabpanel">
             <div class="card-body">
-                <h3>{{ staff.name }} {{ 'permissions'|trans }}</h3>
-                <button class="btn btn-primary" onclick="toggleAll(true);">{{ 'Give all permissions'|trans }}</button>
-                <button class="btn btn-primary" onclick="toggleAll(false);">{{ 'Revoke all permissions'|trans }}</button>
-
-                {% if staff.role == 'admin' %}
-                <p>{{ 'This administrator is allowed to do everything'|trans }}</p>
+                <div class="d-flex justify-content-between align-items-center">
+                    <h3>{{ staff.name }} {{ 'permissions'|trans }}</h3>
+                    <div>
+                        {% if staff.role != 'admin' %}
+                            <button class="btn btn-secondary btn-sm d-inline" onclick="toggleAll(true);">{{ 'Give all permissions'|trans }}</button>
+                            <button class="btn btn-danger btn-sm d-inline" onclick="toggleAll(false);">{{ 'Revoke all permissions'|trans }}</button>
+                        {% endif %}
+                    </div>
                 </div>
-                {% else %}
+
+            {% if staff.role == 'admin' %}
+                <p>{{ 'This administrator is allowed to do everything'|trans }}</p>
+            {% else %}
 
             {% set prms = admin.staff_permissions_get({ 'id': staff.id }) %}
-            <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
-                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+                <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">
                 <input type="hidden" name="permissions[default]" value="">
-
+            
                 {% for modName, mod in mods %}
-                    <h2 class="text-capitalize">{{ modName }}</h2>
-                    {% if not mod.permissions.can_always_access %}
-                        <input class="form-check-input permission-box mb-1" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
-                        <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
-                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                    {% else %}
-                        <input data-always-given="1" class="form-check-input permission-box mb-1" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
-                        <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
-                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                    {% endif %}
-
-                    {% for permissionName, permission in mod.permissions %}
+                <div class="card mb-3">
+                    <div class="card-header text-capitalize">
+                        {{ modName }}
+                    </div>
+                    <div class="card-body">
+                        {% if not mod.permissions.can_always_access %}
+                        <div class="mb-3 form-check">
+                            <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                            <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
+                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                            </label>
+                        </div>
+                        {% else %}
+                        <div class="mb-3 form-check">
+                            <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
+                            <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
+                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                            </label>
+                        </div>
+                        {% endif %}
+            
+                        {% for permissionName, permission in mod.permissions %}
                         <div class="form-group">
                             {% if permission.type == 'bool' %}
-                                <input class="form-check-input permission-box mb-1" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
-                                <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
-                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                            <div class="mb-3 form-check">
+                                <input class="form-check-input permission-box" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
+                                <label class="form-check-label" for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}
+                                    <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                                </label>
+                            </div>
                             {% endif %}
-
+            
                             {% if permission.type == 'select' %}
-                                <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
-                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                                <select  class="form-control permission-select mb-1 w-25" name="permissions[{{ modName }}][{{ permissionName }}]">
-                                    <option value="">{{ 'None'|trans }}</option>
-                                    {% for optionName, option in permission.options %}
-                                    <option value="{{ optionName }}" {% if prms[modName][permissionName] == optionName %} selected {% endif %}>{{ option }}</option>
-                                    {% endfor %}
-                                </select>
+                                <div class="row">
+                                    <div class="col-3">
+                                        <div class="d-flex align-items-center">
+                                            <label for="input-{{ modName }}-{{ permissionName }}" class="mb-3 text-nowrap" style="margin-right: 10px; margin-left: 5px;">{{ permission.display_name }}</label>
+                                            <select class="form-control mb-3 permission-select" name="permissions[{{ modName }}][{{ permissionName }}]" style="margin-right: 5px;">
+                                                <option value="">{{ 'None'|trans }}</option>
+                                                {% for optionName, option in permission.options %}
+                                                    <option value="{{ optionName }}" {% if prms[modName][permissionName] == optionName %} selected {% endif %}>{{ option }}</option>
+                                                {% endfor %}
+                                            </select>
+                                            <svg class="icon mb-3" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right" style="width: 32px; height: 32px;"><use xlink:href="#info"/></svg>
+                                        </div>
+                                    </div>
+                                </div>
                             {% endif %}
                         </div>
-                    {% endfor %}
-                    <hr/>
+                        {% endfor %}
+                    </div>
+                </div>
                 {% endfor %}
-
+            
                 <input type="hidden" name="id" value="{{ staff.id }}">
-
+            
                 <div class="card-footer">
                     <input type="submit" value="{{ 'Save'|trans }}" class="btn btn-primary w-100">
                 </div>
             </form>
+                 
             </div>
             {% endif %}
         </div>

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -109,28 +109,24 @@
             <form method="post" action="admin/staff/permissions_update" class="api-form" data-api-msg="{{ 'Permissions updated'|trans }}">
                 <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <input type="hidden" name="permissions[default]" value="">
-                <table class="table card-table table-vcenter table-striped text-nowrap">
-                    <thead>
-                        <tr>
-                            <th class="w-1">
-                                <input class="form-check-input m-0 align-middle js-permission-check-master" type="checkbox">
-                            </th>
-                            <th>{{ 'Module'|trans }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for mod in mods %}
-                        <tr>
-                            <td>
-                                <input class="form-check-input m-0 align-middle js-permission-check" id="input-{{ mod }}" type="checkbox" name="permissions[{{ mod }}]" value="1"{% if prms[mod] %} checked{% endif %}>
-                            </td>
-                            <td>
-                                <label for="input-{{ mod }}">{{ mod|title }}</label>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+
+                {% for modName, mod in mods %}
+                    <h2 class="text-capitalize">{{ modName }}</h2>
+                    <input class="form-check-input" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                    <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
+                    <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+
+                    {% for permissionName, permission in mod.permissions %}
+                        <div class="form-group">
+                            {% if permission.type == 'bool' %}
+                                <input class="form-check-input" id="input-{{ modName }}-{{ permissionName }}" type="checkbox" name="permissions[{{ modName }}][{{ permissionName }}]" value="1"{% if prms[modName][permissionName] %} checked {% endif %}>
+                                <label for="input-{{ modName }}-{{ permissionName }}">{{ permission.display_name }}</label>
+                                <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ permission.description }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                    <hr/>
+                {% endfor %}
 
                 <input type="hidden" name="id" value="{{ staff.id }}">
 

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -131,14 +131,7 @@
                                         <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
                                     </label>
                                 </div>
-                            {% else %}
-                                <div class="mt-2 form-check">
-                                    <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
-                                    <label class="form-check-label" for="input-{{ modName }}">{{ 'Module access'|trans }}
-                                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
-                                </label>
-                                </div>
-                             {% endif %}
+                            {% endif %}
                         
                             {% for permissionName, permission in mod.permissions %}
                                 <div class="form-group">

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -114,9 +114,15 @@
 
                 {% for modName, mod in mods %}
                     <h2 class="text-capitalize">{{ modName }}</h2>
-                    <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
-                    <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
-                    <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                    {% if not mod.permissions.can_always_access %}
+                        <input class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" name="permissions[{{ modName }}][access]" value="1"{% if prms[modName] %} checked {% endif %}>
+                        <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
+                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Can be disabled to prevent the staff member from using any part of this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                    {% else %}
+                        <input data-always-given="1" class="form-check-input permission-box" id="input-{{ modName }}" type="checkbox" value="1" checked disabled>
+                        <label for="input-{{ modName }}">{{ 'Module access'|trans }}</label>
+                        <svg class="icon" data-bs-toggle="tooltip" data-bs-title="{{ 'Base-level access is permanently enabled for this module.'|trans }}" data-bs-placement="right"><use xlink:href="#info"/></svg>
+                    {% endif %}
 
                     {% for permissionName, permission in mod.permissions %}
                         <div class="form-group">
@@ -173,7 +179,11 @@
     function toggleAll(check){
         const  elements = document.getElementsByClassName('permission-box');
         Array.from(elements).forEach( (element) => {
-            element.checked = check;
+            if(element.dataset.alwaysGiven){
+                element.checked = true;
+            } else {
+                element.checked = check;
+            }
         });
     }
 </script>

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -141,10 +141,7 @@ class Admin extends \Api_Abstract
      */
     public function clear_cache()
     {
-        $staff_service = $this->di['mod_service']('Staff');
-        if (!$staff_service->hasPermission(null, 'system', 'invalidate_cache')) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
-        }
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'invalidate_cache');
 
         return $this->getService()->clearCache();
     }
@@ -187,10 +184,7 @@ class Admin extends \Api_Abstract
             throw new \FOSSBilling\InformationException('You have latest version of FOSSBilling. You do not need to update.');
         }
 
-        $staff_service = $this->di['mod_service']('Staff');
-        if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
-        }
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'system_update');
 
         $new_version = $updater->getLatestVersion();
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminUpdateCore']);
@@ -211,11 +205,7 @@ class Admin extends \Api_Abstract
      */
     public function manual_update()
     {
-
-        $staff_service = $this->di['mod_service']('Staff');
-        if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
-            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
-        }
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'system_update');
 
         $updater = $this->di['updater'];
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminManualUpdate']);

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -141,6 +141,11 @@ class Admin extends \Api_Abstract
      */
     public function clear_cache()
     {
+        $staff_service = $this->di['mod_service']('Staff');
+        if (!$staff_service->hasPermission(null, 'system', 'invalidate_cache')) {
+            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+        }
+
         return $this->getService()->clearCache();
     }
 
@@ -182,6 +187,11 @@ class Admin extends \Api_Abstract
             throw new \FOSSBilling\InformationException('You have latest version of FOSSBilling. You do not need to update.');
         }
 
+        $staff_service = $this->di['mod_service']('Staff');
+        if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
+            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+        }
+
         $new_version = $updater->getLatestVersion();
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminUpdateCore']);
         $updater->performUpdate();
@@ -201,6 +211,12 @@ class Admin extends \Api_Abstract
      */
     public function manual_update()
     {
+
+        $staff_service = $this->di['mod_service']('Staff');
+        if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
+            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+        }
+
         $updater = $this->di['updater'];
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminManualUpdate']);
         $updater->performManualUpdate();

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -143,7 +143,7 @@ class Admin extends \Api_Abstract
     {
         $staff_service = $this->di['mod_service']('Staff');
         if (!$staff_service->hasPermission(null, 'system', 'invalidate_cache')) {
-            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
         }
 
         return $this->getService()->clearCache();
@@ -189,7 +189,7 @@ class Admin extends \Api_Abstract
 
         $staff_service = $this->di['mod_service']('Staff');
         if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
-            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
         }
 
         $new_version = $updater->getLatestVersion();
@@ -214,7 +214,7 @@ class Admin extends \Api_Abstract
 
         $staff_service = $this->di['mod_service']('Staff');
         if (!$staff_service->hasPermission(null, 'system', 'system_update')) {
-            throw new \Box_Exception("You do not have permission to perform this action", [], 403);
+            throw new \Box_Exception('You do not have permission to perform this action', [], 403);
         }
 
         $updater = $this->di['updater'];

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -38,11 +39,6 @@ class Service
                 'type' => 'bool',
                 'display_name' => __trans('Manage company legal'),
                 'description' => __trans('Allows the staff member to update company legal as set under the system module.'),
-            ],
-            'manage_countries' => [
-                'type' => 'bool',
-                'display_name' => __trans('Manage countries'),
-                'description' => __trans('Allows the staff member to edit the countries list.'),
             ],
             'invalidate_cache' => [
                 'type' => 'bool',
@@ -84,6 +80,11 @@ class Service
 
     public function setParamValue($param, $value, $createIfNotExists = true)
     {
+        // Skip this param if the user isn't permitted to update it.
+        if (!$this->canUpdateParam($param)) {
+            return true;
+        }
+
         $pdo = $this->di['pdo'];
         if ($this->paramExists($param)) {
             $query = 'UPDATE setting SET value = :value WHERE param = :param';
@@ -1712,6 +1713,26 @@ class Service
             }
         } catch (\Exception $e) {
             error_log($e->getMessage());
+        }
+    }
+
+    private function canUpdateParam(string $param): bool
+    {
+        $company = [
+            'company_name', 'company_email', 'company_tel', 'company_address_1',
+            'company_address_2', 'company_address_3', 'company_logo', 'company_logo_dark',
+            'company_favicon', 'company_number', 'company_vat_number', 'company_account_number',
+            'hide_version_public', 'hide_company_public', 'company_signature'
+        ];
+        $comaony_legal = ['company_tos', 'company_privacy_policy', 'company_note'];
+
+        $staff_service = $this->di['mod_service']('Staff');
+        if (in_array($param, $company) && !$staff_service->hasPermission(null, 'system', 'manage_company_details')) {
+            return false;
+        }
+
+        if (in_array($param, $comaony_legal) && !$staff_service->hasPermission(null, 'system', 'manage_company_legal')) {
+            return false;
         }
 
         return true;

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -30,6 +30,8 @@ class Service
     public function getModulePermissions(): array
     {
         return [
+            'can_always_access' => true,
+            'manage_settings' => [],
             'manage_company_details' => [
                 'type' => 'bool',
                 'display_name' => __trans('Manage company details'),

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -26,6 +26,37 @@ class Service
         $this->di = $di;
     }
 
+    public function getModulePermissions(): array
+    {
+        return [
+            'manage_company_details' => [
+                'type' => 'bool',
+                'display_name' => __trans('Manage company details'),
+                'description' => __trans('Allows the staff member to update company details as set under the system module.'),
+            ],
+            'manage_company_legal' => [
+                'type' => 'bool',
+                'display_name' => __trans('Manage company legal'),
+                'description' => __trans('Allows the staff member to update company legal as set under the system module.'),
+            ],
+            'manage_countries' => [
+                'type' => 'bool',
+                'display_name' => __trans('Manage countries'),
+                'description' => __trans('Allows the staff member to edit the countries list.'),
+            ],
+            'invalidate_cache' => [
+                'type' => 'bool',
+                'display_name' => __trans('Invalidate cache'),
+                'description' => __trans('Allows the staff member to invalidate the FOSSBilling cache from within the system settings.'),
+            ],
+            'system_update' => [
+                'type' => 'bool',
+                'display_name' => __trans('Update FOSSBilling'),
+                'description' => __trans('Allows the staff member to update FOSSBilling.'),
+            ],
+        ];
+    }
+
     /**
      * @param string $param
      * @param bool   $default

--- a/src/modules/Wysiwyg/Service.php
+++ b/src/modules/Wysiwyg/Service.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright 2022-2023 FOSSBilling
+ * Copyright 2011-2021 BoxBilling, Inc.
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace Box\Mod\Wysiwyg;
+
+use FOSSBilling\InjectionAwareInterface;
+
+class Service implements InjectionAwareInterface
+{
+    protected ?\Pimple\Container $di = null;
+
+    public function setDi(\Pimple\Container $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function getDi(): ?\Pimple\Container
+    {
+        return $this->di;
+    }
+
+    public function getModulePermissions(): array
+    {
+        return [
+            'can_always_access' => true,
+            'manage_settings' => [],
+        ];
+    }
+}

--- a/src/themes/admin_default/html/error.html.twig
+++ b/src/themes/admin_default/html/error.html.twig
@@ -10,7 +10,7 @@
             <p class="empty-title">{{ 'Oops... You just found an error page'|trans }}</p>
             <p class="empty-subtitle text-muted">{{ exception.getMessage }}</p>
             <div class="empty-action">
-                {% if exception.getCode == 403 %}
+                {% if exception.getCode == 403 and not admin %}
                     <a href="{{ '/staff/login'|alink }}" class="btn btn-primary">{{ 'Login'|trans }}</a>
                 {% else %}
                     <a href="{{ '/index'|alink }}" class="btn btn-primary">

--- a/tests/modules/Activity/Api/AdminTest.php
+++ b/tests/modules/Activity/Api/AdminTest.php
@@ -128,12 +128,21 @@ class AdminTest extends \BBTestCase {
         $databaseMock->expects($this->atLeastOnce())->
             method('trash');
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')->setMethods(array('hasPermission'))->getMock();
+            $serviceMock->expects($this->atLeastOnce())
+                ->method('hasPermission')
+                ->willReturn(true);
+
         $di['db'] = $databaseMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
             ->will($this->returnValue(null));
         $di['validator'] = $validatorMock;
+
+        $di['mod_service'] = $di->protect(function () use ($serviceMock) {
+            return $serviceMock;
+        });
 
         $activity = new \Box\Mod\Activity\Api\Admin();
         $activity->setDi($di);

--- a/tests/modules/Activity/Api/AdminTest.php
+++ b/tests/modules/Activity/Api/AdminTest.php
@@ -128,7 +128,7 @@ class AdminTest extends \BBTestCase {
         $databaseMock->expects($this->atLeastOnce())->
             method('trash');
 
-        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')->setMethods(array('hasPermission'))->getMock();
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')->onlyMethods(array('hasPermission'))->getMock();
             $serviceMock->expects($this->atLeastOnce())
                 ->method('hasPermission')
                 ->willReturn(true);

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -70,6 +70,7 @@ class ServiceTest extends \BBTestCase
             return $modMock;
         $this->service->setDi($di);
 
+        $result = $this->service->isExtensionActive('mod', 'extension');
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -57,24 +57,6 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisExtensionActiveModAndCoreModule()
-    {
-        $coreModules = array('extension', 'cron', 'staff');
-        $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
-        $modMock->expects($this->atLeastOnce())
-            ->method('getCoreModules')
-            ->will($this->returnValue($coreModules));
-
-        $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn($name) => $modMock);
-            return $modMock;
-        $this->service->setDi($di);
-
-        $result = $this->service->isExtensionActive('mod', 'extension');
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
     public function testisExtensionActiveModNotFound()
     {
         $coreModules = array('extension', 'cron', 'staff');

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -324,7 +324,7 @@ class ServiceTest extends \BBTestCase
         $extensionMock = $this->getMockBuilder('\\' . \FOSSBilling\ExtensionManager::class)->getMock();
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
@@ -354,7 +354,7 @@ class ServiceTest extends \BBTestCase
         );
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
@@ -408,7 +408,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(true));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -437,7 +437,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(array($ext->name)));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['mod'] = $di->protect(fn($name) => $modMock);
@@ -472,7 +472,7 @@ class ServiceTest extends \BBTestCase
             ->willThrowException(new \FOSSBilling\Exception($exceptionMessage));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['mod'] = $di->protect(fn($name) => $modMock);
@@ -500,7 +500,7 @@ class ServiceTest extends \BBTestCase
             ->method('trash');
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -534,7 +534,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(true));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -559,7 +559,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(array()));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('hasPermission')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -686,9 +686,12 @@ class ServiceTest extends \BBTestCase {
             'ext' => 'extensionName',
         );
 
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->onlyMethods(['getConfig'])->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->onlyMethods(['getConfig', 'getCoreAndActiveModulesAndPermissions'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getConfig')
+            ->will($this->returnValue(array()));
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getCoreAndActiveModulesAndPermissions')
             ->will($this->returnValue(array()));
 
         $toolsMock = $this->getMockBuilder(\FOSSBilling\Tools::class)->getMock();
@@ -710,9 +713,6 @@ class ServiceTest extends \BBTestCase {
             method('fire');
 
         $staffMock = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffMock->expects($this->atLeastOnce())
-            ->method('hasPermission')
-            ->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -711,8 +711,8 @@ class ServiceTest extends \BBTestCase {
 
         $staffMock = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
         $staffMock->expects($this->atLeastOnce())
-            ->method('getCoreAndActiveModulesAndPermissions')
-            ->will($this->returnValue([]));
+            ->method('hasPermission')
+            ->will($this->returnValue(true));
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -709,6 +709,11 @@ class ServiceTest extends \BBTestCase {
         $eventMock->expects($this->atLeastOnce())->
             method('fire');
 
+        $staffMock = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
+        $staffMock->expects($this->atLeastOnce())
+            ->method('getCoreAndActiveModulesAndPermissions')
+            ->will($this->returnValue([]));
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['tools'] = $toolsMock;
@@ -716,6 +721,9 @@ class ServiceTest extends \BBTestCase {
         $di['events_manager'] = $eventMock;
         $di['logger'] = new \Box_Log();
         $di['config'] = array('salt' => '');
+        $di['mod_service'] = $di->protect(function () use ($staffMock) {
+            return $staffMock;
+        });
 
         $serviceMock->setDi($di);
         $result = $serviceMock->setConfig($data);

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -690,9 +690,6 @@ class ServiceTest extends \BBTestCase {
         $serviceMock->expects($this->atLeastOnce())
             ->method('getConfig')
             ->will($this->returnValue(array()));
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getCoreAndActiveModulesAndPermissions')
-            ->will($this->returnValue(array()));
 
         $toolsMock = $this->getMockBuilder(\FOSSBilling\Tools::class)->getMock();
 
@@ -714,6 +711,9 @@ class ServiceTest extends \BBTestCase {
 
         $staffMock = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
 
+        $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
+        $modMock->expects($this->atLeastOnce())->method('getCoreModules')->willReturn([]);
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['tools'] = $toolsMock;
@@ -721,6 +721,9 @@ class ServiceTest extends \BBTestCase {
         $di['events_manager'] = $eventMock;
         $di['logger'] = new \Box_Log();
         $di['config'] = array('salt' => '');
+        $di['mod'] = $di->protect(function () use ($modMock) {
+            return $modMock;
+         });
         $di['mod_service'] = $di->protect(function () use ($staffMock) {
             return $staffMock;
         });

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -153,6 +153,18 @@ class ServiceTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions');
 
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock->expects($this->atLeastOnce())
+                ->method('getSpecificModulePermissions')
+                ->willReturn([]);
+    
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
+            return $extensionServiceMock;
+        });
+    
+        $serviceMock->setDi($di);
+    
         $result = $serviceMock->hasPermission($member, 'example');
         $this->assertFalse($result);
     }
@@ -171,6 +183,17 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('cart' => array(), 'client' => array())));
 
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock->expects($this->atLeastOnce())
+            ->method('getSpecificModulePermissions')
+            ->willReturn([]);
+        
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
+            return $extensionServiceMock;
+        });
+        
+        $serviceMock->setDi($di);
 
         $result = $serviceMock->hasPermission($member, 'example');
         $this->assertFalse($result);
@@ -190,6 +213,17 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('example' => array(), 'client' => array())));
 
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock->expects($this->atLeastOnce())
+            ->method('getSpecificModulePermissions')
+            ->willReturn([]);
+            
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
+            return $extensionServiceMock;
+        });
+
+        $serviceMock->setDi($di);
 
         $result = $serviceMock->hasPermission($member, 'example', 'get_list');
         $this->assertFalse($result);

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -157,7 +157,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions');
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
@@ -187,7 +187,7 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('cart' => array(), 'client' => array())));
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
@@ -217,7 +217,7 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('example' => array(), 'client' => array())));
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
@@ -977,7 +977,7 @@ class ServiceTest extends \BBTestCase
             ->method('store');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1009,7 +1009,7 @@ class ServiceTest extends \BBTestCase
             ->method('trash');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1062,7 +1062,7 @@ class ServiceTest extends \BBTestCase
         $profileService = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1119,7 +1119,7 @@ class ServiceTest extends \BBTestCase
             ->with($data['password']);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1178,7 +1178,7 @@ class ServiceTest extends \BBTestCase
             ->with($data['password']);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1313,7 +1313,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($newGroupId));
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1364,7 +1364,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(0));
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1387,7 +1387,7 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel->id = 1;
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1408,7 +1408,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue(2));
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1433,7 +1433,7 @@ class ServiceTest extends \BBTestCase
             ->method('store');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1557,7 +1557,7 @@ class ServiceTest extends \BBTestCase
             ->will($this->returnValue($pdoStatementMock));
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->setMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(array('hasPermission'))->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -195,25 +195,6 @@ class ServiceTest extends \BBTestCase
         $this->assertFalse($result);
     }
 
-    public function testhasPermissionRoleStaffWithGoodPerms()
-    {
-        $member = new \Model_Admin();
-        $member->loadBean(new \DummyBean());
-        $member->role = 'staff';
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
-            ->onlyMethods(array('getPermissions'))
-            ->getMock();
-
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getPermissions')
-            ->will($this->returnValue(array('example' => array('get_list'), 'client' => array())));
-
-
-        $result = $serviceMock->hasPermission($member, 'example', 'get_list');
-        $this->assertTrue($result);
-    }
-
     public function testonAfterClientReplyTicket()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -157,7 +157,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions');
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
@@ -187,7 +187,7 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('cart' => array(), 'client' => array())));
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
@@ -217,7 +217,7 @@ class ServiceTest extends \BBTestCase
             ->method('getPermissions')
             ->will($this->returnValue(array('example' => array(), 'client' => array())));
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -4,12 +4,16 @@ namespace Box\Mod\Staff;
 
 class PdoMock extends \PDO
 {
-    public function __construct() { }
+    public function __construct()
+    {
+    }
 }
 
 class PdoStatementMock extends \PDOStatement
 {
-    public function __construct() { }
+    public function __construct()
+    {
+    }
 }
 
 class ServiceTest extends \BBTestCase
@@ -155,16 +159,16 @@ class ServiceTest extends \BBTestCase
 
         $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Order\Extension')->setMethods(array('getSpecificModulePermissions'))->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
-                ->method('getSpecificModulePermissions')
-                ->willReturn([]);
-    
+            ->method('getSpecificModulePermissions')
+            ->willReturn([]);
+
         $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
             return $extensionServiceMock;
         });
-    
+
         $serviceMock->setDi($di);
-    
+
         $result = $serviceMock->hasPermission($member, 'example');
         $this->assertFalse($result);
     }
@@ -187,12 +191,12 @@ class ServiceTest extends \BBTestCase
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
-        
+
         $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
             return $extensionServiceMock;
         });
-        
+
         $serviceMock->setDi($di);
 
         $result = $serviceMock->hasPermission($member, 'example');
@@ -217,7 +221,7 @@ class ServiceTest extends \BBTestCase
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
-            
+
         $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function () use ($extensionServiceMock) {
             return $extensionServiceMock;
@@ -819,19 +823,23 @@ class ServiceTest extends \BBTestCase
             array(
                 array(),
                 'SELECT * FROM admin',
-                array()),
+                array()
+            ),
             array(
                 array('search' => 'keyword'),
                 '(name LIKE :name OR email LIKE :email )',
-                array(':name' => '%keyword%', ':email' => '%keyword%')),
+                array(':name' => '%keyword%', ':email' => '%keyword%')
+            ),
             array(
                 array('status' => 'active'),
                 'status = :status',
-                array(':status' => 'active')),
+                array(':status' => 'active')
+            ),
             array(
                 array('no_cron' => 'true'),
                 'role != :role',
-                array(':role' => \Model_Admin::ROLE_CRON)),
+                array(':role' => \Model_Admin::ROLE_CRON)
+            ),
         );
     }
 
@@ -968,15 +976,20 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
         $di['db']             = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->update($adminModel, $data);
+        $result = $serviceMock->update($adminModel, $data);
         $this->assertTrue($result);
     }
 
@@ -995,15 +1008,20 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
         $di['db']             = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->delete($adminModel);
+        $result = $serviceMock->delete($adminModel);
         $this->assertTrue($result);
     }
 
@@ -1043,6 +1061,12 @@ class ServiceTest extends \BBTestCase
 
         $profileService = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
@@ -1050,10 +1074,9 @@ class ServiceTest extends \BBTestCase
         $di['password']       = $passwordMock;
         $di['mod_service'] = $di->protect(fn() => $profileService);
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->changePassword($adminModel, $plainTextPassword);
+        $result = $serviceMock->changePassword($adminModel, $plainTextPassword);
         $this->assertTrue($result);
     }
 
@@ -1095,17 +1118,23 @@ class ServiceTest extends \BBTestCase
             ->method('hashIt')
             ->with($data['password']);
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
         $di['db']             = $dbMock;
         $di['mod_service']    = $di->protect(fn() => $systemServiceMock);
+
         $di['password']       = $passwordMock;
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->create($data);
+        $result = $serviceMock->create($data);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
     }
@@ -1148,20 +1177,26 @@ class ServiceTest extends \BBTestCase
             ->method('hashIt')
             ->with($data['password']);
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                   = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
         $di['logger']         = $logMock;
         $di['db']             = $dbMock;
         $di['mod_service']    = $di->protect(fn() => $systemServiceMock);
+
         $di['password']       = $passwordMock;
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(788954);
         $this->expectExceptionMessage(sprintf('Staff member with email %s is already registered', $data['email']));
-        $service->create($data);
+        $serviceMock->create($data);
     }
 
     public function testcreateAdmin()
@@ -1277,15 +1312,20 @@ class ServiceTest extends \BBTestCase
             ->method('store')
             ->will($this->returnValue($newGroupId));
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di                = new \Pimple\Container();
         $di['db']          = $dbMock;
         $di['logger']      = new \Box_Log();
         $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->createGroup('new_group_name');
+        $result = $serviceMock->createGroup('new_group_name');
         $this->assertIsInt($result);
         $this->assertEquals($newGroupId, $result);
     }
@@ -1323,14 +1363,19 @@ class ServiceTest extends \BBTestCase
             ->method('getCell')
             ->will($this->returnValue(0));
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di           = new \Pimple\Container();
         $di['db']     = $dbMock;
         $di['logger'] = new \Box_Log();
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
-        $result = $service->deleteGroup($adminGroupModel);
+        $result = $serviceMock->deleteGroup($adminGroupModel);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
@@ -1341,11 +1386,15 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel->loadBean(new \DummyBean());
         $adminGroupModel->id = 1;
 
-        $service = new \Box\Mod\Staff\Service();
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Administrators group can not be removed');
-        $service->deleteGroup($adminGroupModel);
+        $serviceMock->deleteGroup($adminGroupModel);
     }
 
     public function testdeleteGroupGroupHasMembers()
@@ -1358,15 +1407,20 @@ class ServiceTest extends \BBTestCase
             ->method('getCell')
             ->will($this->returnValue(2));
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di       = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Can not remove group which has staff members');
-        $service->deleteGroup($adminGroupModel);
+        $serviceMock->deleteGroup($adminGroupModel);
     }
 
     public function testupdateGroup()
@@ -1378,15 +1432,20 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
+
         $di           = new \Pimple\Container();
         $di['db']     = $dbMock;
         $di['logger'] = new \Box_Log();
 
-        $service = new \Box\Mod\Staff\Service();
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
         $data   = array('name' => 'OhExampleName');
-        $result = $service->updateGroup($adminGroupModel, $data);
+        $result = $serviceMock->updateGroup($adminGroupModel, $data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
@@ -1397,15 +1456,18 @@ class ServiceTest extends \BBTestCase
             array(
                 array(),
                 'SELECT m.*, a.email, a.name',
-                array()),
+                array()
+            ),
             array(
                 array('search' => 'keyword'),
                 'a.name LIKE :name OR a.id LIKE :id OR a.email LIKE :email',
-                array('name' => '%keyword%', 'id' => '%keyword%', 'email' => '%keyword%')),
+                array('name' => '%keyword%', 'id' => '%keyword%', 'email' => '%keyword%')
+            ),
             array(
                 array('admin_id' => '2'),
                 'm.admin_id = :admin_id',
-                array('admin_id' => '2')),
+                array('admin_id' => '2')
+            ),
         );
     }
 
@@ -1494,14 +1556,18 @@ class ServiceTest extends \BBTestCase
             ->method('prepare')
             ->will($this->returnValue($pdoStatementMock));
 
-        $service = new \Box\Mod\Staff\Service();
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
+            ->setMethods(array('hasPermission'))->getMock();
+
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')->willReturn(true);
 
         $di        = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
-        $service->setDi($di);
+        $serviceMock->setDi($di);
 
         $member_id = 1;
-        $result    = $service->setPermissions($member_id, array());
+        $result    = $serviceMock->setPermissions($member_id, array());
         $this->assertTrue($result);
     }
 

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -130,7 +130,7 @@ class ServiceTest extends \BBTestCase
 
     public function testhasPermissionRoleAdmin()
     {
-        $member = new \Model_Client();
+        $member = new \Model_Admin();
         $member->loadBean(new \DummyBean());
         $member->role = 'admin';
 
@@ -142,7 +142,7 @@ class ServiceTest extends \BBTestCase
 
     public function testhasPermissionRoleStaffWithEmptyPerms()
     {
-        $member = new \Model_Client();
+        $member = new \Model_Admin();
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
@@ -159,7 +159,7 @@ class ServiceTest extends \BBTestCase
 
     public function testhasPermissionRoleStaffWithNoPerm()
     {
-        $member = new \Model_Client();
+        $member = new \Model_Admin();
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
@@ -178,7 +178,7 @@ class ServiceTest extends \BBTestCase
 
     public function testhasPermissionRoleStaffWithNoMethodPerm()
     {
-        $member = new \Model_Client();
+        $member = new \Model_Admin();
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
@@ -197,7 +197,7 @@ class ServiceTest extends \BBTestCase
 
     public function testhasPermissionRoleStaffWithGoodPerms()
     {
-        $member = new \Model_Client();
+        $member = new \Model_Admin();
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 

--- a/tests/modules/System/Api/AdminTest.php
+++ b/tests/modules/System/Api/AdminTest.php
@@ -164,26 +164,4 @@ class AdminTest extends \BBTestCase {
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
-
-    public function testclear_cache()
-    {
-        $data = array();
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('clearCache')
-            ->will($this->returnValue(true));
-
-        $this->api->setService($serviceMock);
-
-        $result = $this->api->clear_cache();
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
-
-
-
-
 }
-


### PR DESCRIPTION
Relates to, but won't fully close out #1050 as this PR won't implement group-level permissions.

# TODO List

There's more todo than below, however despite a ~1 month break away from this PR I am still feeling completely burnt out on it. In terms of the basic implementation I think it's done reasonably well and the base-line technical requirements are there.

We have a good handful of starting permissions added, modules which don't need to have permissions are correctly hidden from the list, and many of our modules are set to be always accessible to help prevent someone getting the permissions wrong and causing the system to be broken for a given user.

I think it's a fairly decent starting place that can be built on over time.

- [x] Implemented a way for each module to define their permissions.
- [x] Boolean (on/off) permission support.
- [x] Drop-down "select" permissions where a module can check if a user has a specific permission given from the drop-down.
- [x] Calls a module's `setDi` method before `getModulePermissions`, so modules can actually use that to read from the DB, perform actions, and dynamically build their permissions list.
- [x] Our default modules are hidden from the list when needed.
- [x] Where needed, our modules have access permissions permanently enabled.
- [x] FOSSBilling automatically generates a "module access" permission key for all modules.

## Implemented Module Permissions

### Activity
- [x] Delete activity

### Currency
- [x] Manage settings

### Email
- [x] Manage settings

### Extension
- [x] Manage extensions

### Staff
- [x] Create and edit administrators
- [x] Delete administrators
- [x] Reset administrator passwords
- [x] Create and edit staff members
- [x] Delete staff members
- [x] Reset staff passwords
- [x] Manage groups     

### System
- [x] Manage company details
- [x] Manage company legal
- [x] Invalidate cache
- [x] Update FOSSBilling

## Documentation
- [Example module PR](https://github.com/FOSSBilling/example-module/pull/3)
- [Website documentation](https://github.com/FOSSBilling/fossbilling.org/pull/138)

## Screenshot of the permissions list in the UI
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/0ed105a8-2742-4314-986a-3d1610d9a28c)
