### PR TITLE
Cache requests to the Extension Directory

### DIFF
--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\Cache\ItemInterface;
 
 class ExtensionManager implements InjectionAwareInterface

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -11,6 +12,7 @@
 namespace FOSSBilling;
 
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class ExtensionManager implements InjectionAwareInterface
 {
@@ -148,29 +150,34 @@ class ExtensionManager implements InjectionAwareInterface
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
+        $key = $endpoint . serialize($params);
 
-        $httpClient = \Symfony\Component\HttpClient\HttpClient::create();
-        $response = $httpClient->request('GET', $url, [
-            'timeout' => 5,
-            'query' => array_merge($params, [
-                'fossbilling_version' => \FOSSBilling\Version::VERSION,
-            ]),
-        ]);
+        return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
+            $item->expiresAfter(60 * 60);
 
-        $json = $response->toArray();
+            $httpClient = \Symfony\Component\HttpClient\HttpClient::create();
+            $response = $httpClient->request('GET', $url, [
+                'timeout' => 5,
+                'query' => array_merge($params, [
+                    'fossbilling_version' => \FOSSBilling\Version::VERSION,
+                ]),
+            ]);
 
-        if (is_null($json)) {
-            throw new \Box_Exception('Unable to connect to the FOSSBilling extension directory.', null, 1545);
-        }
+            $json = $response->toArray();
 
-        if (isset($json['error']) && is_array($json['error'])) {
-            throw new \Box_Exception($json['error']['message'], null, 746);
-        }
+            if (is_null($json)) {
+                throw new \Box_Exception('Unable to connect to the FOSSBilling extension directory.', null, 1545);
+            }
 
-        if (!isset($json['result']) || !is_array($json['result'])) {
-            throw new \Box_Exception('Invalid response from the FOSSBilling extension directory.', null, 746);
-        }
+            if (isset($json['error']) && is_array($json['error'])) {
+                throw new \Box_Exception($json['error']['message'], null, 746);
+            }
 
-        return $json['result'];
+            if (!isset($json['result']) || !is_array($json['result'])) {
+                throw new \Box_Exception('Invalid response from the FOSSBilling extension directory.', null, 746);
+            }
+
+            return $json['result'];
+        });
     }
 }


### PR DESCRIPTION
Right now, FOSSBilling fetches the latest extension data every time a related page is loaded (payment gateways, extensions, etc).
Currently the data available updates no more than maybe once a month and even if it was being updated daily, fetching it on every request is excessive.

This pull request changes that behavior so all requests to the Extension Directory are cached for an hour which significantly reduces the number of requests needed and can also reduce the time for these pages to load once the data is first fetched.

Relates to #1595
