### PR TITLE
Tweak the HTTPS check and secure cookie flag behavior

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -235,7 +235,10 @@ $di['session'] = function () use ($di) {
 
     $mode = $di['config']['security']['mode'] ?? 'strict';
     $lifespan = $di['config']['security']['cookie_lifespan'] ?? 7200;
-    $secure = $di['config']['security']['force_https'] ?? true;
+
+    // Mark the cookie as secure either if force HTTPS is enbled or if we can detect that HTTPS is being used.
+    $forceSSL = $di['config']['security']['force_https'] ?? true;
+    $secure = ($forceSSL || FOSSBilling\Tools::isHTTPS());
 
     $session = new \FOSSBilling\Session($handler, $mode, $lifespan, $secure);
     $session->setDi($di);

--- a/src/di.php
+++ b/src/di.php
@@ -236,7 +236,7 @@ $di['session'] = function () use ($di) {
     $mode = $di['config']['security']['mode'] ?? 'strict';
     $lifespan = $di['config']['security']['cookie_lifespan'] ?? 7200;
 
-    // Mark the cookie as secure either if force HTTPS is enbled or if we can detect that HTTPS is being used.
+    // Mark the cookie as secure either if force HTTPS is enabled or if we can detect that HTTPS is being used.
     $forceSSL = $di['config']['security']['force_https'] ?? true;
     $secure = ($forceSSL || FOSSBilling\Tools::isHTTPS());
 

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -198,14 +198,14 @@ class Tools
         if ($capitalize_first_char) {
             $str[0] = strtoupper($str[0]);
         }
-        $func = fn($c) => strtoupper($c[1]);
+        $func = fn ($c) => strtoupper($c[1]);
         return preg_replace_callback('/-([a-z])/', $func, $str);
     }
 
     public function from_camel_case($str)
     {
         $str[0] = strtolower($str[0]);
-        $func = fn($c) => "-" . strtolower($c[1]);
+        $func = fn ($c) => "-" . strtolower($c[1]);
         return preg_replace_callback('/([A-Z])/', $func, $str);
     }
 
@@ -284,5 +284,13 @@ class Tools
         }
 
         return $email;
+    }
+
+    public static function isHTTPS(): bool
+    {
+        $protocol = $_SERVER['HTTPS'] ?? $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? $_SERVER['REQUEST_SCHEME'] ?? '';
+
+        // $_SERVER['HTTPS'] will be set to `on` to indicate HTTPS and the other to will be set to `https`, so either one means we are connected via HTTPS.
+        return (strcasecmp($protocol, 'on') === 0 || strcasecmp($protocol, 'https'));
     }
 }

--- a/src/load.php
+++ b/src/load.php
@@ -98,19 +98,7 @@ function checkSSL()
 {
     $config = include PATH_CONFIG;
     if (isset($config['security']['force_https']) && $config['security']['force_https'] && 'cli' !== PHP_SAPI) {
-        $isHTTPS = false;
-
-        if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
-            $isHTTPS = true;
-        }
-        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') {
-            $isHTTPS = true;
-        }
-        if (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on') {
-            $isHTTPS = true;
-        }
-
-        if (!$isHTTPS) {
+        if (!FOSSBilling\Tools::isHTTPS()) {
             $url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
             header('Location: ' . $url);
             exit;


### PR DESCRIPTION
Minor patch to slightly improve our HTTPS check & how FOSSBilling decides to mark a cookie as secure 
1. I've added the check to our tools class so we can easily use it anywhere
2. The actual logic is quite a bit cleaner than before, and the headers it checks are more up-to-date
3. FOSSBilling will now mark cookies as secure if it's able to detect that HTTPS is being used, even if the `force_https` setting isn't enabled