### PR TITLE
Error reporting bug fixes

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -13,14 +13,6 @@ $di = include __DIR__ . '/di.php';
 $url = $_GET['_url'] ?? $_SERVER['PATH_INFO'] ?? '';
 $http_err_code = $_GET['_errcode'] ?? null;
 
-if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
-    $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));
-    $app = new Box_AppAdmin();
-} else {
-    $appUrl = $url;
-    $app = new Box_AppClient();
-}
-
 if ($url === '/run-patcher') {
     $patcher = new FOSSBilling\UpdatePatcher();
     $patcher->setDi($di);
@@ -36,6 +28,20 @@ if ($url === '/run-patcher') {
     } catch (\Exception $e) {
         exit('An error occurred while attempting to apply patches: <br>' . $e->getMessage());
     }
+}
+
+if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
+    $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));
+    $app = new Box_AppAdmin();
+} else {
+    $appUrl = $url;
+    $app = new Box_AppClient();
+}
+
+// Prevent errors from being displayed in API mode as it can cause invalid JSON to be returned.
+if (defined('API_MODE')) {
+    ini_set('display_errors', '0');
+    ini_set('display_startup_errors', '0');
 }
 
 $app->setUrl($appUrl);

--- a/src/index.php
+++ b/src/index.php
@@ -38,12 +38,6 @@ if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
     $app = new Box_AppClient();
 }
 
-// Prevent errors from being displayed in API mode as it can cause invalid JSON to be returned.
-if (defined('API_MODE')) {
-    ini_set('display_errors', '0');
-    ini_set('display_startup_errors', '0');
-}
-
 $app->setUrl($appUrl);
 $di['translate']();
 $app->setDi($di);

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -17,6 +17,10 @@ class Box_AppClient extends Box_App
 
         if ('api' == $this->mod) {
             define('API_MODE', true);
+
+            // Prevent errors from being displayed in API mode as it can cause invalid JSON to be returned.
+            ini_set('display_errors', '0');
+            ini_set('display_startup_errors', '0');
         } else {
             $extensionService = $this->di['mod_service']('extension');
             if ($extensionService->isExtensionActive('mod', 'redirect')) {

--- a/src/load.php
+++ b/src/load.php
@@ -152,7 +152,6 @@ function errorHandler(int $number, string $message, string $file, int $line)
         $completedMessage = ($errorType . " ($number): " . $message . ' in ' . $file . ' on line ' . $line);
 
         \Sentry\captureMessage($completedMessage, FOSSBilling\SentryHelper::getSeverityLevel($errorType));
-        error_log($completedMessage);
     }
 
     return false;
@@ -272,9 +271,7 @@ checkSSL();
 ini_set('log_errors', '1');
 ini_set('html_errors', false);
 ini_set('error_log', PATH_LOG . DIRECTORY_SEPARATOR . 'php_error.log');
-
-// We disable PHP's error reporting as our own error handler will log it and send it to Sentry.
-error_reporting(0);
+error_reporting(E_ALL);
 
 if (DEBUG) {
     ini_set('display_errors', '1');


### PR DESCRIPTION
This pull request aims to resolve two issues with the error reporting / handling:

1. I re-enabled PHP's error reporting as disabling it preventing it from sending things to the browser. Instead, our error handler no longer logs items. I have also set it to log all errors as they are generally useful and we don't want them exclusively during debug mode. But they will only be displayed on the page with debug enabled.
2. For a long time now (since BoxBilling), enabling debug mode had the possibility to break the API as it could return plain text errors and break the JSON response. To fix that, `display_errors` is now disabled when FOSSBilling is running under API mode.
3. I shifted the order of some checks in the `index.php` to ensure that errors in the app can't prevent the backup patching method from being accessed. 