### PR TITLE
Enable stock control for all product types

### DIFF
--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -44,9 +44,12 @@
 <div class="card">
     <div class="tab-content">
         <div class="tab-pane fade show active" id="tab-settings" role="tabpanel">
+            <div class="card-header">
+                <h1>{{ product.title|title }} {{ 'General Settings'|trans }}</h1>
+            </div>
             <div class="card-body">
-                <h5>{{ product.type|title }} {{ 'General settings'|trans }}</h5>
                 <form method="post" action="admin/product/update" class="api-form" data-api-msg="{{ 'Product configuration updated'|trans }}" name="form">
+                    <h2>{{'General Settings'|trans }}</h1>
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Category'|trans }}:</label>
@@ -149,10 +152,48 @@
                         </div>
                     </div>
 
+                    <hr>
+
+                    <h2>{{'Pricing & Stock Control'|trans }}</h2>
+                    <div class="form-group mb-3 row">
+                        <label class="form-label col-3 col-form-label">{{ 'Enable stock control'|trans }}:</label>
+                        <div class="col">
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" id="radioStockControlYes" name="stock_control" value="1"{% if product.stock_control %} checked{% endif %}>
+                                <label class="form-check-label" for="radioStockControlYes">{{ 'Yes'|trans }}</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" id="radioStockControlNo" name="stock_control" value="0"{% if not product.stock_control %} checked{% endif %}>
+                                <label class="form-check-label" for="radioStockControlNo">{{ 'No'|trans }}</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group mb-3 row">
+                        <label class="form-label col-3 col-form-label">{{ 'Allow quantity selection on order form'|trans }}:</label>
+                        <div class="col">
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" id="radioAllowQuantitySelectYes" name="allow_quantity_select" value="1"{% if product.allow_quantity_select %} checked{% endif %}>
+                                <label class="form-check-label" for="radioAllowQuantitySelectYes">{{ 'Yes'|trans }}</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" id="radioAllowQuantitySelectNo" name="allow_quantity_select" value="0"{% if not product.allow_quantity_select %} checked{% endif %}>
+                                <label class="form-check-label" for="radioAllowQuantitySelectNo">{{ 'No'|trans }}</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group mb-3 row">
+                        <label class="form-label col-3 col-form-label">{{ 'Quantity in stock'|trans }}:</label>
+                        <div class="col">
+                            <input class="form-control" type="text" name="quantity_in_stock" value="{{ product.quantity_in_stock }}">
+                        </div>
+                    </div>
+
                     {% include 'partial_pricing.html.twig' with { 'product': product } %}
 
+                    <hr>
+
+                    <h2>{{'Description'|trans }}</h2>
                     <div class="form-group mb-3 row">
-                        <label class="form-label col-3 col-form-label">{{ 'Description'|trans }}:</label>
                         <div class="col">
                             <textarea class="bb-textarea" name="description" rows="5">{{ product.description }}</textarea>
                         </div>

--- a/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
+++ b/src/modules/Servicecustom/html_admin/mod_servicecustom_config.html.twig
@@ -1,45 +1,6 @@
 <div class="card-body">
     <h5>{{ 'Stock control settings'|trans }}</h5>
 
-    <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
-        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
-        <div class="form-group mb-3 row">
-            <label class="form-label col-3 col-form-label">{{ 'Enable stock control'|trans }}:</label>
-            <div class="col">
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" id="radioStockControlYes" name="stock_control" value="1"{% if product.stock_control %} checked{% endif %}>
-                    <label class="form-check-label" for="radioStockControlYes">{{ 'Yes'|trans }}</label>
-                </div>
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" id="radioStockControlNo" name="stock_control" value="0"{% if not product.stock_control %} checked{% endif %}>
-                    <label class="form-check-label" for="radioStockControlNo">{{ 'No'|trans }}</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group mb-3 row">
-            <label class="form-label col-3 col-form-label">{{ 'Allow quantity select on order form'|trans }}:</label>
-            <div class="col">
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" id="radioAllowQuantitySelectYes" name="allow_quantity_select" value="1"{% if product.allow_quantity_select %} checked{% endif %}>
-                    <label class="form-check-label" for="radioAllowQuantitySelectYes">{{ 'Yes'|trans }}</label>
-                </div>
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" id="radioAllowQuantitySelectNo" name="allow_quantity_select" value="0"{% if not product.allow_quantity_select %} checked{% endif %}>
-                    <label class="form-check-label" for="radioAllowQuantitySelectNo">{{ 'No'|trans }}</label>
-                </div>
-            </div>
-        </div>
-        <div class="form-group mb-3 row">
-            <label class="form-label col-3 col-form-label">{{ 'Quantity in stock'|trans }}:</label>
-            <div class="col">
-                <input class="form-control" type="text" name="quantity_in_stock" value="{{ product.quantity_in_stock }}">
-            </div>
-        </div>
-        <input type="hidden" name="id" value="{{ product.id }}">
-        <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary">
-    </form>
-    <hr>
-
     <h5>{{ 'Plugin'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update'|link }}" class="api-form save" data-api-msg="{{ 'Settings updated'|trans }}">
         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>


### PR DESCRIPTION
The system already has support for stock control, however for some odd reason the configuration options for it were only found in the config template for the "custom" product type. I have no idea if this was an accident or yet another extremely odd decision from the old BoxBilling team, but I'm considering it to be another dumb bug.

(Also to make it clear, the stock control functionality is indeed in the core and not implemented in the custom product type. It works with all product types)

So, this PR moves it to the main product configuration template & also makes a few tweaks to that template to improve it.


## Old
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/ac30a03c-5e76-46f5-8d88-2fa8c296e424)

## New
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/76d0ce9e-1702-4b89-ab1c-31c8a6c4add0)
