### PR TITLE
Reworked Password-Reset flow

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -354,7 +354,8 @@
         "ordermodel",
         "TINYINT",
         "hostings",
-        "rulesets"
+        "rulesets",
+        "pwreset"
 
     ],
     "ignorePaths": [

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -186,14 +186,18 @@ class Guest extends \Api_Abstract
             'to_client' => $c->id,
             'code' => 'mod_client_password_reset_request',
             'hash' => $reset->hash,
+            'send_now' => true,
         ];
-        // Send the email if the reset request has the same created_at and updated_at
+
         $emailService = $this->di['mod_service']('email');
+
+        // Send the email if the reset request has the same created_at and updated_at or if at least 1 full minute has passed since the last request.
         if ($reset->created_at == $reset->updated_at) {
             $emailService->sendTemplate($email);
         } elseif (strtotime($reset->updated_at) - time() + 60 < 0) {
             $emailService->sendTemplate($email);
         }
+
         // update the client password reset time
         $reset->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($reset);

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -194,7 +194,7 @@ class Guest extends \Api_Abstract
         } elseif (strtotime($reset->updated_at) - time() + 60 < 0) {
             $emailService->sendTemplate($email);
         }
-        // update the client password reset time 
+        // update the client password reset time
         $reset->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($reset);
 
@@ -211,7 +211,7 @@ class Guest extends \Api_Abstract
             'password' => 'Password required',
             'password_confirm' => 'Password confirmation required',
         ];
