### PR TITLE
Improve the behavior of the test email button

### DIFF
--- a/src/modules/Email/Api/Admin.php
+++ b/src/modules/Email/Api/Admin.php
@@ -339,7 +339,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Sends test email to admins.
+     * Sends the test email to the currently authenticated admin / staff member.
      *
      * @param type $data
      *
@@ -347,9 +347,15 @@ class Admin extends \Api_Abstract
      */
     public function send_test($data)
     {
-        $email = [];
-        $email['to_staff'] = true;
-        $email['code'] = 'mod_email_test';
+        $currentUser = $this->di['loggedin_admin'];
+
+        $email = [
+            'code' => 'mod_email_test',
+            'to' => $currentUser->email,
+            'to_name' => $currentUser->name,
+            'send_now' => true,
+            'throw_exceptions' => true,
+        ];
 
         return $this->getService()->sendTemplate($email);
     }

--- a/src/modules/Email/Api/Admin.php
+++ b/src/modules/Email/Api/Admin.php
@@ -355,6 +355,7 @@ class Admin extends \Api_Abstract
             'to_name' => $currentUser->name,
             'send_now' => true,
             'throw_exceptions' => true,
+            'staff_member_name' => $currentUser->name,
         ];
 
         return $this->getService()->sendTemplate($email);

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -134,7 +134,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
         $vars = $data;
         unset($vars['to'], $vars['to_client'], $vars['to_staff'], $vars['to_name'], $vars['from'], $vars['from_name'], $vars['to_admin']);
-        unset($vars['default_description'], $vars['default_subject'], $vars['default_template'], $vars['code']);
+        unset($vars['default_description'], $vars['default_subject'], $vars['default_template'], $vars['code'], $vars['send_now'], $vars['throw_exceptions']);
 
         $send_now = $data['send_now'] ?? false;
         $throw_exceptions = $data['throw_exceptions'] ?? false;

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -630,7 +630,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             }
 
             if($throw_exceptions){
-                // We truncate a long error messag here to ensure it won't fill the entire side of the screen.
+                // If the error message is long, truncate it and inform the user the rest is in the error log.
                 $truncated = (strlen($message) > 350) ? __trans('Error message truncated due to length, please check the error log for the complete message: ') . substr($message,0,350).'...' : $message;
                 throw new \Box_Exception($truncated);
             }

--- a/src/modules/Email/html_admin/mod_email_settings.html.twig
+++ b/src/modules/Email/html_admin/mod_email_settings.html.twig
@@ -289,7 +289,7 @@
                                 <svg class="icon">
                                     <use xlink:href="#wifi" />
                                 </svg>
-                                {{ 'Send test email to staff members'|trans }}
+                                {{ 'Send a test email to yourself'|trans }}
                             </button>
                             <input type="submit" value="{{ 'Update email settings'|trans }}" class="btn btn-primary">
                         </div>
@@ -306,6 +306,9 @@ $(function() {
     $('#emailTest').on('click', function() {
         API.admin.post('email/send_test', {}, function(result) {
             FOSSBilling.message("{{ 'Email was successfully sent'|trans }}");
+        },
+        function(result){
+            FOSSBilling.message(result.message, 'error');
         });
 
         return false;

--- a/src/modules/Email/html_email/mod_email_test.html.twig
+++ b/src/modules/Email/html_email/mod_email_test.html.twig
@@ -36,7 +36,7 @@
 </head>
 <body>
 	<h1>Test email from [{{ guest.system_company.name }}]</h1>
-	<p>Hi {{ staff.name }},</p>
+	<p>Hi {{ to.name }},</p>
 	<p>If you are reading this email, FOSSBilling is <strong>configured properly</strong> and is <strong>able to send emails</strong>.</p>
 	<p class="signature">{{ guest.system_company.signature }}</p>
 </body>

--- a/src/modules/Email/html_email/mod_email_test.html.twig
+++ b/src/modules/Email/html_email/mod_email_test.html.twig
@@ -36,7 +36,7 @@
 </head>
 <body>
 	<h1>Test email from [{{ guest.system_company.name }}]</h1>
-	<p>Hi {{ to.name }},</p>
+	<p>Hi {{ staff_member_name }},</p>
 	<p>If you are reading this email, FOSSBilling is <strong>configured properly</strong> and is <strong>able to send emails</strong>.</p>
 	<p class="signature">{{ guest.system_company.signature }}</p>
 </body>


### PR DESCRIPTION
Somewhat a followup to #1592, however ultimately the goal is to fix issues with this button that existed before this PR was merged.

1. Instead of sending the test email to **all** staff members, it now only sends it to the staff member who made the request.
2. Under normal conditions any exceptions during the send process are caught and then silently logged, but this resulted in the test button always returning a success. This PR changes that behavior so that the test email will throw exceptions and they are also truncated (the mailer package throws some very long exceptions).
3. After #1592 the test email was also put into the queue, I've modified the behavior so it's sent instantly instead, that way we can actually give feedback to the user.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/3d6662c9-8761-48a4-83f9-40fc58b9a2e1)
