### PR TITLE
Fix email resend option

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -325,6 +325,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             return false;
         }
 
+        if (Environment::isTesting()) {
+            if (DEBUG) {
+                error_log('Skipping email sending in test environment');
+            }
+            return true;
+        }
+
         $clientService = $this->di['mod_service']('client');
         $customer = $clientService->get(['id' => $email->client_id]);
         $customer = $clientService->toApiArray($customer);

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -323,31 +324,15 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         if ($extensionService->isExtensionActive('mod', 'demo')) {
             return false;
         }
-        $settings = $this->di['mod_config']('email');
 
-        $mail = new \FOSSBilling\Mail($email->sender, $email->recipients, $email->sender, $email->content_html, $settings['mailer'] ?? 'sendmail', $settings['custom_dsn'] ?? null);
+        $clientService = $this->di['mod_service']('client');
+        $customer = $clientService->get(['id' => $email->client_id]);
+        $customer = $clientService->toApiArray($customer);
 
-        if (Environment::isTesting()) {
-            if (DEBUG) {
-                error_log('Skipping email sending in test environment');
-            }
+        $systemService = $this->di['mod_service']('system');
+        $from_name = $systemService->getParamValue('company_name');
 
-            return true;
-        }
-
-        try {
-            $mod = $this->di['mod']('email');
-            $settings = $mod->getConfig();
-
-            if (isset($settings['log_enabled']) && $settings['log_enabled']) {
-                $activityService = $this->di['mod_service']('activity');
-                $activityService->logEmail($email->subject, $email->client_id, $email->sender, $email->recipients, $email->content_html, $email->content_text);
-            }
-
-            $mail->send($settings);
-        } catch (\Exception $e) {
-            error_log($e->getMessage());
-        }
+        $this->sendMail($email->recipients, $email->sender, $email->subject, $email->content_html, $customer['first_name'] . ' ' . $customer['last_name'], $from_name, $email->client_id);
 
         $this->di['logger']->info('Resent email #%s', $email->id);
 


### PR DESCRIPTION
This pull request does three things:
1. It closes #1832 by correcting the wrong parameters being passed
2. It changes the behavior from invoking the email class and sending the email immediately to instead using the `sendMail` function that the email module defines to add the email to the queue.
3. It populates more of the recipient's info than what it previously would have done.