### PR TITLE
Improve color-picker design

### DIFF
--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -82,24 +82,18 @@
                             <div class="row mb-3">
                                 <label class="col-sm-4 col-md-3 col-form-label">Sizing</label>
                                 <div class="col-sm-7 col-md-6">
-                                    <div class="row">
-                                        <div class="col row">
+                                    <div class="row mb-2">
+                                        <div class="col">
                                             <label class="col-form-label" for="popup_width">{{ 'Width'|trans }}</label>
-                                        </div>
-                                        <div class="col row">
-                                            <label class="col-form-label" for="popup_width">{{ 'Border radius'|trans }}</label>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col row">
                                             <div class="input-group mb-2">
-                                                <input type="text" class="form-control" name="popup_width" id="popup_width" value="{{ params.popup_width | default(600) }}" placeholder="600">
+                                                <input class="form-control" type="text" name="popup_width" id="popup_width" value="{{ params.popup_width | default(600) }}" placeholder="600">
                                                 <span class="input-group-text">px</span>
                                             </div>
                                         </div>
-                                        <div class="col row">
+                                        <div class="col">
+                                            <label class="col-form-label" for="border-radius">{{ 'Border radius'|trans }}</label>
                                             <div class="input-group mb-2">
-                                                <input class="form-control" type="text" name="border_radius" value="{{ params.border_radius | default('0') }}" size="3" id="border-radius">
+                                                <input class="form-control" type="text" name="border_radius" value="{{ params.border_radius | default('0') }}" id="border-radius">
                                                 <span class="input-group-text">px</span>
                                             </div>
                                         </div>
@@ -110,22 +104,16 @@
                             <div class="row mb-3">
                                 <label class="col-sm-4 col-md-3 col-form-label">Background</label>
                                 <div class="col-sm-7 col-md-6">
-                                    <div class="row">
-                                        <div class="col row">
+                                    <div class="row mb-2">
+                                        <div class="col">
                                             <label class="col-form-label" for="coloris-picker">{{ 'Color'|trans }}</label>
-                                        </div>
-                                        <div class="col row">
-                                            <label class="col-form-label" for="background_opacity">{{ 'Opacity'|trans }}</label>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col row">
-                                            <div class="input-group mb-2">
+                                            <div>
                                                 <input type="text" class="form-control" name="background_color"
                                                        id="coloris-picker" value="{{ params.background_color | default('#000000') }}">
                                             </div>
                                         </div>
-                                        <div class="col row">
+                                        <div class="col">
+                                            <label class="col-form-label" for="background_opacity">{{ 'Opacity'|trans }}</label>
                                             <div class="input-group mb-2">
                                                 <input type="text" class="form-control" name="background_opacity"
                                                        id="background_opacity" value="{{ params.background_opacity | default(50) }}">

--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -20,8 +20,7 @@ globalThis.$ = globalThis.jQuery = $;
 init();
 coloris({
   el: '#coloris-picker',
-  alpha: false,
-  themeMode: localStorage.getItem('theme')
+  alpha: false
 });
 
 

--- a/src/themes/admin_default/assets/scss/fossbilling.scss
+++ b/src/themes/admin_default/assets/scss/fossbilling.scss
@@ -1,5 +1,6 @@
 @import "~@tabler/core/src/scss/tabler";
 @import "~@tabler/core/src/scss/vendor/_litepicker.scss";
+@import "~@tabler/core/src/scss/vendor/_coloris.scss";
 @import "flags";
 @import "~tom-select/dist/css/tom-select.bootstrap5.css";
 @import "theme_settings";
@@ -68,14 +69,6 @@
 @media (max-width: 320px) {
     .js-theme-toggler {
         display: none;
-    }
-}
-
-.clr-field {
-    display: flex;
-    width: 100%;
-    button {
-        border-radius: 0 4px 4px 0;
     }
 }
 


### PR DESCRIPTION
Tabler has added Coloris in their latest release of `1.0.0-beta20`. This PR improves the color picker design by using Tabler's CSS and fixes nearby input grouping.

 Before | After
-|-
<img width="529" alt="coloris-old" src="https://github.com/FOSSBilling/FOSSBilling/assets/11484121/4436819a-14d2-4255-a1b7-c772de0229ae"> | <img width="529" alt="coloris-new" src="https://github.com/FOSSBilling/FOSSBilling/assets/11484121/a7403d16-974e-4b6a-8249-f554a425abff">
<img width="529" alt="coloris-old-dark" src="https://github.com/FOSSBilling/FOSSBilling/assets/11484121/8298d177-27f8-408f-8bcf-2877f022b76e"> | <img width="529" alt="coloris-new-dark" src="https://github.com/FOSSBilling/FOSSBilling/assets/11484121/8e54645d-4fe6-4f5c-bd75-89a112b30431">
