### PR TITLE
Allow clients to choose if they want a subscription

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -367,6 +367,7 @@
         "valuenow",
         "valuemin",
         "valuemax",
+        "concat"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/modules/Invoice/Controller/Client.php
+++ b/src/modules/Invoice/Controller/Client.php
@@ -95,7 +95,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
     {
         $api = $this->di['api_guest'];
         $data = [
-            'subscription' => $_GET['subscription'] ?? null,
+            'allow_subscription' => $_GET['allow_subscription'] ?? true,
             'hash' => $hash,
             'gateway_id' => $id,
             'auto_redirect' => true,

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1113,6 +1113,7 @@ class Service implements InjectionAwareInterface
 
     public function processInvoice(array $data)
     {
+        $allowSubscribe = $data['allow_subscription'] ?? true;
         $subscribe = false;
 
         $invoice = $this->di['db']->findOne('Invoice', 'hash = ?', [$data['hash']]);
@@ -1131,7 +1132,7 @@ class Service implements InjectionAwareInterface
 
         $subscribeService = $this->di['mod_service']('Invoice', 'Subscription');
         $payGatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
-        if ($subscribeService->isSubscribable($invoice->id) && $payGatewayService->canPerformRecurrentPayment($gtw)) {
+        if ($subscribeService->isSubscribable($invoice->id) && $payGatewayService->canPerformRecurrentPayment($gtw) && $allowSubscribe) {
             $subscribe = true;
         }
 

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -290,16 +290,16 @@
         canAnyGatewayDoSubs = {{ anyGatewayDoesSubscriptions ? 'true' : 'false' }};
 
         if(supportsSubscription && invoiceSubscribable){
-            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and the selected payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
+            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and your choosen payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
             document.getElementById('subscription').style.display = '';
         } else if (!invoiceSubscribable) {
-            document.getElementById('bodyText').textContent = "{{ 'This invoice can not be paid with a subscription.'|trans }}";
+            document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
             document.getElementById('subscription').style.display = 'none';
         } else {
             if(canAnyGatewayDoSubs){
-                document.getElementById('bodyText').textContent = "{{ 'If you would like to pay with a subscription, please use another payment gateway.'|trans }}";
+                document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it. Optionally, you may choose a different payment gateway if you wish to pay using a subscription.'|trans }}";
             } else {
-                document.getElementById('bodyText').textContent = "{{ 'This invoice can not be paid with a subscription.'|trans }}";
+                document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
             }
             document.getElementById('subscription').style.display = 'none';
         }

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -277,7 +277,7 @@
     function paymentPrompt(id, supportsSubscription, title){
         invoiceHash = "{{ invoice.hash }}";
         backLink    = "{{ 'invoice/banklink'|link }}";
-        paymentLink = backLink.concat('/', invoiceHash, '/', id);
+        paymentLink = new URL(backLink.concat('/', invoiceHash, '/', id));
         invoiceSubscribable = {{ invoice.subscribable ? 'true' : 'false' }};
 
         {% set anyGatewayDoesSubscriptions = false %}
@@ -306,7 +306,8 @@
 
         document.getElementById('paymentPromptLabel').textContent = "{{ 'Pay with'|trans }}".concat(" ", title);
         document.getElementById('subscription').href = paymentLink;
-        document.getElementById('single').href = paymentLink.concat('?', 'allow_subscription=false');
+        paymentLink.searchParams.append('allow_subscription', 0); 
+        document.getElementById('single').href = paymentLink;
 
         $('#paymentPrompt').modal();
     }

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -29,10 +29,13 @@
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <input type="hidden" name="hash" value="{{ invoice.hash }}"/>
                         {% for gtw in guest.invoice_gateways %}
-                        {% if invoice.currency in gtw.accepted_currencies %}
-                        {% set banklink = 'invoice/banklink'|link %}
-                        <button type="button"  class="hover-popover" style="background: transparent url('{{gtw.logo.logo}}') no-repeat scroll 0% 0%; height:{{gtw.logo.height}}; width:{{gtw.logo.width}}; background-size: contain; border: 0; margin: 10px;" type="radio" name="gateway_id" gateway_id="{{ gtw.id }}" data-toggle="tooltip" title="{{ 'Pay with'|trans }} {{gtw.title}}" onclick="window.location.replace('{{banklink}}/{{invoice.hash}}/{{gtw.id}}')")></button>
-                        {% endif %}
+                            {% if invoice.currency in gtw.accepted_currencies %}
+                                <button type="button"  class="hover-popover"
+                                    style="background: transparent url('{{gtw.logo.logo}}') no-repeat scroll 0% 0%; height:{{gtw.logo.height}}; width:{{gtw.logo.width}}; background-size: contain; border: 0; margin: 10px;"
+                                    type="radio" name="gateway_id" gateway_id="{{ gtw.id }}" data-toggle="tooltip" title="{{ 'Pay with'|trans }} {{gtw.title}}"
+                                    onclick="paymentPromt('{{ gtw.id }}', {{ gtw.allow_recurrent ? 'true' : 'false' }}, '{{ gtw.title }}')">
+                                </button>
+                            {% endif %}
                         {% endfor %}
                         <input type="hidden" name="gateway_id" id="gateway_id">
                     </form>
@@ -241,15 +244,71 @@
             </section>
         </div>
     </article>
-</div>
+
+
+    <div class="modal fade" id="paymentPromt" tabindex="-1" role="dialog" aria-labelledby="paymentPromtLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="paymentPromtLabel"></h4>
+                </div>
+                <div class="modal-body">
+                    <p id="bodyText"></p>
+                    <a href="#" class="btn btn-primary" id="single">{{ "Pay now with a one-time payment"|trans }}</a>
+                    <a href="#" class="btn btn-primary" id="subscription" hidden="true">{{ "Pay now and create a subscription"|trans }}</a>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'Cancel'|trans }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
-{% block js%}
+{% block js %}
 <script>
     $(function() {
         $(".hover-popover").tooltip({
             placement: 'top'
         });
     });
+
+    function paymentPromt(id, supportsSubscription, title){
+        invoiceHash = "{{ invoice.hash }}";
+        backLink    = "{{ 'invoice/banklink'|link }}";
+        paymentLink = backLink.concat('/', invoiceHash, '/', id);
+        invoiceSubscribable = {{ invoice.subscribable ? 'true' : 'false' }};
+
+        {% set anyGatewayDoesSubscriptions = false %}
+        {% for gtw in guest.invoice_gateways %}
+            {% if gtw.allow_recurrent %}
+                {% set anyGatewayDoesSubscriptions = true %}
+            {% endif %}
+        {% endfor %}
+
+        canAnyGatewayDoSubs = {{ anyGatewayDoesSubscriptions ? 'true' : 'false' }};
+
+        if(supportsSubscription && invoiceSubscribable){
+            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and the selected payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
+            document.getElementById('subscription').style.display = '';
+        } else if (!invoiceSubscribable) {
+            document.getElementById('bodyText').textContent = "{{ 'This invoice can not be paid with a subscription.'|trans }}";
+            document.getElementById('subscription').style.display = 'none';
+        } else {
+            if(canAnyGatewayDoSubs){
+                document.getElementById('bodyText').textContent = "{{ 'If you would like to pay with a subscription, please use another payment gateway.'|trans }}";
+            } else {
+                document.getElementById('bodyText').textContent = "{{ 'This invoice can not be paid with a subscription.'|trans }}";
+            }
+            document.getElementById('subscription').style.display = 'none';
+        }
+
+        document.getElementById('paymentPromtLabel').textContent = "{{ 'Pay with'|trans }}".concat(" ", title);
+        document.getElementById('subscription').href = paymentLink;
+        document.getElementById('single').href = paymentLink.concat('?', 'allow_subscription=false');
+
+        $('#paymentPromt').modal();
+    }
 </script>
-{% endblock%}
+{% endblock %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -290,7 +290,7 @@
         canAnyGatewayDoSubs = {{ anyGatewayDoesSubscriptions ? 'true' : 'false' }};
 
         if(supportsSubscription && invoiceSubscribable){
-            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and your choosen payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
+            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and your chosen payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
             document.getElementById('subscription').style.display = '';
         } else if (!invoiceSubscribable) {
             document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -33,7 +33,7 @@
                                 <button type="button"  class="hover-popover"
                                     style="background: transparent url('{{gtw.logo.logo}}') no-repeat scroll 0% 0%; height:{{gtw.logo.height}}; width:{{gtw.logo.width}}; background-size: contain; border: 0; margin: 10px;"
                                     type="radio" name="gateway_id" gateway_id="{{ gtw.id }}" data-toggle="tooltip" title="{{ 'Pay with'|trans }} {{gtw.title}}"
-                                    onclick="paymentPromt('{{ gtw.id }}', {{ gtw.allow_recurrent ? 'true' : 'false' }}, '{{ gtw.title }}')">
+                                    onclick="paymentPrompt('{{ gtw.id }}', {{ gtw.allow_recurrent ? 'true' : 'false' }}, '{{ gtw.title }}')">
                                 </button>
                             {% endif %}
                         {% endfor %}
@@ -246,12 +246,12 @@
     </article>
 
 
-    <div class="modal fade" id="paymentPromt" tabindex="-1" role="dialog" aria-labelledby="paymentPromtLabel" aria-hidden="true">
+    <div class="modal fade" id="paymentPrompt" tabindex="-1" role="dialog" aria-labelledby="paymentPromptLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="paymentPromtLabel"></h4>
+                    <h4 class="modal-title" id="paymentPromptLabel"></h4>
                 </div>
                 <div class="modal-body">
                     <p id="bodyText"></p>
@@ -274,7 +274,7 @@
         });
     });
 
