### PR TITLE
Add missing import on installer

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -11,6 +11,7 @@
 use Box\Mod\Email\Service;
 use Twig\Loader\FilesystemLoader;
 use Symfony\Component\HttpClient\HttpClient;
+use FOSSBilling\Environment;
 
 date_default_timezone_set('UTC');
 

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -9,9 +9,9 @@
  */
 
 use Box\Mod\Email\Service;
-use Twig\Loader\FilesystemLoader;
-use Symfony\Component\HttpClient\HttpClient;
 use FOSSBilling\Environment;
+use Symfony\Component\HttpClient\HttpClient;
+use Twig\Loader\FilesystemLoader;
 
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
I've noticed a missing import statement in PR #1622, which is causing the installer to crash. 

https://github.com/FOSSBilling/FOSSBilling/blob/dbcf9a3ad495e5629b846cad1b4f79da3bb0f095/src/install/install.php#L511