### PR TITLE
Fix to allow analysis to run against the installer

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         php: [ 8.0 ]
 
-    name: PHPStan
+    name: PHP ${{ matrix.php }} - PHPStan
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -71,14 +71,13 @@ jobs:
       - name: Extract build archive
         run: tar -xvf /tmp/builds/build.tar ./
 
-      - name: Run PHPStan
-        uses: php-actions/phpstan@v3
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
         with:
-          php_version: ${{ matrix.php }}
-          configuration: phpstan.neon
-          memory_limit: 512M
-          version: composer
-          path: src/
+          php-version: ${{ matrix.php }}
+
+      - name: Run PHPStan
+        run: php src/vendor/bin/phpstan --memory-limit=512M
 
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -77,7 +77,8 @@ jobs:
           php_version: ${{ matrix.php }}
           configuration: phpstan.neon
           memory_limit: 512M
-          version: latest
+          version: composer
+          path: src/
 
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -45,7 +45,6 @@ jobs:
           echo > ./src/data/log/license.log
           echo > ./src/data/log/application.log
           echo > ./src/data/log/php_error.log
-          rm -rf ./src/install
           mkdir /tmp/builds/ && tar -cvf /tmp/builds/build.tar ./
 
       - name: Upload Build Archive for Tests

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -71,13 +71,13 @@ jobs:
       - name: Extract build archive
         run: tar -xvf /tmp/builds/build.tar ./
 
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
       - name: Run PHPStan
-        run: php src/vendor/bin/phpstan --memory-limit=512M
+        uses: php-actions/phpstan@v3
+        with:
+          php_version: ${{ matrix.php }}
+          configuration: phpstan.neon
+          memory_limit: 512M
+          version: latest
 
   phpunit:
     runs-on: ubuntu-latest

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,11 @@ parameters:
 	level: 1
 	paths:
 		- src
+	bootstrapFiles:
+		- src/load.php
 	excludePaths:
 		analyse:
 		- src/vendor
-		- src/library/Registrar/Adapter/srsx.php
 		- src/library/Box/Request.php
 		- src/library/Box/Response.php
 		- src/library/Model/Admin.php
@@ -17,7 +18,6 @@ parameters:
 		- src/library/Model/Product.php
 		- src/library/Server/Manager/Custom.php
 		- src/library/Server/Manager/Whm.php
-		- src/rector.php
 	ignoreErrors:
 		- '#^Function __trans not found\.$#'
 		- '#^Function __pluralTrans not found\.$#'

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -151,25 +151,8 @@ final class Box_Installer
                     $this->generateEmailTemplates();
                     session_destroy();
                     // Try to remove install folder
-                    function rmAllDir($dir)
-                    {
-                        if (is_dir($dir)) {
-                            $contents = scandir($dir);
-                            foreach ($contents as $content) {
-                                if ('.' !== $content && '..' !== $content) {
-                                    if ('dir' === filetype($dir . DIRECTORY_SEPARATOR . $content)) {
-                                        rmAllDir($dir . DIRECTORY_SEPARATOR . $content);
-                                    } else {
-                                        unlink($dir . DIRECTORY_SEPARATOR . $content);
-                                    }
-                                }
-                            }
-                            reset($contents);
-                            rmdir($dir);
-                        }
-                    }
                     try {
-                        rmAllDir('..' . DIRECTORY_SEPARATOR . 'install');
+                        $this->rmAllDir('..' . DIRECTORY_SEPARATOR . 'install');
                     } catch (Exception) {
                         // do nothing
                     }
@@ -502,6 +485,24 @@ final class Box_Installer
         $emailService->setDi($di);
 
         return $emailService->templateBatchGenerate();
+    }
+
+    public function rmAllDir($dir)
+    {
+        if (is_dir($dir)) {
+            $contents = scandir($dir);
+            foreach ($contents as $content) {
+                if ('.' !== $content && '..' !== $content) {
+                    if ('dir' === filetype($dir . DIRECTORY_SEPARATOR . $content)) {
+                        $this->rmAllDir($dir . DIRECTORY_SEPARATOR . $content);
+                    } else {
+                        unlink($dir . DIRECTORY_SEPARATOR . $content);
+                    }
+                }
+            }
+            reset($contents);
+            rmdir($dir);
+        }
     }
 }
 

--- a/src/load.php
+++ b/src/load.php
@@ -51,7 +51,7 @@ function checkInstaller()
     $filesystem = new Filesystem();
 
     // Check if /install directory still exists after installation has been completed.
-    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install/index.php')) {
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install/install.php') && Environment::isProduction()) {
         throw new Exception('For security reasons, you have to delete the install directory before you can use FOSSBilling.', 2);
     }
 }
@@ -214,9 +214,6 @@ checkConfig();
 // All seems good, so load the config file.
 $config = require PATH_CONFIG;
 
-// Verify the installer was removed.
-checkInstaller();
-
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', $config['debug']);
@@ -236,6 +233,9 @@ $loader->addNamespace('', PATH_LIBRARY, 'psr0');
 $loader->addNamespace('Box\\Mod\\', PATH_MODS);
 $loader->checkClassMap();
 $loader->register();
+
+// Verify the installer was removed.
+checkInstaller();
 
 // Check if SSL required, and enforce if so.
 checkSSL();


### PR DESCRIPTION
Relates to #1632 and #1620.

A few of times now we've accidentally introduced issues into the installer which is pretty easy to do as it's separate from the main application and not something that's frequently re-tested.

A big part of the issue is that the CI workflow removes the installer directory so that it can pass [one of the checks](https://github.com/FOSSBilling/FOSSBilling/blob/main/src/load.php#L55).
This PR adds an additional requirement to that check so it will only be in use when FOSSBilling is running in production. With this change, we don't need to delete the installer directory for the tests and PHPStan can now do static analysis against it which should catch a lot of potential issues.