### PR TITLE
Removed passwords from event data

### DIFF
--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -29,7 +29,6 @@ class Service implements InjectionAwareInterface
     public function changeAdminPassword(\Model_Admin $admin, $new_password)
     {
         $event_params = [];
-        $event_params['password'] = $new_password;
         $event_params['id'] = $admin->id;
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffProfilePasswordChange', 'params' => $event_params]);
 
@@ -195,7 +194,6 @@ class Service implements InjectionAwareInterface
     public function changeClientPassword(\Model_Client $client, $new_password)
     {
         $event_params = [];
-        $event_params['password'] = $new_password;
         $event_params['id'] = $client->id;
         $this->di['events_manager']->fire(['event' => 'onBeforeClientProfilePasswordChange', 'params' => $event_params]);
 


### PR DESCRIPTION
I've noticed that on several locations, user and admin-provided passwords were passed to events. 
Because events can be hooked from any extension, this would allow any extension to get passwords in cleartext when they get changed. 
IMO, we should do as few things as possible with cleartext password data, this is why I've removed it from where I found. I've only found one location where any of the events were used: onBeforeClientSignup is used in the Spamchecker module, but that doesn't do anything with the password, so there should be no impact at all. 