### PR TITLE
Don't attempt to set the country with Plesk

### DIFF
--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -489,9 +489,6 @@ class Server_Manager_Plesk extends Server_Manager
             'description'       =>  "Created using FOSSBilling.",
         ];
 
-        // We don't want to send these data if they are empty. Plesk will throw an error.
-        $client->getCountry() ? $props['country'] = $client->getCountry() : null;
-
     	if ($a->getReseller()) {
     		$result = $this->_client->reseller()->create($props);
     	} else {
@@ -516,9 +513,6 @@ class Server_Manager_Plesk extends Server_Manager
     		'city'				=>	$client->getCity(),
     		'state'				=>	$client->getState(),
         ];
-
-        // Sending the country name blank causes an error. So we won't assign it to our request if it's blank.
-        $client->getCountry() ? $props['country'] = $client->getCountry() : null;
 
         return $props;
     }


### PR DESCRIPTION
A user on our discord validated that this fixes the Plesk server manager for them and allows it to function as expected.
Without this, Plesk returns an error.