### PR TITLE
Fix redirect issue with stripe

### DIFF
--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -330,7 +330,9 @@ class Service
         } else {
             // attempt adding admin api to twig
             try {
-                $twig->addGlobal('admin', $this->di['api_admin']);
+                if($this->di['auth']->isAdminLoggedIn()){
+                    $twig->addGlobal('admin', $this->di['api_admin']);
+                }
             } catch (\Exception) {
                 // skip if admin is not logged in
             }


### PR DESCRIPTION
Closes #1631 and closes #1630

When I introduced a change to cleanly handle someone not being authenticated, I then broke this code from BoxBilling that **relied** on `$this->di['api_admin']` to throw an exception because the code did not use the built in functionality to actually check if a staff member is authenticated. 

When sending / queuing an email template, `renderString` is used to to render the twig template into HTML which then resulted in `$this->di['api_admin']` calling `$di['loggedin_admin']`, which redirects to the login page if there is no staff member logged in or if the account was destroyed.

Email templates are automatically sent / queued after paying for an invoice, hence the issue.