### PR TITLE
Bump PHPStan analysis level

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -358,6 +358,7 @@
         "pwreset",
         "pagebottom",
         "forceable",
+        "phpstan"
 
     ],
     "ignorePaths": [
@@ -397,6 +398,7 @@
         "src/modules/Wysiwyg/src/ckeditor.js",
         ".github/**",
         ".gitignore",
-        "src/.htaccess"
+        "src/.htaccess",
+        "phpstan-baseline.neon"
     ]
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method Monolog\\\\Handler\\\\HandlerInterface\\:\\:setFormatter\\(\\)\\.$#"
+			count: 1
+			path: src/library/FOSSBilling/Monolog.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$DomainGetRegistrarLockResult\\.$#"
+			count: 2
+			path: src/library/Registrar/Adapter/Namecheap.php
+
+		-
 			message: "#^Method Registrar_Adapter_Resellerclub\\:\\:_makeRequest\\(\\) should return string but returns array\\.$#"
 			count: 1
 			path: src/library/Registrar/Adapter/Resellerclub.php
@@ -129,6 +139,16 @@ parameters:
 			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailLists\\(\\)\\.$#"
 			count: 2
 			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Access to an undefined property PleskX\\\\Api\\\\Struct\\\\Dns\\\\Info\\:\\:\\$dns\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Call to an undefined method PleskX\\\\Api\\\\Operator\\\\Reseller\\:\\:setProperties\\(\\)\\.$#"
+			count: 4
+			path: src/library/Server/Manager/Plesk.php
 
 		-
 			message: "#^Call to an undefined method Server_Package\\:\\:getHasAnonymousFtp\\(\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,84 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Payment_AdapterAbstract\\:\\:init\\(\\)\\.$#"
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasAnonymousFtp\\(\\)\\.$#"
 			count: 1
-			path: src/library/Payment/AdapterAbstract.php
+			path: src/library/Server/Manager/Directadmin.php
 
 		-
-			message: "#^Method Registrar_Adapter_Internetbs\\:\\:getDomainDetails\\(\\) should return Registrar_Domain but return statement is missing\\.$#"
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasCatchAll\\(\\)\\.$#"
 			count: 1
-			path: src/library/Registrar/Adapter/Internetbs.php
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasCgi\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasCron\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasPhp\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasShell\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasSll\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasSpamFilter\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailAutoresponders\\(\\)\\.$#"
+			count: 2
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailForwarders\\(\\)\\.$#"
+			count: 2
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailLists\\(\\)\\.$#"
+			count: 2
+			path: src/library/Server/Manager/Directadmin.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasAnonymousFtp\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasCron\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasShell\\(\\)\\.$#"
+			count: 2
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getHasSpamFilter\\(\\)\\.$#"
+			count: 1
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailLists\\(\\)\\.$#"
+			count: 3
+			path: src/library/Server/Manager/Plesk.php
 
 		-
 			message: "#^Method Server_Manager_Plesk\\:\\:changeAccountDomain\\(\\) should return bool but return statement is missing\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,81 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Registrar_Adapter_Resellerclub\\:\\:_makeRequest\\(\\) should return string but returns array\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Method Registrar_Adapter_Resellerclub\\:\\:addSubReseller\\(\\) should return stdClass but returns string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Method Registrar_Adapter_Resellerclub\\:\\:transferDomain\\(\\) should return bool but returns string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'actionstatus' does not exist on string\\.$#"
+			count: 3
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'admincontact' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'creationtime' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'currentstatus' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'domsecret' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'endtime' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'isprivacyprotected' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'recsonpage' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'result' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'status' does not exist on non\\-falsy\\-string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'status' does not exist on string\\.$#"
+			count: 6
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
+			message: "#^Offset 'version' does not exist on string\\.$#"
+			count: 1
+			path: src/library/Registrar/Adapter/Resellerclub.php
+
+		-
 			message: "#^Call to an undefined method Server_Package\\:\\:getHasAnonymousFtp\\(\\)\\.$#"
 			count: 1
 			path: src/library/Server/Manager/Directadmin.php
@@ -78,6 +153,11 @@ parameters:
 		-
 			message: "#^Call to an undefined method Server_Package\\:\\:getMaxEmailLists\\(\\)\\.$#"
 			count: 3
+			path: src/library/Server/Manager/Plesk.php
+
+		-
+			message: "#^Method Server_Manager_Plesk\\:\\:_createClient\\(\\) should return int but returns true\\.$#"
+			count: 1
 			path: src/library/Server/Manager/Plesk.php
 
 		-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 1
+	level: 2
 	paths:
 		- src
 	bootstrapFiles:
@@ -18,6 +18,10 @@ parameters:
 		- src/library/Model/Product.php
 		- src/library/Server/Manager/Custom.php
 		- src/library/Server/Manager/Whm.php
+		- src/Data/Cache
+	universalObjectCratesClasses:
+		- \RedBeanPHP\SimpleModel
+		- \RedBeanPHP\OODBBean
 	ignoreErrors:
 		- '#^Function __trans not found\.$#'
 		- '#^Function __pluralTrans not found\.$#'
@@ -26,3 +30,15 @@ parameters:
 		  path: src/modules/Custompages/Controller/Client.php
 		- message: '#^Variable \$ext_id on left side of \?\?\= is never defined\.$#'
 		  path: src/modules/Extension/Service.php
+		- '#^Call to an undefined method Symfony\\Component\\HttpClient\\HttpClient\:\:withOptions\(\)\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$updated_at\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$pass\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$username\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$sld\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$tld\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$client_id\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$config\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$api_key\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$updated_at\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$created_at\.$#'
+		- '#^Access to an undefined property RedBeanPHP\\OODBBean\:\:\$id\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	level: 2
+	level: 3
 	paths:
 		- src
 	bootstrapFiles:
@@ -30,7 +30,6 @@ parameters:
 		  path: src/modules/Custompages/Controller/Client.php
 		- message: '#^Variable \$ext_id on left side of \?\?\= is never defined\.$#'
 		  path: src/modules/Extension/Service.php
-		- '#^Call to an undefined method Symfony\\Component\\HttpClient\\HttpClient\:\:withOptions\(\)\.$#'
 		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$updated_at\.$#'
 		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$pass\.$#'
 		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$username\.$#'

--- a/src/library/Api/Abstract.php
+++ b/src/library/Api/Abstract.php
@@ -22,13 +22,11 @@ class Api_Abstract implements InjectionAwareInterface
      */
     protected $mod  = null;
 
-    /**
-     * @var \Box\Mod\X\Service
-     */
+    // TODO: Find a way to correctly set the type. Maybe a module's service should extend a "Service" class?
     protected $service  = null;
 
     /**
-     * @var Model_Admin | Model_Client | Model_Guest
+     * @var Model_Admin|Model_Client|Model_Guest
      */
     protected $identity = null;
 
