### PR TITLE
Miscellaneous autoloader improvements

### DIFF
--- a/bin/prepare.php
+++ b/bin/prepare.php
@@ -27,13 +27,8 @@ const HURAGA_CONFIG_TEMPLATE = PATH_THEMES . DIRECTORY_SEPARATOR . 'huraga' . DI
 require PATH_VENDOR . DIRECTORY_SEPARATOR . 'autoload.php';
 
 // Set up the autoloader
-$loader = new AntCMS\AntLoader([
-    'mode' => 'filesystem',
-    'path' => PATH_CACHE . DIRECTORY_SEPARATOR . 'classMap.php',
-]);
-$loader->addNamespace('', PATH_LIBRARY, 'psr0');
-$loader->addNamespace('Box\\Mod\\', PATH_MODS);
-$loader->checkClassMap();
+include PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'Autoloader.php';
+$loader = new FOSSBilling\AutoLoader();
 $loader->register();
 
 use FOSSBilling\Environment;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "ext-zlib": "*",
-        "antcms/antloader": "^2.0",
+        "antcms/antloader": "^2.0.2",
         "dompdf/dompdf": "^2.0.1",
         "filp/whoops": "^2.14",
         "gabordemooij/redbean": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18655dfb9031e78d906b1954d3d11b4d",