-        $this->di['events_manager']->fire(['event' => 'onBeforeClientProfilePasswordSet', 'params' => $data['hash']]);
+        $this->di['events_manager']->fire(['event' => 'onBeforeClientProfilePasswordReset', 'params' => $data['hash']]);
 
         $validator = $this->di['validator'];
         $validator->checkRequiredParamsForArray($required, $data);

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -150,78 +150,104 @@ class Guest extends \Api_Abstract
     public function reset_password($data)
     {
         $this->di['events_manager']->fire(['event' => 'onBeforePasswordResetClient']);
-        $required = [
-            'email' => 'Email required',
-        ];
-        $this->di['validator']->checkRequiredParamsForArray($required, $data);
+    
+        // Validate required parameters
+        $this->di['validator']->checkRequiredParamsForArray(['email' => 'Email required'], $data);
+    
+        // Sanitize email
         $data['email'] = $this->di['tools']->validateAndSanitizeEmail($data['email']);
-
+    
         $this->di['events_manager']->fire(['event' => 'onBeforeGuestPasswordResetRequest', 'params' => $data]);
-
+    
+        // Fetch the client by email
         $c = $this->di['db']->findOne('Client', 'email = ?', [$data['email']]);
         if (!$c instanceof \Model_Client) {
             return true;
         }
-
-        $hash = hash('sha256', time() . random_bytes(13));
-
-        $reset = $this->di['db']->dispense('ClientPasswordReset');
-        $reset->client_id = $c->id;
-        $reset->ip = $this->ip;
-        $reset->hash = $hash;
-        $reset->created_at = date('Y-m-d H:i:s');
+    
+        // Check if a password reset request exists in the last 5 minutes
+        $reset = $this->di['db']->findOne('ClientPasswordReset', 'client_id = ? AND created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE)', [$c->id]);
+        
+        // If no recent reset request exists, create a new one
+        if (!$reset instanceof \Model_ClientPasswordReset) {
+            $hash = hash('sha256', time() . random_bytes(13));
+            $reset = $this->di['db']->dispense('ClientPasswordReset');
+            $reset->client_id = $c->id;
+            $reset->ip = $this->ip;
+            $reset->hash = $hash;
+            $reset->created_at = date('Y-m-d H:i:s');
+            $reset->updated_at = date('Y-m-d H:i:s');
+            $this->di['db']->store($reset);
+        }
+    
+        // Send reset email
+        $email = [
+            'to_client' => $c->id,
+            'code' => 'mod_client_password_reset_request',
+            'hash' => $reset->hash,
+        ];
+        // Send the email if the reset request has the same created_at and updated_at
+        $emailService = $this->di['mod_service']('email');
+        if ($reset->created_at == $reset->updated_at) {
+            // Send the password reset email
+            $emailService->sendTemplate($email);
+        } elseif (strtotime($reset->updated_at) - time() + 60 < 0)
+        {
+            // Send the password reset email
+            $emailService->sendTemplate($email);
+        }
+        // update the updated_at field
         $reset->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($reset);
+    
+        $this->di['logger']->info('Client requested password reset. Sent to email %s', $c->email);
+    
+        return true;
+
+
+    }
+    
+
+    public function update_password($data)
+    {
+       $required = [
+            'hash' => 'No Hash provided',
+            'password' => 'Password required',
+            'password_confirm' => 'Password confirmation required',
+        ];
+        $this->di['events_manager']->fire(['event' => 'onBeforeClientProfilePasswordSet', 'params' => $data['hash']]);
+
+        $validator = $this->di['validator'];
+        $validator->checkRequiredParamsForArray($required, $data);
+
+        if ($data['password'] != $data['password_confirm']) {
+            throw new \Box_Exception('Passwords do not match');
+        }
+
+        $reset = $this->di['db']->findOne('ClientPasswordReset', 'hash = ?', [$data['hash']]);
+        if (!$reset instanceof \Model_ClientPasswordReset) {
+            throw new \Box_Exception('The link has expired or you have already reset your password.');
+        }
+
+        if (strtotime($reset->created_at) - time() + 900 < 0) {
+            throw new \Box_Exception('The link has expired or you have already reset your password.');
+        }
+
+        $c = $this->di['db']->getExistingModelById('Client', $reset->client_id, 'User not found');
+        $c->pass = $this->di['password']->hashIt($data['password']);
+        $this->di['db']->store($c);
+
+        $this->di['logger']->info('Client requested password reset. Sent to email %s', $c->email);
 
         // send email
         $email = [];
         $email['to_client'] = $c->id;
-        $email['code'] = 'mod_client_password_reset_request';
-        $email['hash'] = $hash;
-        $emailService = $this->di['mod_service']('email');
-        $emailService->sendTemplate($email);
-
-        $this->di['logger']->info('Client requested password reset. Sent to email %s', $c->email);
-
-        return true;
-    }
-
-    /**
-     * Confirm password reset action.
-     *
-     * @return bool
-     *
-     * @throws \Box_Exception
-     */
-    public function confirm_reset($data)
-    {
-        $required = [
-            'hash' => 'Hash required',
-        ];
-        $this->di['events_manager']->fire(['event' => 'onBeforePasswordResetClient']);
-        $this->di['validator']->checkRequiredParamsForArray($required, $data);
-
-        $reset = $this->di['db']->findOne('ClientPasswordReset', 'hash = ?', [$data['hash']]);
-        if (!$reset instanceof \Model_ClientPasswordReset) {
-            throw new \Box_Exception('The link have expired or you have already confirmed password reset.');
-        }
-
-        $new_pass = $this->di['tools']->generatePassword();
-
-        $c = $this->di['db']->getExistingModelById('Client', $reset->client_id, 'Client not found');
-        $c->pass = $this->di['password']->hashIt($new_pass);
-        $this->di['db']->store($c);
-
-        // send email
-        $email = [];
-        $email['to_client'] = $reset->client_id;
-        $email['code'] = 'mod_client_password_reset_approve';
-        $email['password'] = $new_pass;
+        $email['code'] = 'mod_client_password_reset_information';
         $emailService = $this->di['mod_service']('email');
         $emailService->sendTemplate($email);
 
         $this->di['db']->trash($reset);
-        $this->di['logger']->info('Client password reset request was approved');
+        $this->di['events_manager']->fire(['event' => 'onAfterClientProfilePasswordChange', 'params' => ['id' => $c->id]]);
 
         return true;
     }

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -150,24 +151,24 @@ class Guest extends \Api_Abstract
     public function reset_password($data)
     {
         $this->di['events_manager']->fire(['event' => 'onBeforePasswordResetClient']);
-    
+
         // Validate required parameters
         $this->di['validator']->checkRequiredParamsForArray(['email' => 'Email required'], $data);
-    
+
         // Sanitize email
         $data['email'] = $this->di['tools']->validateAndSanitizeEmail($data['email']);
-    
+
         $this->di['events_manager']->fire(['event' => 'onBeforeGuestPasswordResetRequest', 'params' => $data]);
-    
+
         // Fetch the client by email
         $c = $this->di['db']->findOne('Client', 'email = ?', [$data['email']]);
         if (!$c instanceof \Model_Client) {
             return true;
         }
-    
-        // Check if a password reset request exists in the last 5 minutes
-        $reset = $this->di['db']->findOne('ClientPasswordReset', 'client_id = ? AND created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE)', [$c->id]);
-        
+
+        // Check if a password reset request exists
+        $reset = $this->di['db']->findOne('ClientPasswordReset', 'client_id = ?', [$c->id]);
+
         // If no recent reset request exists, create a new one
         if (!$reset instanceof \Model_ClientPasswordReset) {
             $hash = hash('sha256', time() . random_bytes(13));
@@ -179,8 +180,8 @@ class Guest extends \Api_Abstract
             $reset->updated_at = date('Y-m-d H:i:s');
             $this->di['db']->store($reset);
         }
-    
-        // Send reset email
+
+        // prepare reset email
         $email = [
             'to_client' => $c->id,
             'code' => 'mod_client_password_reset_request',
@@ -189,28 +190,23 @@ class Guest extends \Api_Abstract
         // Send the email if the reset request has the same created_at and updated_at
         $emailService = $this->di['mod_service']('email');
         if ($reset->created_at == $reset->updated_at) {
-            // Send the password reset email
             $emailService->sendTemplate($email);
-        } elseif (strtotime($reset->updated_at) - time() + 60 < 0)
-        {
-            // Send the password reset email
+        } elseif (strtotime($reset->updated_at) - time() + 60 < 0) {
             $emailService->sendTemplate($email);
         }
-        // update the updated_at field
+        // update the client password reset time 
         $reset->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($reset);
-    
+
         $this->di['logger']->info('Client requested password reset. Sent to email %s', $c->email);
-    
+
         return true;
-
-
     }
-    
+
 
     public function update_password($data)
     {
-       $required = [
+        $required = [
             'hash' => 'No Hash provided',
             'password' => 'Password required',
             'password_confirm' => 'Password confirmation required',
@@ -233,7 +229,7 @@ class Guest extends \Api_Abstract
             throw new \Box_Exception('The link has expired or you have already reset your password.');
         }
 
-        $c = $this->di['db']->getExistingModelById('Client', $reset->client_id, 'User not found');
+        $c = $this->di['db']->getExistingModelById('Client', $reset->client_id, 'Client not found');
         $c->pass = $this->di['password']->hashIt($data['password']);
         $this->di['db']->store($c);
 

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -243,7 +243,7 @@ class Guest extends \Api_Abstract
         $emailService->sendTemplate($email);
 
         $this->di['db']->trash($reset);
-        $this->di['events_manager']->fire(['event' => 'onAfterClientProfilePasswordChange', 'params' => ['id' => $c->id]]);
+        $this->di['events_manager']->fire(['event' => 'onAfterClientProfilePasswordReset', 'params' => ['id' => $c->id]]);
 
         return true;
     }

--- a/src/modules/Client/Controller/Client.php
+++ b/src/modules/Client/Controller/Client.php
@@ -71,10 +71,10 @@ class Client implements \FOSSBilling\InjectionAwareInterface
             'hash' => $hash,
         ];
         $template = 'mod_client_set_new_password';
-        
-        // Call pwreset_valid API and if true, then render the template, otherwise redirect to the index page
-        $result = $service->pwreset_valid($data);
-        if ($result) {
+
+        // Call password_reset_valid function and if true, then render the template, otherwise redirect to the index page
+        $result = $service->password_reset_valid($data);
+        if ($result !== false) {
             return $app->render($template);
         } else {
             $app->redirect('/');

--- a/src/modules/Client/Controller/Client.php
+++ b/src/modules/Client/Controller/Client.php
@@ -10,8 +10,6 @@
 
 namespace Box\Mod\Client\Controller;
 
-use Error;
-
 class Client implements \FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;

--- a/src/modules/Client/Controller/Client.php
+++ b/src/modules/Client/Controller/Client.php
@@ -74,14 +74,12 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         ];
         $template = 'mod_client_set_new_password';
         
-        // Chech if the hash is valid
-        // Call confirm_reset_vsalid API and if true, then render the template, otherwise redirect to login page
+        // Call pwreset_valid API and if true, then render the template, otherwise redirect to the index page
         $result = $service->pwreset_valid($data);
-        error_log("Result: " . print_r($result, true));
         if ($result) {
             return $app->render($template);
         } else {
-            $app->redirect('/login');
+            $app->redirect('/');
         }
     }
 }

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -702,8 +702,7 @@ class Service implements InjectionAwareInterface
         }
 
         $c = $this->di['db']->findOne('Client', 'id = ?', [$reset->client_id]);
