### PR TITLE
Redirect admin to previous url after login

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -374,6 +374,7 @@ $di['is_client_logged'] = function () use ($di) {
             throw new Exception('Client is not logged in');
         } else {
             // Redirect to login page if browser request
+            $di['set_redirect_uri'];
             $login_url = $di['url']->link('login');
             header("Location: $login_url");
         }
@@ -413,12 +414,9 @@ $di['is_admin_logged'] = function () use ($di) {
             throw new Exception('Admin is not logged in');
         }
 
-        unset($_GET['_url']);
+        $di['set_redirect_uri'];
 
-        $redirectUri = str_replace('/admin', '', $url) . '?' . http_build_query($_GET);
-        $loginUrl = sprintf('%s?redirect=%s', $di['url']->adminLink('staff/login'), urlencode($redirectUri));
-
-        header(sprintf('Location: %s', $loginUrl));
+        header(sprintf('Location: %s', $di['url']->adminLink('staff/login')));
         exit;
     }
 
@@ -493,6 +491,15 @@ $di['loggedin_admin'] = function () use ($di) {
             exit;
         }
     }
+};
+
+$di['set_redirect_uri'] = function () use ($di) {
+    $url = $_GET['_url'] ?? ($_SERVER['PATH_INFO'] ?? '');
+    unset($_GET['_url']);
+
+    $redirectUri = str_replace('/admin', '', $url) . '?' . http_build_query($_GET);
+
+    $di['session']->set('redirect_uri', $redirectUri);
 };
 
 /*

--- a/src/di.php
+++ b/src/di.php
@@ -413,6 +413,8 @@ $di['is_admin_logged'] = function () use ($di) {
             throw new Exception('Admin is not logged in');
         }
 
+        unset($_GET['_url']);
+
         $redirectUri = str_replace('/admin', '', $url) . '?' . http_build_query($_GET);
         $loginUrl = sprintf('%s?redirect=%s', $di['url']->adminLink('staff/login'), urlencode($redirectUri));
 

--- a/src/di.php
+++ b/src/di.php
@@ -497,9 +497,8 @@ $di['set_return_uri'] = function () use ($di) {
     $url = $_GET['_url'] ?? ($_SERVER['PATH_INFO'] ?? '');
     unset($_GET['_url']);
 
-    $admin_prefix = $di['config']['admin_area_prefix'];
-    if (str_starts_with($url, $admin_prefix)) {
-        $url = substr($url, strlen($admin_prefix));
+    if (str_starts_with($url, ADMIN_PREFIX)) {
+        $url = substr($url, strlen(ADMIN_PREFIX));
     }
     $redirectUri = $url . '?' . http_build_query($_GET);
 

--- a/src/di.php
+++ b/src/di.php
@@ -374,7 +374,7 @@ $di['is_client_logged'] = function () use ($di) {
             throw new Exception('Client is not logged in');
         } else {
             // Redirect to login page if browser request
-            $di['set_redirect_uri'];
+            $di['set_return_uri'];
             $login_url = $di['url']->link('login');
             header("Location: $login_url");
         }
@@ -414,7 +414,7 @@ $di['is_admin_logged'] = function () use ($di) {
             throw new Exception('Admin is not logged in');
         }
 
-        $di['set_redirect_uri'];
+        $di['set_return_uri'];
 
         header(sprintf('Location: %s', $di['url']->adminLink('staff/login')));
         exit;
@@ -493,11 +493,15 @@ $di['loggedin_admin'] = function () use ($di) {
     }
 };
 
-$di['set_redirect_uri'] = function () use ($di) {
+$di['set_return_uri'] = function () use ($di) {
     $url = $_GET['_url'] ?? ($_SERVER['PATH_INFO'] ?? '');
     unset($_GET['_url']);
 
-    $redirectUri = str_replace('/admin', '', $url) . '?' . http_build_query($_GET);
+    $admin_prefix = $di['config']['admin_area_prefix'];
+    if (str_starts_with($url, $admin_prefix)) {
+        $url = substr($url, strlen($admin_prefix));
+    }
+    $redirectUri = $url . '?' . http_build_query($_GET);
 
     $di['session']->set('redirect_uri', $redirectUri);
 };

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -138,6 +138,11 @@ class Guest extends \Api_Abstract
 
         $this->di['logger']->info('Client #%s logged in', $client->id);
 
+        $redirectUri = $this->di['session']->get('redirect_uri') ?? '';
+        $this->di['session']->delete('redirect_uri');
+
+        $result['redirect_uri'] = $redirectUri;
+
         return $result;
     }
 

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -68,7 +68,8 @@ $(function() {
         bb.post('guest/client/login',
             $(this).serialize(),
             function(result) {
-                bb.redirect();
+                const { redirect_uri } = result;
+                bb.redirect(redirect_uri || undefined);
             }
         );
 

--- a/src/modules/Staff/Controller/Admin.php
+++ b/src/modules/Staff/Controller/Admin.php
@@ -64,11 +64,8 @@ class Admin implements InjectionAwareInterface
             return $app->redirect('');
         }
 
-        $redirect_uri = 'index';
-
-        if (isset($_GET['redirect'])) {
-            $redirect_uri = urldecode($_GET['redirect']);
-        }
+        $redirect_uri = $this->di['session']->get('redirect_uri') ?: 'index';
+        $this->di['session']->delete('redirect_uri');
 
         return $app->render('mod_staff_login', ['create_admin' => $create, 'redirect_uri' => $redirect_uri]);
     }

--- a/src/modules/Staff/Controller/Admin.php
+++ b/src/modules/Staff/Controller/Admin.php
@@ -64,7 +64,13 @@ class Admin implements InjectionAwareInterface
             return $app->redirect('');
         }
 
-        return $app->render('mod_staff_login', ['create_admin' => $create]);
+        $redirect_uri = 'index';
+
+        if (isset($_GET['redirect'])) {
+            $redirect_uri = urldecode($_GET['redirect']);
+        }
+
+        return $app->render('mod_staff_login', ['create_admin' => $create, 'redirect_uri' => $redirect_uri]);
     }
 
     public function get_profile(\Box_App $app)

--- a/src/modules/Staff/html_admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login.html.twig
@@ -36,7 +36,7 @@
                 {% else %}
                 {% set params = guest.extension_settings({ 'ext': 'mod_staff' }) %}
                     <h2 class="h2 text-center mb-4">{{ 'Log into your account' | trans }}</h2>
-                    <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ 'index'|alink }}">
+                    <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ redirect_uri|alink }}">
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email' | trans }}</label>


### PR DESCRIPTION
Closes #1224 

This pull request introduces a new feature aimed at improving the user experience during the authentication flow. 

If an unauthenticated administrator attempts to access a route that requires authentication, they will be redirected to the login page. A redirect parameter, capturing the initially requested route, is appended to the login page URL. 

Upon successful login, the administrator is automatically redirected back to the page they were initially trying to access, ensuring a seamless navigation experience. This enhancement not only streamlines the navigation process but also retains the user's intended navigation path post-authentication.