### PR TITLE
Fix extension installation

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -453,7 +453,7 @@ class Service implements InjectionAwareInterface
 
         switch ($type) {
             case \FOSSBilling\ExtensionManager::TYPE_MOD:
-                $destination = PATH_MODS . DIRECTORY_SEPARATOR . $id;
+                $destination = PATH_MODS . DIRECTORY_SEPARATOR . ucfirst($id);
 
                 break;
             case \FOSSBilling\ExtensionManager::TYPE_THEME:
@@ -465,7 +465,7 @@ class Service implements InjectionAwareInterface
 
                 break;
             case \FOSSBilling\ExtensionManager::TYPE_PG:
-                $destination = PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Payment' . DIRECTORY_SEPARATOR . 'Adapter' . DIRECTORY_SEPARATOR . $id;
+                $destination = PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Payment' . DIRECTORY_SEPARATOR . 'Adapter' . DIRECTORY_SEPARATOR . ucfirst($id);
 
                 break;
         }


### PR DESCRIPTION
Extensions are expected to be all lowercase, however the folder is expected to start with a capital letter.

So if it's told to install an extension with the ID of `example` it will install it to `/modules/example` when the expected is `/modules/Example`, resulting in the extension not being displayed in the administrator panel.

The same issue applies to payment gateways.

This PR fixes that