-        // Return the Client ID if the reset request is valid (younger than 15 Minutes), otherwise return false
-        // This shouldn't happen because we clear out expired requests every 15 minutes, but just in case
+        // Return the client ID if the reset request is valid (from within the last 15 minutes), otherwise return false
         if (strtotime($reset->created_at) - time() + 900 < 0) {
             return false;
         } else {
@@ -712,7 +711,7 @@ class Service implements InjectionAwareInterface
     }
 
     /*
-     * Function that cleans out expired password reset requests ( 15 minutes )
+     * Prunes the `client_password_reset` table of reset requests older than 15 minutes
      *
      * @return void
      */

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -680,4 +680,34 @@ class Service implements InjectionAwareInterface
 
         return $this->di['table_export_csv']('client', 'clients.csv', $headers);
     }
+        /**
+     * Confirm password reset action.
+     *
+     * @return bool
+     *
+     * @throws \Box_Exception
+     */
+    public function pwreset_valid($data)
+    {
+        $required = [
+            'hash' => 'Hash required',
+        ];
+        $this->di['events_manager']->fire(['event' => 'onBeforePasswordResetClient']);
+        $this->di['validator']->checkRequiredParamsForArray($required, $data);
+
+        $reset = $this->di['db']->findOne('ClientPasswordReset', 'hash = ?', [$data['hash']]);
+        if (!$reset instanceof \Model_ClientPasswordReset) {
+            throw new \Box_Exception('The link have expired or you have already confirmed password reset.');
+        }
+
+        $c = $this->di['db']->findOne('Client', 'id = ?', [$reset->client_id]);
+        // Return the Client ID if the reset request is valid, otherwise return false
+        if (strtotime($reset->created_at) - time() + 9000 < 0) {
+            return false;
+        } else {
+            return $c->id;
+        }
+
+
+    }
 }

