### PR TITLE
Fix missing allow paths in our htaccess

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -20,7 +20,7 @@ Options -Indexes +SymLinksIfOwnerMatch
     RewriteRule ^bb-ipn\.php$ /ipn.php [L]
 
     # Allow access to the index.php and ipn.php files.
-    RewriteCond %{REQUEST_URI} ^/(index|ipn)\.php [NC]
+    RewriteCond %{REQUEST_URI} ^/(install\.php|ipn\.php|install/index\.php|install/install\.php) [NC]
     RewriteRule ^ - [L]
 
     # Block direct access to sensitive files and file types.

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -19,8 +19,8 @@ Options -Indexes +SymLinksIfOwnerMatch
     # Alias from bb-ipn.php to ipn.php for those who have upgraded from BoxBilling.
     RewriteRule ^bb-ipn\.php$ /ipn.php [L]
 
-    # Allow access to the index.php and ipn.php files.
-    RewriteCond %{REQUEST_URI} ^/(install\.php|ipn\.php|install/index\.php|install/install\.php) [NC]
+    # Allow access to the index.php, ipn.php, /install/index.php, and /install/install.php files.
+    RewriteCond %{REQUEST_URI} ^/(index\.php|ipn\.php|install/index\.php|install/install\.php) [NC]
     RewriteRule ^ - [L]
 
     # Block direct access to sensitive files and file types.


### PR DESCRIPTION
Edit: this actually breaks everything except the specified file. I'll mark this as ready for review once it's working correctly

Fixes the installation issue as described in #1583 by adding in the missing allow for `/install/index.php` and `/install/install.php`