-    function paymentPromt(id, supportsSubscription, title){
+    function paymentPrompt(id, supportsSubscription, title){
         invoiceHash = "{{ invoice.hash }}";
         backLink    = "{{ 'invoice/banklink'|link }}";
         paymentLink = backLink.concat('/', invoiceHash, '/', id);
@@ -304,11 +304,11 @@
             document.getElementById('subscription').style.display = 'none';
         }
 
-        document.getElementById('paymentPromtLabel').textContent = "{{ 'Pay with'|trans }}".concat(" ", title);
+        document.getElementById('paymentPromptLabel').textContent = "{{ 'Pay with'|trans }}".concat(" ", title);
         document.getElementById('subscription').href = paymentLink;
         document.getElementById('single').href = paymentLink.concat('?', 'allow_subscription=false');
 
-        $('#paymentPromt').modal();
+        $('#paymentPrompt').modal();
     }
 </script>
 {% endblock %}

--- a/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_invoice.html.twig
@@ -257,6 +257,7 @@
                     <p id="bodyText"></p>
                     <a href="#" class="btn btn-primary" id="single">{{ "Pay now with a one-time payment"|trans }}</a>
                     <a href="#" class="btn btn-primary" id="subscription" hidden="true">{{ "Pay now and create a subscription"|trans }}</a>
