### PR TITLE
Update monolog/monolog to version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "lcharette/webpack-encore-twig": "^1.1.0",
         "league/commonmark": "^2.3",
         "league/csv": "^9.8",
-        "monolog/monolog": "^2.9",
+        "monolog/monolog": "^3.5",
         "nelexa/zip": "^4.0.2",
         "php-http/message-factory": "*",
         "phpmyadmin/motranslator": "^5.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f03beb832acee11934e708d2aeaefb94",
+    "content-hash": "4185d6884e6230b99e05eaab87944a1b",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -1535,42 +1535,41 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.9.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                "psr/log-implementation": "3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "aws/aws-sdk-php": "^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
-                "guzzlehttp/guzzle": "^7.4",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5.14",
-                "predis/predis": "^1.1 || ^2.0",
-                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
                 "ruflin/elastica": "^7",
-                "swiftmailer/swiftmailer": "^5.3|^6.0",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -1593,7 +1592,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1621,7 +1620,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
+                "source": "https://github.com/Seldaek/monolog/tree/3.5.0"
             },
             "funding": [
                 {
@@ -1633,7 +1632,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-27T15:25:26+00:00"
+            "time": "2023-10-27T15:32:31+00:00"
         },
         {
             "name": "nelexa/zip",
@@ -2792,16 +2791,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v13.2.0",
+            "version": "v13.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "e0a960c8655b21b21c3ba2e5927f432eeda9105f"
+                "reference": "3f39dcd583b5e9ff2b65281034d38c79358a8095"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/e0a960c8655b21b21c3ba2e5927f432eeda9105f",
-                "reference": "e0a960c8655b21b21c3ba2e5927f432eeda9105f",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/3f39dcd583b5e9ff2b65281034d38c79358a8095",
+                "reference": "3f39dcd583b5e9ff2b65281034d38c79358a8095",
                 "shasum": ""
             },
             "require": {
@@ -2845,9 +2844,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v13.2.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v13.2.1"
             },
-            "time": "2023-11-02T22:32:22+00:00"
+            "time": "2023-11-06T23:24:49+00:00"
         },
         {
             "name": "symfony/asset",
@@ -6087,16 +6086,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.37.1",
+            "version": "v3.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "c3fe76976081ab871aa654e872da588077e19679"
+                "reference": "7e6070026e76aa09d77a47519625c86593fb8e31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/c3fe76976081ab871aa654e872da588077e19679",
-                "reference": "c3fe76976081ab871aa654e872da588077e19679",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7e6070026e76aa09d77a47519625c86593fb8e31",
+                "reference": "7e6070026e76aa09d77a47519625c86593fb8e31",
                 "shasum": ""
             },
             "require": {
@@ -6168,7 +6167,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.37.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.38.0"
             },
             "funding": [
                 {
@@ -6176,7 +6175,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-29T20:51:23+00:00"
+            "time": "2023-11-07T08:44:54+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8603,5 +8602,5 @@
         "ext-zlib": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -10,6 +10,7 @@
 
 namespace FOSSBilling;
 
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
@@ -38,7 +39,7 @@ class Monolog
             $path = PATH_LOG . DIRECTORY_SEPARATOR . $channel . '.log';
 
             $this->logger[$channel] = new Logger($channel);
-            $stream = new StreamHandler($path, Logger::DEBUG);
+            $stream = new StreamHandler($path, Level::Debug);
             $this->logger[$channel]->pushHandler($stream);
 
             $formatter = new LineFormatter($this->outputFormat, $this->dateFormat, true, true, true);
@@ -63,17 +64,17 @@ class Monolog
     {
         // Map numeric priority to Monolog priority
         $map = [
-            \Box_Log::EMERG => Logger::EMERGENCY,
-            \Box_Log::ALERT => Logger::ALERT,
-            \Box_Log::CRIT => Logger::CRITICAL,
-            \Box_Log::ERR => Logger::ERROR,
-            \Box_Log::WARN => Logger::WARNING,
-            \Box_Log::NOTICE => Logger::NOTICE,
-            \Box_Log::INFO => Logger::INFO,
-            \Box_Log::DEBUG => Logger::DEBUG,
+            \Box_Log::EMERG => Level::Emergency->value,
+            \Box_Log::ALERT => Level::Alert->value,
+            \Box_Log::CRIT => Level::Critical->value,
+            \Box_Log::ERR => Level::Error->value,
+            \Box_Log::WARN => Level::Warning->value,
+            \Box_Log::NOTICE => Level::Notice->value,
+            \Box_Log::INFO => Level::Info->value,
+            \Box_Log::DEBUG => Level::Debug->value,
         ];
 
-        return $map[$priority] ?? Logger::DEBUG;
+        return $map[$priority] ?? Level::Debug->value;
     }
 
     public function write(array $event, string $channel = 'application'): void


### PR DESCRIPTION
Update monolog/monolog to version >=3.5 and update `Monolog` library class to use `Levels` enum as previous `Logger` constants depreciated.

Closes #1796.