### PR TITLE
Improvements to the Extension Directory integration

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -834,4 +834,17 @@ $di['table_export_csv'] = $di->protect(function (string $table, string $outputNa
     exit;
 });
 
+/**
+ * Converts markdown into HTML and returns the result.
+ * 
+ * @param string|null $content The content to convert
+ * 
+ * @return string
+ */
+$di['parse_markdown'] = $di->protect(function (?string $content) {
+    $parser = new League\CommonMark\GithubFlavoredMarkdownConverter(['html_input' => 'escape', 'allow_unsafe_links' => false, 'max_nesting_level' => 50]);
+    $content ??= '';
+    return $parser->convert($content);
+});
+
 return $di;

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -287,9 +287,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_markdown_filter(Twig\Environment $env, $value)
     {
-        $content = $value ?? '';
-        $markdownParser = new GithubFlavoredMarkdownConverter(['html_input' => 'escape', 'allow_unsafe_links' => false, 'max_nesting_level' => 50]);
-        return $markdownParser->convert($content);
+        return $this->di['parse_markdown']($value);
     }
 
     public function twig_truncate_filter(Twig\Environment $env, $value, $length = 30, $preserve = false, $separator = '...')

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -50,6 +50,22 @@ class Admin extends \Api_Abstract
     }
 
     /**
+     * Gets the readme as HTML for a given extension
+     * 
+     * @return string 
+     */
+    public function get_extension_readme($data): string
+    {
+        $required = [
+            'extension_id' => 'Extension ID was not passed',
+        ];
+
+        $this->di['validator']->checkRequiredParamsForArray($required, $data);   
+        $extensionInfo =  $this->di['extension_manager']->getExtension($data['extension_id']);
+        return $this->di['parse_markdown']($extensionInfo['readme']);
+    }
+
+    /**
      * Get admin area navigation.
      *
      * @return array

--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -124,8 +124,6 @@
                     {% include 'partial_extensions.html.twig' %}
                 </div>
 
-
-
                 <div class="tab-pane fade" id="tab-about" role="tabpanel">
                     <div class="card-header">
                         <div>

--- a/src/modules/Extension/html_admin/mod_extension_languages.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_languages.html.twig
@@ -138,7 +138,7 @@
                 </div>
 
                 <div class="tab-pane fade" id="tab-new" role="tabpanel">
-                    {% include "partial_extensions.html.twig" with { 'type': 'translation', 'header': 'List of translations on extensions site'|trans } only %}
+                    {% include "partial_extensions.html.twig" with { 'type': 'translation', 'header': 'List of translations on the Extension Directory'|trans } only %}
                     <div class="card-body">
                         <h3 class="card-title">{{ 'FOSSBilling in your language'|trans }}</h3>
                         <p class="card-subtitle">{{ 'Although FOSSBilling displays in U.S. English by default, it has the capability to be used in any language. Follow instructions bellow to install new language.'|trans }}</p>

--- a/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_gateways.html.twig
@@ -19,6 +19,14 @@
                 {{ 'New payment gateway'|trans }}
             </a>
         </li>
+        <li class="nav-item" role="presentation">
+            <a class="nav-link" href="#tab-extension-directory" data-bs-toggle="tab">
+                <svg class="icon me-2">
+                    <use xlink:href="#plus" />
+                </svg>
+                {{ 'Install from the Extension Directory'|trans }}
+            </a>
+        </li>
     </ul>
 
 <div class="card">
@@ -82,7 +90,6 @@
         </div>
 
         <div class="tab-pane fade" id="tab-new" role="tabpanel">
-            {% include "partial_extensions.html.twig" with {'type': 'payment-gateway', 'header':"List of payment gateways on extensions site"} only %}
             <div class="card-body">
                 <h1>{{ 'Adding new payment gateway'|trans }}</h1>
                 <p class="text-muted">{{ 'Although FOSSBilling ships with most popular payment gateways, you can install other gateways.'|trans }}</p>
@@ -130,6 +137,10 @@
                 {% endfor %}
             </table>
             {% endif %}
+        </div>
+
+        <div class="tab-pane fade" id="tab-extension-directory" role="tabpanel">
+            {% include "partial_extensions.html.twig" with {'type': 'payment-gateway', 'header':"List of payment gateways on the Extension Directory"} only %}
         </div>
     </div>
 </div>

--- a/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/html_admin/mod_servicedomain_index.html.twig
@@ -31,6 +31,14 @@
             </a>
         </li>
         <li class="nav-item" role="presentation">
+            <a class="nav-link" href="#tab-extension-directory" data-bs-toggle="tab">
+                <svg class="icon me-2">
+                    <use xlink:href="#plus" />
+                </svg>
+                {{ 'Install from the Extension Directory'|trans }}
+            </a>
+        </li>
+        <li class="nav-item" role="presentation">
             <a class="nav-link" href="#tab-nameservers" data-bs-toggle="tab">{{ 'Nameservers'|trans }}</a>
         </li>
     </ul>
@@ -225,7 +233,6 @@
         </div>
 
         <div class="tab-pane fade" id="tab-new-registrar" role="tabpanel">
-            {% include "partial_extensions.html.twig" with { 'type': 'domain-registrar', 'header': 'List of domain registrars on extensions site' } only %}
             <div class="card-body">
                 <h1>{{ 'Adding new domain registrar'|trans }}</h1>
                 <p>{{ 'Follow instructions below to install new domain registrar.'|trans }}</p>
@@ -271,6 +278,10 @@
                 {% endfor %}
             </table>
             {% endif %}
+        </div>
+
+        <div class="tab-pane fade" id="tab-extension-directory" role="tabpanel">
+            {% include "partial_extensions.html.twig" with { 'type': 'domain-registrar', 'header': 'List of domain registrars on the Extension Directory' } only %}
         </div>
 
         <div class="tab-pane fade" id="tab-nameservers" role="tabpanel">

--- a/src/themes/admin_default/html/partial_extensions.html.twig
+++ b/src/themes/admin_default/html/partial_extensions.html.twig
@@ -5,12 +5,28 @@
 {% endif %}
 
 <div class="table-responsive">
+    <div class="modal" id="extensionReadMe">
+        <div class="modal-dialog modal-xl">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="extension-name"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div id="extension-readme" class="modal-body">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Close'|trans }}</button>
+                </div>
+            </div>
+        </div>
+    </div>    
     <table class="table card-table table-vcenter table-striped text-nowrap sortable">
         <thead>
         <tr>
             <th class="no-sort"></th>
             <th>{{ 'Extension'|trans }}</th>
             <th>{{ 'Description'|trans }}</th>
+            <th class="w-1"></th>
             <th class="w-1"></th>
         </tr>
         </thead>
@@ -30,6 +46,13 @@
                     {{ extension.description|truncate(150) }}<br>
                     <a href="https://extensions.fossbilling.org/extension/{{ extension.id }}" target="_blank">{{ 'View on the extension directory'|trans }}</a>
                 </td>
+                <td  data-bs-toggle="tooltip" data-bs-title="{{ 'View extension readme'|trans }}">
+                    <a class="btn btn-icon" data-bs-toggle="modal" data-bs-target="#extensionReadMe" onclick="getExtensionReadme('{{ extension.id }}', '{{ extension.name }}');">
+                     <svg class="icon">
+                         <use xlink:href="#eye" />
+                     </svg>
+                    </a>
+                </td>
                 <td>
                     <a class="btn btn-icon api-link"
                        data-api-confirm="Are you sure?"
@@ -37,7 +60,7 @@
                        data-api-confirm-content='By installing "{{ extension.name }}", you agree with terms and conditions. Only install extensions you trust. You also might want to have a full backup ready in case something goes wrong.'
                        data-api-reload="1"
                        href="{{ 'api/admin/extension/install'|link ({ 'type': extension.type, 'id': extension.id, 'CSRFToken': CSRFToken }) }}"
-                       data-bs-toggle="tooltip" data-bs-title="Install extension">
+                       data-bs-toggle="tooltip" data-bs-title="{{ 'Install extension'|trans }}">
                         <svg class="icon">
                             <use xlink:href="#download" />
                         </svg>
@@ -47,10 +70,24 @@
         {% else %}
             <tr>
                 <td colspan="4" class="text-center">
-                    <a href="https://extensions.fossbilling.org/" target="_blank">Explore FOSSBilling extensions</a>
+                    <a href="https://extensions.fossbilling.org/" target="_blank">{{ 'Explore FOSSBilling extensions'|trans }}</a>
                 </td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
+
+    <script>
+        function getExtensionReadme(extensionID, extensionName){
+            header = document.getElementById("extension-name");
+            header.innerText = extensionName;
+
+            readme = document.getElementById("extension-readme");
+            readme.innerText = "{{ 'Fetching extension details.'|trans }}";
+
+            API.admin.post('extension/get_extension_readme', {extension_id: extensionID, CSRFToken: "{{ CSRFToken }}"}, function(result){
+                readme.innerHTML = result;
+            });
+        }
+    </script>
 </div>


### PR DESCRIPTION
This PR improves a few ways the existing Extension Directory integration was very lacking. Relates to #1677 even if these changes aren't directly listed on that issue.

1. It's been moved to a new tab for both payment gateways and also domain registrars.
2. You can now view an extension's readme from within FOSSBilling.
3. A few cases of odd wording has been corrected / improved.

## Viewing a module's readme
![Animation](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/cc2c2faf-a71a-443f-98b2-1497253b8392)

## Separate tabs
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/cd6a3a93-53a1-48be-aa2a-c386c6176dd1)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/1b0cd3fd-2e01-40a5-bafe-f9bea576df57)