--- a/src/modules/Client/html_client/mod_client_set_new_password.html.twig
+++ b/src/modules/Client/html_client/mod_client_set_new_password.html.twig
@@ -1,0 +1,72 @@
+{% extends "layout_public.html.twig" %}
+
+{% block meta_title %}{{ 'Set new Password'|trans }}{% endblock %}
+
+{% block body_class %}page-set-password{% endblock %}
+{% block body %}
+
+<section class="container login" role="main">
+
+{% if settings.login_page_show_logo %}
+    {% set company = guest.system_company %}
+    <h1 style="text-align: center">
+        {% if settings.login_page_show_logo %}
+        <a href="{{ settings.login_page_logo_url|default('/') }}" target="_blank">
+            <img src="{{ guest.system_company.logo_url }}" alt="{{ guest.system_company.name }}"/>
+        </a>
+        {% endif %}
+    </h1>
+{% endif %}
+    <h2>{{ 'Set new password'|trans }}</h2>
+
+    <div class="data-block">
+        <div class="data-container">
+        <form class="api-form" action="{{ 'api/guest/client/update_password'|link }}" method="post" data-api-redirect="{{ '/login'|link }}">
+                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+                <input type="hidden" id="hash" name="hash" value="{{ hash }}"/>
+                <fieldset>
+                    <div class="control-group">
+                        <label class="control-label" for="password">{{ 'New password'|trans }}</label>
+                        <div class="controls">
+                            <input id="password" type="password" placeholder="{{ 'New password'|trans }}" name="password" required="required" value>
+                            <div class="help-block"></div>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label" for="password2">{{ 'Repeat new password'|trans }}</label>
+                        <div class="controls">
+                            <input id="password2" type="password" placeholder="{{ 'Repeat new password' | trans }}" name="password_confirm" required="required" value>
+                            <div class="help-block"></div>
+                        </div>
+                    </div>
+                    <div class="form-actions">
+                        <button class="btn btn-block btn-large btn-inverse btn-alt" type="submit">{{ 'Set new password'|trans }}</button>
+                    </div>
+                </fieldset>
+            </form>
+
+        </div>
+    </div>
+
+    {% if settings.show_password_reset_link or settings.show_signup_link %}
+    <ul class="login-footer">
+        {% if settings.show_signup_link%}
+        <li><a href="{{ 'signup'|link }}"><small>{{ 'Sign Up'|trans }}</small></a></li>
+        {% endif %}
+    </ul>
+    
+    <li><a href="{{ 'login'|link }}"><small>{{ 'Login'|trans }}</small></a></li>
+    {% endif %}
+</section>
+{% endblock%}
+
+{% block js %}
+<script type="text/javascript">
+    // Set value of hash field to last part of URL
+    $(document).ready(function() {
+        var hash = window.location.href.split('/').pop();
+        $('#hash').val(hash);
+    });
+</script>
+
+{% endblock %}