+                    <a href="#" class="btn btn-primary" id="pay-nondescript" hidden="true">{{ "Pay now"|trans }}</a>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'Cancel'|trans }}</button>
@@ -289,23 +290,31 @@
 
         canAnyGatewayDoSubs = {{ anyGatewayDoesSubscriptions ? 'true' : 'false' }};
 
-        if(supportsSubscription && invoiceSubscribable){
-            document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and your chosen payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
-            document.getElementById('subscription').style.display = '';
-        } else if (!invoiceSubscribable) {
+        {% if settings.prompt_subscription %}
+            if(supportsSubscription && invoiceSubscribable){
+                document.getElementById('bodyText').textContent = "{{ 'The invoice you are paying and your chosen payment gateway both support subscription payments. What type of payment would you like to continue with?'|trans }}";
+                document.getElementById('subscription').style.display = '';
+            } else if (!invoiceSubscribable) {
+                document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
+                document.getElementById('subscription').style.display = 'none';
+            } else {
+                if(canAnyGatewayDoSubs){
+                    document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it. Optionally, you may choose a different payment gateway if you wish to pay using a subscription.'|trans }}";
+                } else {
+                    document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
+                }
+                document.getElementById('subscription').style.display = 'none';
+            }
+        {% else %}
             document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
             document.getElementById('subscription').style.display = 'none';
-        } else {
-            if(canAnyGatewayDoSubs){
-                document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it. Optionally, you may choose a different payment gateway if you wish to pay using a subscription.'|trans }}";
-            } else {
-                document.getElementById('bodyText').textContent = "{{ 'If you are happy with the selected payment gateway, please use the button below to continue with it.'|trans }}";
-            }
-            document.getElementById('subscription').style.display = 'none';
-        }
+            document.getElementById('single').style.display = 'none';
+            document.getElementById('pay-nondescript').style.display = '';
+        {% endif %}
 
         document.getElementById('paymentPromptLabel').textContent = "{{ 'Pay with'|trans }}".concat(" ", title);
         document.getElementById('subscription').href = paymentLink;
+        document.getElementById('pay-nondescript').href = paymentLink;
         paymentLink.searchParams.append('allow_subscription', 0); 
         document.getElementById('single').href = paymentLink;
 

--- a/src/themes/huraga/config/settings.html
+++ b/src/themes/huraga/config/settings.html
@@ -311,5 +311,17 @@
             <td><textarea name="inject_javascript" id="inject_javascript"></textarea></td>
         </tr>
     </table>
+</fieldset>
 
+<fieldset>
+    <legend>Invoice</legend>
+    <table>
+    <tr>
+        <td><label>Allow clients to choose between one-time and subscription payments</label></td>
+        <td>
+            <label><input type="radio" name="prompt_subscription" value="1" id="prompt_subscription"/>Yes</label>
+            <label><input type="radio" name="prompt_subscription" value="0" id="prompt_subscription" checked="checked"/>No</label>
+        </td>
+    </tr>
+    </table>
 </fieldset>


### PR DESCRIPTION
This pull request introduces new functionality to the back-end and front-end to give clients the opportunity to choose if they want to pay with a subscription or a 1-time payment.

With the current behavior the client is forced to pay using a subscription if it's enabled on the payment gateway and the invoice is payable using a subscription. The only method right now to give clients the choice would be to duplicate your payment gateways and have one with subscriptions enabled and another without, which I think is a rather clunky option.

This change instead gives a modal prompt before taking the client to the payment screen, giving them the option to pick whichever they'd prefer.
It also gives them the chance to go back if they happened to click on the wrong payment gateway.

## Invoice supports subscriptions as does the selected gateway
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/a9c0ccfd-4d39-45bf-8251-36e0c765c225)

## Invoice supports subscriptions as does a different gateway
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/ccf05699-0119-410e-868c-a1c7e38f9c8e)

## Invoice cannot be paid with a subscription or no enabled payment gateways support them
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/fb139300-01bc-43cc-8c64-f30785923da6)