+    "content-hash": "119d25326d8f78dd5113a79c0bb999fd",
     "packages": [
         {
             "name": "antcms/antloader",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AntCMS-org/AntLoader.git",
-                "reference": "b0f3b484908ae438464e83e5098be815acf571c6"
+                "reference": "ce5aeeb28544b85150382989d463b8dc71efec87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AntCMS-org/AntLoader/zipball/b0f3b484908ae438464e83e5098be815acf571c6",
-                "reference": "b0f3b484908ae438464e83e5098be815acf571c6",
+                "url": "https://api.github.com/repos/AntCMS-org/AntLoader/zipball/ce5aeeb28544b85150382989d463b8dc71efec87",
+                "reference": "ce5aeeb28544b85150382989d463b8dc71efec87",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "A small and simple autoloader for PHP applications",
             "support": {
                 "issues": "https://github.com/AntCMS-org/AntLoader/issues",
-                "source": "https://github.com/AntCMS-org/AntLoader/tree/2.0.1"
+                "source": "https://github.com/AntCMS-org/AntLoader/tree/2.0.2"
             },
-            "time": "2023-06-08T06:44:00+00:00"
+            "time": "2023-10-03T13:13:17+00:00"
         },
         {
             "name": "composer/ca-bundle",

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -56,13 +56,8 @@ set_include_path(implode(PATH_SEPARATOR, [
 
 require PATH_VENDOR . DIRECTORY_SEPARATOR . 'autoload.php';
 
-$loader = new AntCMS\AntLoader([
-    'mode' => 'filesystem',
-    'path' => PATH_CACHE . DIRECTORY_SEPARATOR . 'classMap.php',
-]);
-$loader->addNamespace('', PATH_LIBRARY, 'psr0');
-$loader->addNamespace('Box\\Mod\\', PATH_MODS);
-$loader->checkClassMap();
+include PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'Autoloader.php';
+$loader = new FOSSBilling\AutoLoader();
 $loader->register();
 
 $protocol = FOSSBilling\Tools::isHTTPS() ? 'https' : 'http';

--- a/src/library/FOSSBilling/Autoloader.php
+++ b/src/library/FOSSBilling/Autoloader.php
@@ -26,7 +26,7 @@ class AutoLoader
      * Creates a new instance of AntLoader and then loads the classmap.
      * The instance is configured for filesystem caching within the FOSSBilling cache directory.
      * 
-     * @param bool (optional) $registerFOSSBillingDefaults Set to true if you want the autoloader to be shipped with the default paths and namespaces for FOSSBilling. Defaults to true.
+     * @param bool $registerFOSSBillingDefaults (optional) Set to true if you want the autoloader to be shipped with the default paths and namespaces for FOSSBilling. Defaults to true.
      */
     public function __construct(bool $registerFOSSBillingDefaults = true)
     {

--- a/src/library/FOSSBilling/Autoloader.php
+++ b/src/library/FOSSBilling/Autoloader.php
@@ -24,7 +24,7 @@ class AutoLoader
 
     /**
      * Creates a new instance of AntLoader and then loads the classmap.
-     * The instance is configured for filesystem caching within the FOSSBilling cache directroy.
+     * The instance is configured for filesystem caching within the FOSSBilling cache directory.
      * 
      * @param bool (optional) $registerFOSSBillingDefaults Set to true if you want the autoloader to be shipped with the default paths and namespaces for FOSSBilling. Defaults to true.
      */

--- a/src/library/FOSSBilling/Autoloader.php
+++ b/src/library/FOSSBilling/Autoloader.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+/**
+ * Copyright 2022-2023 FOSSBilling
+ * Copyright 2011-2021 BoxBilling, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling;
+
+use AntCMS\AntLoader;
+
+class AutoLoader
+{
+    public AntLoader $AntLoader;
+
+    public function getAntLoader(): AntLoader
+    {
+        return $this->AntLoader;
+    }
+
+    /**
+     * Creates a new instance of AntLoader and then loads the classmap.
+     * The instance is configured for filesystem caching within the FOSSBilling cache directroy.
+     * 
+     * @param bool (optional) $registerFOSSBillingDefaults Set to true if you want the autoloader to be shipped with the default paths and namespaces for FOSSBilling. Defaults to true.
+     */
+    public function __construct(bool $registerFOSSBillingDefaults = true)
+    {
+        $this->AntLoader = new AntLoader([
+            'mode' => 'filesystem',
+            'path' => PATH_CACHE . DIRECTORY_SEPARATOR . 'classMap.php',
+        ]);
+
+        if ($registerFOSSBillingDefaults) {
+            $this->AntLoader->addNamespace('', PATH_LIBRARY, 'psr0');
+            $this->AntLoader->addNamespace('Box\\Mod\\', PATH_MODS);
+        }
+
+        $this->AntLoader->checkClassMap();
+    }
+
+    /**
+     * Registers the autoloader with PHP.
+     * 
+     * @param bool $prepend (optional) Set to true to have this autoloader be placed before others currently registered, meaning it will be checked first. Defaults to true.
+     */
+    public function register(bool $prepend = true): void
+    {
+        $this->AntLoader->register($prepend);
+    }
+}

--- a/src/load.php
+++ b/src/load.php
@@ -225,13 +225,8 @@ define('ADMIN_PREFIX', $config['admin_area_prefix']);
 define('BB_URL_API', $config['url'] . 'api/');
 
 // Initial setup and checks passed, now we setup our custom autoloader.
-$loader = new AntCMS\AntLoader([
-    'mode' => 'filesystem',
-    'path' => PATH_CACHE . DIRECTORY_SEPARATOR . 'classMap.php',
-]);
-$loader->addNamespace('', PATH_LIBRARY, 'psr0');
-$loader->addNamespace('Box\\Mod\\', PATH_MODS);
-$loader->checkClassMap();
+include PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'Autoloader.php';
+$loader = new FOSSBilling\AutoLoader();
 $loader->register();
 
 // Verify the installer was removed.

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1668,8 +1668,12 @@ class Service
     {
         $di = $event->getDi();
 
-        // Prune the FS cache
         try {
+            // Prune the classmap to remove classes which are no logner on the disk or that have moved.
+            $loader = new \FOSSBilling\AutoLoader();
+            $loader->getAntLoader()->pruneClassmap();
+
+            // Prune the FS cache
             $cache = $di['cache'];
             if ($cache->prune()) {
                 $di['logger']->setChannel('cron')->info('Pruned the filesystem cache');


### PR DESCRIPTION
Partially relates to #1595.

This PR makes a few minor tweaks to how we use AntLoader with the following changes:
1. We now use the newly added `pruneClassmap` function to prune classmaps when cron runs. This removes any classes that are no longer at the location recorded in the classmap. Leaving them there can have a slight impact to performance. For the most part this change should do nothing unless someone is actively installing & uninstalling extensions from the disk,
2. I've introduced a new `AutoLoader` class which just acts as an easy alias to `AntLoader` so we don't need to repeat the same exact steps many times over.
3. The autoloader is now prepended to the PHP autoloader list, meaning ours will come before composer's. This won't make a significant difference, but it means lookups for classes in our source code will go ever so slightly faster than before.