--- a/src/modules/Client/html_email/mod_client_password_reset_information.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_information.html.twig
@@ -37,13 +37,9 @@
 <body>
 	<h1>Password reset</h1>
 	<p>Hello {{ c.first_name }} {{ c.last_name }},</p>
-	<p>As you requested, your password for our client area has now been reset.</p>
-    <p>Your new login details are as follows:</p>
-    <ul>
-        <li><strong>Email:</strong> {{ c.email }}</li>
-        <li><strong>Password:</strong> {{ password }}</li>
-    </ul>
-    <p>Once you have logged in, feel free to go to the edit profile page to change your password to be more memorable.</p>
+	<p>The password to your account has been changed.</p>
+    <p>If you did not perform this request, please contact your support immediately.</p>
+
     <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
 	<p class="signature">{{ guest.system_company.signature }}</p>

--- a/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
@@ -43,9 +43,9 @@
     <p>To reset your password, please visit the link below:</p>
     <a href="{{'client/reset-password-confirm'|link}}/{{ hash }}" target="_blank">Reset password.</a>
 
-    <p>Once visiting the link above, you will be emailed a new password that you may login with.</p>
+    <p>Once visiting the link above, you will be able to set a new Password.</p>
 
-    <p>You may <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
+    <p>You may then <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
 	<p class="signature">{{ guest.system_company.signature }}</p>
 </body>

--- a/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
+++ b/src/modules/Client/html_email/mod_client_password_reset_request.html.twig
@@ -43,8 +43,6 @@
     <p>To reset your password, please visit the link below:</p>
     <a href="{{'client/reset-password-confirm'|link}}/{{ hash }}" target="_blank">Reset password.</a>
 
-    <p>Once visiting the link above, you will be able to set a new Password.</p>
-
     <p>You may then <a href="{{'login'|link({'email' : c.email }) }}" target="_blank">login</a> or <a href="{{'client/profile'|link}}" target="_blank">edit your profile.</a>
 
 	<p class="signature">{{ guest.system_company.signature }}</p>

