### PR TITLE
Replace direct config references with constants

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -27,16 +27,16 @@ use Twig\Extra\Intl\IntlExtension;
 $di = new \Pimple\Container();
 
 /*
- * Returns the current FOSSBilling config from config.php
+ * Returns the current FOSSBilling config.
  *
  * @param void
  *
  * @return array
  */
 $di['config'] = function () {
-    $array = include PATH_ROOT . '/config.php';
+    $config = include PATH_CONFIG;
 
-    return $array;
+    return $config;
 };
 
 /*
@@ -66,7 +66,7 @@ $di['logger'] = function () use ($di) {
 
         $log->addWriter($writer2);
     } else {
-        $monolog = new \FOSSBilling\Monolog($di);
+        $monolog = new \FOSSBilling\Monolog();
         $log->addWriter($monolog);
     }
 

--- a/src/di.php
+++ b/src/di.php
@@ -176,7 +176,7 @@ $di['pager'] = function () use ($di) {
 $di['url'] = function () use ($di) {
     $url = new Box_Url();
     $url->setDi($di);
-    $url->setBaseUri(BB_URL);
+    $url->setBaseUri(SYSTEM_URL);
 
     return $url;
 };

--- a/src/index.php
+++ b/src/index.php
@@ -13,9 +13,8 @@ $di = include __DIR__ . '/di.php';
 $url = $_GET['_url'] ?? $_SERVER['PATH_INFO'] ?? '';
 $http_err_code = $_GET['_errcode'] ?? null;
 
-$admin_prefix = $di['config']['admin_area_prefix'];
-if (strncasecmp($url, $admin_prefix, strlen($admin_prefix)) === 0) {
-    $appUrl = str_replace($admin_prefix, '', preg_replace('/\?.+/', '', $url));
+if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
+    $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));
     $app = new Box_AppAdmin();
 } else {
     $appUrl = $url;

--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -6,7 +6,7 @@
         <link href="./assets/css/pico.min.css" rel="stylesheet">
         <script src="./assets/js/modal.js"></script>
         <title>FOSSBilling Installation</title>
-        <base href="{{ constant('BB_URL_INSTALL') }}"/>
+        <base href="{{ constant('URL_INSTALL') }}"/>
         <style type="text/css">
             .green {
                 color: green;
@@ -41,7 +41,7 @@
         <main class="container">
             <nav style='padding-bottom: 1em;'>
                 <ul>
-                    <li><a href="{{ constant('BB_URL_INSTALL') }}" title="FOSSBilling"><img src="../themes/huraga/assets/img/logo_white.svg" alt="FOSSBilling Logo" height="50px" width="238"/></a></li>
+                    <li><a href="{{ constant('URL_INSTALL') }}" title="FOSSBilling"><img src="../themes/huraga/assets/img/logo_white.svg" alt="FOSSBilling Logo" height="50px" width="238"/></a></li>
                 </ul>
                 <ul>
                     <li><a href="https://fossbilling.org/docs" target="_blank" data-tooltip="Opens in a new window.">Documentation</a></li>

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -35,14 +35,14 @@ const PATH_CRON = PATH_ROOT . DIRECTORY_SEPARATOR . 'cron.php';
 const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
 const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
 const PATH_CACHE = PATH_ROOT . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'cache';
-const BB_HURAGA_CONFIG = PATH_THEMES . DIRECTORY_SEPARATOR . 'huraga' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'settings_data.json';
-const BB_HURAGA_CONFIG_TEMPLATE = PATH_THEMES . DIRECTORY_SEPARATOR . 'huraga' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'settings_data.json.example';
+const HURAGA_CONFIG = PATH_THEMES . DIRECTORY_SEPARATOR . 'huraga' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'settings_data.json';
+const HURAGA_CONFIG_TEMPLATE = PATH_THEMES . DIRECTORY_SEPARATOR . 'huraga' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'settings_data.json.example';
 const PATH_HTACCESS = PATH_ROOT . DIRECTORY_SEPARATOR . '.htaccess';
 const PAGE_INSTALL = './assets/install.html.twig';
 const PAGE_RESULT = './assets/result.html.twig';
 
 // Some functions and classes reference this, so we define it here to avoid errors.
-const BB_DEBUG = false;
+const DEBUG = false;
 
 // Set default include path
 set_include_path(implode(PATH_SEPARATOR, [
@@ -61,9 +61,9 @@ $protocol = FOSSBilling\Tools::isHTTPS() ? 'https' : 'http';
 $url = $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 $current_url = pathinfo($url, PATHINFO_DIRNAME);
 $root_url = str_replace('/install', '', $current_url) . '/';
-define('BB_URL', $root_url);
-const BB_URL_INSTALL = BB_URL . 'install/';
-const BB_URL_ADMIN = BB_URL . 'index.php?_url=/admin';
+define('SYSTEM_URL', $root_url);
+const URL_INSTALL = SYSTEM_URL . 'install/';
+const URL_ADMIN = SYSTEM_URL . 'index.php?_url=/admin';
 
 // Load action and initialize the installer
 $action = $_GET['a'] ?? 'index';
@@ -99,7 +99,7 @@ final class FOSSBilling_Installer
             case 'install':
                 // Make sure this is a POST request
                 if ($_SERVER['REQUEST_METHOD'] != 'POST') {
-                    header('Location: ' . BB_URL_INSTALL);
+                    header('Location: ' . URL_INSTALL);
                     die;
                 }
 
@@ -143,8 +143,8 @@ final class FOSSBilling_Installer
                         'config_file_path' => PATH_CONFIG,
                         'cron_path' => PATH_CRON,
                         'install_module_path' => PATH_INSTALL,
-                        'url_customer' => BB_URL,
-                        'url_admin' => BB_URL_ADMIN,
+                        'url_customer' => SYSTEM_URL,
+                        'url_admin' => URL_ADMIN,
                     ]);
 
                     // Try to remove install folder
@@ -197,9 +197,9 @@ final class FOSSBilling_Installer
                     'install_module_path' => PATH_INSTALL,
                     'cron_path' => PATH_CRON,
                     'config_file_path' => PATH_CONFIG,
-                    'live_site' => BB_URL,
-                    'admin_site' => BB_URL_ADMIN,
-                    'domain' => pathinfo(BB_URL, PATHINFO_BASENAME),
+                    'live_site' => SYSTEM_URL,
+                    'admin_site' => URL_ADMIN,
+                    'domain' => pathinfo(SYSTEM_URL, PATHINFO_BASENAME),
                 ];
                 echo $this->render(PAGE_INSTALL, $vars);
                 break;
@@ -311,7 +311,7 @@ final class FOSSBilling_Installer
      */
     private function isSubfolder(): bool
     {
-        return substr_count(BB_URL_INSTALL, '/') > 4 ? true : false;
+        return substr_count(URL_INSTALL, '/') > 4 ? true : false;
     }
 
     /**
@@ -386,8 +386,8 @@ final class FOSSBilling_Installer
         ]);
 
         // Copy config templates when applicable
-        if (!file_exists(BB_HURAGA_CONFIG) && file_exists(BB_HURAGA_CONFIG_TEMPLATE)) {
-            copy(BB_HURAGA_CONFIG_TEMPLATE, BB_HURAGA_CONFIG); // Copy the file instead of renaming it. This allows local dev instances to not need to restore the original file manually.
+        if (!file_exists(HURAGA_CONFIG) && file_exists(HURAGA_CONFIG_TEMPLATE)) {
+            copy(HURAGA_CONFIG_TEMPLATE, HURAGA_CONFIG); // Copy the file instead of renaming it. This allows local dev instances to not need to restore the original file manually.
         }
 
         // If .htaccess doesn't exist, fetch the latest from GitHub.
@@ -429,7 +429,7 @@ final class FOSSBilling_Installer
         $data['update_branch'] = $updateBranch;
         $data['info']['salt'] = bin2hex(random_bytes(16));
         $data['info']['instance_id'] = Uuid::uuid4()->toString();
-        $data['url'] = BB_URL;
+        $data['url'] = SYSTEM_URL;
         $data['path_data'] = PATH_ROOT . '/data';
         $data['path_logs'] = PATH_ROOT . '/data/log/application.log';
         $data['db'] = [

--- a/src/library/Api/Handler.php
+++ b/src/library/Api/Handler.php
@@ -74,7 +74,7 @@ final class Api_Handler implements InjectionAwareInterface
                 if($this->_acl_exception) {
                     throw new \FOSSBilling\Exception('You do not have access to :mod module', array(':mod'=>$mod), 725);
                 } else {
-                    if(BB_DEBUG) {
+                    if(DEBUG) {
                         error_log('You do not have access to '.$mod. ' module');
                     }
                     return null;

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -263,7 +263,6 @@ class Box_App
         $REQUEST_URI = $_SERVER['REQUEST_URI'] ?? null;
 
         $allowedURLs = $this->di['config']['maintenance_mode']['allowed_urls'];
-        $rootUrl = $this->di['config']['url'];
 
         // Allow access to the staff panel all the time
         $adminApiPrefixes = [
@@ -274,7 +273,7 @@ class Box_App
         ];
 
         foreach ($adminApiPrefixes as $adminApiPrefix) {
-            $realAdminApiUrl = '/' === $rootUrl[-1] ? substr($rootUrl, 0, -1) . $adminApiPrefix : $rootUrl . $adminApiPrefix;
+            $realAdminApiUrl = '/' === BB_URL[-1] ? substr(BB_URL, 0, -1) . $adminApiPrefix : BB_URL . $adminApiPrefix;
             $allowedURLs[] = parse_url($realAdminApiUrl)['path'];
         }
         foreach ($allowedURLs as $url) {
@@ -322,10 +321,8 @@ class Box_App
     protected function checkAdminPrefix()
     {
         $REQUEST_URI = $_SERVER['REQUEST_URI'] ?? null;
-        $adminPrefix = $this->di['config']['admin_area_prefix'];
-        $rootUrl = $this->di['config']['url'];
 
-        $realAdminUrl = '/' === $rootUrl[-1] ? substr($rootUrl, 0, -1) . $adminPrefix : $rootUrl . $adminPrefix;
+        $realAdminUrl = '/' === BB_URL[-1] ? substr(BB_URL, 0, -1) . ADMIN_PREFIX : BB_URL . ADMIN_PREFIX;
         $realAdminPath = parse_url($realAdminUrl)['path'];
 
         if (0 !== preg_match('/^' . str_replace('/', '\/', $realAdminPath) . '(.*)/', $REQUEST_URI)) {

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -273,7 +273,7 @@ class Box_App
         ];
 
         foreach ($adminApiPrefixes as $adminApiPrefix) {
-            $realAdminApiUrl = '/' === BB_URL[-1] ? substr(BB_URL, 0, -1) . $adminApiPrefix : BB_URL . $adminApiPrefix;
+            $realAdminApiUrl = '/' === SYSTEM_URL[-1] ? substr(SYSTEM_URL, 0, -1) . $adminApiPrefix : SYSTEM_URL . $adminApiPrefix;
             $allowedURLs[] = parse_url($realAdminApiUrl)['path'];
         }
         foreach ($allowedURLs as $url) {
@@ -322,7 +322,7 @@ class Box_App
     {
         $REQUEST_URI = $_SERVER['REQUEST_URI'] ?? null;
 
-        $realAdminUrl = '/' === BB_URL[-1] ? substr(BB_URL, 0, -1) . ADMIN_PREFIX : BB_URL . ADMIN_PREFIX;
+        $realAdminUrl = '/' === SYSTEM_URL[-1] ? substr(SYSTEM_URL, 0, -1) . ADMIN_PREFIX : SYSTEM_URL . ADMIN_PREFIX;
         $realAdminPath = parse_url($realAdminUrl)['path'];
 
         if (0 !== preg_match('/^' . str_replace('/', '\/', $realAdminPath) . '(.*)/', $REQUEST_URI)) {

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -16,7 +16,7 @@ class Box_AppClient extends Box_App
         $m->registerClientRoutes($this);
 
         if ('api' == $this->mod) {
-            define('BB_MODE_API', true);
+            define('API_MODE', true);
         } else {
             $extensionService = $this->di['mod_service']('extension');
             if ($extensionService->isExtensionActive('mod', 'redirect')) {
@@ -51,7 +51,7 @@ class Box_AppClient extends Box_App
         try {
             return $this->render($tpl, ['post' => $_POST], $ext);
         } catch (Exception $e) {
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log($e);
             }
         }

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -132,7 +132,7 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
         }
 
         //do not log debug level messages if debug is OFF
-        if (!BB_DEBUG && $event['priority'] > self::INFO) {
+        if (!DEBUG && $event['priority'] > self::INFO) {
             return;
         }
 

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -167,19 +167,19 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_mod_asset_url($asset, $mod)
     {
-        return BB_URL . 'modules/' . ucfirst($mod) . '/assets/' . $asset;
+        return SYSTEM_URL . 'modules/' . ucfirst($mod) . '/assets/' . $asset;
     }
 
     public function twig_asset_url(Twig\Environment $env, $asset)
     {
         $globals = $env->getGlobals();
 
-        return BB_URL . 'themes/' . $globals['current_theme'] . '/assets/' . $asset;
+        return SYSTEM_URL . 'themes/' . $globals['current_theme'] . '/assets/' . $asset;
     }
 
     public function twig_library_url($path)
     {
-        return BB_URL . 'library/' . $path;
+        return SYSTEM_URL . 'library/' . $path;
     }
 
     public function twig_img_tag($path, $alt = null)

--- a/src/library/Box/Url.php
+++ b/src/library/Box/Url.php
@@ -54,8 +54,7 @@ class Box_Url implements \FOSSBilling\InjectionAwareInterface
     public function adminLink($uri, $params = array())
     {
         $uri = trim($uri, '/');
-        $prefix = $this->di['config']['admin_area_prefix'];
-        $uri = $prefix . '/' . $uri;
+        $uri = ADMIN_PREFIX . '/' . $uri;
         return $this->link($uri, $params);
     }
 }

--- a/src/library/FOSSBilling/Exception.php
+++ b/src/library/FOSSBilling/Exception.php
@@ -12,7 +12,7 @@ namespace FOSSBilling;
 
 /**
  * The base FOSSBilling exception class. Implements translation and stacktrace logging.
- * 
+ *
  * @package FOSSBilling
  */
 class Exception extends \Exception
