### PR TITLE
Minor improvements to Sentry.io integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "monolog/monolog": "^2.9",
         "nelexa/zip": "^4.0.2",
         "nyholm/psr7": "^1.8",
+        "php-http/message-factory": "*",
         "phpmyadmin/motranslator": "^5.3.0",
         "pimple/pimple": "^3.3",
         "plesk/api-php-lib": "^2.0.0",
@@ -74,5 +75,8 @@
             "php-http/discovery": true
         },
         "vendor-dir": "src/vendor"
+    },
+    "replace": {
+        "php-http/message-factory": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "044d14773ba454259337bba123511342",
+    "content-hash": "9b511e011a36c158a7dfd97da511132b",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -1849,16 +1849,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "cead6637226456b35e1175cc53797dd585d85545"
+                "reference": "a9d127dd6a203ce6d255b2e2db49759f7506e015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/cead6637226456b35e1175cc53797dd585d85545",
-                "reference": "cead6637226456b35e1175cc53797dd585d85545",
+                "url": "https://api.github.com/repos/nette/utils/zipball/a9d127dd6a203ce6d255b2e2db49759f7506e015",
+                "reference": "a9d127dd6a203ce6d255b2e2db49759f7506e015",
                 "shasum": ""
             },
             "require": {
@@ -1929,9 +1929,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.2"
+                "source": "https://github.com/nette/utils/tree/v4.0.3"
             },
-            "time": "2023-09-19T11:58:07+00:00"
+            "time": "2023-10-29T21:02:13+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -2373,61 +2373,6 @@
                 "source": "https://github.com/php-http/message/tree/1.16.0"
             },
             "time": "2023-05-17T06:43:38+00:00"
