### PR TITLE
Prevent fatal errors on missing message authors

### DIFF
--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -688,6 +688,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $author = $this->di['db']->load('Client', $model->client_id);
         }
 
+        if(!$author){
+            return [];
+        }
+
         return [
             'name' => $author->getFullName(),
             'email' => $author->email,


### PR DESCRIPTION
Minor change to prevent fatal errors like seen below when the system fails to fetch a client / admin from the DB when loading messages:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/55505bc1-7bc3-4d51-bf8e-a58fd30cd4f5)

Instead of completely preventing access to the support list, this change just means that not all of a message's info will be displayed