### PR TITLE
Small bug fixes

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -338,6 +338,7 @@ VALUES
 	(20,'invoice_refund_logic','credit_note',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(21,'invoice_cn_series','CN-',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(22,'invoice_cn_starting_number','1',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(22,'invoice_starting_number','1',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(23,'nameserver_1',NULL,0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(24,'nameserver_2',NULL,0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(25,'nameserver_3',NULL,0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -29,7 +29,7 @@ class i18n
          * If the locale cookie is set and it's one of the enabled locales, use that.
          * Otherwise, fallback to auto-detection when enable.
          */
-        if (!empty($_COOKIE['BBLANG'] && in_array($_COOKIE['BBLANG'], self::getLocales()))) {
+        if (!empty($_COOKIE['BBLANG']) && in_array($_COOKIE['BBLANG'], self::getLocales())) {
             $locale = $_COOKIE['BBLANG'];
         } elseif ($autoDetect) {
             $locale = self::getBrowserLocale();


### PR DESCRIPTION
This PR fixes two bugs:
1. The default SQL content only includes a starting invoice number for credit invoices, not regular invoices. This + the changes to how invoice number meant a fresh install of `main` couldn't get the starting invoice number.
2. I accidentally goofed the placement of a parentheses with the locale improvements & that's now fixed as well.