### PR TITLE
Prune the filesystem cache during cron

### DIFF
--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -74,12 +74,6 @@ class Service
         $count = $this->clearOldSessions() ?? 0;
         $this->di['logger']->setChannel('cron')->info("Cleared $count outdated sessions from the database");
 
-        // Prune the FS cache
-        $cache = $this->di['cache'];
-        if($cache->prune()){
-            $this->di['logger']->setChannel('cron')->info("Pruned the filesystem cache");
-        }
-
         $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
         $this->di['logger']->setChannel('cron')->info('Finished executing cron jobs');
 

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -65,15 +65,22 @@ class Service
         $this->_exec($api, 'cart_batch_expire');
         $this->_exec($api, 'email_batch_sendmail');
 
+        // Update the last time cron was executed
         $create = (APPLICATION_ENV == 'production');
         $ss = $this->di['mod_service']('system');
         $ss->setParamValue('last_cron_exec', date('Y-m-d H:i:s'), $create);
 
+        // Purge old sessions from the DB
         $count = $this->clearOldSessions() ?? 0;
         $this->di['logger']->setChannel('cron')->info("Cleared $count outdated sessions from the database");
 
-        $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
+        // Prune the FS cache
+        $cache = $this->di['cache'];
+        if($cache->prune()){
+            $this->di['logger']->setChannel('cron')->info("Pruned the filesystem cache");
+        }
 
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
         $this->di['logger']->setChannel('cron')->info('Finished executing cron jobs');
 
         return true;

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1633,4 +1633,20 @@ class Service
 
         return true;
     }
+
+    public static function onBeforeAdminCronRun(\Box_Event $event)
+    {
+        $di = $event->getDi();
+        // Prune the FS cache
+        try {
+            $cache = $di['cache'];
+            if ($cache->prune()) {
+                $di['logger']->setChannel('cron')->info("Pruned the filesystem cache");
+            }
+        } catch (\Exception $e) {
+            error_log($e->getMessage());
+        }
+
+        return true;
+    }
 }

--- a/tests/modules/Cron/ServiceTest.php
+++ b/tests/modules/Cron/ServiceTest.php
@@ -73,6 +73,7 @@ class ServiceTest extends \BBTestCase {
         $di['mod_service'] = $di->protect(function() use($systemServiceMock) {return $systemServiceMock;});
         $serviceMock->setDi($di);
         $di['db'] = $dbMock;
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
         $di['config'] = [
             'security' => [
                 'mode' => 'strict',


### PR DESCRIPTION
Although it doesn't currently get a ton of usage, we are using [Symfony's file system cache](https://github.com/FOSSBilling/FOSSBilling/blob/main/src/di.php#L267) for caching outside of Twig.

As part of #1595 I do intend on us taking advantage of this more to reduce how frequently info that doesn't regularly change needs to be re-calculated or fetched from their source. However, this implementation doesn't have any way to prune it's cache automatically which means that a cache entry which doesn't get accessed can potentially stay on the disk until something else clears it out (during an update most likely for us).

We can pretty easily combat this by using the `prune` method they provide during scheduled tasks which will get rid of outdated cache entries for us.