### PR TITLE
Copy Option for Order Button Code Examples

### DIFF
--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -216,7 +216,7 @@
                                     <span class="d-block mb-2">{{ 'Add order-button class to your elements which must call popup. For example:'|trans }}</span>
                                     <div class="col">
                                         <div class="input-group input-group-flat">
-                                            <textarea id="html-code" rows="3" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot;&nbsp;class=&quot;order-button&quot;&gt;Order Now&lt;/button&gt;</textarea>
+                                            <textarea id="html-code" rows="1" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot;&nbsp;class=&quot;order-button&quot;&gt;Order Now&lt;/button&gt;</textarea>
                                             <span class="input-group-text align-items-start pt-3">
                                                 <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code"
                                                     data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
@@ -231,7 +231,7 @@
                                 <span class="d-block mt-3 mb-2">{{ 'Add data-product attribute to your element to open specific product. For example:'|trans }}</span>
                                 <div class="col">
                                     <div class="input-group input-group-flat">
-                                        <textarea id="html-code2" rows="3" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot; class=&quot;order-button" data-product="2"&gt;Order Product#2 Now&lt;/button&gt;</textarea>
+                                        <textarea id="html-code2" rows="1" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot; class=&quot;order-button" data-product="2"&gt;Order Product#2 Now&lt;/button&gt;</textarea>
                                         <span class="input-group-text align-items-start pt-3">
                                             <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code2"
                                                 data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -214,11 +214,35 @@
                                 <span class="d-block mb-2">{{ 'You need to add ID (if you want to use it for one html element) or class (if you want to use it for multiple elements) in order for it to work'|trans }}</span>
                                 <div id="button-code-info">
                                     <span class="d-block mb-2">{{ 'Add order-button class to your elements which must call popup. For example:'|trans }}</span>
-                                    <pre>&lt;button type=&quot;button&quot;<span class="text-orange">&nbsp;class=&quot;order-button</span>&quot;&gt;Order Now&lt;/button&gt;</pre>
+                                    <div class="col">
+                                        <div class="input-group input-group-flat">
+                                            <textarea id="html-code" rows="3" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot;&nbsp;class=&quot;order-button&quot;&gt;Order Now&lt;/button&gt;</textarea>
+                                            <span class="input-group-text align-items-start pt-3">
+                                                <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code"
+                                                    data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                                                    <svg class="icon">
+                                                        <use xlink:href="#copy">
+                                                    </svg>
+                                                </span>
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <span class="d-block mb-2">{{ 'Add data-product attribute to your element to open specific product. For example:'|trans }}</span>
-                                <pre>&lt;button type=&quot;button&quot; class=&quot;order-button" <span class="text-orange">data-product="2"</span>&gt;Order Product#2 Now&lt;/button&gt;</pre>
-                                <span class="d-block">{{ 'data-product attribute value will be overridden if popup\'s product is selected from select-box above'|trans }}</span>
+                                <span class="d-block mt-3 mb-2">{{ 'Add data-product attribute to your element to open specific product. For example:'|trans }}</span>
+                                <div class="col">
+                                    <div class="input-group input-group-flat">
+                                        <textarea id="html-code2" rows="3" class="form-control" onclick="$(this).trigger('select')">&lt;button type=&quot;button&quot; class=&quot;order-button" data-product="2"&gt;Order Product#2 Now&lt;/button&gt;</textarea>
+                                        <span class="input-group-text align-items-start pt-3">
+                                            <span class="input-group-link cursor-pointer clipboard-copy" data-clipboard-target="#html-code2"
+                                                data-bs-toggle="tooltip" aria-label="Copy" data-bs-original-title="Copy">
+                                                <svg class="icon">
+                                                    <use xlink:href="#copy">
+                                                </svg>
+                                            </span>
+                                        </span>
+                                    </div>
+                                </div>
+                                <span class="d-block mt-3">{{ 'data-product attribute value will be overridden if popup\'s product is selected from select-box above'|trans }}</span>
                             </div>
                         </div>
                     </div>

--- a/src/themes/admin_default/assets/scss/fossbilling.scss
+++ b/src/themes/admin_default/assets/scss/fossbilling.scss
@@ -72,7 +72,7 @@
     }
 }
 
-#script-code {
+#script-code, #html-code, #html-code2 {
     resize: none;
 }
 


### PR DESCRIPTION
Closes #1237 

I converted the code example `pre` tags to `textarea`  with the same layout as the dynamic one. This makes the UI look consistent and solves the original request, but it does lose the extra styling of the `pre` tags.

I think this is OK and not something to be too concerned about. However, this could be adjusted to some other solution that retains the `pre` tags. I personally could not get something working right, but perhaps someone else can improve it.

### Before:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/104653539/cb26b87e-cb60-4756-8772-cc256e2e2307)

### After:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/104653539/be712706-03fe-469b-986d-09ad8fe0894d)

