### PR TITLE
Fix and improve cron messages in the admin panel

### DIFF
--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -88,7 +88,7 @@
                                     <tr>
                                         <td>FOSSBilling version</td>
                                         <td><strong class="{{ fossbilling_ver_ok ? 'green' : 'red'}}">{{ fossbilling_ver }}</strong></td>
-					<td>{% if not fossbilling_ver_ok %}FOSSBilling couldn't find valid version information. This is okay if you downloaded FOSSBilling directly from the master branch, instead of a released version. But beware, the master branch may not be stable enough for production use.{% endif %}</td>                                    </tr>
+					<td>{% if not fossbilling_ver_ok %}FOSSBilling couldn't find valid version information. This is okay if you downloaded FOSSBilling directly from the main branch, instead of a released version. But beware, the main branch may not be stable enough for production use.{% endif %}</td>                                    </tr>
 
                                     <tr>
                                         <td>PHP version</td>

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -260,12 +260,12 @@ class Service
                 // And now return the correctly message for the given situation
                 if (!$last_exec) {
                     return [
-                        'text' => 'Cron was never executed, please ensure you have configured the cronjob or else scheduled tasks within FOSSBilling will not behave correctly.',
+                        'text' => 'Cron was never executed, please ensure you have configured the cronjob or else scheduled tasks within FOSSBilling will not behave correctly. (Message is cached for 15 minutes)',
                         'url' => $cronUrl,
                     ];
                 } elseif ((time() - strtotime($last_exec)) / 60 >= 15) {
                     return [
-                        'text' => 'FOSSBilling has detected that cron hasn\'t been run in an abnormal time period. Please ensure the cronjob is configured to be run every 5 minutes.',
+                        'text' => 'FOSSBilling has detected that cron hasn\'t been run in an abnormal time period. Please ensure the cronjob is configured to be run every 5 minutes. (Message is cached for 15 minutes)',
                         'url' => $cronUrl,
                     ];
                 } else {

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -12,6 +12,8 @@ namespace Box\Mod\System;
 
 use Pimple\Container;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\Cache\ItemInterface;
+use FOSSBilling\Environment;
 
 class Service
 {
@@ -215,10 +217,11 @@ class Service
         return true;
     }
 
-    public function getMessages($type, $runFromTest = false)
+    public function getMessages($type)
     {
         $msgs = [];
 
+        // Check if there's an update available 
         try {
             $updater = $this->di['updater'];
             if ($updater->isUpdateAvailable()) {
@@ -232,26 +235,46 @@ class Service
         } catch (\Exception $e) {
             error_log($e->getMessage());
         }
+
+
         $last_exec = $this->getParamValue('last_cron_exec');
         $disableAutoCron = $this->di['config']['disable_auto_cron'] ?? false;
-        if ($runFromTest === false && $disableAutoCron === false) {
-            if (!$last_exec) {
-                $msgs['info'][] = [
-                    'text' => 'Cron was never executed. FOSSBilling will automatically execute cron when you access the admin panel, but you should make sure you have setup the cron job.',
-                ];
-                $cronService = $this->di['mod_service']('cron');
-                $cronService->runCrons();
-            } else {
-                $minSinceLastExec = (time() - strtotime($last_exec)) / 60;
-                if ($minSinceLastExec >= 15) {
-                    $minSinceLastExec = round($minSinceLastExec, 2);
-                    $msgs['info'][] = [
-                        'text' => 'Cron hasn\'t been executed in ' . $minSinceLastExec . ' minutes. FOSSBilling will automatically execute cron when you access the admin panel, but you should make sure you have setup the cron job.',
-                    ];
-                    $cronService = $this->di['mod_service']('cron');
+
+        /**
+         * Here we check if cron has been run at all or within a recent timeframe.
+         * No matter what, a message will be displayed within the dashboard and by default cron will also be performed to ensure functionality, however this can be disabled.
+         * Results are cached so even if `getMessages` is called multiple times it will still display correctly & so it won't go away before it's noticed.
+         */
+        if ((Environment::isProduction())) {
+            $cronService = $this->di['mod_service']('cron');
+
+            $result = $this->di['cache']->get('cron_issue', function (ItemInterface $item) use ($cronService, $last_exec, $disableAutoCron) {
+                $item->expiresAfter(15 * 60);
+                $cronUrl = $this->di['url']->adminLink('extension/settings/cron');
+
+                // Perform the fallback behavior if enabled
+                if (!$disableAutoCron && (!$last_exec || (time() - strtotime($last_exec)) / 60 >= 15)) {
                     $cronService->runCrons();
-                    error_log("Cron hasn't been run in $minSinceLastExec minutes. Manually executing.");
                 }
+
+                // And now return the correctly message for the given situation
+                if (!$last_exec) {
+                    return [
+                        'text' => 'Cron was never executed, please ensure you have configured the cronjob or else scheduled tasks within FOSSBilling will not behave correctly.',
+                        'url' => $cronUrl,
+                    ];
+                } elseif ((time() - strtotime($last_exec)) / 60 >= 15) {
+                    return [
+                        'text' => 'FOSSBilling has detected that cron hasn\'t been run in an abnormal time period. Please ensure the cronjob is configured to be run every 5 minutes.',
+                        'url' => $cronUrl,
+                    ];
+                } else {
+                    return [];
+                }
+            });
+
+            if ($result) {
+                $msgs['danger'][] = $result;
             }
         }
 
@@ -264,7 +287,7 @@ class Service
 
         if ($this->getVersion() == '0.0.1') {
             $msgs['warning'][] = [
-                'text' => 'FOSSBilling couldn\'t find valid version information. This is okay if you downloaded FOSSBilling directly from the master branch, instead of a released version. But beware, the master branch may not be stable enough for production use.',
+                'text' => 'FOSSBilling couldn\'t find valid version information. This is okay if you downloaded FOSSBilling directly from the main branch, instead of a released version. But beware, the main branch may not be stable enough for production use.',
             ];
         }
 
@@ -330,7 +353,7 @@ class Service
         } else {
             // attempt adding admin api to twig
             try {
-                if($this->di['auth']->isAdminLoggedIn()){
+                if ($this->di['auth']->isAdminLoggedIn()) {
                     $twig->addGlobal('admin', $this->di['api_admin']);
                 }
             } catch (\Exception) {

--- a/tests/modules/System/ServiceTest.php
+++ b/tests/modules/System/ServiceTest.php
@@ -170,7 +170,7 @@ class ServiceTest extends \BBTestCase
 
         $systemServiceMock->setDi($di);
 
-        $result = $systemServiceMock->getMessages($type, true);
+        $result = $systemServiceMock->getMessages($type);
         $this->assertIsArray($result);
     }
 


### PR DESCRIPTION
FOSSBilling is supposed to display a warning message to the administrator when they login to the panel if the cronjob hadn't been run at all or for an extended period of time.

At some point, this stopped working because `getMessages` gets called multiple times, resulting in cron being run and the message not being displayed. 

This PR corrects this behavior by instead caching the result of it, ensuring it'll be displayed in the admin panel for 15 minutes before re-checking if cron is again working as it should.

I've also tweaked the wording of it and changed it from an `info` message `danger` as cron **needs to be** working correctly, especially now that all emails are queued rather than sent on-demand.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/71765316-bc11-428e-854b-c6dc801c220c)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/e57d4739-58ba-45e2-9df6-92cd11b4c21a)
