### PR TITLE
Password reset fix

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -218,7 +218,7 @@ class Guest extends \Api_Abstract
         $email['code'] = 'mod_client_password_reset_approve';
         $email['password'] = $new_pass;
         $emailService = $this->di['mod_service']('email');
-        $emailService->sendTemplate($email);
+        $emailService->sendTemplate($email, true);
 
         $this->di['db']->trash($reset);
         $this->di['logger']->info('Client password reset request was approved');

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -122,7 +122,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->di['tools']->decodeJ($json);
     }
 
-    public function sendTemplate($data)
+    public function sendTemplate($data, $noadmin = false)
     {
         $required = [
             'code' => 'Template code not passed',
@@ -181,7 +181,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
         $systemService = $this->di['mod_service']('system');
 
-        [$subject, $content] = $this->_parse($t, $vars);
+        [$subject, $content] = $this->_parse($t, $vars, $noadmin);
         $from = $data['from'] ?? $systemService->getParamValue('company_email');
         $from_name = $data['from_name'] ?? $systemService->getParamValue('company_name');
         $sent = false;

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -181,7 +181,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
         $systemService = $this->di['mod_service']('system');
 
-        [$subject, $content] = $this->_parse($t, $vars, $noadmin);
+        [$subject, $content] = $this->_parse($t, $vars, $no_admin);
         $from = $data['from'] ?? $systemService->getParamValue('company_email');
         $from_name = $data['from_name'] ?? $systemService->getParamValue('company_name');
         $sent = false;
@@ -298,11 +298,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $str;
     }
 
-    private function _parse(\Model_EmailTemplate $t, $vars, $noadmin = false)
+    private function _parse(\Model_EmailTemplate $t, $vars, $no_admin = false)
     {
         $systemService = $this->di['mod_service']('System');
-        $pc = $systemService->renderString($t->content, false, $vars, $noadmin);
-        $ps = $systemService->renderString($t->subject, false, $vars, $noadmin);
+        $pc = $systemService->renderString($t->content, false, $vars, $no_admin);
+        $ps = $systemService->renderString($t->subject, false, $vars, $no_admin);
 
         return [$ps, $pc];
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -298,11 +298,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $str;
     }
 
-    private function _parse(\Model_EmailTemplate $t, $vars)
+    private function _parse(\Model_EmailTemplate $t, $vars, $noadmin = false)
     {
         $systemService = $this->di['mod_service']('System');
-        $pc = $systemService->renderString($t->content, false, $vars);
-        $ps = $systemService->renderString($t->subject, false, $vars);
+        $pc = $systemService->renderString($t->content, false, $vars, $noadmin);
+        $ps = $systemService->renderString($t->subject, false, $vars, $noadmin);
 
         return [$ps, $pc];
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -122,7 +122,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->di['tools']->decodeJ($json);
     }
 
-    public function sendTemplate($data, $noadmin = false)
+    public function sendTemplate($data, $no_admin = false)
     {
         $required = [
             'code' => 'Template code not passed',

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -308,7 +308,7 @@ class Service
         return false;
     }
 
-    public function renderString($tpl, $try_render, $vars, $noadmin = false)
+    public function renderString($tpl, $try_render, $vars, $no_admin = false)
     {
         $twig = $this->di['twig'];
         // add client api if _client_id is set

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -308,7 +308,7 @@ class Service
         return false;
     }
 
-    public function renderString($tpl, $try_render, $vars)
+    public function renderString($tpl, $try_render, $vars, $noadmin = false)
     {
         $twig = $this->di['twig'];
         // add client api if _client_id is set
@@ -321,7 +321,7 @@ class Service
                     error_log('api_client could not be added to template: ' . $e->getMessage());
                 }
             }
-        } else {
+        } else if(!$noadmin) {
             // attempt adding admin api to twig
             try {
                 $twig->addGlobal('admin', $this->di['api_admin']);

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -321,7 +321,7 @@ class Service
                     error_log('api_client could not be added to template: ' . $e->getMessage());
                 }
             }
-        } else if(!$noadmin) {
+        } else if(!$no_admin) {
             // attempt adding admin api to twig
             try {
                 $twig->addGlobal('admin', $this->di['api_admin']);


### PR DESCRIPTION
This fixes an issue with the password reset. There is probably a better way, but I don't understand the system well enough yet. However, I did need this working on my production system, so I wanted to create the pull request just in case the solution is sufficient. 

The problem is the function _parse() in src/modules/System/Service.php tries to add the admin API to all requests. This attempt to add the API will result in the user being redirected to the admin login if the request is not an API request and if the user is not an admin. What I was seeing is when a user clicked on the password reset confirmation link, they were redirected to the admin login. 

Thanks. 