### PR TITLE
Significantly improve translation management

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,15 +36,21 @@ jobs:
       - name: Check PHP Version
         run: php -v
 
-      - name: Clone and update the locale submodule.
-        run: git submodule update --init --remote --recursive
+      - name: Remove placeholder locale files
+        run: rm -r ./*
         working-directory: ./src/locale
 
-      - name: Remove unneeded files from the locale folder
+      - name: Download the latest translations
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: "FOSSBilling/locale"
+          fileName: "translations.zip"
+          out-file-path: "./src/locale"
+
+      - name: Extract the translations
         run: |
-          find -name '*.po' -delete
-          rm -rf .github
-          rm -f crowdin.yml messages.pot .git
+          unzip translations.zip
+          rm -f translations.zip
         working-directory: ./src/locale
 
       - name: Validate composer.json and composer.lock

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,6 +46,7 @@ jobs:
           repository: "FOSSBilling/locale"
           fileName: "translations.zip"
           out-file-path: "./src/locale"
+          latest: true
 
       - name: Extract the translations
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,7 +37,7 @@ jobs:
         run: php -v
 
       - name: Remove placeholder locale files
-        run: rm -r ./*
+        run: rm -rf *
         working-directory: ./src/locale
 
       - name: Download the latest translations

--- a/cspell.json
+++ b/cspell.json
@@ -359,7 +359,11 @@
         "pwreset",
         "pagebottom",
         "forceable",
-        "phpstan"
+        "phpstan",
+        "progressbar",
+        "valuenow",
+        "valuemin",
+        "valuemax"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -128,7 +128,7 @@ class i18n
      *  
      * @throws \Box_Exception 
      */
-    public static function ToggleLocale(string $locale): bool
+    public static function toggleLocale(string $locale): bool
     {
         $basePath = PATH_LANGS . DIRECTORY_SEPARATOR . $locale;
         if (!is_dir($basePath)) {
@@ -144,6 +144,29 @@ class i18n
             file_put_contents($disablePath, '');
             return file_exists($disablePath);
         }
+    }
+
+    /**
+     * Returns how complete a locale is.
+     * Will return 0 if the `completion.php` doesn't exist or if it doesn't include the specified locale.
+     * 
+     * @param string $local The locale ID (Example: `en_US`)
+     * 
+     * @return int The percetnage complete for the specified locale. 
+     */
+    public static function getLocaleCompletionPercent(string $local): int
+    {
+        if ($local === 'en_US') {
+            return 100;
+        }
+
+        $completionFile = PATH_LANGS . DIRECTORY_SEPARATOR . 'completion.php';
+        if (!file_exists($completionFile)) {
+            return 0;
+        }
+
+        $completion = include $completionFile;
+        return intval($completion[$local] ?? 0);
     }
 
     /**

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -124,7 +124,7 @@ class i18n
      * 
      * @param string $locale The locale code to toggle. (Example: `en_US`)
      * 
-     * @return bool To indicate if it was sucsessful,
+     * @return bool To indicate if it was successful,
      *  
      * @throws \Box_Exception 
      */
@@ -152,7 +152,7 @@ class i18n
      * 
      * @param string $local The locale ID (Example: `en_US`)
      * 
