### PR TITLE
Implemented PHP DebugBar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "league/commonmark": "^2.3",
         "league/csv": "^9.8",
         "mattketmo/email-checker": "^2.2",
+        "maximebf/debugbar": "^1.19",
         "monolog/monolog": "^3.5",
         "nelexa/zip": "^4.0.2",
         "php-http/message-factory": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79c29e23a40f0445462732d646598da7",
+    "content-hash": "3d4b63964636f34023ab6f102ba19219",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -1483,6 +1483,72 @@
                 "source": "https://github.com/MattKetmo/EmailChecker/tree/v2.2.0"
             },
             "time": "2023-09-01T21:18:03+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.19.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "03dd40a1826f4d585ef93ef83afa2a9874a00523"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/03dd40a1826f4d585ef93ef83afa2a9874a00523",
+                "reference": "03dd40a1826f4d585ef93ef83afa2a9874a00523",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^4|^5|^6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=7.5.20 <10.0",
+                "twig/twig": "^1.38|^2.7|^3.0"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "support": {
+                "issues": "https://github.com/maximebf/php-debugbar/issues",
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.19.1"
+            },
+            "time": "2023-10-12T08:10:52+00:00"
         },
         {
             "name": "maxmind-db/reader",

--- a/cspell.json
+++ b/cspell.json
@@ -367,7 +367,8 @@
         "valuenow",
         "valuemin",
         "valuemax",
-        "concat"
+        "concat",
+        "debugbar"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/di.php
+++ b/src/di.php
@@ -39,6 +39,19 @@ $di['config'] = function () {
     return $config;
 };
 
+$di['debugbar'] = function () use ($di) {
+    $debugbar = new \DebugBar\StandardDebugBar();
+
+    // Configuration collector
+    $config = $di['config'];
+    $config['salt'] = '********';
+    $config['db'] = array_fill_keys(array_keys($config['db']), '********');
+
+    $debugbar->addCollector(new \DebugBar\DataCollector\ConfigCollector($config));
+
+    return $debugbar;
+};
+
 /*
  * Create a new logger instance and configures it based on the settings in the configuration file.
  *
@@ -266,8 +279,8 @@ $di['request'] = function () use ($di) {
  * @return \Symfony\Component\Cache\Adapter\FilesystemAdapter
  */
 $di['cache'] = fn () =>
-    // Reference: https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html
-    new FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
+// Reference: https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html
+new FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
 
 /*
  *
@@ -319,6 +332,7 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addExtension(new DebugExtension());
     $twig->addExtension(new TranslationExtension());
     $twig->addExtension($box_extensions);
+    $twig->addExtension(new \FOSSBilling\TwigExtensions\DebugBar($di));
     $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
 
     try {

--- a/src/di.php
+++ b/src/di.php
@@ -39,19 +39,6 @@ $di['config'] = function () {
     return $config;
 };
 
-$di['debugbar'] = function () use ($di) {
-    $debugbar = new \DebugBar\StandardDebugBar();
-
-    // Configuration collector
-    $config = $di['config'];
-    $config['salt'] = '********';
-    $config['db'] = array_fill_keys(array_keys($config['db']), '********');
-
-    $debugbar->addCollector(new \DebugBar\DataCollector\ConfigCollector($config));
-
-    return $debugbar;
-};
-
 /*
  * Create a new logger instance and configures it based on the settings in the configuration file.
  *
@@ -332,7 +319,6 @@ $di['twig'] = $di->factory(function () use ($di) {
     $twig->addExtension(new DebugExtension());
     $twig->addExtension(new TranslationExtension());
     $twig->addExtension($box_extensions);
-    $twig->addExtension(new \FOSSBilling\TwigExtensions\DebugBar($di));
     $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
 
     try {

--- a/src/index.php
+++ b/src/index.php
@@ -11,8 +11,21 @@
 require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
 
+// Setting up the debug bar
 $debugBar = new \DebugBar\StandardDebugBar;
+$debugBar['request']->useHtmlVarDumper();
+$debugBar['messages']->useHtmlVarDumper();
 
+$config = $di['config'];
+$config['salt'] = '********';
+$config['db'] = array_fill_keys(array_keys($config['db']), '********');
+
+$configCollector = new \DebugBar\DataCollector\ConfigCollector($config);
+$configCollector->useHtmlVarDumper();
+
+$debugBar->addCollector($configCollector);
+
+// Now move onto the actual process of setting up the app & routing
 $url = $_GET['_url'] ?? $_SERVER['PATH_INFO'] ?? '';
 $http_err_code = $_GET['_errcode'] ?? null;
 

--- a/src/index.php
+++ b/src/index.php
@@ -47,7 +47,7 @@ if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
 $app->setUrl($appUrl);
 $app->setDi($di);
 
-$debugBar['time']->startMeasure('translate', 'Setup translations');
+$debugBar['time']->startMeasure('translate', 'Setting up translations');
 $di['translate']();
 $debugBar['time']->stopMeasure('translate');
 

--- a/src/index.php
+++ b/src/index.php
@@ -17,7 +17,7 @@ $debugBar['request']->useHtmlVarDumper();
 $debugBar['messages']->useHtmlVarDumper();
 
 $config = $di['config'];
-$config['salt'] = '********';
+$config['info']['salt'] = '********';
 $config['db'] = array_fill_keys(array_keys($config['db']), '********');
 
 $configCollector = new \DebugBar\DataCollector\ConfigCollector($config);

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -8,7 +9,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
+use DebugBar\StandardDebugBar;
 
 class Box_App
 {
@@ -21,12 +23,19 @@ class Box_App
     protected $ext = 'html.twig';
     protected $mod = 'index';
     protected $url = '/';
+    protected StandardDebugBar $debugBar;
 
     public $uri = null;
 
-    public function __construct($options = [])
+    public function __construct($options = [], null|StandardDebugBar $debugBar = null)
     {
         $this->options = new ArrayObject($options);
+
+        if (!$debugBar) {
+            $this->debugBar = new \DebugBar\StandardDebugBar;
+        } else {
+            $this->debugBar = $debugBar;
+        }
     }
 
     public function setDi(\Pimple\Container $di): void
@@ -37,6 +46,11 @@ class Box_App
     public function setUrl($url)
     {
         $this->url = $url;
+    }
+
+    public function getDebugBar(): StandardDebugBar
+    {
+        return $this->debugBar;
     }
 
     protected function registerModule()
@@ -147,8 +161,13 @@ class Box_App
 
     public function run()
     {
+        $this->debugBar['time']->startMeasure('registerModule', 'Registering module routes');
         $this->registerModule();
+        $this->debugBar['time']->stopMeasure('registerModule');
+
+        $this->debugBar['time']->startMeasure('init', 'Initializing app');
         $this->init();
+        $this->debugBar['time']->stopMeasure('init');
 
         return $this->processRequest();
     }

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -8,13 +9,18 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
+use FOSSBilling\TwigExtensions\DebugBar;
+use Twig\Profiler\Profile;
+use Twig\Extension\ProfilerExtension;
+use DebugBar\Bridge\NamespacedTwigProfileCollector;
+
 class Box_AppAdmin extends Box_App
 {
     public function init()
     {
         $m = $this->di['mod']($this->mod);
         $controller = $m->getAdminController();
-        if(!is_null($controller)){
+        if (!is_null($controller)) {
             $controller->register($this);
         }
     }
@@ -38,7 +44,8 @@ class Box_AppAdmin extends Box_App
         $service = $this->di['mod_service']('theme');
         $theme = $service->getCurrentAdminAreaTheme();
 
-        $loader = new Box_TwigLoader([
+        $loader = new Box_TwigLoader(
+            [
                 'mods' => PATH_MODS,
                 'theme' => PATH_THEMES . DIRECTORY_SEPARATOR . $theme['code'],
                 'type' => 'admin',
@@ -47,8 +54,13 @@ class Box_AppAdmin extends Box_App
 
         $twig = $this->di['twig'];
         $twig->setLoader($loader);
-
         $twig->addGlobal('theme', $theme);
+
+        $profile = new Profile();
+        $twig->addExtension(new ProfilerExtension($profile));
+        $this->debugBar->addCollector(new NamespacedTwigProfileCollector($profile));
+
+        $twig->addExtension(new DebugBar($this->getDebugBar()));
 
         if ($this->di['auth']->isAdminLoggedIn()) {
             $twig->addGlobal('admin', $this->di['api_admin']);

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -7,6 +8,11 @@
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
+
+use FOSSBilling\TwigExtensions\DebugBar;
+use Twig\Profiler\Profile;
+use Twig\Extension\ProfilerExtension;
+use DebugBar\Bridge\NamespacedTwigProfileCollector;
 
 class Box_AppClient extends Box_App
 {
@@ -107,6 +113,12 @@ class Box_AppClient extends Box_App
 
         $twig->addGlobal('current_theme', $code);
         $twig->addGlobal('settings', $settings);
+
+        $profile = new Profile();
+        $twig->addExtension(new ProfilerExtension($profile));
+        $this->debugBar->addCollector(new NamespacedTwigProfileCollector($profile));
+
+        $twig->addExtension(new DebugBar($this->getDebugBar()));
 
         if ($this->di['auth']->isClientLoggedIn()) {
             $twig->addGlobal('client', $this->di['api_client']);

--- a/src/library/FOSSBilling/TwigExtensions/DebugBar.php
+++ b/src/library/FOSSBilling/TwigExtensions/DebugBar.php
@@ -15,6 +15,7 @@ use DebugBar\JavascriptRenderer;
 use DebugBar\StandardDebugBar;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use FOSSBilling\Environment;
 
 class DebugBar extends AbstractExtension
 {
@@ -41,7 +42,7 @@ class DebugBar extends AbstractExtension
 
     public function renderHead(): string
     {
-        if (1 === 1) { // Environment::isDevelopment() once it's merged
+        if (Environment::isDevelopment()) {
             return $this->debugbarRenderer->renderHead();
         } else {
             return '';
@@ -50,7 +51,7 @@ class DebugBar extends AbstractExtension
 
     public function render(): string
     {
-        if (1 === 1) { // Environment::isDevelopment() once it's merged
+        if (Environment::isDevelopment()) {
             return $this->debugbarRenderer->render();
         } else {
             return '';

--- a/src/library/FOSSBilling/TwigExtensions/DebugBar.php
+++ b/src/library/FOSSBilling/TwigExtensions/DebugBar.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2023 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling\TwigExtensions;
+
+use DebugBar\JavascriptRenderer;
+use FOSSBilling\InjectionAwareInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class DebugBar extends AbstractExtension implements InjectionAwareInterface
+{
+    protected ?\Pimple\Container $di;
+    private JavascriptRenderer $debugbarRenderer;
+
+    public function __construct(\Pimple\Container $di)
+    {
+        $this->di = $di;
+
+        $this->debugbarRenderer = $di['debugbar']->getJavascriptRenderer();
+    }
+
+    public function setDi(\Pimple\Container $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function getDi(): ?\Pimple\Container
+    {
+        return $this->di;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('DebugBar_renderHead', [$this, 'renderHead'], ['is_safe' => ['html']]),
+            new TwigFunction('DebugBar_render', [$this, 'render'], ['is_safe' => ['html']])
+        ];
+    }
+
+    public function getName(): string
+    {
+        return 'DebugBar';
+    }
+
+    public function renderHead(): string
+    {
+        if (1 === 1) { // Environment::isDevelopment() once it's merged
+            return $this->debugbarRenderer->renderHead();
+        } else {
+            return '';
+        }
+    }
+
+    public function render(): string
+    {
+        if (1 === 1) { // Environment::isDevelopment() once it's merged
+            return $this->debugbarRenderer->render();
+        } else {
+            return '';
+        }
+    }
+}

--- a/src/library/FOSSBilling/TwigExtensions/DebugBar.php
+++ b/src/library/FOSSBilling/TwigExtensions/DebugBar.php
@@ -12,30 +12,18 @@ declare(strict_types=1);
 namespace FOSSBilling\TwigExtensions;
 
 use DebugBar\JavascriptRenderer;
-use FOSSBilling\InjectionAwareInterface;
+use DebugBar\StandardDebugBar;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-class DebugBar extends AbstractExtension implements InjectionAwareInterface
+class DebugBar extends AbstractExtension
 {
     protected ?\Pimple\Container $di;
     private JavascriptRenderer $debugbarRenderer;
 
-    public function __construct(\Pimple\Container $di)
+    public function __construct(StandardDebugBar $debugBar)
     {
-        $this->di = $di;
-
-        $this->debugbarRenderer = $di['debugbar']->getJavascriptRenderer();
-    }
-
-    public function setDi(\Pimple\Container $di): void
-    {
-        $this->di = $di;
-    }
-
-    public function getDi(): ?\Pimple\Container
-    {
-        return $this->di;
+        $this->debugbarRenderer = $debugBar->getJavascriptRenderer();
     }
 
     public function getFunctions(): array

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -20,6 +20,7 @@
     {{ encore_entry_link_tags('fossbilling') }}
     {{ "Api/API.js" | library_url | script_tag }}
     {{ encore_entry_script_tags('fossbilling') }}
+    {{ DebugBar_renderHead() }}
 
     {% block head %}{% endblock %}
 </head>
@@ -238,6 +239,8 @@
         <div class="msg error">NOTE: Many features on FOSSBilling require Javascript and cookies. You can enable both via your browser's preference settings.</div>
     </noscript>
     {% endif %}
+
+    {{ DebugBar_render() }}
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1070;">
     </div>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -36,6 +36,8 @@
     <script src="{{ 'js/bootstrap/bootstrap.min.js' | asset_url}}" defer="defer"></script>
     <script src="{{ 'js/plugins/jGrowl/jquery.jgrowl.js' | asset_url }}" defer="defer"></script>
 
+    {{ DebugBar_renderHead() }}
+
     {% block head %}{% endblock %}
     {% block js %}{% endblock %}
 </head>
@@ -376,5 +378,6 @@
     {{ settings.inject_javascript | raw}}
 {% endif %}
 {% include 'partial_pending_messages.html.twig' ignore missing %}
+{{ DebugBar_render() }}
 </body>
 </html>


### PR DESCRIPTION
This pull request adds in the [PHP Debug Bar](http://phpdebugbar.com/) package which should prove to be useful when developing or debugging FOSSBillng. It will be hidden by default and will only be displayed when the `APP_ENV` enviroment variable is set to `dev`.

The instance of the debug bar is created during the app initialization in `index.php` and then passed onto the app.
This makes it available throughout the entire application and means that it should be generally available everywhere to add in messages or data points, although I haven't done that here. This is really just the basic implementation that we can build on over time.

Built on the initial work done by @evrifaessa

## Data collectors that are enabled:
- Twig
- Time
- Messages
- Exception
- Request info
- FOSSBilling config data
- PHP version
- Memory usage

## Sample screenshots
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/41930ab9-bc3e-4f8b-a04d-3110587098a1)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/32ffd582-b92d-4875-89ca-d5de3c85c567)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/7b828cb1-4fa7-42fa-9202-7ee8b8f8e3ad)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/b8998d30-fb38-4c90-8112-bcd0b0424b90)


