### PR TITLE
Set related order to Registrar_AdapterAbstract

### DIFF
--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -20,6 +20,11 @@ abstract class Registrar_AdapterAbstract
     protected $_testMode = false;
 
     /**
+    * Related order
+     */
+    protected ?\Model_ClientOrder $_order = null;
+
+    /**
      * Return array with configuration
      * 
      * Must be overriden in adapter class
@@ -238,6 +243,16 @@ abstract class Registrar_AdapterAbstract
     public function enableTestMode()
     {
         $this->_testMode = true;
+        return $this;
+    }
+
+    /**
+     * Sets the order related to the domain.
+     */
+    public function setOrder(\Model_ClientOrder $order): static
+    {
+        $this->_order = $order;
+
         return $this;
     }
 }

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -954,7 +954,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $class;
     }
 
-    public function registrarGetRegistrarAdapter(\Model_TldRegistrar $r, \Model_ClientOrder $order = null)
+    public function registrarGetRegistrarAdapter(\Model_TldRegistrar $r, ?\Model_ClientOrder $order = null)
     {
         $config = $this->registrarGetConfiguration($r);
         $class = $this->registrarGetRegistrarAdapterClassName($r);

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -643,16 +643,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         $tldRegistrar = $this->di['db']->load('TldRegistrar', $model->tld_registrar_id);
 
-        /*
-            TODO: registrarGetRegistrarAdapter Only accepts one parameter
         if ($order instanceof \Model_ClientOrder) {
             $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar, $order);
         } else {
             $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
         }
-        */
-
-        $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
 
         $d = new \Registrar_Domain();
 
@@ -959,7 +954,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $class;
     }
 
-    public function registrarGetRegistrarAdapter(\Model_TldRegistrar $r)
+    public function registrarGetRegistrarAdapter(\Model_TldRegistrar $r, \Model_ClientOrder $order = null)
     {
         $config = $this->registrarGetConfiguration($r);
         $class = $this->registrarGetRegistrarAdapterClassName($r);
@@ -969,6 +964,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
 
         $registrar->setLog($this->di['logger']);
+
+        if ($order) {
+            $registrar->setOrder($order);
+        }
 
         if (isset($r->test_mode) && $r->test_mode) {
             $registrar->enableTestMode();


### PR DESCRIPTION
Add the order to `Registrar_AdapterAbstract` to be able to access the additional inputs added to `mod_servicedomain_order_form.html.twig`