-     * @return int The percetnage complete for the specified locale. 
+     * @return int The percentage complete for the specified locale. 
      */
     public static function getLocaleCompletionPercent(string $local): int
     {

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -132,7 +132,7 @@ class i18n
     {
         $basePath = PATH_LANGS . DIRECTORY_SEPARATOR . $locale;
         if (!is_dir($basePath)) {
-            throw new \Box_Exception('Unable to enable / disable locale, it does not exist on the disk.');
+            throw new \Box_Exception('Unable to enable / disable the locale as it is not present in the locale folder.');
         }
 
         $disablePath = $basePath . DIRECTORY_SEPARATOR . '.disabled';
@@ -150,13 +150,13 @@ class i18n
      * Returns how complete a locale is.
      * Will return 0 if the `completion.php` doesn't exist or if it doesn't include the specified locale.
      * 
-     * @param string $local The locale ID (Example: `en_US`)
+     * @param string $locale The locale ID (Example: `en_US`)
      * 
      * @return int The percentage complete for the specified locale. 
      */
-    public static function getLocaleCompletionPercent(string $local): int
+    public static function getLocaleCompletionPercent(string $locale): int
     {
-        if ($local === 'en_US') {
+        if ($locale === 'en_US') {
             return 100;
         }
 
@@ -166,7 +166,7 @@ class i18n
         }
 
         $completion = include $completionFile;
-        return intval($completion[$local] ?? 0);
+        return intval($completion[$locale] ?? 0);
     }
 
     /**

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -67,12 +67,28 @@ class Admin extends \Api_Abstract
 
     /**
      * Get list of available languages on the system.
-     *
-     * @return array
      */
-    public function languages()
+    public function languages(array $data): array
     {
-        return \FOSSBilling\i18n::getLocales(true);
+        $data['disabled'] ??= false; 
+        return \FOSSBilling\i18n::getLocales(true, $data['disabled']);
+    }
+
+    /**
+     * Toggles a given locale to either enable or disable it depending on it's current status.
+     * 
+     * @param array $data The post data sent to the API. Should contain a key named `locale_id` which is set to the locale ID to change. (`en_US` for example)
+     * 
+     * @throws \Box_Exception 
+     */
+    public function toggle_language(array $data): bool
+    {
+        $required = [
+            'locale_id' => 'Extension ID was not passed',
+        ];
+
+        $this->di['validator']->checkRequiredParamsForArray($required, $data);
+        return \FOSSBilling\i18n::ToggleLocale($data['locale_id']);
     }
 
     /**

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -70,7 +70,7 @@ class Admin extends \Api_Abstract
      */
     public function languages(array $data): array
     {
-        $data['disabled'] ??= false; 
+        $data['disabled'] ??= false;
         return \FOSSBilling\i18n::getLocales(true, $data['disabled']);
     }
 
@@ -84,11 +84,25 @@ class Admin extends \Api_Abstract
     public function toggle_language(array $data): bool
     {
         $required = [
-            'locale_id' => 'Extension ID was not passed',
+            'locale_id' => 'Locale ID was not passed',
         ];
 
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
-        return \FOSSBilling\i18n::ToggleLocale($data['locale_id']);
+        return \FOSSBilling\i18n::toggleLocale($data['locale_id']);
+    }
+
+    /**
+     * Returns how complete a given locale is.
+     * @param array $data $data The post data sent to the API. Should contain a key named `locale_id` which is set to the locale ID to get the completion percentage for. (`en_US` for example)
+     */
+    public function locale_completion(array $data): int
+    {
+        $required = [
+            'locale_id' => 'Locale ID was not passed',
+        ];
+
+        $this->di['validator']->checkRequiredParamsForArray($required, $data);
+        return \FOSSBilling\i18n::getLocaleCompletionPercent($data['locale_id']);
     }
 
     /**

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -150,7 +150,7 @@
                         </div>
 
                         <h5>{{ 'Changing default language'|trans }}</h5>
-                        <p>{{ 'Instructions for changing the default language can be found on the FOSSBilling documentation.'|trans }} <a target="_blank" href="https://fossbilling.org/docs/customizing-fossbilling/localization#changing-the-default-language">({{ 'Changinge the default language'|trans }})<a></p>
+                        <p>{{ 'Instructions for changing the default language can be found on the FOSSBilling documentation.'|trans }} <a target="_blank" href="https://fossbilling.org/docs/customizing-fossbilling/localization#changing-the-default-language">({{ 'Changing the default language'|trans }})<a></p>
                     </div>
                 </div>
             </div>

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -144,15 +144,13 @@
                         <p class="card-subtitle">{{ 'Although FOSSBilling displays in U.S. English by default, it has the capability to be used in any language. Follow instructions bellow to install new language.'|trans }}</p>
                         <div>
                             <ul>
-                                <li>{{ 'Check if your language translation files are available at the '|trans }} <a href="https://github.com/FOSSBilling/locale" target="_blank">{{ 'FOSSBilling translations repository'|trans }}</a></li>
-                                <li>{{ 'Download the language files and place them under'|trans }} <code>{{ constant('PATH_LANGS') }}</code></li>
-                                <li>{{ 'The language will automatically be detected and made available for use.'|trans }}</li>
-                                <li>{{ 'Read'|trans }} <a href="https://fossbilling.org/docs/customizing-fossbilling/localization" data-bs-toggle="tooltip" data-bs-title="Using FOSSBilling in your language" target="_blank">{{ 'Using FOSSBilling in your language'|trans }}</a> {{ 'to learn how to install a new language.'|trans }}</li>
+                                <li>{{ 'Check the FOSSBilling locale repository to see if the language you are looking for is available.'}} <a target="_blank" href="https://github.com/FOSSBilling/locale">({{ 'Locale repository'|trans }})<a></li>
+                                <li>{{ 'Follow the instructions on the FOSSBilling documentation to install the new language\'s translation files.'|trans }} <a target="_blank" href="https://fossbilling.org/docs/customizing-fossbilling/localization#installing-a-new-language">({{ 'Installing a new language'|trans }})<a></li>
                             </ul>
                         </div>
 
                         <h5>{{ 'Changing default language'|trans }}</h5>
-                        <p>{{ 'Default language can be set in'|trans }} <em>config.php</em> parameter <code>'locale' => 'en_US'</code></p>
+                        <p>{{ 'Instructions for changing the default language can be found on the FOSSBilling documentation.'|trans }} <a target="_blank" href="https://fossbilling.org/docs/customizing-fossbilling/localization#changing-the-default-language">({{ 'Changinge the default language'|trans }})<a></p>
                     </div>
                 </div>
             </div>

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -141,21 +141,18 @@
                     {% include "partial_extensions.html.twig" with { 'type': 'translation', 'header': 'List of translations on extensions site'|trans } only %}
                     <div class="card-body">
                         <h3 class="card-title">{{ 'FOSSBilling in your language'|trans }}</h3>
-                        <p class="card-subtitle">{{ 'Although FOSSBilling displays in U.S. English by default, the software has the built-in capability to be used in any language. Follow instructions bellow to install new language.'|trans }}</p>
+                        <p class="card-subtitle">{{ 'Although FOSSBilling displays in U.S. English by default, it has the capability to be used in any language. Follow instructions bellow to install new language.'|trans }}</p>
                         <div>
                             <ul>
-                                <li>{{ 'Check if your language translation file is available at'|trans }} <a href="https://translate.fossbilling.org" target="_blank">{{ 'FOSSBilling translations repository'|trans }}</a></li>
-                                <li>{{ 'Download language files and place them to'|trans }} <code>{{ constant('PATH_LANGS') }}</code></li>
-                                <li>{{ 'Language will be automatically available and can be changed in client area'|trans }}</li>
+                                <li>{{ 'Check if your language translation files are available at the '|trans }} <a href="https://github.com/FOSSBilling/locale" target="_blank">{{ 'FOSSBilling translations repository'|trans }}</a></li>
+                                <li>{{ 'Download the language files and place them under'|trans }} <code>{{ constant('PATH_LANGS') }}</code></li>
+                                <li>{{ 'The language will automatically be detected and made available for use.'|trans }}</li>
                                 <li>{{ 'Read'|trans }} <a href="https://fossbilling.org/docs/customizing-fossbilling/localization" data-bs-toggle="tooltip" data-bs-title="Using FOSSBilling in your language" target="_blank">{{ 'Using FOSSBilling in your language'|trans }}</a> {{ 'to learn how to install a new language.'|trans }}</li>
                             </ul>
                         </div>
 
                         <h5>{{ 'Changing default language'|trans }}</h5>
-                        <p>{{ 'Default language can be set in'|trans }} <em>config.php</em> parameter <code>define('BB_LOCALE', 'en_US');</code></p>
-
-                        <h5>{{ 'Removing language'|trans }}</h5>
-                        <p>{{ 'Removing languages from FOSSBilling is really simple. Just delete language folder you wish from'|trans }} <code>{{ constant('PATH_LANGS') }}</code></p>
+                        <p>{{ 'Default language can be set in'|trans }} <em>config.php</em> parameter <code>'locale' => 'en_US'</code></p>
                     </div>
                 </div>
             </div>

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -1,6 +1,6 @@
 {% extends 'layout_default.html.twig' %}
 
-{% block meta_title %}{{ 'Client area languages'|trans }}{% endblock %}
+{% block meta_title %}{{ 'Manage translations'|trans }}{% endblock %}
 
 {% set active_menu = 'extensions' %}
 
@@ -8,7 +8,7 @@
     <div class="card-tabs">
         <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Installed translations'|trans }}</a>
+                <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Manage translations'|trans }}</a>
             </li>
             <li class="nav-item" role="presentation">
                 <a class="nav-link" href="#tab-new" data-bs-toggle="tab">
@@ -29,6 +29,7 @@
                             <tr>
                                 <th>{{ 'Country'|trans }}</th>
                                 <th>{{ 'Language'|trans }}</th>
+                                <th>{{ 'Completion'|trans}}</th>
                                 <th>{{ 'Code'|trans }}</th>
                                 <th>{{ 'Disable'|trans }}</th>
                             </tr>
@@ -36,8 +37,23 @@
                             <tbody>
                             {% for lang in admin.extension_languages %}
                             <tr>
-                                <td><span class="w-3 flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span></td>
-                                <td>{{ lang.name }}</td>
+                                <td class="w-2">
+                                    <span class="flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span>
+                                </td>
+                                <td class="w-6">{{ lang.name }}</td>
+                                <td>
+                                    {% set progress = admin.extension_locale_completion({'locale_id': lang.locale})%}
+                                    {% if progress > 75 %}
+                                        {% set background = 'success' %}
+                                    {% elseif progress > 50 %}
+                                        {% set background = 'warning' %}
+                                    {% else %}
+                                        {% set background = 'danger' %}
+                                    {% endif %}
+                                    <div class="progress" style="height: 15px;">
+                                        <div class="progress-bar bg-{{ background }}" role="progressbar" style="width: {{ progress }}%" aria-valuenow="{{ progress }}" aria-valuemin="0" aria-valuemax="100">{{ progress }}%</div>
+                                    </div>
+                                </td>
                                 <td class="w-1">{{ lang.locale }}</td>
                                 <td class="w-1">
                                     <a class="btn btn-icon api-link"
@@ -61,7 +77,7 @@
                         </table>
                     </div>
 
-                    <hr>
+                    <hr/>
 
                     <div class="container">
                         <h2 class="mb-1 mt-1">{{ 'Disabled translations'|trans}}</h2>
@@ -70,26 +86,44 @@
                             <tr>
                                 <th>{{ 'Country'|trans }}</th>
                                 <th>{{ 'Language'|trans }}</th>
+                                <th>{{ 'Completion'|trans}}</th>
                                 <th>{{ 'Code'|trans }}</th>
                                 <th>{{ 'Enable'|trans }}</th>
                             </tr>
                             </thead>
                             <tbody>
                             {% for lang in admin.extension_languages({'disabled': true}) %}
-                            <tr>
-                                <td><span class="w-3 flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span></td>
-                                <td>{{ lang.name }}</td>
-                                <td class="w-1">{{ lang.locale }}</td>
-                                <td class="w-1">
-                                    <a class="btn btn-icon api-link"
-                                        href="{{ 'api/admin/extension/toggle_language'|link({ 'locale_id': lang.locale }) }}"
-                                        data-api-reload="1">
-                                        <svg class="icon">
-                                            <use xlink:href="#check" />
-                                        </svg>
-                                    </a>
-                                </td>
-                            </tr>
+                                <tr>
+                                    <td class="w-2">
+                                        <span class="flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span>
+                                    </td>
+                                    <td class="w-6">{{ lang.name }}</td>
+                                    <td>
+                                        {% set progress = admin.extension_locale_completion({'locale_id': lang.locale})%}
+                                        {% if progress > 75 %}
+                                            {% set background = 'success' %}
+                                        {% elseif progress > 50 %}
+                                            {% set background = 'warning' %}
+                                        {% else %}
+                                            {% set background = 'danger' %}
+                                        {% endif %}
+                                        <div class="progress" style="height: 15px;">
+                                            <div class="progress" style="height: 15px;">
+                                                <div class="progress-bar bg-{{ background }}" role="progressbar" style="width: {{ progress }}%" aria-valuenow="{{ progress }}" aria-valuemin="0" aria-valuemax="100">{{ progress }}%</div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="w-1">{{ lang.locale }}</td>
+                                    <td class="w-1">
+                                        <a class="btn btn-icon api-link"
+                                            href="{{ 'api/admin/extension/toggle_language'|link({ 'locale_id': lang.locale }) }}"
+                                            data-api-reload="1">
+                                            <svg class="icon">
+                                                <use xlink:href="#check" />
+                                            </svg>
+                                        </a>
+                                    </td>
+                                </tr>
                             </tbody>
                             {% else %}
                                 <tbody>

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -8,45 +8,99 @@
     <div class="card-tabs">
         <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Client area languages'|trans }}</a>
+                <a class="nav-link active" href="#tab-index" data-bs-toggle="tab">{{ 'Installed translations'|trans }}</a>
             </li>
             <li class="nav-item" role="presentation">
                 <a class="nav-link" href="#tab-new" data-bs-toggle="tab">
                     <svg class="icon me-2">
                         <use xlink:href="#plus" />
                     </svg>
-                    {{ 'New language'|trans }}
+                    {{ 'New translations'|trans }}
                 </a>
             </li>
         </ul>
         <div class="card">
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="tab-index" role="tabpanel">
-                    <table class="table card-table table-vcenter table-striped text-nowrap">
-                        <thead>
-                        <tr>
-                            <th>{{ 'Country'|trans }}</th>
-                            <th>{{ 'Language'|trans }}</th>
-                            <th>{{ 'Code'|trans }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for lang in admin.extension_languages %}
-                        <tr>
-                            <td><span class="flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span></td>
-                            <td>{{ lang.title }}</td>
-                            <td class="w-1">{{ lang.locale }}</td>
-                        </tr>
-                        </tbody>
-                        {% else %}
-                            <tbody>
+                    <div class="container">
+                        <h2 class="mb-1 mt-1">{{ 'Enabled translations'|trans}}</h2>
+                        <table class="table card-table table-vcenter table-striped text-nowrap">
+                            <thead>
                             <tr>
-                                <td class="text-muted" colspan="2">{{ 'The list is empty'|trans }}
+                                <th>{{ 'Country'|trans }}</th>
+                                <th>{{ 'Language'|trans }}</th>
+                                <th>{{ 'Code'|trans }}</th>
+                                <th>{{ 'Disable'|trans }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for lang in admin.extension_languages %}
+                            <tr>
+                                <td><span class="w-3 flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span></td>
+                                <td>{{ lang.name }}</td>
+                                <td class="w-1">{{ lang.locale }}</td>
+                                <td class="w-1">
+                                    <a class="btn btn-icon api-link"
+                                        href="{{ 'api/admin/extension/toggle_language'|link({ 'locale_id': lang.locale }) }}"
+                                        data-api-reload="1">
+                                        <svg class="icon">
+                                            <use xlink:href="#close" />
+                                        </svg>
+                                    </a>
                                 </td>
                             </tr>
                             </tbody>
-                        {% endfor %}
-                    </table>
+                            {% else %}
+                                <tbody>
+                                <tr>
+                                    <td class="text-muted" colspan="2">{{ 'The list is empty'|trans }}
+                                    </td>
+                                </tr>
+                                </tbody>
+                            {% endfor %}
+                        </table>
+                    </div>
+
+                    <hr>
+
+                    <div class="container">
+                        <h2 class="mb-1 mt-1">{{ 'Disabled translations'|trans}}</h2>
+                        <table class="table card-table table-vcenter table-striped text-nowrap">
+                            <thead>
+                            <tr>
+                                <th>{{ 'Country'|trans }}</th>
+                                <th>{{ 'Language'|trans }}</th>
+                                <th>{{ 'Code'|trans }}</th>
+                                <th>{{ 'Enable'|trans }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for lang in admin.extension_languages({'disabled': true}) %}
+                            <tr>
+                                <td><span class="w-3 flag flag-country-{{ lang.locale|split('_')[1]|lower }}"></span></td>
+                                <td>{{ lang.name }}</td>
+                                <td class="w-1">{{ lang.locale }}</td>
+                                <td class="w-1">
+                                    <a class="btn btn-icon api-link"
+                                        href="{{ 'api/admin/extension/toggle_language'|link({ 'locale_id': lang.locale }) }}"
+                                        data-api-reload="1">
+                                        <svg class="icon">
+                                            <use xlink:href="#check" />
+                                        </svg>
+                                    </a>
+                                </td>
+                            </tr>
+                            </tbody>
+                            {% else %}
+                                <tbody>
+                                <tr>
+                                    <td class="text-muted" colspan="2">{{ 'The list is empty'|trans }}
+                                    </td>
+                                </tr>
+                                </tbody>
+                            {% endfor %}
+                        </table>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade" id="tab-new" role="tabpanel">

--- a/tests/modules/Extension/Api/AdminTest.php
+++ b/tests/modules/Extension/Api/AdminTest.php
@@ -102,7 +102,7 @@ class AdminTest extends \BBTestCase {
 
     public function testlanguages()
     {
-        $result = $this->api->languages();
+        $result = $this->api->languages([]);
         $this->assertIsArray($result);
     }
 


### PR DESCRIPTION
Closes #660 and also brings in the work I did in the locale repo to use [automated releases](https://github.com/FOSSBilling/locale/releases/tag/latest) that exclude translations with low completion percentages (less than 25%.

Once merged, this PR will allow users to disable translations from within the admin panel & this will not be lost when performing an updated, unlike the current option of deleting a translation's source.
Additionally, if a client's cookie is set to a locale that is disabled it will instead restore them back to the installation's default.

This also introduces a completion progress bar for translations. This value is automatically calculated and shipped with the automated release I previously talked about, for any translation that's not part of those releases it'll just default to 0%.

![Animation](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/10409c63-ca5f-4dd9-8f2b-758ad82e5328)
