### PR TITLE
#1342 Fix Email Queue

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -215,9 +215,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function sendMail($to, $from, $subject, $content, $to_name = null, $from_name = null, $client_id = null, $admin_id = null)
     {
-        $email = $this->_queue($to, $from, $subject, $content, $to_name, $from_name, $client_id, $admin_id);
-        $this->_sendFromQueue($email);
+        // Store message into the queue. Return `false` if we get no output.
+        if (! $this->_queue($to, $from, $subject, $content, $to_name, $from_name, $client_id, $admin_id)) return false;
 
+        // Email queued successfully.
         return true;
     }
 


### PR DESCRIPTION
This ended up being a one line fix and more simple than anticipated. I adjusted formatting and added comments for readability. Possibly a past oversight.

Closes #1342

The send function was properly storing into the queue, then immediately processing the message from the queue. I removed the `_sendFromQueue()` call and then observed normal sending behavior on the next manual cron run.

This fix will make all mails queue to be later sent by the cron, including order activation emails. They all call back to `sendTemplate()`, which is what was mistakenly later sending instead of just queuing and moving on... causing the user experience delay.

The `$email` reference was never used, so I removed it.

Disclaimer: I am new to the code base, so I may have overlooked something not yet obvious to me.

# Response Time Comparison

![image](https://github.com/FOSSBilling/FOSSBilling/assets/104653539/7b2541a4-8ae2-48ad-878f-87892eef2db8)

# Cron Test

![image](https://github.com/FOSSBilling/FOSSBilling/assets/104653539/ce1ab14f-3729-4ad7-ab49-24b39b6e2a0b)