### PR TITLE
Remove the generate EU VAT rates button

### DIFF
--- a/src/modules/Invoice/ServiceTax.php
+++ b/src/modules/Invoice/ServiceTax.php
@@ -129,21 +129,6 @@ class ServiceTax implements InjectionAwareInterface
         return [$sql, []];
     }
 
-    public function setupEUTaxes(array $data)
-    {
-        $sql = 'TRUNCATE tax;';
-        $this->di['db']->exec($sql);
-
-        $systemService = $this->di['mod_service']('System');
-        $eu_countries = $systemService->getEuCountries();
-        $eu_vat = $systemService->getEuVat();
-        foreach ($eu_vat as $code => $taxRate) {
-            $this->create(['name' => $eu_countries[$code], 'taxrate' => $taxRate, 'country' => $code]);
-        }
-
-        return true;
-    }
-
     public function toApiArray(\Model_Tax $model, $deep = false, $identity = null)
     {
         return $this->di['db']->toArray($model);

--- a/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_tax.html.twig
@@ -24,9 +24,6 @@
         <li>
             <a class="nav-link" href="#tab-settings" data-bs-toggle="tab">{{ 'Tax settings'|trans }}</a>
         </li>
-        <li class="nav-item" role="presentation">
-            <a class="nav-link" href="#tab-eu-vat" data-bs-toggle="tab">{{ 'EU VAT'|trans }}</a>
-        </li>
     </ul>
 
 <div class="card">
@@ -158,22 +155,6 @@
 
                     <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary w-100">
                 </form>
-            </div>
-        </div>
-
-        <div class="tab-pane fade" id="tab-eu-vat" role="tabpanel">
-            <div class="card-body">
-                <h3>{{ 'Automatic VAT Tax Rules Setup'|trans }}</h3>
-                <p class="text-muted">{{ 'If you would like FOSSBilling to automatically setup the EU VAT tax rules for you for all EU Member States then simply enter your VAT Label & local VAT rate below and click the submit button.' |trans }} <b>{{ 'This action will delete any existing tax rules' |trans }}</b> {{ 'and configure the VAT rates for all EU countries.'|trans }}</p>
-
-                <div class="text-center">
-                    <a href="{{ 'api/admin/invoice/tax_setup_eu'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-reload="1" data-api-confirm="{{ 'It will overwrite your existing VAT rules. Are you sure?'|trans }}">
-                        <svg class="icon">
-                            <use xlink:href="#play" />
-                        </svg>
-                        <span>{{ 'Generate VAT rates'|trans }}</span>
-                    </a>
-                </div>
             </div>
         </div>
     </div>

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1056,39 +1056,6 @@ class Service
         return $res;
     }
 
-    public function getEuVat()
-    {
-        return [
-            'AT' => 20, // Austria
-            'BE' => 21, // Belgium
-            'BG' => 20, // Bulgaria
-            'HR' => 25, // Croatia
-            'CY' => 19, // Cyprus
-            'CZ' => 21, // Czech Republic
-            'DK' => 25, // Denmark
-            'EE' => 20, // Estonia
-            'FI' => 24, // Finland
-            'FR' => 20, // France
-            'DE' => 19, // Germany
-            'GR' => 24, // Greece
-            'HU' => 27, // Hungary
-            'IE' => 23, // Ireland
-            'IT' => 22, // Italy
-            'LV' => 21, // Latvia
-            'LT' => 21, // Lithuania
-            'LU' => 17, // Luxembourg
-            'MT' => 18, // Malta
-            'NL' => 21, // Netherlands
-            'PL' => 23, // Poland
-            'PT' => 23, // Portugal
-            'RO' => 19, // Romania
-            'SK' => 20, // Slovakia
-            'SI' => 22, // Slovenia
-            'ES' => 21, // Spain
-            'SE' => 25, // Sweden
-        ];
-    }
-
     public function getStates()
     {
         return [

--- a/tests/modules/Invoice/Api/AdminTest.php
+++ b/tests/modules/Invoice/Api/AdminTest.php
@@ -1322,25 +1322,6 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-
-    public function testtax_setup_eu()
-    {
-        $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
-        $taxService->expects($this->atLeastOnce())
-            ->method('setupEUTaxes')
-            ->will($this->returnValue(true));
-
-
-        $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $taxService);
-
-        $this->api->setDi($di);
-
-        $result = $this->api->tax_setup_eu(array());
-        $this->assertIsBool($result);
-        $this->assertTrue($result);
-    }
-
     public function testBatch_delete()
     {
         $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Api\Admin::class)->onlyMethods(array('delete'))->getMock();

--- a/tests/modules/Invoice/ServiceTaxTest.php
+++ b/tests/modules/Invoice/ServiceTaxTest.php
@@ -299,46 +299,6 @@ class ServiceTaxTest extends \BBTestCase
         $this->assertEquals(array(), $result[1]);
     }
 
-    public function testsetupEUTaxes()
-    {
-        $dbMock = $this->getMockBuilder('\Box_Database')
-            ->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('exec');
-
-        $systemService   = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->getMock();
-        $euCountriesData = array(
-            'AT' => 'Austria',
-        );
-
-        $euVatData = array(
-            'AT' => 20,
-        );
-
-        $systemService->expects($this->atLeastOnce())
-            ->method('getEuCountries')
-            ->will($this->returnValue($euCountriesData));
-
-        $systemService->expects($this->atLeastOnce())
-            ->method('getEuVat')
-            ->will($this->returnValue($euVatData));
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)
-            ->onlyMethods(array('create'))
-            ->getMock();
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('create');
-
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $systemService);
-        $serviceMock->setDi($di);
-
-        $result = $serviceMock->setupEUTaxes(array());
-        $this->assertTrue($result);
-    }
-
     public function testtoApiArray()
     {
         $taxModel = new \Model_Tax();


### PR DESCRIPTION
This PR removes the option that was found in the UI to perform "automatic VAT tax rules setup".
The rates were hard-coded. This function does nothing but risk potential confusion where someone may thing that the values are correct. (The text also references options that don't exist?)

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/feeb5923-d964-43d4-8a6b-54919af0857c)
