### PR TITLE
Fix a logged error

### DIFF
--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
@@ -79,13 +80,18 @@ class i18n
             }
             foreach (self::getLocales() as $locale) {
                 if (str_starts_with($locale, substr($detectedLocale, 0, 2))) {
-                    setcookie("BBLANG", $locale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+                    if (!headers_sent()) {
+                        setcookie("BBLANG", $locale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+                    }
                     return $locale;
                 }
             }
         }
 
-        setcookie("BBLANG", $matchingLocale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+        if (!headers_sent()) {
+            setcookie("BBLANG", $matchingLocale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+        }
+
         return $matchingLocale;
     }
 
@@ -180,10 +186,10 @@ class i18n
     {
         if ($disabled) {
             // Only get a list of the disabled locales
-            $locales = array_filter(glob(PATH_LANGS . DIRECTORY_SEPARATOR . '*'), fn($dir) => is_dir($dir) && file_exists($dir . DIRECTORY_SEPARATOR . '.disabled'));
+            $locales = array_filter(glob(PATH_LANGS . DIRECTORY_SEPARATOR . '*'), fn ($dir) => is_dir($dir) && file_exists($dir . DIRECTORY_SEPARATOR . '.disabled'));
         } else {
             // Only get a list of the enabled locales
-            $locales = array_filter(glob(PATH_LANGS . DIRECTORY_SEPARATOR . '*'), fn($dir) => is_dir($dir) && !file_exists($dir . DIRECTORY_SEPARATOR . '.disabled'));
+            $locales = array_filter(glob(PATH_LANGS . DIRECTORY_SEPARATOR . '*'), fn ($dir) => is_dir($dir) && !file_exists($dir . DIRECTORY_SEPARATOR . '.disabled'));
         }
 
         $locales = array_map('basename', $locales); // get only the directory name


### PR DESCRIPTION
This pull request prevents the il8n class from setting cookies after sending headers, resolving the following error:
`Warning: Cannot modify header information - headers already sent`