@@ -23,7 +23,7 @@ class Exception extends \Exception
 	 * @param string $message error message
 	 * @param array|null $variables translation variables
 	 * @param int $code The exception code.
-	 * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace. 
+	 * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace.
 	 */
 	public function __construct(string $message, ?array $variables = null, int $code = 0, bool $protected = false)
 	{
@@ -31,7 +31,7 @@ class Exception extends \Exception
 		$logStack = $config['debug_and_monitoring']['log_stacktrace'] ?? true;
 		$stackLength = $config['debug_and_monitoring']['stacktrace_length'] ?? 25;
 
-		if (BB_DEBUG && $logStack) {
+		if (DEBUG && $logStack) {
 			error_log('An exception has been thrown. Stacktrace:');
 			error_log($this->stackTrace($stackLength, $protected));
 		}

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -14,7 +14,7 @@ use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 
-class Monolog implements InjectionAwareInterface
+class Monolog
 {
     protected $logger = null;
     public string $dateFormat = "d-M-Y H:i:s e";
@@ -29,22 +29,13 @@ class Monolog implements InjectionAwareInterface
         "event"
     ];
 
-    public function setDi(\Pimple\Container $di): void
-    {
-        $this->di = $di;
-    }
-
-    public function getDi(): ?\Pimple\Container
-    {
-        return $this->di;
-    }
-
-    public function __construct(protected ?\Pimple\Container $di)
+    public function __construct()
     {
         $channels = $this->channels;
 
         foreach ($channels as $channel) {
-            $path = $di['config']['path_data'] . '/log/' . $channel . '.log';
+
+            $path = PATH_LOG . DIRECTORY_SEPARATOR . $channel . '.log';
 
             $this->logger[$channel] = new Logger($channel);
             $stream = new StreamHandler($path, Logger::DEBUG);

--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -67,7 +67,7 @@ class Requirements implements InjectionAwareInterface
         $data['PHP_VERSION']    = PHP_VERSION;
 
         $data['FOSSBilling']    = array(
-            'BB_LOCALE'     =>  $this->di['config']['i18n']['locale'],
+            'locale'        =>  $this->di['config']['i18n']['locale'],
             'version'       =>  \FOSSBilling\Version::VERSION,
         );
 
@@ -150,7 +150,7 @@ class Requirements implements InjectionAwareInterface
                     $result[$file] = true;
                 } else {
                     $result[$file] = false;
-                    $this->_all_ok = false;   
+                    $this->_all_ok = false;
                 }
                 @unlink($file);
             } else {

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -28,7 +28,7 @@ class SentryHelper
 
     /**
      * Registers Sentry for error reporting. Skips the steps to enable Sentry if error reporting is not enabled.
-     *  
+     *
      * @param array $config The FOSSBilling config.
      */
     public static function registerSentry(array $config): void
@@ -60,7 +60,7 @@ class SentryHelper
             'send_default_pii' => false,
 
             // Stack traces are always sent for Exceptions, but if debug mode is enabled we will send them for errors too.
-            'attach_stacktrace' => (bool)BB_DEBUG,
+            'attach_stacktrace' => (bool)DEBUG,
         ];
 
         /**
@@ -78,7 +78,7 @@ class SentryHelper
 
     /**
      * Captures an exception and sends it to Sentry, adding additional information that we'd find useful.
-     * 
+     *
      * @param \Exception|\Error $e
      */
     public static function captureException(\Exception|\Error $e)

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -55,7 +55,7 @@ class Tools
     public function url($link = null)
     {
         $link = trim($link, '/');
-        return BB_URL . $link;
+        return SYSTEM_URL . $link;
     }
 
     public function hasService($type)

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -17,12 +17,12 @@ class i18n
      * Attempts to get the correct locale for the current user, or a suitable fallback option if it's unavailable.
      *
      * @param bool $autoDetect Indicates if the user's Accept-Language header should be used to select the correct locale for them.
-     * 
+     *
      * @return string The locale code to use for the system.
      */
     public static function getActiveLocale(bool $autoDetect = true): string
     {
-        $config = include PATH_ROOT . '/config.php';
+        $config = include PATH_CONFIG;
         $locale = null;
 
         /**
@@ -93,7 +93,7 @@ class i18n
      * Retrieve a list of available locales, optionally including their details.
      *
      * @param bool $includeLocaleDetails (optional) Whether to include locale details or not. Defaults to false.
-     * 
+     *
      * @param bool $disabled Set to true if you want it to return a list of the disabled locales, defaults to false which will return the enabled locales.
      *
      * @return array An array of locales, sorted alphabetically. If `$includeLocaleDetails` is true, the array will contain
@@ -121,12 +121,12 @@ class i18n
 
     /**
      * Enables / disables a locale depending on it's current status.
-     * 
+     *
      * @param string $locale The locale code to toggle. (Example: `en_US`)
-     * 
+     *
      * @return bool To indicate if it was successful,
-     *  
-     * @throws InformationException 
+     *
+     * @throws InformationException
      */
     public static function toggleLocale(string $locale): bool
     {
@@ -149,10 +149,10 @@ class i18n
     /**
      * Returns how complete a locale is.
      * Will return 0 if the `completion.php` doesn't exist or if it doesn't include the specified locale.
-     * 
+     *
      * @param string $locale The locale ID (Example: `en_US`)
-     * 
-     * @return int The percentage complete for the specified locale. 
+     *
+     * @return int The percentage complete for the specified locale.
      */
     public static function getLocaleCompletionPercent(string $locale): int
     {
@@ -171,9 +171,9 @@ class i18n
 
     /**
      * Internal helper function that gets the list of locales off of the disk.
-     * 
+     *
      * @param bool $disabled Set to true to get the list of disabled locales. True returns the list of enabled locales.
-     * 
+     *
      * @return array The list of locale codes, sorted alphabetically.
      */
     private static function getLocaleList(bool $disabled = false): array

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -125,7 +125,7 @@ class Payment_Adapter_Stripe implements \FOSSBilling\InjectionAwareInterface
         $tx->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($tx);
 
-        if (BB_DEBUG) {
+        if (DEBUG) {
             error_log(json_encode($e->getJsonBody()));
         }
         throw new Exception($tx->error);

--- a/src/load.php
+++ b/src/load.php
@@ -176,7 +176,7 @@ function exceptionHandler($e)
 
     $message = htmlspecialchars($e->getMessage());
 
-    if (defined('BB_MODE_API')) {
+    if (defined('API_MODE')) {
         $code = $e->getCode() ?: 9998;
         $result = ['result' => null, 'error' => ['message' => $message, 'code' => $code]];
         echo json_encode($result);
@@ -184,7 +184,7 @@ function exceptionHandler($e)
         return false;
     }
 
-    if (defined('BB_DEBUG') && BB_DEBUG && file_exists(PATH_VENDOR)) {
+    if (defined('DEBUG') && DEBUG && file_exists(PATH_VENDOR)) {
         /**
          * If advanced debugging is enabled, print Whoops instead of our error page.
          * flip/whoops documentation: https://github.com/filp/whoops/blob/master/docs/API%20Documentation.md.
@@ -242,14 +242,12 @@ $config = require PATH_CONFIG;
 
 // Config loaded - set globals and relevant settings.
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
-define('BB_DEBUG', (bool) $config['debug_and_monitoring']['debug']);
-define('BB_URL', $config['url']);
+define('ADMIN_PREFIX', $config['admin_area_prefix']);
+define('DEBUG', (bool) $config['debug_and_monitoring']['debug']);
 define('PATH_DATA', $config['path_data']);
 define('PATH_CACHE', PATH_DATA . DIRECTORY_SEPARATOR . 'cache');
 define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
-define('BB_SSL', str_starts_with(BB_URL, 'https'));
-define('ADMIN_PREFIX', $config['admin_area_prefix']);
-define('BB_URL_API', BB_URL . 'api/');
+define('SYSTEM_URL', $config['url']);
 if (!empty($config['info']['instance_id'])) {
     define('INSTANCE_ID', $config['info']['instance_id']);
 } else {
@@ -278,7 +276,7 @@ ini_set('error_log', PATH_LOG . DIRECTORY_SEPARATOR . 'php_error.log');
 // We disable PHP's error reporting as our own error handler will log it and send it to Sentry.
 error_reporting(0);
 
-if (BB_DEBUG) {
+if (DEBUG) {
     ini_set('display_errors', '1');
     ini_set('display_startup_errors', '1');
 } else {

--- a/src/load.php
+++ b/src/load.php
@@ -247,9 +247,9 @@ define('BB_URL', $config['url']);
 define('PATH_DATA', $config['path_data']);
 define('PATH_CACHE', PATH_DATA . DIRECTORY_SEPARATOR . 'cache');
 define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
-define('BB_SSL', str_starts_with($config['url'], 'https'));
+define('BB_SSL', str_starts_with(BB_URL, 'https'));
 define('ADMIN_PREFIX', $config['admin_area_prefix']);
-define('BB_URL_API', $config['url'] . 'api/');
+define('BB_URL_API', BB_URL . 'api/');
 if (!empty($config['info']['instance_id'])) {
     define('INSTANCE_ID', $config['info']['instance_id']);
 } else {

--- a/src/load.php
+++ b/src/load.php
@@ -21,7 +21,6 @@ const PATH_THEMES = PATH_ROOT . DIRECTORY_SEPARATOR . 'themes';
 const PATH_MODS = PATH_ROOT . DIRECTORY_SEPARATOR . 'modules';
 const PATH_LANGS = PATH_ROOT . DIRECTORY_SEPARATOR . 'locale';
 const PATH_UPLOADS = PATH_ROOT . DIRECTORY_SEPARATOR . 'uploads';
-const PATH_DATA = PATH_ROOT . DIRECTORY_SEPARATOR . 'data';
 const PATH_CONFIG = PATH_ROOT . DIRECTORY_SEPARATOR . 'config.php';
 
 /*
@@ -245,8 +244,9 @@ $config = require PATH_CONFIG;
 date_default_timezone_set($config['i18n']['timezone'] ?? 'UTC');
 define('BB_DEBUG', (bool) $config['debug_and_monitoring']['debug']);
 define('BB_URL', $config['url']);
-define('PATH_CACHE', $config['path_data'] . DIRECTORY_SEPARATOR . 'cache');
-define('PATH_LOG', $config['path_data'] . DIRECTORY_SEPARATOR . 'log');
+define('PATH_DATA', $config['path_data']);
+define('PATH_CACHE', PATH_DATA . DIRECTORY_SEPARATOR . 'cache');
+define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
 define('BB_SSL', str_starts_with($config['url'], 'https'));
 define('ADMIN_PREFIX', $config['admin_area_prefix']);
 define('BB_URL_API', $config['url'] . 'api/');

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -124,10 +124,10 @@ class Client implements InjectionAwareInterface
         // snake oil: check request is from the same domain as FOSSBilling is installed if present
         $check_referer_header = isset($this->_api_config['require_referrer_header']) ? (bool) $this->_api_config['require_referrer_header'] : false;
         if ($check_referer_header) {
-            $url = strtolower(BB_URL);
+            $url = strtolower(SYSTEM_URL);
             $referer = isset($_SERVER['HTTP_REFERER']) ? strtolower($_SERVER['HTTP_REFERER']) : null;
             if (!$referer || !str_starts_with($referer, $url)) {
-                throw new \FOSSBilling\InformationException('Invalid request. Make sure request origin is :from', [':from' => BB_URL], 1004);
+                throw new \FOSSBilling\InformationException('Invalid request. Make sure request origin is :from', [':from' => SYSTEM_URL], 1004);
             }
         }
 

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -328,7 +328,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $mail = new \FOSSBilling\Mail($email->sender, $email->recipients, $email->sender, $email->content_html, $settings['mailer'] ?? 'sendmail', $settings['custom_dsn'] ?? null);
 
         if (Environment::isTesting()) {
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log('Skipping email sending in test environment');
             }
 

--- a/src/modules/Embed/html_client/mod_embed_contact.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_contact.html.twig
@@ -111,7 +111,7 @@ $(function() {
     $('#anti-spam').remove();
 
     $('#public-ticket-create').on('submit', function(event) {
-        $.post("{{ constant('BB_URL_API') }}guest/support/ticket_create",
+        $.post("{{ constant('SYSTEM_URL') }}api/guest/support/ticket_create",
         $(this).serialize(),
         function(json) {
             if(json.error) {

--- a/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_domainchecker.html.twig
@@ -67,7 +67,7 @@
 <script>
     $(function() {
         $('#domain-checker').on('submit', function(event) {
-            $.post("{{ constant('BB_URL_API') }}guest/servicedomain/check",
+            $.post("{{ constant('SYSTEM_URL') }}api/guest/servicedomain/check",
             $(this).serialize(),
             function(json) {
                 if (json.error) {

--- a/src/modules/Embed/html_client/mod_embed_loginform.html.twig
+++ b/src/modules/Embed/html_client/mod_embed_loginform.html.twig
@@ -47,13 +47,13 @@
 <script type="text/javascript">
 $(function() {
     $('#client-login').on('submit', function(event) {
-        $.post("{{ constant('BB_URL_API') }}guest/client/login",
+        $.post("{{ constant('SYSTEM_URL') }}api/guest/client/login",
             $(this).serialize(),
             function(json) {
                 if(json.error) {
                     alert(json.error.message);
                 } else {
-                    parent.window.location = "{{ constant('BB_URL') }}";
+                    parent.window.location = "{{ constant('SYSTEM_URL') }}";
                 }
             }, 'json')
         ;

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -195,7 +195,7 @@ class Service implements InjectionAwareInterface
             $iconPath = 'assets/icons/cog.svg';
             $icon_url = $value['icon_url'] ?? null;
             if ($icon_url) {
-                $iconPath = BB_URL . $icon_url;
+                $iconPath = SYSTEM_URL . $icon_url;
             }
             $result[$key]['icon_url'] = $iconPath;
         }

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -195,7 +195,7 @@ class Service implements InjectionAwareInterface
             $iconPath = 'assets/icons/cog.svg';
             $icon_url = $value['icon_url'] ?? null;
             if ($icon_url) {
-                $iconPath = $this->di['config']['url'] . $icon_url;
+                $iconPath = BB_URL . $icon_url;
             }
             $result[$key]['icon_url'] = $iconPath;
         }

--- a/src/modules/Hook/Api/Admin.php
+++ b/src/modules/Hook/Api/Admin.php
@@ -47,7 +47,7 @@ class Admin extends \Api_Abstract
 
         $event = $data['event'];
         $params = $data['params'] ?? null;
-        if (BB_DEBUG) {
+        if (DEBUG) {
             try {
                 $this->di['logger']->info($event . ': ' . var_export($params, 1));
             } catch (\Exception $e) {

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -559,7 +559,7 @@ class Service implements InjectionAwareInterface
         $epsilon = 0.05;
 
         if (abs($balance - $required) < $epsilon) {
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log(sprintf('Setting invoice %s as paid with credits', $invoice->id));
             }
             $this->markAsPaid($invoice);
@@ -568,14 +568,14 @@ class Service implements InjectionAwareInterface
         }
 
         if ($balance - $required > 0.00001) {
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log(sprintf('Setting invoice %s as paid with credits', $invoice->id));
             }
             $this->markAsPaid($invoice);
 
             return true;
         }
-        if (BB_DEBUG) {
+        if (DEBUG) {
             error_log(sprintf('Invoice %s could not be paid with credits. Money in balance %s Required: %s', $invoice->id, $balance, $required));
         }
     }
@@ -708,7 +708,7 @@ class Service implements InjectionAwareInterface
                 break;
 
             case 'manual':
-                if (BB_DEBUG) {
+                if (DEBUG) {
                     error_log('Refunds are managed manually. No actions performed');
                 }
 
@@ -876,7 +876,7 @@ class Service implements InjectionAwareInterface
                 $model = $this->di['db']->getExistingModelById('Invoice', $proforma['id']);
                 $this->tryPayWithCredits($model);
             } catch (\Exception $e) {
-                if (BB_DEBUG) {
+                if (DEBUG) {
                     error_log($e->getMessage());
                 }
             }

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -347,7 +347,7 @@ class ServicePayGateway implements InjectionAwareInterface
             $p['bb_invoice_id'] = $model->id;
         }
 
-        return $this->di['config']['url'] . 'ipn.php?' . http_build_query($p);
+        return BB_URL . 'ipn.php?' . http_build_query($p);
     }
 
     /**
@@ -389,6 +389,6 @@ class ServicePayGateway implements InjectionAwareInterface
             $p['bb_redirect'] = 1;
         }
 
-        return $this->di['config']['url'] . 'ipn.php?' . http_build_query($p);
+        return BB_URL . 'ipn.php?' . http_build_query($p);
     }
 }

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -347,7 +347,7 @@ class ServicePayGateway implements InjectionAwareInterface
             $p['bb_invoice_id'] = $model->id;
         }
 
-        return BB_URL . 'ipn.php?' . http_build_query($p);
+        return SYSTEM_URL . 'ipn.php?' . http_build_query($p);
     }
 
     /**
@@ -389,6 +389,6 @@ class ServicePayGateway implements InjectionAwareInterface
             $p['bb_redirect'] = 1;
         }
 
-        return BB_URL . 'ipn.php?' . http_build_query($p);
+        return SYSTEM_URL . 'ipn.php?' . http_build_query($p);
     }
 }

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -402,7 +402,7 @@ class ServiceTransaction implements InjectionAwareInterface
             $transaction->updated_at = date('Y-m-d H:i:s');
             $this->di['db']->store($transaction);
 
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log($e->getMessage());
             }
             if (Environment::isTesting()) {
@@ -561,7 +561,7 @@ class ServiceTransaction implements InjectionAwareInterface
                 $invoiceService = $this->di['mod_service']('Invoice');
                 $invoiceService->tryPayWithCredits($tx->Invoice);
             } catch (\Exception $e) {
-                if (BB_DEBUG) {
+                if (DEBUG) {
                     error_log($e->getMessage());
                 }
             }

--- a/src/modules/Massmailer/Service.php
+++ b/src/modules/Massmailer/Service.php
@@ -162,7 +162,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
 
         if (!Environment::isProduction()) {
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log('Skip email sending. Application ENV: ' . Environment::getCurrentEnvironment());
             }
 

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
@@ -9,7 +9,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta property="bb:url" content="{{ constant('BB_URL') }}"/>
+    <meta property="bb:url" content="{{ constant('SYSTEM_URL') }}"/>
     <meta property="bb:client_area" content="{{ '/'|link }}"/>
 
     <meta charset="utf-8">

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -232,7 +232,7 @@
                             bb.msg(data.error.message, 'error');
                         }
                     } else {
-                        bb.redirect("{{ constant('BB_URL') }}");
+                        bb.redirect("{{ constant('SYSTEM_URL') }}");
                     }
                 }
             });

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -740,7 +740,7 @@ class Service implements InjectionAwareInterface
 
     public function getSavePath($filename = null)
     {
-        $path = $this->di['config']['path_data'] . '/uploads/';
+        $path = PATH_DATA . '/uploads/';
         if ($filename !== null) {
             $path .= md5($filename);
         }

--- a/src/modules/Seo/Service.php
+++ b/src/modules/Seo/Service.php
@@ -38,7 +38,7 @@ class Service implements InjectionAwareInterface
             return false;
         }
 
-        $url = urldecode(BB_URL . 'sitemap.xml');
+        $url = urldecode(SYSTEM_URL . 'sitemap.xml');
 
         $engines = $this->_getEngines();
 
@@ -70,7 +70,7 @@ class Service implements InjectionAwareInterface
         $systemService = $this->di['mod_service']('system');
 
         $result = [
-            'sitemap_url' => BB_URL . 'sitemap.xml',
+            'sitemap_url' => SYSTEM_URL . 'sitemap.xml',
             'last_exec' => $systemService->getParamValue('mod_seo_last_sitemap_submit'),
             'engines' => $this->_getEngineDetails(),
         ];

--- a/src/modules/Servicecustom/Service.php
+++ b/src/modules/Servicecustom/Service.php
@@ -263,7 +263,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $file = sprintf('Plugin/%s/%s.php', $plugin, $plugin);
         if (!Environment::isTesting() && !file_exists(PATH_LIBRARY . DIRECTORY_SEPARATOR . $file)) {
             $e = new \FOSSBilling\Exception('Plugin class file :file was not found', [':file' => $file], 3124);
-            if (BB_DEBUG) {
+            if (DEBUG) {
                 error_log($e->getMessage());
             }
 

--- a/src/modules/Servicelicense/Service.php
+++ b/src/modules/Servicelicense/Service.php
@@ -431,7 +431,7 @@ class Service implements InjectionAwareInterface
     {
         $result = [];
         $log = $this->di['logger']->setChannel('license');
-        if (BB_DEBUG) {
+        if (DEBUG) {
             $log->debug(print_r($data, 1));
         }
 

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -141,22 +141,22 @@ class Service
 
         $logoUrl = $results['company_logo'] ?? null;
         if ($logoUrl !== null && !str_contains($logoUrl, 'http')) {
-            $logoUrl = BB_URL . $logoUrl;
+            $logoUrl = SYSTEM_URL . $logoUrl;
         }
 
         $logoUrlDark = $results['company_logo_dark'] ?? null;
         if ($logoUrlDark !== null && !str_contains($logoUrlDark, 'http')) {
-            $logoUrlDark = BB_URL . $logoUrlDark;
+            $logoUrlDark = SYSTEM_URL . $logoUrlDark;
         }
         $logoUrlDark ??= $logoUrl;
 
         $faviconUrl = $results['company_favicon'] ?? null;
         if ($faviconUrl !== null && !str_contains($faviconUrl, 'http')) {
-            $faviconUrl = BB_URL . $faviconUrl;
+            $faviconUrl = SYSTEM_URL . $faviconUrl;
         }
 
         return [
-            'www' => BB_URL,
+            'www' => SYSTEM_URL,
             'name' => isset($results['company_name']) ? htmlspecialchars($results['company_name'], ENT_QUOTES, 'UTF-8') : null,
             'email' => isset($results['company_email']) ? htmlspecialchars($results['company_email'], ENT_QUOTES, 'UTF-8') : null,
             'tel' => isset($results['company_tel']) ? htmlspecialchars($results['company_tel'], ENT_QUOTES, 'UTF-8') : null,

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -139,25 +139,24 @@ class Service
         ];
         $results = $this->_getMultipleParams($c);
 
-        $baseUrl = $this->di['config']['url'];
         $logoUrl = $results['company_logo'] ?? null;
         if ($logoUrl !== null && !str_contains($logoUrl, 'http')) {
-            $logoUrl = $baseUrl . $logoUrl;
+            $logoUrl = BB_URL . $logoUrl;
         }
 
         $logoUrlDark = $results['company_logo_dark'] ?? null;
         if ($logoUrlDark !== null && !str_contains($logoUrlDark, 'http')) {
-            $logoUrlDark = $baseUrl . $logoUrlDark;
+            $logoUrlDark = BB_URL . $logoUrlDark;
         }
         $logoUrlDark ??= $logoUrl;
 
         $faviconUrl = $results['company_favicon'] ?? null;
         if ($faviconUrl !== null && !str_contains($faviconUrl, 'http')) {
-            $faviconUrl = $baseUrl . $faviconUrl;
+            $faviconUrl = BB_URL . $faviconUrl;
         }
 
         return [
-            'www' => $baseUrl,
+            'www' => BB_URL,
             'name' => isset($results['company_name']) ? htmlspecialchars($results['company_name'], ENT_QUOTES, 'UTF-8') : null,
             'email' => isset($results['company_email']) ? htmlspecialchars($results['company_email'], ENT_QUOTES, 'UTF-8') : null,
             'tel' => isset($results['company_tel']) ? htmlspecialchars($results['company_tel'], ENT_QUOTES, 'UTF-8') : null,

--- a/src/modules/Theme/Model/Theme.php
+++ b/src/modules/Theme/Model/Theme.php
@@ -145,7 +145,7 @@ class Theme
 
     public function getUrl()
     {
-        return BB_URL . 'themes/' . $this->name;
+        return SYSTEM_URL . 'themes/' . $this->name;
     }
 
     public function getPath()

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -237,7 +237,7 @@ class Service implements InjectionAwareInterface
         if ($theme == null || !file_exists($path . $theme)) {
             $theme = $default;
         }
-        $url = BB_URL . 'themes' . DIRECTORY_SEPARATOR . $theme . DIRECTORY_SEPARATOR;
+        $url = SYSTEM_URL . 'themes' . DIRECTORY_SEPARATOR . $theme . DIRECTORY_SEPARATOR;
 
         return ['code' => $theme, 'url' => $url];
     }
@@ -251,11 +251,7 @@ class Service implements InjectionAwareInterface
 
     public function getCurrentClientAreaThemeCode()
     {
-        if (defined('BB_THEME_CLIENT')) {
-            $theme = BB_THEME_CLIENT;
-        } else {
-            $theme = $this->di['db']->getCell("SELECT value FROM setting WHERE param = 'theme' ");
-        }
+        $theme = $this->di['db']->getCell("SELECT value FROM setting WHERE param = 'theme' ");
 
         return !empty($theme) ? $theme : 'huraga';
     }
@@ -345,10 +341,10 @@ class Service implements InjectionAwareInterface
             $ext = trim($config['extends'], '/');
             $ext = str_replace('.', '', $ext);
 
-            $config['url'] = BB_URL . 'themes/' . $ext . '/';
+            $config['url'] = SYSTEM_URL . 'themes/' . $ext . '/';
             $paths[] = $this->getThemesPath() . $ext . '/html';
         } else {
-            $config['url'] = BB_URL . 'themes/' . $theme . '/';
+            $config['url'] = SYSTEM_URL . 'themes/' . $theme . '/';
         }
 
         // add installed modules paths

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -237,7 +237,7 @@ class Service implements InjectionAwareInterface
         if ($theme == null || !file_exists($path . $theme)) {
             $theme = $default;
         }
-        $url = $this->di['config']['url'] . 'themes' . DIRECTORY_SEPARATOR . $theme . DIRECTORY_SEPARATOR;
+        $url = BB_URL . 'themes' . DIRECTORY_SEPARATOR . $theme . DIRECTORY_SEPARATOR;
 
         return ['code' => $theme, 'url' => $url];
     }

--- a/src/themes/admin_default/html/partial_bb_meta.html.twig
+++ b/src/themes/admin_default/html/partial_bb_meta.html.twig
@@ -1,3 +1,3 @@
 <base href="{{ theme.url }}"/>
-<meta property="bb:url" content="{{ constant('BB_URL') }}"/>
+<meta property="bb:url" content="{{ constant('SYSTEM_URL') }}"/>
 <meta property="bb:client_area" content="{{ '/'|link }}"/>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
     <title>{% block meta_title %}{{ settings.meta_title }}{% endblock %}</title>
 
-    <meta property="bb:url" content="{{ constant('BB_URL') }}">
+    <meta property="bb:url" content="{{ constant('SYSTEM_URL') }}">
     <meta property="bb:client_area" content="{{ '/'|link }}">
     <meta name="csrf-token" content="{{ CSRFToken }}">
 

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
     <title>{% block meta_title %}{{ settings.meta_title }}{% endblock %}</title>
 
-    <meta property="bb:url" content="{{ constant('BB_URL') }}">
+    <meta property="bb:url" content="{{ constant('SYSTEM_URL') }}">
     <meta property="bb:client_area" content="{{ '/'|link }}">
     <meta name="csrf-token" content="{{ CSRFToken }}">
 

--- a/tests/integration/bb-modules/mod_servicedomain/ServiceDownloadableTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/ServiceDownloadableTest.php
@@ -11,14 +11,14 @@ class Api_Admin_ServiceDownloadableTest extends BBDbApiTestCase
         $this->assertTrue(true);
 
         /*
-        $endpoint = BB_URL . 'bb-api/rest.php/admin/servicedownloadable/upload';
+        $endpoint = SYSTEM_URL . 'bb-api/rest.php/admin/servicedownloadable/upload';
         $file_name = PATH_TESTS.'/fixtures/services.xml';
 
         $params = array(
             'id'            =>  7, // product id
             'file_data'     =>  '@'.realpath($file_name),
         );
-        
+
         // @TODO Post the file
 
         $this->assertEquals('{"result":true,"error":null}', $rsp);

--- a/tests/integration/bb-modules/mod_theme/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_theme/ServiceTest.php
@@ -79,7 +79,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
         $result = $service->getCurrentAdminAreaTheme();
         $this->assertIsArray($result);
         $this->assertEquals('admin_default', $result['code']);
-        $this->assertEquals($this->di['config']['url'].'themes/admin_default/', $result['url']);
+        $this->assertEquals(BB_URL . 'themes/admin_default/', $result['url']);
     }
 
     public function testgetCurrentClientAreaTheme()

--- a/tests/integration/bb-modules/mod_theme/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_theme/ServiceTest.php
@@ -79,7 +79,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
         $result = $service->getCurrentAdminAreaTheme();
         $this->assertIsArray($result);
         $this->assertEquals('admin_default', $result['code']);
-        $this->assertEquals(BB_URL . 'themes/admin_default/', $result['url']);
+        $this->assertEquals(SYSTEM_URL . 'themes/admin_default/', $result['url']);
     }
 
     public function testgetCurrentClientAreaTheme()

--- a/tests/modules/Invoice/ServicePayGatewayTest.php
+++ b/tests/modules/Invoice/ServicePayGatewayTest.php
@@ -163,7 +163,7 @@ class ServicePayGatewayTest extends \BBTestCase {
         $serviceMock->expects($this->atLeastOnce())
             ->method('getDescription');
 
-        $url = 'http://fossbilling.vm/';
+        $url = 'http://localhost/';
         $expected = array(
             'id'                         => null,
             'code'                       => null,

--- a/tests/modules/Product/ServiceTest.php
+++ b/tests/modules/Product/ServiceTest.php
@@ -1062,7 +1062,7 @@ class ServiceTest extends \BBTestCase
     {
         $filename = 'cfg.file';
         $config   = array('path_data' => '/home');
-        $expected = $config['path_data'] . '/uploads/' . md5($filename);
+        $expected = PATH_DATA . '/uploads/' . md5($filename);
 
         $di           = new \Pimple\Container();
         $di['config'] = $config;

--- a/tests/modules/System/ServiceTest.php
+++ b/tests/modules/System/ServiceTest.php
@@ -29,7 +29,7 @@ class ServiceTest extends \BBTestCase
     {
         $config = array('url' => 'www.fossbilling.org');
         $expected = array(
-            'www'                   => $config['url'],
+            'www'                   => 'http://localhost/',
             'name'                  => 'Inc. Test',
             'email'                 => 'work@example.eu',
             'tel'                   =>   NULL,


### PR DESCRIPTION
Replace direct references to `config.php` file and specific config options in favour of global constants, where available. Also, fix the `PATH_DATA` constant not using the `path_data` config parameter.

Additionally, removes `BB_*` prefix from constants, where appropriate.

Resolves #1760. Progresses #1679.