### PR TITLE
Use the configured max domains with Plesk

### DIFF
--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -403,6 +403,10 @@ class Server_Manager_Plesk extends Server_Manager
                                 'name'	=>	'max_subftp_users',
                                 'value'	=>	$p->getMaxFtp() ?: 0,
                             ),
+                            array(
+                                'name'	=>	'max_site',
+                                'value'	=>	$p->getMaxDomains() ?: 0,
+                            ),
                         ), 
                     ),
                     'permissions'	=>	array(


### PR DESCRIPTION
Our Plesk server manager currently doesn't do anything with the hosting plan's configured maximum domains which led to orders being setup with the wrong value.

This PR fixes that. Confirmed fix via a user on our discord