### PR TITLE
Revert of the model changes from the PHPStan PR

### DIFF
--- a/src/library/Model/MassmailerMessage.php
+++ b/src/library/Model/MassmailerMessage.php
@@ -10,7 +10,4 @@
 
 class Model_MassmailerMessage extends \RedBeanPHP\SimpleModel
 {
-    public int $id = 0;
-    public string $status = '';
-    public string $sent_at = '';
 }

--- a/src/library/Model/Transaction.php
+++ b/src/library/Model/Transaction.php
@@ -14,7 +14,4 @@ class Model_Transaction extends \RedBeanPHP\SimpleModel
     public const STATUS_APPROVED        = 'approved';
     public const STATUS_PROCESSED       = 'processed';
     public const STATUS_ERROR           = 'error';
-
-    public int $gateway_id = 0 ;
-    public string $ipn = '';
 }


### PR DESCRIPTION
Unfortunately, having these properties set causes issues when it comes to writing info to the database with RedBeanPHP. I don't honestly know why at the moment, but removing the added properties is enough to get things working as they should be.

I thought I had added these specifically to make PHPStan happy, however when I ran it again with the properties removed it was still happy. So.. I'm actually a bit confused.

But no matter what we do need to figure out how to add the properties to the models as PHP 8.2 deprecates dynamic properties and they are to be completely removed by  PHP 9.0. Until then, this revert is needed for functionality. 