### PR TITLE
Extend search functionality to include multiple client fields

### DIFF
--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -84,7 +84,7 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
-    public function getSearchQuery($data, $selectStmt = 'SELECT c.*')
+    public function getSearchQuery($data, $selectStmt = 'SELECT c.*'): array
     {
         $sql = $selectStmt;
         $sql .= ' FROM client as c left join client_group as cg on c.client_group_id = cg.id';
@@ -183,7 +183,7 @@ class Service implements InjectionAwareInterface
             throw new \Box_Exception('Invalid per page number');
         }
 
-        [$sql, $params] = $this->getSearchQuery($data, "SELECT c.id, CONCAT_WS('', c.first_name,  ' ', c.last_name) as full_name");
+        [$sql, $params] = $this->getSearchQuery($data, "SELECT c.id, CONCAT(c.company, ': (', c.first_name, ' ', c.last_name, ')') as client");
         $sql .= sprintf(' LIMIT %u', $limit);
 
         return $this->di['db']->getAssoc($sql, $params);

--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       optionClass: "dropdown-item",
       valueField: "value",
       labelField: "label",
-      searchField: ["label", "value"],
+      searchField: [],
       load: (query, callback) => {
         let items;
         let restUrl = new URL(


### PR DESCRIPTION
Closes: #1686 

In this pull request, the client-side search functionality has been extended to support multiple client fields, aligning with the existing server-side capabilities. Previously, although the server-side search was able to handle queries across multiple client fields, the client-side filtering mechanism restricted the visibility of these items in the select dropdown.