### PR TITLE
Improvements to the Stripe payment gateway

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -229,9 +229,6 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
                             name: \'never\',
                             email: \'never\',
                         },
-                        business: {
-                            name: \':business_name\',
-                        }
                     });
 
                     paymentElement.mount(\'#payment-element\');
@@ -276,7 +273,6 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
             ':callbackUrl' => $payGatewayService->getCallbackUrl($payGateway, $invoice),
             ':redirectUrl' => $this->di['tools']->url('invoice/' . $invoice->hash),
             ':invoice_hash' => $invoice->hash,
-            ':business_name' => $invoice->seller_company
         ];
         return strtr($form, $bindings);
     }

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -8,6 +8,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
+use \Stripe\StripeClient;
+
 class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
@@ -26,17 +28,25 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
 
     public function __construct(private $config)
     {
-        if (!isset($this->config['api_key'])) {
-            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'API key']);
+        if ($this->config['test_mode']) {
+            if (!isset($this->config['test_api_key'])) {
+                throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'Test API Key']);
+            }
+            if (!isset($this->config['test_pub_key'])) {
+                throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'Test publishable key']);
+            }
+
+            $this->stripe = new StripeClient($this->config['test_api_key']);
+        } else {
+            if (!isset($this->config['api_key'])) {
+                throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'API key']);
+            }
+            if (!isset($this->config['pub_key'])) {
+                throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'Publishable key']);
+            }
+
+            $this->stripe = new StripeClient($this->config['api_key']);
         }
-
-        if (!isset($this->config['pub_key'])) {
-            throw new Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'Stripe', ':missing' => 'Publishable key']);
-        }
-
-        $api_key = $this->config['test_mode'] ? $this->get_test_api_key() : $this->config['api_key'];
-
-        $this->stripe = new \Stripe\StripeClient($api_key);
     }
 
     public static function getConfig()
@@ -50,10 +60,14 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
                 'width' => '65px',
             ),
             'form'  => [
-                'test_api_key' => [
+                'pub_key' => [
                     'text', [
-                        'label' => 'Test Secret key:',
-                        'required' => false,
+                        'label' => 'Live publishable key:',
+                    ],
+                ],
+                'api_key' => [
+                    'text', [
+                        'label' => 'Live Secret key:',
                     ],
                 ],
                 'test_pub_key' => [
@@ -62,14 +76,10 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
                         'required' => false,
                     ],
                 ],
-                'api_key' => [
+                'test_api_key' => [
                     'text', [
-                        'label' => 'Live Secret key:',
-                    ],
-                ],
-                'pub_key' => [
-                    'text', [
-                        'label' => 'Live publishable key:',
+                        'label' => 'Test Secret key:',
+                        'required' => false,
                     ],
                 ],
             ],
@@ -128,7 +138,6 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
         $tx      = $this->di['db']->getExistingModelById('Transaction', $id);
 
         $tx->invoice_id = $invoice->id;
-        $tx->type = $data['post']['stripeTokenType'];
 
         try {
             $charge = $this->stripe->paymentIntents->retrieve(
@@ -187,12 +196,11 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
             "receipt_email" => $invoice->buyer_email
         ]);
 
-        $pubKey = ($this->config['test_mode']) ? $this->get_test_pub_key() : $this->config['pub_key'];
+        $pubKey = ($this->config['test_mode']) ? $this->config['test_pub_key'] : $this->config['pub_key'];
 
         $dataAmount = $this->getAmountInCents($invoice);
 
         $settingService = $this->di['mod_service']('System');
-        $company = $settingService->getCompany();
 
         $title = $this->getInvoiceTitle($invoice);
 
@@ -218,10 +226,11 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
 
                     var paymentElement = elements.create(\'payment\', {
                         billingDetails: {
-                            email: \':email\',
+                            name: \'never\',
+                            email: \'never\',
                         },
                         business: {
-                            name: \':name\',
+                            name: \':business_name\',
                         }
                     });
 
@@ -236,6 +245,12 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
                         elements,
                         confirmParams: {
                             return_url: \':callbackUrl&bb_redirect=true&bb_invoice_hash=:invoice_hash\',
+                            payment_method_data: {
+                                billing_details: {
+                                    name: \':buyer_name\',
+                                    email: \':buyer_email\',
+                                },
+                            },
                         },
                     });
 
@@ -256,27 +271,13 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
             ':amount' => $dataAmount,
             ':currency' => $invoice->currency,
             ':description' => $title,
-            ':email' => $invoice->buyer_email,
+            ':buyer_email' => $invoice->buyer_email,
+            ':buyer_name' => trim($invoice->buyer_first_name . ' ' . $invoice->buyer_last_name),
             ':callbackUrl' => $payGatewayService->getCallbackUrl($payGateway, $invoice),
             ':redirectUrl' => $this->di['tools']->url('invoice/' . $invoice->hash),
-            ':invoice_hash' => $invoice->hash
+            ':invoice_hash' => $invoice->hash,
+            ':business_name' => $invoice->seller_company
         ];
         return strtr($form, $bindings);
-    }
-
-    public function get_test_pub_key()
-    {
-        if (!isset($this->config['test_pub_key'])) {
-            throw new Payment_Exception('Payment gateway "Stripe" is not configured properly. Please update configuration parameter "test_pub_key" at "Configuration -> Payments".');
-        }
-        return $this->config['test_pub_key'];
-    }
-
-    public function get_test_api_key()
-    {
-        if (!isset($this->config['test_api_key'])) {
-            throw new Payment_Exception('Payment gateway "Stripe" is not configured properly. Please update configuration parameter "test_api_key" at "Configuration -> Payments".');
-        }
-        return $this->config['test_api_key'];
     }
 }


### PR DESCRIPTION
This PR improved the Stripe payment gateway in the following ways:
1. The configuration items have been reordered so the non-test keys are on the top & the order that each key appear matches the Stripe dashboard. (Publishable key above the secret key)
2. It will now correctly set the name and email for a client which improves Stripe's [fraud model by 14%](https://stripe.com/docs/radar/integration#important-signals-to-send-to-stripe) and makes for better payment tracking in the dashboard.
3. I've removed the code which set the company name, it was done wrong and Stripe will pull that info from the recipient's account.
4. Minor code cleanups, including the removal of the `stripeTokenType` POST info which isn't set and even if it was, it doesn't make sense for the transaction type to be referencing the token type. 