--- a/tests/modules/Client/Api/GuestTest.php
+++ b/tests/modules/Client/Api/GuestTest.php
@@ -4,7 +4,8 @@
 namespace Box\Mod\Client\Api;
 
 
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
 
     public function testgetDi()
     {
@@ -55,7 +56,9 @@ class GuestTest extends \BBTestCase {
 
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function ($name) use($configArr) { return $configArr;  });
+        $di['mod_config'] = $di->protect(function ($name) use ($configArr) {
+            return $configArr;
+        });
         $di['validator'] = $validatorMock;
         $di['tools'] = $toolsMock;
 
@@ -99,7 +102,9 @@ class GuestTest extends \BBTestCase {
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function ($name) use($configArr) { return $configArr;  });
+        $di['mod_config'] = $di->protect(function ($name) use ($configArr) {
+            return $configArr;
+        });
         $di['validator'] = $validatorMock;
 
         $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
@@ -130,7 +135,9 @@ class GuestTest extends \BBTestCase {
 
         $client = new \Box\Mod\Client\Api\Guest();
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function ($name) use($configArr) { return $configArr;  });
+        $di['mod_config'] = $di->protect(function ($name) use ($configArr) {
+            return $configArr;
+        });
         $client->setDi($di);
 
         $this->expectException(\Box_Exception::class);
@@ -155,7 +162,9 @@ class GuestTest extends \BBTestCase {
 
         $client = new \Box\Mod\Client\Api\Guest();
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function ($name) use($configArr) { return $configArr;  });
+        $di['mod_config'] = $di->protect(function ($name) use ($configArr) {
+            return $configArr;
+        });
         $di['validator'] = $validatorMock;
         $client->setDi($di);
 
@@ -184,8 +193,7 @@ class GuestTest extends \BBTestCase {
             ->will($this->returnValue(array()));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-            method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $sessionMock = $this->getMockBuilder('\FOSSBilling\Session')
             ->disableOriginalConstructor()
@@ -222,10 +230,12 @@ class GuestTest extends \BBTestCase {
     {
         $data['email'] = 'Joghn@exmapl.com';
 
+        // Mock for the events manager
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-            method('fire');
+        $eventMock->expects($this->atLeastOnce())
+            ->method('fire');
 
+        // Mock for the database service
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
 
@@ -233,29 +243,43 @@ class GuestTest extends \BBTestCase {
         $modelPasswordReset->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('findOne')->will($this->returnValue($modelClient));
-        $dbMock->expects($this->atLeastOnce())
-            ->method('dispense')->will($this->returnValue($modelPasswordReset));
-        $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
+        $dbMock->expects($this->once())
+            ->method('findOne')
+            ->withConsecutive(['Client', 'email = ?', [$data['email']]])
+            ->willReturnOnConsecutiveCalls($modelClient, null);
 
-        $emailServiceMock =  $serviceMock = $this->getMockBuilder('\Box\Mod\Email\Service')->getMock();
-        $emailServiceMock->expects($this->atLeastOnce())->
-            method('sendTemplate');
+        $dbMock->expects($this->atLeastOnce())
+            ->method('dispense')
+            ->will($this->returnValue($modelPasswordReset));
 
+        $dbMock->expects($this->atLeastOnce())
+            ->method('store')
+            ->will($this->returnValue(1));
+
+        // Mock for the email service
+        $emailServiceMock = $this->getMockBuilder('\Box\Mod\Email\Service')->getMock();
+        $emailServiceMock->expects($this->once())
+            ->method('sendTemplate');
+
+        // Mock for the validator
         $validatorMock = $this->getMockBuilder('\FOSSBilling\Validate')->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
+        $validatorMock->expects($this->once())
             ->method('checkRequiredParamsForArray')
             ->will($this->returnValue(null));
 
+        // Mock for tools (for email sanitization)
         $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
+        $toolsMock->expects($this->once())
+            ->method('validateAndSanitizeEmail')
+            ->will($this->returnValue($data['email']));
 
+        // Dependency injection container setup
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(function ($name) use($emailServiceMock) {return $emailServiceMock;});
+        $di['mod_service'] = $di->protect(function ($name) use ($emailServiceMock) {
+            return $emailServiceMock;
+        });
         $di['logger'] = new \Box_Log();
         $di['tools'] = $toolsMock;
         $di['validator'] = $validatorMock;
@@ -267,13 +291,13 @@ class GuestTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
+
     public function testreset_passwordEmailNotFound()
     {
         $data['email'] = 'joghn@example.eu';
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-            method('fire');
+        $eventMock->expects($this->atLeastOnce())->method('fire');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -300,11 +324,16 @@ class GuestTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testconfirm_reset()
+    public function testUpdatePassword()
     {
         $data = array(
-            'hash' => 'hashedString'
+            'hash' => 'hashedString',
+            'password' => 'newPassword',
+            'password_confirm' => 'newPassword'
         );
+
+        // Mocks for dependent services and classes
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
 
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -312,91 +341,100 @@ class GuestTest extends \BBTestCase {
         $modelPasswordReset = new \Model_ClientPasswordReset();
         $modelPasswordReset->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
+        $dbMock->expects($this->once())
             ->method('findOne')->will($this->returnValue($modelPasswordReset));
 
-        $dbMock->expects($this->atLeastOnce())
+        $dbMock->expects($this->once())
             ->method('getExistingModelById')->will($this->returnValue($modelClient));
 
-        $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
+        $dbMock->expects($this->once())
+            ->method('store');
 
-        $dbMock->expects($this->atLeastOnce())
+        $dbMock->expects($this->once())
             ->method('trash');
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-            method('fire');
-
-        $emailServiceMock =  $serviceMock = $this->getMockBuilder('\Box\Mod\Email\Service')->getMock();
-        $emailServiceMock->expects($this->atLeastOnce())->
-            method('sendTemplate');
+        $eventMock->expects($this->exactly(2))
+            ->method('fire');
 
         $passwordMock = $this->getMockBuilder('\Box_Password')->getMock();
-        $passwordMock->expects($this->atLeastOnce())
+        $passwordMock->expects($this->once())
             ->method('hashIt');
+
+        $validatorMock = $this->getMockBuilder('\FOSSBilling\Validate')->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->once())
+            ->method('checkRequiredParamsForArray')
+            ->will($this->returnValue(null));
+
+        $emailServiceMock = $this->getMockBuilder('\Box\Mod\Email\Service')->getMock();
+        $emailServiceMock->expects($this->once())
+            ->method('sendTemplate');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $di['logger'] = new \Box_Log();
-        $di['mod_service'] =  $di->protect(function ($name) use($emailServiceMock) {return $emailServiceMock;});
         $di['password'] = $passwordMock;
-        $validatorMock = $this->getMockBuilder('\FOSSBilling\Validate')->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
-            ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
         $di['validator'] = $validatorMock;
-
-        $toolsMock = $this->getMockBuilder('\FOSSBilling\Tools')->getMock();
-        $toolsMock->expects($this->atLeastOnce())->method('generatePassword');
-        $di['tools'] = $toolsMock;
+        $di['logger'] = new \Box_Log();
+        $di['mod_service'] =  $di->protect(function ($name) use ($emailServiceMock) {
+            return $emailServiceMock;
+        });
 
         $client = new \Box\Mod\Client\Api\Guest();
         $client->setDi($di);
 
-        $result = $client->confirm_reset($data);
+        $result = $client->update_password($data);
         $this->assertTrue($result);
     }
 
-    public function testconfirm_resetResetNotFound()
+    public function testUpdatePasswordResetNotFound()
     {
         $data = array(
-            'hash' => 'hashedString'
+            'hash' => 'hashedString',
+            'password' => 'newPassword',
+            'password_confirm' => 'newPassword'
         );
 
+        // Mock for the database service
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
+        $dbMock->expects($this->once())
             ->method('findOne')->will($this->returnValue(null));
 
+        // Mock for the events manager
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())->
-            method('fire');
+        $eventMock->expects($this->once())
+            ->method('fire');
 
+        // Mock for the validator
+        $validatorMock = $this->getMockBuilder('\FOSSBilling\Validate')->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->once())
+            ->method('checkRequiredParamsForArray')
+            ->will($this->returnValue(null));
+
+        // Dependency injection container setup
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $validatorMock = $this->getMockBuilder('\FOSSBilling\Validate')->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
-            ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
         $di['validator'] = $validatorMock;
 
         $client = new \Box\Mod\Client\Api\Guest();
         $client->setDi($di);
 
+        // Expect a Box_Exception to be thrown with a specific message
         $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage('The link have expired or you have already confirmed password reset.');
-        $client->confirm_reset($data);
+        $this->expectExceptionMessage('The link has expired or you have already reset your password.');
+        $client->update_password($data);
     }
+
 
     public function testrequired()
     {
         $configArr = array();
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function ($name) use($configArr) { return $configArr;  });
+        $di['mod_config'] = $di->protect(function ($name) use ($configArr) {
+            return $configArr;
+        });
 
         $client = new \Box\Mod\Client\Api\Guest();
         $client->setDi($di);


### PR DESCRIPTION
The reset password Functionality has been reworked. 

If a user presses the Reset Password button, they will get an E-Mail with a link to a page to reset their password.

The hash in the Link is only generated once (Previously it was generated each time someone clicked). If the Button is pressed again, the same link will be sent again, but only if the last E-Mail has been sent more than 60 seconds prior.

When the user changes their password, they will receive an E-Mail with the information that their password has been changed. (Without login information in it of course.)

The redirect now points to the correct login page.

TLDR;
- No more (user & admin) Passwords sent via E-Mail
- Fixed possible DoS
- Correct redirects