### PR TITLE
Officially drop huntr.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/FOSSBilling/FOSSBilling/badge)](https://www.codefactor.io/repository/github/fossbilling/fossbilling)
 [![Financial Contributors](https://opencollective.com/FOSSBilling/tiers/badge.svg?color=brightgreen)](https://opencollective.com/fossbilling)
 [![Crowdin](https://badges.crowdin.net/e/c70c78b4ab1e71424ce53dcf6bca9b12/localized.svg)](https://fossbilling.crowdin.com/FOSSBilling)
-[![huntr](https://cdn.huntr.dev/huntr_security_badge_mono.svg)](https://huntr.dev/repos/fossbilling/fossbilling/)
 
 </div>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,33 +12,31 @@
 
 ## Reporting Vulnerabilities
 
-To report a vulnerability, please make a submission on [Huntr.dev](https://huntr.dev/bounties/disclose/?target=https://github.com/FOSSBilling/FOSSBilling).
-Their website should provide guidance on how to create a comprehensive vulnerability report. It's crucial to submit vulnerabilities through their platform to keep them private and prevent exploitation while a patch is being developed.
+FOSSBilling accepts vulnerability reports directly through GitHub, to open a new one simply [click here](https://github.com/FOSSBilling/FOSSBilling/security/advisories/new).
+Existing advisories can be found [here on GitHub](https://github.com/FOSSBilling/FOSSBilling/security/advisories) as well.
 
-If you have a bug or a suggestion that is not related to an exploit, it should be reported on our [GitHub](https://github.com/FOSSBilling/FOSSBilling/issues/new/choose). 
+If you have a bug or a suggestion that is not related to an exploit, it should be reported [via a new issue](https://github.com/FOSSBilling/FOSSBilling/issues/new/choose). (But please check if someone has already submitted it first!)
 
 A well-written vulnerability report should include the following information:
+
  - Identification of the file(s) affected by the exploit
  - Description of how the vulnerability can be exploited
  - Potential ramifications of the vulnerability
  - A proof of concept exploit (if possible)
  - Insights into a possible solution
 
-Submitting a proper vulnerability report on Huntr.dev may entitle you to a cash reward. Additionally, if you provide a patch, you may also be eligible for a reward.
-
 ### Non-Qualifying Vulnerabilities
-Reports covering any of the following topics will be rejected and do not qualify for bounties.
-Such reports may reduce your credibility as a researcher on the Huntr.dev platform or potentially cause you to be blocked from reporting vulnerabilities against FOSSBilling.
+
+Reports covering any of the following topics will be rejected by the FOSSBilling team:
 
 - Reports describing the lack of granular permissions within FOSSBilling. This is a known limitation and the permission system will be completely replaced before FOSSBilling is considered production-ready (version 1.0.0).
-- Reports from automated tools or scanners
-- Theoretical attacks without proof of exploitability
-- Attacks that are the result of a third party library should be reported to the library maintainers
-- Social engineering
-- Reflected file download
-- Physical attacks
-- Weak SSL/TLS/SSH algorithms or protocols
+- Reports from automated tools or scanners.
+- Theoretical attacks without proof of exploitability.
+- Attacks that are the result of a third party library should be reported to the library maintainers.
+- Social engineering.
+- Reflected file download.
+- Physical attacks.
+- Weak SSL/TLS/SSH algorithms or protocols.
 - Attacks involving physical access to a user’s device, or involving a device or network that’s already seriously compromised (eg man-in-the-middle).
-- The user attacks themselves
-- Anything in `/tests`
-- Anything in `/cypress`
+- The user attacks themselves.
+- Anything in `/tests`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 ## Reporting Vulnerabilities
 
 FOSSBilling accepts vulnerability reports directly through GitHub, to open a new one simply [click here](https://github.com/FOSSBilling/FOSSBilling/security/advisories/new).
-Existing advisories can be found [here on GitHub](https://github.com/FOSSBilling/FOSSBilling/security/advisories) as well.
+If you are looking for existing advisories, those can be found [here on GitHub](https://github.com/FOSSBilling/FOSSBilling/security/advisories).
 
 If you have a bug or a suggestion that is not related to an exploit, it should be reported [via a new issue](https://github.com/FOSSBilling/FOSSBilling/issues/new/choose). (But please check if someone has already submitted it first!)
 


### PR DESCRIPTION
Huntr.dev is fully transitioning to supporting only AI/ML projects so even if we wanted to continue to use it we no longer can:
> • As a non-AI/ML OSS maintainer should I stop using huntr for our vulnerability disclosure programme (VDP)?
>
>We strongly suggest that you adopt another solution for your VDP (such as GitHub’s vulnerability reporting) as we can’t guarantee that we’ll be able to process reports against your project after November 30th, 2023.

Private reporting is enabled for us on GitHub and this PR updates the security policy to direct people to that instead.