### PR TITLE
Implement warnings about major and minor updates

### DIFF
--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -66,6 +66,17 @@ class Update implements InjectionAwareInterface
     }
 
     /**
+     * Gets what type of update is available (Major, minor, or patch)
+     *
+     * @return int And int from 0-2 representing the patch type
+     */
+    public function getUpdateType(): int
+    {
+        $updateBranch = $this->getUpdateBranch();
+        return $this->getLatestVersionInfo($updateBranch)['update_type'];
+    }
+
+    /**
      * Returns information about the latest version of the specified branch.
      *
      * @param string $branch The branch to return the latest information for;
@@ -89,6 +100,7 @@ class Update implements InjectionAwareInterface
                 'version' => Version::VERSION,
                 'download_url' => $downloadUrl,
                 'release_notes' => "Release notes are not available for the preview branch. You can check the latest changes on our [GitHub]($compareLink) repository.",
+                'update_type' => 0,
             ];
         } else {
             return $this->di['cache']->get("Update.latest_{$branch}_version_info", function (ItemInterface $item) {
@@ -109,6 +121,7 @@ class Update implements InjectionAwareInterface
                     'download_url' => $releaseInfo['assets'][0]['browser_download_url'],
                     'release_date' => $releaseInfo['published_at'],
                     'release_notes' => $releaseInfo['body'] ?: '**Error: Release notes unavailable.**',
+                    'update_type' => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
                 ];
             });
         }

--- a/src/library/FOSSBilling/Version.php
+++ b/src/library/FOSSBilling/Version.php
@@ -13,6 +13,9 @@ namespace FOSSBilling;
 final class Version
 {
     public const VERSION = '0.0.1';
+    public const PATCH = 0;
+    public const MINOR = 1;
+    public const MAJOR = 2;
 
     /**
      * Compare the specified FOSSBilling version string $version
@@ -27,5 +30,30 @@ final class Version
     public static function compareVersion(string $version): int
     {
         return version_compare(strtolower($version), strtolower(self::VERSION));
+    }
+
+    // Used to compare two different FOSSBilling versions to determine if updating between them is considered a major, minor, or a patch update.
+    public static function getUpdateType(string $new, ?string $current = null): int
+    {
+        $current = explode('.', $current ?? self::VERSION);
+        $new = explode('.', $new);
+
+        if (intval($new[0]) === 0) {
+            // We are still in pre-release status, so handle the version increments differently
+            if ($new[1] !== $current[1]) {
+                return self::MAJOR;
+            } else {
+                return self::MINOR;
+            }
+        } else {
+            // We aren't in pre-production anymore, so treat it using normal semver practices
+            if ($new[0] !== $current[0]) {
+                return self::MAJOR;
+            } elseif ($new[1] !== $current[1]) {
+                return self::MINOR;
+            } else {
+                return self::PATCH;
+            }
+        }
     }
 }

--- a/src/library/FOSSBilling/Version.php
+++ b/src/library/FOSSBilling/Version.php
@@ -32,7 +32,13 @@ final class Version
         return version_compare(strtolower($version), strtolower(self::VERSION));
     }
 
-    // Used to compare two different FOSSBilling versions to determine if updating between them is considered a major, minor, or a patch update.
+    /**
+     * Used to compare two different FOSSBilling versions to determine if updating between them is considered a major, minor, or a patch update.
+     * 
+     * @param string $new The new FOSSBilling version to compare against
+     * @param null|string $current (optional) Defaults to the current version, however you can override it if you wanted / needed
+     * @return int 0-2 to indicate the type of update.
+     */
     public static function getUpdateType(string $new, ?string $current = null): int
     {
         $current = explode('.', $current ?? self::VERSION);

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -155,6 +155,18 @@ class Admin extends \Api_Abstract
     }
 
     /**
+     * Gets the update type.
+     *
+     * @return int
+     */
+    public function update_type()
+    {
+        $updater = $this->di['updater'];
+
+        return $updater->getUpdateType();
+    }
+
+    /**
      * Update FOSSBilling core.
      *
      * @return bool

--- a/src/modules/System/html_admin/mod_system_update.html.twig
+++ b/src/modules/System/html_admin/mod_system_update.html.twig
@@ -5,6 +5,7 @@
 {% block meta_title %}{{ 'Update'|trans }}{% endblock %}
 
 {% block content %}
+    {% set update_type = admin.system_update_type %}
     <div class="card">
         <div class="card-header">
             <h3 class="card-title">Update</h3>
@@ -12,6 +13,19 @@
         <div class="card-body">
             <h3 class="card-title">{{ 'Automatic Update'|trans }}</h3>
             <p class="card-subtitle">{{ 'The automatic updater is a one-click tool for updating FOSSBilling. PHP must be able to write to the directory where FOSSBilling is installed.'|trans }}</p>
+
+            {% if update_type == 2 %}
+                <div class="alert alert-danger" role="alert">
+                    <span>{{ 'This update is considered to be a major update, you should check the release notes for any breaking changes.'|trans }}</span>
+                </div>
+            {% endif %}
+
+            {% if update_type == 1 %}
+                <div class="alert alert-warning" role="alert">
+                    <span>{{ 'This update is considered to be a minor update, there are low chances of incompatibilities.'|trans }}</span>
+                </div>
+            {% endif %}
+
             {{ admin.system_release_notes|markdown }}
             <a href="{{ 'api/admin/system/update_core'|link({ 'CSRFToken': CSRFToken }) }}"
             class="btn btn-primary api-link"


### PR DESCRIPTION
This PR implements a simple alert dialog for both major and minor updates to help inform the system administrator of when an update may introduce backwards compatibility issue.

While FOSSBilling is considered per-production, all changes will be considered to be at least a minor patch, however once we hit version 1.0.0 it will automatically begin to follow correct semver practices of `MAJOR`.`MINOR`.`PATCH`.

## Major
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/02029913-6b2a-428e-8b29-5e86c5259e6d)


## Minor
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/4ecb4e86-c717-475f-b2d0-45800d0ae7ec)
