### PR TITLE
Adjust Recurrent Product Pricing UI Behavior

### DIFF
--- a/src/themes/admin_default/html/partial_pricing.html.twig
+++ b/src/themes/admin_default/html/partial_pricing.html.twig
@@ -66,7 +66,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][1W][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1W][enabled]" value="1"{% if product.pricing.recurrent['1W'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1W][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['1W'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -82,7 +82,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][1M][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1M][enabled]" value="1"{% if product.pricing.recurrent['1M'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1M][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['1M'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -100,7 +100,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][3M][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][3M][enabled]" value="1"{% if product.pricing.recurrent['3M'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][3M][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['3M'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -118,7 +118,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][6M][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][6M][enabled]" value="1"{% if product.pricing.recurrent['6M'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][6M][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['6M'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -134,7 +134,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][1Y][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1Y][enabled]" value="1"{% if product.pricing.recurrent['1Y'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][1Y][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['1Y'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -152,7 +152,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][2Y][enabled]" value="0">
-                <input class="form-check-input" type="checkbox" name="pricing[recurrent][2Y][enabled]" value="1"{% if product.pricing.recurrent['2Y'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][2Y][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['2Y'].enabled) %} checked{% endif %}>
             </td>
         </tr>
         <tr>
@@ -170,7 +170,7 @@
             </td>
             <td>
                 <input type="hidden" name="pricing[recurrent][3Y][enabled]" value="0">
-                <input class="form-check-input"type="checkbox" name="pricing[recurrent][3Y][enabled]" value="1"{% if product.pricing.recurrent['3Y'].enabled %} checked{% endif %}>
+                <input class="form-check-input" type="checkbox" name="pricing[recurrent][3Y][enabled]" value="1"{% if (product.pricing.type == 'recurrent') and (product.pricing.recurrent['3Y'].enabled) %} checked{% endif %}>
             </td>
         </tr>
     </tbody>
@@ -178,15 +178,29 @@
 
 <script>
     $(function() {
+        // Self-triggers to loop each input box and sets the default total values.
         $('input.price:not(:disabled)').keyup(function() {
             var row = $(this).parents('tr:first');
             var s = row.find('input.setup_price').val();
             var p = row.find('input.bill_price').val();
             var total = countTotal(p, s);
             var elem = row.find('input.total');
-
             elem.val(total);
         }).trigger('keyup');
+
+        // Triggers on input change to toggle checkbox if total is above zero.
+        $('input.price:not(:disabled)').change(function() {
+            var row = $(this).parents('tr:first');
+            var s = row.find('input.setup_price').val();
+            var p = row.find('input.bill_price').val();
+            var total = countTotal(p, s);
+            var checkbox = row.find('input.form-check-input');
+            if (total > 0) {
+                checkbox.prop('checked', true);
+            } else {
+                checkbox.prop('checked', false);
+            }
+        });
 
         $('.pp_type input').on('click', function() {
             $('table.pp tbody').hide();


### PR DESCRIPTION
Closes #1058

UI Preview: https://imgur.com/a/jG9PASd

New behavior with these changes:

- All term checkboxs are now unticked by default when first configuring a product as Recurrent.
- If a pricing value above zero is entered on a disabled term, the checkbox will tick itself when the price input loses focus.
- If an enabled term's price totals out to zero, the term's checkbox is automatically unticked.

This does have some boilerplate javascript with the total calculation, but I don't think it is a big concern. I couldn't use the existing `keyup` trigger because it is setup to auto trigger. It would cause the checkboxes to auto-enable on page refresh if they had a price even if a user wanted to keep them disabled.

I could not use `keydown` because the value is not set until the `keyup` event. Using `keydown` resulted in requiring typing two characters before the total would reflect a value.

So while the solution has some boilerplate, I think it is okay given how the page is designed. I did at least add some comments for clarity on what each trigger is doing at a glance.