### PR TITLE
Fix installer ssl check

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -418,7 +418,7 @@ final class Box_Installer
         $data = [
             'security' => [
                 'mode' => 'strict',
-                'force_https' => isSSL() ? true : false,
+                'force_https' => FOSSBilling\Tools::isHTTPS() ? true : false,
                 'cookie_lifespan' => 7200,
             ],
             'debug' => false,

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -291,6 +291,6 @@ class Tools
         $protocol = $_SERVER['HTTPS'] ?? $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? $_SERVER['REQUEST_SCHEME'] ?? '';
 
         // $_SERVER['HTTPS'] will be set to `on` to indicate HTTPS and the other to will be set to `https`, so either one means we are connected via HTTPS.
-        return (strcasecmp($protocol, 'on') === 0 || strcasecmp($protocol, 'https'));
+        return (strcasecmp($protocol, 'on') === 0 || strcasecmp($protocol, 'https') === 0);
     }
 }


### PR DESCRIPTION
**Description**:
This pull request addresses the issue caused by PR #1613, which broke the local installation of FOSSBilling from the main branch. The problem stems from two key issues: 

1. The requirement for assets to have an HTTPS connection even when using http.
2. The replacement of a removed function in the code.