@@ -45,7 +43,7 @@ class Api_Abstract implements InjectionAwareInterface
     }
 
     /**
-     * @param null $mod
+     * @param Box_Mod $mod
      */
     public function setMod($mod)
     {
@@ -57,14 +55,14 @@ class Api_Abstract implements InjectionAwareInterface
      */
     public function getMod()
     {
-        if(!$this->mod) {
+        if (!$this->mod) {
             throw new Box_Exception('Mod object is not set for the service');
         }
         return $this->mod;
     }
 
     /**
-     * @param null $identity
+     * @param Model_Admin|Model_Client|Model_Guest $identity
      */
     public function setIdentity($identity)
     {
@@ -79,24 +77,20 @@ class Api_Abstract implements InjectionAwareInterface
         return $this->identity;
     }
 
-    /**
-     * @param null $service
-     */
+    // TODO: Find a way to correctly set the type. Maybe a module's service should extend a "Service" class?
     public function setService($service)
     {
         $this->service = $service;
     }
 
-    /**
-     * @return
-     */
+    // TODO: Find a way to correctly set the type. Maybe a module's service should extend a "Service" class?
     public function getService()
     {
         return $this->service;
     }
 
     /**
-     * @param null $ip
+     * @param string $ip
      */
     public function setIp($ip)
     {

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -304,7 +304,7 @@ class Box_App
             [$network, $netmask] = explode('/', $network, 2);
             $network_decimal = ip2long($network);
             $ip_decimal = ip2long($visitorIP);
-            $wildcard_decimal = 2 ** (32 - $netmask) - 1;
+            $wildcard_decimal = 2 ** (32 - (int)$netmask) - 1;
             $netmask_decimal = ~$wildcard_decimal;
             if (($ip_decimal & $netmask_decimal) == ($network_decimal & $netmask_decimal)) {
                 return false;

--- a/src/library/Box/BeanHelper.php
+++ b/src/library/Box/BeanHelper.php
@@ -22,33 +22,33 @@ class Box_BeanHelper extends \RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper imple
         return $this->di;
     }
 
-    public function getModelForBean( \RedBeanPHP\OODBBean $bean )
+    /** @phpstan-ignore-next-line */
+    public function getModelForBean(\RedBeanPHP\OODBBean $bean): ?object 
     {
         $prefix    = '\\Model_';
-        $model     = $bean->getMeta( 'type' );
-        $modelName = $prefix.$this->underscoreToCamelCase($model);
+        $model     = $bean->getMeta('type');
+        $modelName = $prefix . $this->underscoreToCamelCase($model);
 
-        if ( !class_exists( $modelName ) ) {
+        if (!class_exists($modelName)) {
             return null;
         }
 
         $model = new $modelName();
-        if($model instanceof \FOSSBilling\InjectionAwareInterface) {
-            $model->setDi( $this->di );
+        if ($model instanceof \FOSSBilling\InjectionAwareInterface) {
+            $model->setDi($this->di);
         }
 
-        $model->loadBean( $bean );
+        $model->loadBean($bean);
 
         return $model;
     }
 
-    private function underscoreToCamelCase( $string, $first_char_caps = true)
+    private function underscoreToCamelCase($string, $first_char_caps = true)
     {
-        if( $first_char_caps === true )
-        {
+        if ($first_char_caps === true) {
             $string[0] = strtoupper($string[0]);
         }
-        $func = fn($c) => strtoupper($c[1]);
+        $func = fn ($c) => strtoupper($c[1]);
         return preg_replace_callback('/_([a-z])/', $func, $string);
     }
 }

--- a/src/library/Box/BeanHelper.php
+++ b/src/library/Box/BeanHelper.php
@@ -22,7 +22,7 @@ class Box_BeanHelper extends \RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper imple
         return $this->di;
     }
 
-    /** @phpstan-ignore-next-line */
+    /** @phpstan-ignore-next-line (No matter what I put for the return type of this function, PHPStan is unhappy) */
     public function getModelForBean(\RedBeanPHP\OODBBean $bean): ?object 
     {
         $prefix    = '\\Model_';

--- a/src/library/Box/EventDispatcher.php
+++ b/src/library/Box/EventDispatcher.php
@@ -28,6 +28,7 @@ class Box_EventDispatcher
     }
 
     /**
+     * TODO: Unsused?
      * Disconnects a listener for a given event name.
      *
      * @param string $name     An event name
@@ -46,9 +47,11 @@ class Box_EventDispatcher
                 unset($this->listeners[$name][$i]);
             }
         }
+        return null;
     }
 
     /**
+     * TODO: Unsused?
      * Disconnects all listeners for a given event name.
      *
      * @param string $name An event name
@@ -64,6 +67,7 @@ class Box_EventDispatcher
         foreach ($this->listeners[$name] as $i => $callable) {
             unset($this->listeners[$name][$i]);
         }
+        return null;
     }
 
     /**

--- a/src/library/Box/Exception.php
+++ b/src/library/Box/Exception.php
@@ -13,10 +13,10 @@ class Box_Exception extends Exception
 	/**
 	 * Creates a new translated exception.
 	 *
-	 * @param   string   error message
-	 * @param   array|null    translation variables
-	 * @param   int 	 The exception code.
-	 * @param 	bool 	 If the variables in this should be considered protect, if so, hide them from the stack trace. 
+	 * @param string $message error message
+	 * @param array|null $variables translation variables
+	 * @param int $code The exception code.
+	 * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace. 
 	 */
 	public function __construct(string $message, ?array $variables = null, int $code = 0, bool $protected = false)
 	{

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -155,7 +155,7 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
     }
 
     /**
-     * @param Box_LogDb|FOSSBilling_Monolog $writer
+     * @param Box_LogDb|FOSSBilling\Monolog $writer
      * @return $this The Box_Log instance
      */
     public function addWriter($writer): static

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -17,7 +17,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(?\Pimple\Container $di): void
     {
         $this->di = $di;
     }

--- a/src/library/Box/TwigLoader.php
+++ b/src/library/Box/TwigLoader.php
@@ -15,7 +15,7 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
     /**
      * Constructor.
      *
-     * @param string|array $options A path or an array of options and paths
+     * @param array $options A path or an array of options and paths
      */
     public function __construct(array $options)
     {

--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -144,11 +144,10 @@ class Mail implements InjectionAwareInterface
      * Sends the email that was created and configured when the class was constructed
      *
      * @param array|null $options An optional array of options specific to the chosen transport method.
+     * 
      * @throws \Box_Exception If the transport method is unknown or if required options for the selected transport aren't defined
-     *
-     * @return void
      */
-    public function send(array|null $options = null)
+    public function send(array|null $options = null): void
     {
         switch ($this->transport) {
             case 'sendmail':
@@ -183,7 +182,6 @@ class Mail implements InjectionAwareInterface
         } catch (TransportExceptionInterface $e) {
             throw new \Box_Exception("Failed to send email via :transport with the exception :e", [':transport' => $this->transport, ':e' => $e]);
         }
-        return true;
     }
 
     /**

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -51,7 +51,7 @@ class Monolog implements InjectionAwareInterface
             $this->logger[$channel]->pushHandler($stream);
 
             $formatter = new LineFormatter($this->outputFormat, $this->dateFormat, true, true, true);
-            $this->logger[$channel]->getHandlers()[0]->setFormatter($formatter); // @phpstan-ignore-line
+            $this->logger[$channel]->getHandlers()[0]->setFormatter($formatter);
         }
     }
 

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -51,7 +51,7 @@ class Monolog implements InjectionAwareInterface
             $this->logger[$channel]->pushHandler($stream);
 
             $formatter = new LineFormatter($this->outputFormat, $this->dateFormat, true, true, true);
-            $this->logger[$channel]->getHandlers()[0]->setFormatter($formatter);
+            $this->logger[$channel]->getHandlers()[0]->setFormatter($formatter); // @phpstan-ignore-line
         }
     }
 

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -122,6 +122,7 @@ class Session implements \FOSSBilling\InjectionAwareInterface
         $maxAge = time() - $this->di['config']['security']['session_lifespan'];
 
         $fingerprint = new \FOSSBilling\Fingerprint;
+        /** @var \RedBeanPHP\OODBBean $session */
         $session = $this->di['db']->findOne('session', 'id = :id', [':id' => $sessionID]);
 
         if (empty($session->fingerprint)) {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -178,7 +178,7 @@ class UpdatePatcher implements InjectionAwareInterface
     /**
      * Set the current patch level of FOSSBilling.
      *
-     * @param int
+     * @param int $patchLevel The last executed patch level
      *
      * @return void
      */

--- a/src/library/Model/MassmailerMessage.php
+++ b/src/library/Model/MassmailerMessage.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Copyright 2022-2023 FOSSBilling
+ * Copyright 2011-2021 BoxBilling, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+class Model_MassmailerMessage extends \RedBeanPHP\SimpleModel
+{
+    public int $id;
+    public string $status;
+    public string $sent_at;
+}

--- a/src/library/Model/ProductDomainTable.php
+++ b/src/library/Model/ProductDomainTable.php
@@ -33,12 +33,12 @@ class Model_ProductDomainTable extends Model_ProductTable
     /**
      * Determine discount for items in cart (Hosting and related domain discount)
      * @param array $items Array of cart products
-     * @param CartProduct $product current product in iteration
+     * @param Model_Product $product current product in iteration
      * @param array $config configurations specified in product config
      * @return number discount
      * 
      */
-    public function getRelatedDiscount(array $items, $product, array $config)
+    public function getRelatedDiscount(array $items, Model_Product $product, array $config)
     {
         /**For each cart product, 
          * Compare it with other items in the cart

--- a/src/library/Model/Transaction.php
+++ b/src/library/Model/Transaction.php
@@ -14,4 +14,7 @@ class Model_Transaction extends \RedBeanPHP\SimpleModel
     public const STATUS_APPROVED        = 'approved';
     public const STATUS_PROCESSED       = 'processed';
     public const STATUS_ERROR           = 'error';
+
+    public int $gateway_id;
+    public string $ipn;
 }

--- a/src/library/Payment/Adapter/Custom.php
+++ b/src/library/Payment/Adapter/Custom.php
@@ -43,21 +43,15 @@ class Payment_Adapter_Custom
                     ),
                 ),
             ),
-        );
+        ); 
     }
 
     /**
      * Generate payment text
-     *
-     * @param Api_Admin $api_admin
-     * @param int $invoice_id
-     * @param bool $subscription
-     *
-     * @since FOSSBilling v2.9.15
-     *
+     * 
      * @return string - html form with auto submit javascript
      */
-    public function getHtml($api_admin, $invoice_id, $subscription)
+    public function getHtml(Api_Handler $api_admin, int $invoice_id, bool $subscription): string
     {
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
         $invoiceService = $this->di['mod_service']("Invoice");
@@ -72,7 +66,7 @@ class Payment_Adapter_Custom
         return $systemService->renderString($vars['_tpl'], true, $vars);
     }
 
-    public function process($tx)
+    public function processTransaction(Api_Handler $api_admin, int $id, array $data, int $gateway_id)
     {
         return true;
     }

--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -264,10 +264,7 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         return $form;
     }
 
-    /**
-     * @param string $txn_id
-     */
-    public function isIpnDuplicate(array $ipn)
+    public function isIpnDuplicate(array $ipn): bool
     {
         $sql = 'SELECT id
                 FROM transaction

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -161,8 +161,7 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
                 }
                 $invoiceService->doBatchPayWithCredits(array('client_id' => $client->id));
             }
-
-        } catch (\Stripe\Exception\CardException|\Stripe\Exception\InvalidRequestException|\Stripe\Exception\AuthenticationException|\Stripe\Exception\ApiConnectionException|\Stripe\Exception\ApiErrorException $e) {
+        } catch (\Stripe\Exception\CardException | \Stripe\Exception\InvalidRequestException | \Stripe\Exception\AuthenticationException | \Stripe\Exception\ApiConnectionException | \Stripe\Exception\ApiErrorException $e) {
             $this->logError($e, $tx);
             throw new \Box_Exception("There was an error when processing the transaction");
         }
@@ -178,10 +177,7 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
         $this->di['db']->store($tx);
     }
 
-    /**
-     * @param string $url
-     */
-    protected function _generateForm(Model_Invoice $invoice)
+    protected function _generateForm(Model_Invoice $invoice): string
     {
         $intent = $this->stripe->paymentIntents->create([
             'amount' => $this->getAmountInCents($invoice),

--- a/src/library/Payment/AdapterAbstract.php
+++ b/src/library/Payment/AdapterAbstract.php
@@ -18,24 +18,18 @@ abstract class Payment_AdapterAbstract
     /**
      * Response text for notify_url
      * This value is set after IPN is received and validated
-     *
-     * @var string
      */
-    protected $output = NULL;
+    protected ?string $output = NULL;
 
     /**
      * Are we in test mode?
-     *
-     * @var boolean
      */
-    public $testMode = false;
+    public bool $testMode = false;
 
     /**
      * Log object
-     *
-     * @var Box_Log
      */
-    private $_log = false;
+    private ?Box_Log $_log = null;
 
     // Stub function that can be overridden by a registrar
     public function init()
@@ -152,11 +146,9 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Gets a new HttpClient object.
-     *
-     * @return Symfony\Component\HttpClient\HttpClient The HttpClient object.
+     * Creates and returns an interface for the Symfony HTTP client.
      */
-    public function getHttpClient()
+    public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
         return \Symfony\Component\HttpClient\HttpClient::create();
     }

--- a/src/library/Payment/AdapterAbstract.php
+++ b/src/library/Payment/AdapterAbstract.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -10,9 +11,9 @@
 
 abstract class Payment_AdapterAbstract
 {
-    public const TYPE_HTML         	= 'html';
-    public const TYPE_FORM         	= 'form';
-    public const TYPE_API          	= 'api';
+    public const TYPE_HTML             = 'html';
+    public const TYPE_FORM             = 'form';
+    public const TYPE_API              = 'api';
 
     /**
      * Response text for notify_url
@@ -36,6 +37,11 @@ abstract class Payment_AdapterAbstract
      */
     private $_log = false;
 
+    // Stub function that can be overridden by a registrar
+    public function init()
+    {
+    }
+
     /**
      * Constructs a new Payment_Adapter object
      *
@@ -48,14 +54,14 @@ abstract class Payment_AdapterAbstract
         /**
          * Redirect client after successful payment, usually to invoice
          */
-        if(!$this->getParam('return_url')) {
+        if (!$this->getParam('return_url')) {
             throw new Payment_Exception('Return URL for payment gateway was not set', array(), 6001);
         }
 
         /**
          * URL to redirect client if payment process was canceled
          */
-        if(!$this->getParam('cancel_url')) {
+        if (!$this->getParam('cancel_url')) {
             throw new Payment_Exception('Cancel URL for payment gateway was not set', array(), 6002);
         }
 
@@ -63,7 +69,7 @@ abstract class Payment_AdapterAbstract
          * IPN notification url. Payment gateway posts data to this URL
          * to inform FOSSBilling about payment
          */
-        if(!$this->getParam('notify_url')) {
+        if (!$this->getParam('notify_url')) {
             throw new Payment_Exception('IPN Notification URL for payment gateway was not set', array(), 6003);
         }
 
@@ -73,18 +79,18 @@ abstract class Payment_AdapterAbstract
          * Client gets redirected to redirect_url, POST, GET data are considered
          * as IPN data, and client gets redirected to invoice page.
          */
-        if(!$this->getParam('redirect_url')) {
+        if (!$this->getParam('redirect_url')) {
             throw new Payment_Exception('IPN redirect URL for payment gateway was not set', array(), 6004);
         }
 
         $this->init();
     }
 
-	/**
-	 * Return gateway configuration options
-	 *
-	 * @return array
-	*/
+    /**
+     * Return gateway configuration options
+     *
+     * @return array
+     */
     public static function getConfig()
     {
         throw new Payment_Exception('Payment adapter class did not implement configuration options method', array(), 749);
@@ -107,7 +113,7 @@ abstract class Payment_AdapterAbstract
      */
     public function getServiceUrl()
     {
-		return '';
+        return '';
     }
 
     /**
@@ -139,7 +145,7 @@ abstract class Payment_AdapterAbstract
     public function getLog()
     {
         $log = $this->_log;
-        if(!$log instanceof Box_Log) {
+        if (!$log instanceof Box_Log) {
             $log = new Box_Log();
         }
         return $log;
@@ -170,9 +176,9 @@ abstract class Payment_AdapterAbstract
     /**
      * Convert money amount to Gateway money format
      *
-     * @param float The amount
+     * @param float $amount The amount
      *
-     * @param string The currency (unused currently)
+     * @param string $currency The currency (unused currently)
      *
      * @return string The formatted money string
      */
@@ -182,19 +188,17 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Set test mode
-     *
-     * @param none
+     * Toggles test mode
      *
      * @return Payment_AdapterAbstract
      */
-    public function setTestMode($bool)
+    public function setTestMode(bool $bool)
     {
         $this->testMode = (bool)$bool;
         return $this;
     }
 
-    public function getTestMode()
+    public function getTestMode(): bool
     {
         return $this->testMode;
     }
@@ -202,19 +206,14 @@ abstract class Payment_AdapterAbstract
     /**
      * Set custom response text to be printed when IPN is received
      * Used only by payment gateways who care about notify_url response
-     *
-     * @param string
-     *
-     * @param string $response
      */
-    public function setOutput($response)
+    public function setOutput(string $response): void
     {
         $this->output = $response;
     }
 
-    public function getOutput()
+    public function getOutput(): string
     {
         return $this->output;
     }
-
 }

--- a/src/library/Payment/Exception.php
+++ b/src/library/Payment/Exception.php
@@ -13,10 +13,9 @@ class Payment_Exception extends Box_Exception
 	/**
 	 * Creates a new translated exception, using the Box_Exception class.
 	 *
-	 * @param   string   error message
-	 * @param   array|null    translation variables
-	 * @param   int 	 The exception code.
-	 * @param 	bool 	 If the variables in this should be considered protect, if so, disable stacktracing abilities.
+	 * @param string $message error message
+	 * @param array|null $variables translation variables
+	 * @param int $code The exception code.
 	 */
     public function __construct(string $message, array $variables = NULL, int $code = 0)
     {

--- a/src/library/Registrar/Adapter/Custom.php
+++ b/src/library/Registrar/Adapter/Custom.php
@@ -129,7 +129,7 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     public function getEpp(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Retrieving domain transfer code: ' . $domain->getName());
-        return true;
+        return '';
     }
 
     public function lock(Registrar_Domain $domain)

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -163,8 +163,12 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 
         $result = $this->_process('/Domain/Info', $params);
 
-        if ($result['status'] == 'SUCCESS')
+        if ($result['status'] == 'SUCCESS'){
             return $this->_createDomainObj($result, $domain);
+        } else {
+            $placeholders = ['action' => __trans('get domain details'), 'type' => 'Internetbs'];
+            throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
+        }
     }
 
     public function deleteDomain(Registrar_Domain $domain)

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -682,7 +682,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
             $placeholders = ['action' => __trans('set the domain lock status'), 'type' => 'Namecheap'];
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
-        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') { // @phpstan-ignore-line
+        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') {
             $domain->setLocked('true');
             return True;
         }
@@ -710,7 +710,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
             $placeholders = ['action' => __trans('set the domain lock status'), 'type' => 'Namecheap'];
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
-        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') { // @phpstan-ignore-line
+        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') {
             $domain->setLocked('false');
             return True;
         }

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -682,7 +682,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
             $placeholders = ['action' => __trans('set the domain lock status'), 'type' => 'Namecheap'];
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
-        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') {
+        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') { // @phpstan-ignore-line
             $domain->setLocked('true');
             return True;
         }
@@ -710,7 +710,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
             $placeholders = ['action' => __trans('set the domain lock status'), 'type' => 'Namecheap'];
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
-        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') {
+        if ($result->CommandResponse->DomainGetRegistrarLockResult['IsSuccess'] == 'true') { // @phpstan-ignore-line
             $domain->setLocked('false');
             return True;
         }

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -223,14 +223,12 @@ abstract class Registrar_AdapterAbstract
     }
 
     /**
-     * Gets a new HttpClient object.
-     *
-     * @return Symfony\Component\HttpClient\HttpClient The HttpClient object.
+     * Creates and returns an interface for the Symfony HTTP client.
      */
-    public function getHttpClient()
+    public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
         return \Symfony\Component\HttpClient\HttpClient::create();
-    }  
+    }
 
     /**
      * Enables test mode for the adapter.

--- a/src/library/Registrar/Exception.php
+++ b/src/library/Registrar/Exception.php
@@ -13,10 +13,9 @@ class Registrar_Exception extends Box_Exception
     /**
      * Creates a new translated exception, using the Box_Exception class.
      *
-     * @param   string   error message
-     * @param   array|null    translation variables
-     * @param   int 	 The exception code.
-     * @param 	bool 	 If the variables in this should be considered protect, if so, disable stacktracing abilities.
+	 * @param string $message error message
+	 * @param array|null $variables translation variables
+	 * @param int $code The exception code.
      */
     public function __construct(string $message, array $variables = NULL, int $code = 0)
     {

--- a/src/library/Server/Account.php
+++ b/src/library/Server/Account.php
@@ -96,10 +96,7 @@ class Server_Account
         return $this;
     }
 
-    /**
-     * @return Server_package
-     */
-    public function getPackage()
+    public function getPackage(): Server_Package
     {
         return $this->package;
     }

--- a/src/library/Server/Exception.php
+++ b/src/library/Server/Exception.php
@@ -13,10 +13,9 @@ class Server_Exception extends Box_Exception
     /**
      * Creates a new translated exception, using the Box_Exception class.
      *
-     * @param   string   error message
-     * @param   array|null    translation variables
-     * @param   int 	 The exception code.
-     * @param 	bool 	 If the variables in this should be considered protect, if so, disable stacktracing abilities.
+	 * @param string $message error message
+	 * @param array|null $variables translation variables
+	 * @param int $code The exception code.
      */
     public function __construct(string $message, array $variables = NULL, int $code = 0)
     {

--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -129,11 +129,9 @@ abstract class Server_Manager
     }
 
     /**
-     * Gets a new HttpClient object.
-     *
-     * @return Symfony\Component\HttpClient\HttpClient The HttpClient object.
+     * Creates and returns an interface for the Symfony HTTP client.
      */
-    public function getHttpClient()
+    public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
         return \Symfony\Component\HttpClient\HttpClient::create();
     }

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -329,8 +329,6 @@ class Server_Manager_Hestia extends Server_Manager
 
     /**
      * Change account username on server.
-     *
-     * @param Server_Account $new - new account username
      */
     public function changeAccountUsername(Server_Account $a, $new)
     {
@@ -339,8 +337,6 @@ class Server_Manager_Hestia extends Server_Manager
 
     /**
      * Change account domain on server.
-     *
-     * @param Server_Account $new - new domain name
      */
     public function changeAccountDomain(Server_Account $a, $new)
     {
@@ -349,8 +345,6 @@ class Server_Manager_Hestia extends Server_Manager
 
     /**
      * Change account password on server.
-     *
-     * @param Server_Account $new - new password
      */
     public function changeAccountPassword(Server_Account $a, $new)
     {
@@ -378,8 +372,6 @@ class Server_Manager_Hestia extends Server_Manager
 
     /**
      * Change account IP on server.
-     *
-     * @param Server_Account $new - account IP
      */
     public function changeAccountIp(Server_Account $a, $new)
     {

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -25,10 +25,8 @@ class Server_Manager_Hestia extends Server_Manager
 
     /**
      * Return server manager parameters.
-     *
-     * @return type
      */
-    public static function getForm()
+    public static function getForm(): array
     {
         return [
             'label' => 'Hestia Control Panel',
@@ -207,7 +205,7 @@ class Server_Manager_Hestia extends Server_Manager
                 'arg1' => $a->getUsername(),
             ];
             $result3 = $this->_makeRequest($postvars3);
-            if(0 !== intval($result3)) {
+            if (0 !== intval($result3)) {
                 $placeholders = ['action1' => __trans('delete domain'), 'action2' => __trans('create domain'), 'type' => 'HestiaCP'];
                 throw new Server_Exception('Failed to :action1: on the :type: server after failed to :action2:, check the error logs for further details', $placeholders);
             }
@@ -332,7 +330,7 @@ class Server_Manager_Hestia extends Server_Manager
     /**
      * Change account username on server.
      *
-     * @param type $new - new account username
+     * @param Server_Account $new - new account username
      */
     public function changeAccountUsername(Server_Account $a, $new)
     {
@@ -342,7 +340,7 @@ class Server_Manager_Hestia extends Server_Manager
     /**
      * Change account domain on server.
      *
-     * @param type $new - new domain name
+     * @param Server_Account $new - new domain name
      */
     public function changeAccountDomain(Server_Account $a, $new)
     {
@@ -352,7 +350,7 @@ class Server_Manager_Hestia extends Server_Manager
     /**
      * Change account password on server.
      *
-     * @param type $new - new password
+     * @param Server_Account $new - new password
      */
     public function changeAccountPassword(Server_Account $a, $new)
     {
@@ -381,7 +379,7 @@ class Server_Manager_Hestia extends Server_Manager
     /**
      * Change account IP on server.
      *
-     * @param type $new - account IP
+     * @param Server_Account $new - account IP
      */
     public function changeAccountIp(Server_Account $a, $new)
     {

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -133,7 +133,6 @@ class Server_Manager_Plesk extends Server_Manager
     public function suspendAccount(Server_Account $a, $suspend = true)
     {
     	if ($a->getReseller()) {
-            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 16]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 16]);
@@ -145,7 +144,6 @@ class Server_Manager_Plesk extends Server_Manager
     public function unsuspendAccount(Server_Account $a)
     {
     	if ($a->getReseller()) {
-            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 0]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 0]);
@@ -191,7 +189,6 @@ class Server_Manager_Plesk extends Server_Manager
     	$this->getLog()->info('Changing password for account ' . $a->getUsername());
 
     	if ($a->getReseller()) {
-            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['passwd' => $a->getPassword()]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['passwd' => $a->getPassword()]);
@@ -275,7 +272,6 @@ class Server_Manager_Plesk extends Server_Manager
 
    		$ns = array();
 
-        // @phpstan-ignore-next-line
    		foreach ($response->dns->get_rec->result as $dns) {
    			if ($dns->data->type == 'NS') {
    				$ns[] = (string)$dns->id;
@@ -302,7 +298,6 @@ class Server_Manager_Plesk extends Server_Manager
         $client = $a->getClient();
 
         if ($a->getReseller()) {
-            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
     		$result = $this->_client->reseller()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
     	} else {
     		$result = $this->_client->customer()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -133,6 +133,7 @@ class Server_Manager_Plesk extends Server_Manager
     public function suspendAccount(Server_Account $a, $suspend = true)
     {
     	if ($a->getReseller()) {
+            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 16]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 16]);
@@ -144,6 +145,7 @@ class Server_Manager_Plesk extends Server_Manager
     public function unsuspendAccount(Server_Account $a)
     {
     	if ($a->getReseller()) {
+            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 0]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 0]);
@@ -189,6 +191,7 @@ class Server_Manager_Plesk extends Server_Manager
     	$this->getLog()->info('Changing password for account ' . $a->getUsername());
 
     	if ($a->getReseller()) {
+            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['passwd' => $a->getPassword()]);
     	} else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['passwd' => $a->getPassword()]);
@@ -221,7 +224,7 @@ class Server_Manager_Plesk extends Server_Manager
             ]
         ];
 
-        $this->_client->webspace()->request($params);   
+        $this->_client->webspace()->request($params);
     }
 
     public function changeAccountIp(Server_Account $a, $new)
@@ -272,6 +275,7 @@ class Server_Manager_Plesk extends Server_Manager
 
    		$ns = array();
 
+        // @phpstan-ignore-next-line
    		foreach ($response->dns->get_rec->result as $dns) {
    			if ($dns->data->type == 'NS') {
    				$ns[] = (string)$dns->id;
@@ -298,6 +302,7 @@ class Server_Manager_Plesk extends Server_Manager
         $client = $a->getClient();
 
         if ($a->getReseller()) {
+            // @phpstan-ignore-next-line (This error is valid, however I don't have access to a plesk Instance to valudate if this request should just be made under `customer`)
     		$result = $this->_client->reseller()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
     	} else {
     		$result = $this->_client->customer()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -531,9 +531,6 @@ class Admin extends \Api_Abstract
      *
      * @optional string $title - new group title
      *
-     * @return bool
-     *
-     * @throws ErrorException
      */
     public function group_update($data)
     {
@@ -556,7 +553,6 @@ class Admin extends \Api_Abstract
      *
      * @return bool
      *
-     * @throws ErrorException
      */
     public function group_delete($data)
     {
@@ -581,7 +577,6 @@ class Admin extends \Api_Abstract
      *
      * @return array
      *
-     * @throws ErrorException
      */
     public function group_get($data)
     {

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -255,7 +255,7 @@ class Guest extends \Api_Abstract
      * Check if given vat number is valid EU country VAT number
      * This method uses http://isvat.appspot.com/ method to validate VAT.
      *
-     * @return bool- true if VAT is valid, false if not
+     * @return bool true if VAT is valid, false if not
      */
     public function is_vat($data)
     {

--- a/src/modules/Currency/Api/Admin.php
+++ b/src/modules/Currency/Api/Admin.php
@@ -234,7 +234,7 @@ class Admin extends \Api_Abstract
 
         $service = $this->getService();
         $model = $service->getByCode($data['code']);
-        if (!$model instanceof \Model_currency) {
+        if (!$model instanceof \Model_Currency) {
             throw new \Box_Exception('Currency not found');
         }
 

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -87,7 +88,7 @@ class Guest extends \Api_Abstract
         }
 
         $c['format'] = ($p >= 0) ? $c['format'] : '-' . $c['format'];
-        $p = $p >= 0 ? $p : -$p;
+        $p = $p >= 0 ? $p : '-' . $p;
 
         return str_replace('{{price}}', $p, $c['format']);
     }

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -150,7 +150,7 @@ class Service implements InjectionAwareInterface
     /**
      * Returns a list of available currencies.
      *
-     * @return string List of currencies in the "[short code] - [name]" format
+     * @return array List of currencies in the "[short code] - [name]" format
      */
     public function getAvailableCurrencies()
     {

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -11,6 +11,7 @@
 namespace Box\Mod\Currency;
 
 use FOSSBilling\InjectionAwareInterface;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use Symfony\Component\HttpClient\HttpClient;
 
 class Service implements InjectionAwareInterface
@@ -391,12 +392,8 @@ class Service implements InjectionAwareInterface
 
     /**
      * Enable or disable updating exchange rates whenever the CRON jobs are run.
-     *
-     * @since 4.22.0
-     *
-     * @var int
      */
-    public function setCron($data)
+    public function setCron($data): void
     {
         $sql = "INSERT INTO `setting` (`param`, `value`, `public`, `created_at`, `updated_at`) VALUES ('currency_cron_enabled', :key, '0', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP()) ON DUPLICATE KEY UPDATE `value`=:key, `updated_at`=CURRENT_TIMESTAMP()";
 
@@ -457,7 +454,7 @@ class Service implements InjectionAwareInterface
         $db = $this->di['db'];
 
         $model = $this->getByCode($code);
-        if (!$model instanceof \Model_currency) {
+        if (!$model instanceof \Model_Currency) {
             throw new \Box_Exception('Currency not found');
         }
 
@@ -523,8 +520,8 @@ class Service implements InjectionAwareInterface
      *
      * @todo use HTTPClient instead of simplexml_load_file()
      *
-     * @var string Short code for the base currency
-     * @var string Short code for the target currency
+     * @param string $from Short code for the base currency
+     * @param string $to Short code for the target currency
      *
      * @return float Exchange rate
      */
@@ -568,7 +565,7 @@ class Service implements InjectionAwareInterface
     {
         $model = $this->getByCode($code);
 
-        if (!$model instanceof \Model_currency) {
+        if (!$model instanceof \Model_Currency) {
             throw new \Box_Exception('Currency not found');
         }
         $code = $model->code;

--- a/src/modules/Email/Api/Admin.php
+++ b/src/modules/Email/Api/Admin.php
@@ -48,9 +48,6 @@ class Admin extends \Api_Abstract
      * Get sent email details.
      *
      * @return array
-     *
-     * @throws \Box_Exception
-     * @throws LogicException
      */
     public function email_get($data)
     {
@@ -71,8 +68,6 @@ class Admin extends \Api_Abstract
      * @optional int $client_id - log this message to client history
      *
      * @return bool
-     *
-     * @throws \Box_Exception
      */
     public function send($data = [])
     {
@@ -105,7 +100,6 @@ class Admin extends \Api_Abstract
      * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function email_resend($data)
     {
@@ -129,7 +123,6 @@ class Admin extends \Api_Abstract
      * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function email_delete($data)
     {
@@ -183,7 +176,6 @@ class Admin extends \Api_Abstract
      * @return array
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function template_get($data)
     {
@@ -203,7 +195,6 @@ class Admin extends \Api_Abstract
      * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function template_delete($data)
     {
@@ -257,8 +248,7 @@ class Admin extends \Api_Abstract
      * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
-     */
+=     */
     public function template_update($data)
     {
         $required = [
@@ -340,12 +330,8 @@ class Admin extends \Api_Abstract
 
     /**
      * Sends the test email to the currently authenticated admin / staff member.
-     *
-     * @param type $data
-     *
-     * @return bool
      */
-    public function send_test($data)
+    public function send_test(array $data): bool
     {
         $currentUser = $this->di['loggedin_admin'];
 

--- a/src/modules/Email/Api/Client.php
+++ b/src/modules/Email/Api/Client.php
@@ -52,7 +52,6 @@ class Client extends \Api_Abstract
      * @return array
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function get($data)
     {
@@ -73,10 +72,9 @@ class Client extends \Api_Abstract
     /**
      * Resend email to client once again.
      *
-     * @return type
+     * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function resend($data)
     {
@@ -96,10 +94,9 @@ class Client extends \Api_Abstract
     /**
      * Remove email from system.
      *
-     * @return type
+     * @return bool
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function delete($data)
     {

--- a/src/modules/Formbuilder/Api/Admin.php
+++ b/src/modules/Formbuilder/Api/Admin.php
@@ -147,7 +147,7 @@ class Admin extends \Api_Abstract
     /**
      * Get array of forms.
      *
-     * @return multidimensional array
+     * @return array
      *
      * @throws \Box_Exception
      */
@@ -200,29 +200,27 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Update form.
+     * Update form field.
      *
-     * @param array
+     * @param array $data - An array containing the field data.
+     * @optional string $data['label'] - The label of the field to be displayed. Default is "Type X," where X is the number of fields in the form (e.g., "Checkbox 2").
+     * @optional string $data['name'] - The name of the field. Default is "new_type_X," where X is the number of fields in the form (e.g., "new_checkbox_2").
+     * @optional bool $data['hide_label'] - Specifies whether to hide the field label.
+     * @optional string $data['description'] - The description of the field.
+     * @optional mixed $data['default_value'] - The default value of the field. If the field is a checkbox or radio button, this should be an array; otherwise, it should be a string.
+     * @optional bool $data['required'] - Specifies whether the field is required (not applicable for checkboxes).
+     * @optional bool $data['hidden'] - Specifies whether the field should be hidden.
+     * @optional bool $data['readonly'] - Specifies whether the field should be read-only.
+     * @optional string $data['prefix'] - The prefix for "text" type fields.
+     * @optional string $data['suffix'] - The suffix for "text" type fields.
+     * @optional array $data['options'] - An array of options for "select," "checkbox," and "radio" type fields. Keys represent labels, and values represent field values. The array must contain unique values.
+     * @optional bool $data['show_initial'] - Specifies whether to show the initial value.
+     * @optional bool $data['show_middle'] - Specifies whether to show the middle value.
+     * @optional bool $data['show_prefix'] - Specifies whether to show the prefix.
+     * @optional bool $data['show_suffix'] - Specifies whether to show the suffix.
+     * @optional int $data['text_size'] - The preferred text size.
      *
-     * @optional
-     * @optional string $label - Label of the field which will be shown. Default value "Type X" where X is number of fields in form. For example "Checkbox 2"
-     * @optional string $name - Name of the field. Default value "new_type_X" where X is number of fields in the form. For example "new_checkbox_2"
-     * @optional bool $hide_label - Option either hide label of field or not
-     * @optional string $description - Description of a field
-     * @optional mixed $default_value - Default value of field. If field is checkbox or radio this variable must be array, otherwise it is string
-     * @optional bool $required - Option wither field need to have "required" attribute (Not applicable for checkboxes)
-     * @optional bool $hidden - Option either field should be hidden
-     * @optional bool $readonly - Option either field needs to be readonly
-     * @optional string $prefix - Prefix for "text" type fields
-     * @optional string $suffix - Suffix for "text" type fields
-     * @optional array $options - Array of options for "select", "checkbox" and "radio" type fields. Key represents label and value will be field's value. Array must be unique.
-     * @optional bool $show_initial - Either show initial or not
-     * @optional bool $show_middle - Either show middle or not
-     * @optional bool $show_prefix - Either to show prefix or not
-     * @optional bool $show_suffix - Either to show suffix or not
-     * @optional int $text_size - Preferred text size
-     *
-     * @return int - ID of the field
+     * @return int - The ID of the updated field.
      *
      * @throws \Box_Exception
      */

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -97,8 +97,8 @@ class Service implements InjectionAwareInterface
                     $p = $method->getParameters();
                     if ($method->isPublic()
                         && isset($p[0])
-                        && $p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null
-                        && in_array($p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null, ['Box_Event', '\Box_Event'])) {
+                        && $p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null // @phpstan-ignore-line
+                        && in_array($p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null, ['Box_Event', '\Box_Event'])) { // @phpstan-ignore-line
                         $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
                     }
                 }

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -97,8 +97,8 @@ class Service implements InjectionAwareInterface
                     $p = $method->getParameters();
                     if ($method->isPublic()
                         && isset($p[0])
-                        && $p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null // @phpstan-ignore-line
-                        && in_array($p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null, ['Box_Event', '\Box_Event'])) { // @phpstan-ignore-line
+                        && $p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null // @phpstan-ignore-line (The code is valid)
+                        && in_array($p[0]->getType() && !$p[0]->getType()->isBuiltin() ? new \ReflectionClass($p[0]->getType()->getName()) : null, ['Box_Event', '\Box_Event'])) { // @phpstan-ignore-line (The code is valid)
                         $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
                     }
                 }

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -207,7 +207,6 @@ class Admin extends \Api_Abstract
      * @return string - invoice id
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function renewal_invoice($data)
     {
@@ -333,10 +332,8 @@ class Admin extends \Api_Abstract
 
     /**
      * Process selected transaction.
-     *
-     * @return transaction output or true;
      */
-    public function transaction_process($data)
+    public function transaction_process($data): bool
     {
         $required = [
             'id' => 'Transaction id is missing',
@@ -553,12 +550,10 @@ class Admin extends \Api_Abstract
 
     /**
      * Return existing module but not activated.
-     *
-     * @param none
-     *
+     * 
      * @return array
      */
-    public function gateway_get_available($data)
+    public function gateway_get_available(array $data)
     {
         $gatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
 
@@ -568,11 +563,9 @@ class Admin extends \Api_Abstract
     /**
      * Install available payment gateway.
      *
-     * @param code - available payment gateway code
-     *
      * @return true
      */
-    public function gateway_install($data)
+    public function gateway_install(array $data)
     {
         $required = [
             'code' => 'Payment gateway code is missing',
@@ -607,8 +600,6 @@ class Admin extends \Api_Abstract
 
     /**
      * Copy gateway from existing one.
-     *
-     * @return int - new id of gateway
      *
      * @throws \Box_Exception
      */
@@ -903,7 +894,7 @@ class Admin extends \Api_Abstract
      * This action will delete any existing tax rules and configure the VAT rates
      * for all EU countries.
      *
-     * @return type
+     * @return bool
      */
     public function tax_setup_eu($data)
     {

--- a/src/modules/Invoice/Api/Client.php
+++ b/src/modules/Invoice/Api/Client.php
@@ -39,7 +39,7 @@ class Client extends \Api_Abstract
     /**
      * Get invoice details.
      *
-     * @return type
+     * @return array
      *
      * @throws \Box_Exception
      */
@@ -96,7 +96,6 @@ class Client extends \Api_Abstract
      * @return string - invoice hash
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function renewal_invoice($data)
     {
@@ -179,7 +178,7 @@ class Client extends \Api_Abstract
      * @optional string $date_from - filter transactions by date
      * @optional string $date_to - filter transactions by date
      *
-     * @return type
+     * @return array
      */
     public function transaction_get_list($data)
     {

--- a/src/modules/Invoice/Api/Guest.php
+++ b/src/modules/Invoice/Api/Guest.php
@@ -95,7 +95,6 @@ class Guest extends \Api_Abstract
      * @return array
      *
      * @throws \Box_Exception
-     * @throws LogicException
      */
     public function payment($data)
     {

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -341,6 +341,7 @@ class ServiceTransaction implements InjectionAwareInterface
      */
     public function processTransaction($id)
     {
+        /** @var \Model_Transaction $tx */
         $tx = $this->di['db']->load('Transaction', $id);
         if (!$tx) {
             throw new \Box_Exception('Transaction :id not found.', ['id' => $id], 404);
@@ -361,7 +362,7 @@ class ServiceTransaction implements InjectionAwareInterface
             throw new \Box_Exception('Payment adapter :adapter does not support action :action', [':adapter' => $gtw->name, ':action' => 'processTransaction'], 705);
         }
 
-        $ipn = json_decode($tx->ipn, 1); // @phpstan-ignore-line
+        $ipn = json_decode($tx->ipn, 1);
 
         return $adapter->processTransaction($this->di['api_system'], $id, $ipn, $tx->gateway_id);
     }

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -310,33 +310,18 @@ class ServiceTransaction implements InjectionAwareInterface
         ];
     }
 
-    /**
-     * @param \Model_Transaction $model
-     */
-    public function oldProcessLogic($model)
-    {
-        $tx = $this->process($model);
-
-        return !empty($tx->output) ? $tx->output : null;
-    }
-
     public function preProcessTransaction(\Model_Transaction $model)
     {
         try {
             $output = $this->processTransaction($model->id);
         } catch (\Box_Exception $e) {
-            // if gateway does not support new logic use old logic
-            if ($e->getCode() == 705) {
-                $output = $this->oldProcessLogic($model);
-            } else {
-                $model->status = \Model_Transaction::STATUS_ERROR;
-                $model->error = $e->getMessage();
-                $model->error_code = $e->getCode();
-                $model->updated_at = date('Y-m-d H:i:s');
-                $this->di['db']->store($model);
+            $model->status = \Model_Transaction::STATUS_ERROR;
+            $model->error = $e->getMessage();
+            $model->error_code = $e->getCode();
+            $model->updated_at = date('Y-m-d H:i:s');
+            $this->di['db']->store($model);
 
-                throw $e;
-            }
+            throw $e;
         }
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminTransactionProcess', 'params' => ['id' => $model->id]]);
@@ -350,7 +335,7 @@ class ServiceTransaction implements InjectionAwareInterface
      *
      * @since 2.9.11
      *
-     * @param type $id
+     * @param int $id
      *
      * @throws \Box_Exception
      */
@@ -376,7 +361,7 @@ class ServiceTransaction implements InjectionAwareInterface
             throw new \Box_Exception('Payment adapter :adapter does not support action :action', [':adapter' => $gtw->name, ':action' => 'processTransaction'], 705);
         }
 
-        $ipn = json_decode($tx->ipn, 1);
+        $ipn = json_decode($tx->ipn, 1); // @phpstan-ignore-line
 
         return $adapter->processTransaction($this->di['api_system'], $id, $ipn, $tx->gateway_id);
     }

--- a/src/modules/Massmailer/Api/Admin.php
+++ b/src/modules/Massmailer/Api/Admin.php
@@ -155,7 +155,7 @@ Order our services at {{ "order"|link }}
 
         $this->getService()->sendMessage($model, $client_id);
 
-        $this->di['logger']->info('Sent test mail message #%s to client ', $model->id);
+        $this->di['logger']->info('Sent test mail message #%s to client ', $model->id); // @phpstan-ignore-line
 
         return true;
     }
@@ -186,13 +186,13 @@ Order our services at {{ "order"|link }}
                 'handler' => 'sendMail',
                 'max' => $max,
                 'interval' => $interval,
-                'params' => ['msg_id' => $model->id, 'client_id' => $c['id']],
+                'params' => ['msg_id' => $model->id, 'client_id' => $c['id']], // @phpstan-ignore-line
             ];
             $this->di['api_admin']->queue_message_add($d);
         }
 
-        $model->status = 'sent';
-        $model->sent_at = date('Y-m-d H:i:s');
+        $model->status = 'sent'; // @phpstan-ignore-line
+        $model->sent_at = date('Y-m-d H:i:s'); // @phpstan-ignore-line
         $id = $this->di['db']->store($model);
 
         $this->di['logger']->info('Added mass mail messages #%s to queue', $id);

--- a/src/modules/Massmailer/Api/Admin.php
+++ b/src/modules/Massmailer/Api/Admin.php
@@ -146,6 +146,7 @@ Order our services at {{ "order"|link }}
      */
     public function send_test($data)
     {
+        /** @var \Model_MassmailerMessage $model */
         $model = $this->_getMessage($data);
         $client_id = $this->_getTestClientId();
 
@@ -155,7 +156,7 @@ Order our services at {{ "order"|link }}
 
         $this->getService()->sendMessage($model, $client_id);
 
-        $this->di['logger']->info('Sent test mail message #%s to client ', $model->id); // @phpstan-ignore-line
+        $this->di['logger']->info('Sent test mail message #%s to client ', $model->id);
 
         return true;
     }
@@ -167,6 +168,7 @@ Order our services at {{ "order"|link }}
      */
     public function send($data)
     {
+        /** @var \Model_MassmailerMessage $model */
         $model = $this->_getMessage($data);
 
         if (empty($model->content)) {
@@ -186,13 +188,13 @@ Order our services at {{ "order"|link }}
                 'handler' => 'sendMail',
                 'max' => $max,
                 'interval' => $interval,
-                'params' => ['msg_id' => $model->id, 'client_id' => $c['id']], // @phpstan-ignore-line
+                'params' => ['msg_id' => $model->id, 'client_id' => $c['id']],
             ];
             $this->di['api_admin']->queue_message_add($d);
         }
 
-        $model->status = 'sent'; // @phpstan-ignore-line
-        $model->sent_at = date('Y-m-d H:i:s'); // @phpstan-ignore-line
+        $model->status = 'sent';
+        $model->sent_at = date('Y-m-d H:i:s');
         $id = $this->di['db']->store($model);
 
         $this->di['logger']->info('Added mass mail messages #%s to queue', $id);

--- a/src/modules/Product/Api/Admin.php
+++ b/src/modules/Product/Api/Admin.php
@@ -51,7 +51,7 @@ class Admin extends \Api_Abstract
     /**
      * Get product details.
      *
-     * @return type
+     * @return array
      */
     public function get($data)
     {

--- a/src/modules/Product/Api/Guest.php
+++ b/src/modules/Product/Api/Guest.php
@@ -21,7 +21,7 @@ class Guest extends \Api_Abstract
      *
      * @optional bool $show_hidden - also get hidden products. Default false
      *
-     * @return type
+     * @return array
      */
     public function get_list($data)
     {

--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -171,12 +171,6 @@ class Service implements InjectionAwareInterface
 
         $client->updated_at = date('Y-m-d H:i:s');
 
-        foreach ($client as $key => $value) {
-            if (empty($value)) {
-                $client->$key = null;
-            }
-        }
-
         $this->di['db']->store($client);
 
         $this->di['events_manager']->fire(['event' => 'onAfterClientProfileUpdate', 'params' => ['id' => $client->id]]);

--- a/src/modules/Serviceapikey/Service.php
+++ b/src/modules/Serviceapikey/Service.php
@@ -8,13 +8,6 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-/**
- * This file is a delegate for module. Class does not extend any other class.
- *
- * All methods provided in this example are optional, but function names are
- * still reserved.
- */
-
 namespace Box\Mod\Serviceapikey;
 
 use FOSSBilling\InjectionAwareInterface;

--- a/src/modules/Servicecustom/Service.php
+++ b/src/modules/Servicecustom/Service.php
@@ -50,7 +50,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     }
 
     /**
-     * @return void
+     * @return \Model_ServiceCustom
      */
     public function action_create(\Model_ClientOrder $order)
     {

--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -309,7 +309,7 @@ class Admin extends \Api_Abstract
     /**
      * Get available registrars for install.
      *
-     * @return type
+     * @return array
      */
     public function registrar_get_available($data)
     {

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -59,7 +59,7 @@ class Service implements InjectionAwareInterface
     /**
      * @todo
      *
-     * @return void
+     * @return \Model_ServiceHosting
      */
     public function action_create(\Model_ClientOrder $order)
     {

--- a/src/modules/Servicemembership/Service.php
+++ b/src/modules/Servicemembership/Service.php
@@ -30,7 +30,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     }
 
     /**
-     * @return void
+     * @return \Model_ServiceMembership
      */
     public function action_create(\Model_ClientOrder $order)
     {

--- a/src/modules/Spamchecker/Api/Guest.php
+++ b/src/modules/Spamchecker/Api/Guest.php
@@ -17,9 +17,9 @@ namespace Box\Mod\Spamchecker\Api;
 class Guest extends \Api_Abstract
 {
     /**
-     * Returns recaptcha public key.
+     * Returns recaptcha configuration info
      *
-     * @return string
+     * @return array
      */
     public function recaptcha($data)
     {

--- a/src/modules/Staff/Api/Admin.php
+++ b/src/modules/Staff/Api/Admin.php
@@ -199,7 +199,7 @@ class Admin extends \Api_Abstract
     /**
      * Return pairs of staff member groups.
      *
-     * @return type
+     * @return array
      */
     public function group_get_pairs($data)
     {
@@ -324,8 +324,6 @@ class Admin extends \Api_Abstract
      * Get details of login history event.
      *
      * @return array
-     *
-     * @throws ErrorException
      */
     public function login_history_get($data)
     {
@@ -343,8 +341,6 @@ class Admin extends \Api_Abstract
      * Delete login history event.
      *
      * @return bool
-     *
-     * @throws ErrorException
      */
     public function login_history_delete($data)
     {

--- a/tests/modules/Invoice/ServiceTransactionTest.php
+++ b/tests/modules/Invoice/ServiceTransactionTest.php
@@ -75,10 +75,10 @@ class ServiceTransactionTest extends \BBTestCase
         $this->service->setDi($di);
 
         $data   = array(
-            'invoice_id'   => '',
-            'txn_id'       => '',
+            'invoice_id'   => 1,
+            'txn_id'       => 2,
             'txn_status'   => '',
-            'gateway_id'   => '',
+            'gateway_id'   => 1,
             'amount'       => '',
             'currency'     => '',
             'type'         => '',
@@ -232,13 +232,12 @@ class ServiceTransactionTest extends \BBTestCase
             'note'         => null,
             'created_at'   => null,
             'updated_at'   => null,
-            'ipn'          => null,
         );
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
         $transactionModel->gateway_id = 1;
 
-        $result = $this->service->toApiArray($transactionModel, true);
+        $result = $this->service->toApiArray($transactionModel, false);
         $this->assertIsArray($result);
         $this->assertEquals($expected, $result);
     }

--- a/tests/modules/Invoice/ServiceTransactionTest.php
+++ b/tests/modules/Invoice/ServiceTransactionTest.php
@@ -381,23 +381,6 @@ class ServiceTransactionTest extends \BBTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testoldProcessLogic()
-    {
-        $transactionModel = new \Model_Transaction();
-        $transactionModel->loadBean(new \DummyBean());
-        $transactionModel->output = 'output String';
-
-        $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\ServiceTransaction')
-            ->setMethods(array('process'))
-            ->getMock();
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('process')
-            ->will($this->returnValue($transactionModel));
-
-        $result = $serviceMock->oldProcessLogic($transactionModel);
-        $this->assertIsString($result);
-    }
-
     public function testpreProcessTransaction()
     {
         $transactionModel = new \Model_Transaction();
@@ -408,35 +391,6 @@ class ServiceTransactionTest extends \BBTestCase
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('processTransaction')
-            ->will($this->returnValue('processedOutputString'));
-
-        $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
-        $eventMock->expects($this->atLeastOnce())
-            ->method('fire');
-
-
-        $di                   = new \Pimple\Container();
-        $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
-        $serviceMock->setDi($di);
-
-        $result = $serviceMock->preProcessTransaction($transactionModel);
-        $this->assertIsString($result);
-    }
-
-    public function testpreProcessTransaction_supportOldLogic()
-    {
-        $transactionModel = new \Model_Transaction();
-        $transactionModel->loadBean(new \DummyBean());
-
-        $serviceMock = $this->getMockBuilder('\Box\Mod\Invoice\ServiceTransaction')
-            ->setMethods(array('processTransaction', 'oldProcessLogic'))
-            ->getMock();
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('processTransaction')
-            ->will($this->throwException(new \Box_Exception('Exception created with PHPUnit Test', null, 705)));
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('oldProcessLogic')
             ->will($this->returnValue('processedOutputString'));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
@@ -478,57 +432,6 @@ class ServiceTransactionTest extends \BBTestCase
         $this->expectException(\Box_Exception::class);
         $this->expectExceptionMessage($exceptionMessage);
         $serviceMock->preProcessTransaction($transactionModel);
-    }
-
-    public function paymentsAdapterProvider_withoutProcessTransaction()
-    {
-        return array(
-            array('\Payment_Adapter_AliPay'),
-            array('\Payment_Adapter_AuthorizeNet'),
-            array('\Payment_Adapter_Interkassa'),
-            array('\Payment_Adapter_Onebip'),
-            array('\Payment_Adapter_Custom'),
-        );
-    }
-
-    /**
-     * @dataProvider paymentsAdapterProvider_withoutProcessTransaction
-     */
-    public function testprocessTransactionWithPayment_Adapter($adapter)
-    {
-        $id               = 1;
-        $transactionModel = new \Model_Transaction();
-        $transactionModel->loadBean(new \DummyBean());
-        $transactionModel->gateway_id = 2;
-        $transactionModel->ipn        = '{}';
-
-        $payGatewayModel = new \Model_PayGateway();
-        $payGatewayModel->loadBean(new \DummyBean());
-        $payGatewayModel->name = substr($adapter, strpos($adapter, '\Payment_Adapter_') + 1);
-
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('load')
-            ->will($this->onConsecutiveCalls($transactionModel, $payGatewayModel));
-
-        $paymentAdapterMock = $this->getMockBuilder('\Payment_Adapter_Custom')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $payGatewayService = $this->getMockBuilder('\Box\Mod\Invoice\ServicePayGateway')->getMock();
-        $payGatewayService->expects($this->atLeastOnce())
-            ->method('getPaymentAdapter')
-            ->will($this->returnValue($paymentAdapterMock));
-
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(function () use ($payGatewayService) { return $payGatewayService; });
-        $di['api_admin']   = new \Api_Handler(new \Model_Admin());
-        $this->service->setDi($di);
-
-        $this->expectException(\Box_Exception::class);
-        $this->expectExceptionMessage(sprintf("Payment adapter %s does not support action %s", $payGatewayModel->name, 'processTransaction'));
-        $this->service->processTransaction($id);
     }
 
     public function paymentsAdapterProvider_withprocessTransaction()


### PR DESCRIPTION
This PR bumps our PHPStan config from level 1 to level 3.

This page describes what each level adds to the scanning:
https://phpstan.org/user-guide/rule-levels

For the most part, the changes I've made are to PHPDocs that were incorrect

Also, I did remove the logic that allowed a payment gateway to continue to function using the outdated `process` function as it added stupid complexity to the possible return value of a few of the internal functions.

The only one of ours that used that was the custom adapter and I've updated it to use the newer `processTransaction` function and anything else remaining likely has not been updated in at least a decade. So I think we are good to drop that code-path.