-        },
-        {
-            "name": "php-http/message-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message-factory.git",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Factory interfaces for PSR-7 HTTP Message",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
-            },
-            "abandoned": "psr/http-factory",
-            "time": "2023-04-14T14:16:17+00:00"
         },
         {
             "name": "php-http/promise",
@@ -7005,16 +6950,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.39",
+            "version": "1.10.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d9dedb0413f678b4d03cbc2279a48f91592c97c4"
+                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d9dedb0413f678b4d03cbc2279a48f91592c97c4",
-                "reference": "d9dedb0413f678b4d03cbc2279a48f91592c97c4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93c84b5bf7669920d823631e39904d69b9c7dc5d",
+                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d",
                 "shasum": ""
             },
             "require": {
@@ -7063,7 +7008,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-17T15:46:26+00:00"
+            "time": "2023-10-30T14:48:31+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -9083,5 +9028,5 @@
         "ext-zlib": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -418,9 +418,7 @@ final class FOSSBilling_Installer
      */
     private function getConfigOutput(): string
     {
-        // Version data
-        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
-        $updateBranch = (preg_match($reg, \FOSSBilling\Version::VERSION, $matches) !== 0) ? "release" : "preview";
+        $updateBranch = \FOSSBilling\Version::isPreviewVersion() ? "preview" : "release";
 
         // Load default sample config
         $data = require PATH_CONFIG_SAMPLE;

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -128,21 +128,6 @@ class Update implements InjectionAwareInterface
     }
 
     /**
-     * Checks if current FOSSBilling version is a preview.
-     *
-     * @return bool True if preview, false if not.
-     */
-    private function isPreviewVersion(): bool
-    {
-        $reg = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
-        if (preg_match($reg, $this->getLatestVersion())) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    /**
      * Check if an update is available for the current FOSSBilling version.
      *
      * @return bool True if update is available, false if not.
@@ -151,7 +136,7 @@ class Update implements InjectionAwareInterface
     {
         $version = $this->getLatestVersion();
         $result = Version::compareVersion($version);
-        $result = ($this->isPreviewVersion() && $this->getUpdateBranch() === "release") ? 1 : $result;
+        $result = (Version::isPreviewVersion() && $this->getUpdateBranch() === "release") ? 1 : $result;
         return ($result > 0);
     }
 

--- a/src/library/FOSSBilling/Version.php
+++ b/src/library/FOSSBilling/Version.php
@@ -16,6 +16,7 @@ final class Version
     public const PATCH = 0;
     public const MINOR = 1;
     public const MAJOR = 2;
+    public const semverRegex = '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$^';
 
     /**
      * Compare the specified FOSSBilling version string $version
@@ -61,5 +62,10 @@ final class Version
                 return self::PATCH;
             }
         }
+    }
+
+    public static function isPreviewVersion(): bool
+    {
+        return (preg_match(self::semverRegex, \FOSSBilling\Version::VERSION, $matches) !== 0) ? false : true;
     }
 }

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -127,7 +127,7 @@ class Client implements InjectionAwareInterface
             $url = strtolower(BB_URL);
             $referer = isset($_SERVER['HTTP_REFERER']) ? strtolower($_SERVER['HTTP_REFERER']) : null;
             if (!$referer || !str_starts_with($referer, $url)) {
-                throw new \FOSSBilling\Exception('Invalid request. Make sure request origin is :from', [':from' => BB_URL], 1004);
+                throw new \FOSSBilling\InformationException('Invalid request. Make sure request origin is :from', [':from' => BB_URL], 1004);
             }
         }
 
@@ -138,7 +138,7 @@ class Client implements InjectionAwareInterface
     {
         $ips = $this->_api_config['allowed_ips'];
         if (!empty($ips) && !in_array($this->_getIp(), $ips)) {
-            throw new \FOSSBilling\Exception('Unauthorized IP', null, 1002);
+            throw new \FOSSBilling\InformationException('Unauthorized IP', null, 1002);
         }
 
         return true;
@@ -192,15 +192,15 @@ class Client implements InjectionAwareInterface
         }
 
         if (!isset($_SERVER['PHP_AUTH_USER'])) {
-            throw new \FOSSBilling\Exception('Authentication Failed', null, 201);
+            throw new \FOSSBilling\InformationException('Authentication Failed', null, 201);
         }
 
         if (!isset($_SERVER['PHP_AUTH_PW'])) {
-            throw new \FOSSBilling\Exception('Authentication Failed', null, 202);
+            throw new \FOSSBilling\InformationException('Authentication Failed', null, 202);
         }
 
         if (empty($_SERVER['PHP_AUTH_PW'])) {
-            throw new \FOSSBilling\Exception('Authentication Failed', null, 206);
+            throw new \FOSSBilling\InformationException('Authentication Failed', null, 206);
         }
 
         return [$_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']];
@@ -214,7 +214,7 @@ class Client implements InjectionAwareInterface
             case 'client':
                 $model = $this->di['db']->findOne('Client', 'api_token = ?', [$password]);
                 if (!$model instanceof \Model_Client) {
-                    throw new \FOSSBilling\Exception('Authentication Failed', null, 204);
+                    throw new \FOSSBilling\InformationException('Authentication Failed', null, 204);
                 }
                 $this->di['session']->set('client_id', $model->id);
 
@@ -223,7 +223,7 @@ class Client implements InjectionAwareInterface
             case 'admin':
                 $model = $this->di['db']->findOne('Admin', 'api_token = ?', [$password]);
                 if (!$model instanceof \Model_Admin) {
-                    throw new \FOSSBilling\Exception('Authentication Failed', null, 205);
+                    throw new \FOSSBilling\InformationException('Authentication Failed', null, 205);
                 }
                 $sessionAdminArray = [
                     'id' => $model->id,
@@ -237,7 +237,7 @@ class Client implements InjectionAwareInterface
 
             case 'guest': // do not allow at the moment
             default:
-                throw new \FOSSBilling\Exception('Authentication Failed', null, 203);
+                throw new \FOSSBilling\InformationException('Authentication Failed', null, 203);
         }
     }
 
@@ -298,7 +298,7 @@ class Client implements InjectionAwareInterface
     /**
      * Checks if the CSRF token provided is valid.
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     public function _checkCSRFToken()
     {
@@ -329,7 +329,7 @@ class Client implements InjectionAwareInterface
         }
 
         if (!is_null($expectedToken) && $expectedToken !== $token) {
-            throw new \FOSSBilling\Exception('CSRF token invalid', null, 403);
+            throw new \FOSSBilling\InformationException('CSRF token invalid', null, 403);
         }
     }
 }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -297,7 +297,7 @@ class Service
                         'text' => 'We\'d apreciate it if you\'d consider opting into error reporting for FOSSBilling. Doing so will help us improve the software and provide you with a better experience. (Message will remain for 15 minutes)',
                         'url' => $url,
                     ];
-                } elseif ((version_compare(SentryHelper::last_change, $lastErrorReportingNudge) === 1) && $this->di['config']['debug_and_monitoring']['report_errors']) {
+                } elseif ((version_compare(SentryHelper::last_change, $lastErrorReportingNudge) === 1) && $this->di['config']['debug_and_monitoring']['report_errors'] && !Version::isPreviewVersion()) {
                     /**
                      * The installation already had error reporting enabled, but something has changed so we should nudge the user to review the changes.
                      * This message is cached for a full 24 hours to help ensure it is seen.


### PR DESCRIPTION
- We now use composer's `replace` feature to prevent it from loading `php-http/message-factory` as it's considered an abandoned package and we shouldn't actually need it.
- A bunch of exceptions in the API controller have been downgraded to `InformationException`s to prevent them from being captured.
- I've moved the logic for checking if the FOSSBilling version is a preview version to the `\FOSSBilling\Version` class, pointed the other checks to that, and then used that check to prevent the "error reporting has changed" dashboard message as that message would be otherwise unreliable in preview builds and would otherwise get annoying.