### PR TITLE
Improve email queue behavior

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -556,10 +556,12 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $sent = 0;
         $start = time();
 
+        $query = 'ORDER BY created_at ASC';
         if ($sendPerCron) {
-            $mailQueue = $this->di['db']->findAll('mod_email_queue', 'LIMIT :limit', [':limit' => $sendPerCron]);
+            $query .= ' LIMIT '  . intval($sendPerCron);
+            $mailQueue = $this->di['db']->findAll('mod_email_queue', $query);
         } else {
-            $mailQueue = $this->di['db']->findAll('mod_email_queue');
+            $mailQueue = $this->di['db']->findAll('mod_email_queue', $query);
         }
 
         foreach ($mailQueue as $email) {

--- a/tests/modules/Email/ServiceTest.php
+++ b/tests/modules/Email/ServiceTest.php
@@ -979,8 +979,7 @@ class ServiceTest extends \BBTestCase
     {
         $service = new \Box\Mod\Email\Service();
 
-        $queueModel = new \Model_ModEmailQueue();
-        $queueModel->loadBean(new \DummyBean());
+        $queueModel = new \DummyBean();
         $queueModel->priority = 10;
         $queueModel->tries = 10;
         $queueModel->subject = 'subject';
@@ -992,9 +991,8 @@ class ServiceTest extends \BBTestCase
         $queueModel->to_name = 'To Name';
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
-        $db->expects($this->exactly(2))
-            ->method('findOne')
-            ->will($this->onConsecutiveCalls($queueModel, false));
+        $db->expects($this->exactly(1))
+            ->method('findOne')->will($this->returnValue([$queueModel], false));
         $db->expects($this->atLeastOnce())
             ->method('store')
             ->will($this->returnValue(true));
@@ -1017,13 +1015,6 @@ class ServiceTest extends \BBTestCase
         $extension->expects($this->atLeastOnce())
             ->method('isExtensionActive')
             ->will($this->returnValue($isExtensionActiveReturn));
-
-
-       /* Will not work be called because APP_ENV != 'prod'
-        * $mailMock->expects($this->atLeastOnce())
-            ->method('send')
-            ->will($this->returnValue(true));
-       */
 
         $di           = new \Pimple\Container();
         $di['db']     = $db;

--- a/tests/modules/Email/ServiceTest.php
+++ b/tests/modules/Email/ServiceTest.php
@@ -992,7 +992,7 @@ class ServiceTest extends \BBTestCase
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->exactly(1))
-            ->method('findOne')->will($this->returnValue([$queueModel], false));
+            ->method('findAll')->will($this->returnValue([$queueModel]));
         $db->expects($this->atLeastOnce())
             ->method('store')
             ->will($this->returnValue(true));


### PR DESCRIPTION
This pull request improves the behavior and implementation of the mail queue.

## Current behavior
1. `batchSend` is run with cron
2. The `batchSend` function will on a loop get the oldest email in the DB and try to send it until the time limit or emails per cron run limit is reached.
3. `_sendFromQueue` will try to send the email, if it fails it increments the number of attempts. If it gets past the max number of attempts, it's then deleted from the DB.

This method means that the same email is retried in a given cron run until it's either reaches the max attempts or sends correctly. In events such as a short email outage this behavior results in emails basically instantly being trashed from the queue never to be seen again.

## Proposed behavior
1. `batchSend` is run with cron
2. The `batchSend` function will will get itself a queue list of either all emails in the queue or just the configured email limit. It will fetch them from oldest to newest first.
3. `batchSend` Will try to send each email only a single time before moving onto the next email in the queue and will do so until it has gone through the entire queue it fetched or until the time limit is reached.
4. `_sendFromQueue` has the same behavior.

The proposed behavior would mean that a brief 1 or 2 min email outage won't result in a ton of emails being dumped from the queue. Instead, they will all get tried a singular time and will remain in the email queue until cron is run again. making the system **much** less likely to unnecessarily drop emails.