### PR TITLE
Changed the text regarding extension development.

### DIFF
--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -142,9 +142,10 @@
                             <li>Create free account at <a href="https://github.com/signup/free" target="_blank">GitHub</a></li>
                             <li>Create new public repository dedicated for extension only</li>
                             <li>Repository must have plugin json file. <a href="https://extensions.fossbilling.org/article/getting-started" target="_blank">More information</a></li>
-                            <li>Login to <a href="https://extensions.fossbilling.org/" target="_blank">FOSSBilling extensions site</a> with github account.</li>
+                            <li>Create a Pull Request <a href="https://github.com/FOSSBilling/extension-directory">here.</a</li>
                             <li>If your repository contains valid json file, it can be registered in extensions site.</li>
-                            <li>Registered extensions can be visible in every FOSSBilling admin area.</li>
+                            <li>The FOSSBilling team will review your extension and will contact you if there are any issues.</li>
+                            <li>Registered extensions will then be visible in every FOSSBilling admin area.</li>
                         </ul>
 
                         <h3>Supported extension types</h3>

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -145,7 +145,7 @@
                             <li>Create a Pull Request <a href="https://github.com/FOSSBilling/extension-directory">here.</a</li>
                             <li>If your repository contains valid json file, it can be registered in extensions site.</li>
                             <li>The FOSSBilling team will review your extension and will contact you if there are any issues.</li>
-                            <li>Registered extensions will then be visible in every FOSSBilling admin area.</li>
+                            <li>Registered extensions will then appear in the extension store page.</li>
                         </ul>
 
                         <h3>Supported extension types</h3>


### PR DESCRIPTION
The previous text instructed developers how to self-publish extensions to the extension directory. 

I've changed it to reflect the current "process" of creating a PR in the extension repo.

Can be changed if we change the process.