### PR TITLE
Quick fix to the models

### DIFF
--- a/src/library/Model/MassmailerMessage.php
+++ b/src/library/Model/MassmailerMessage.php
@@ -10,7 +10,7 @@
 
 class Model_MassmailerMessage extends \RedBeanPHP\SimpleModel
 {
-    public int $id;
-    public string $status;
-    public string $sent_at;
+    public int $id = 0;
+    public string $status = '';
+    public string $sent_at = '';
 }

--- a/src/library/Model/Transaction.php
+++ b/src/library/Model/Transaction.php
@@ -15,6 +15,6 @@ class Model_Transaction extends \RedBeanPHP\SimpleModel
     public const STATUS_PROCESSED       = 'processed';
     public const STATUS_ERROR           = 'error';
 
-    public int $gateway_id;
-    public string $ipn;
+    public int $gateway_id = 0 ;
+    public string $ipn = '';
 }


### PR DESCRIPTION
Quick fix after the PHPStan PR.
It seems like because of how RedBeanPHP works, these model properties need to have placeholder values or else you'll get errors like this:
> Typed property Model_Transaction::$gateway_id must not be accessed before initialization

Thankfully a very easy fix