### PR TITLE
Cache extension configs

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -11,6 +12,7 @@
 namespace Box\Mod\Extension;
 
 use FOSSBilling\InjectionAwareInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class Service implements InjectionAwareInterface
 {
@@ -564,27 +566,32 @@ class Service implements InjectionAwareInterface
 
     public function getConfig($ext)
     {
-        $c = $this->di['db']->findOne('ExtensionMeta', 'extension = :ext AND meta_key = :key', [':ext' => $ext, ':key' => 'config']);
-        if (is_null($c)) {
-            $c = $this->di['db']->dispense('ExtensionMeta');
-            $c->extension = $ext;
-            $c->meta_key = 'config';
-            $c->meta_value = null;
-            $c->created_at = date('Y-m-d H:i:s');
-            $c->updated_at = date('Y-m-d H:i:s');
-            $this->di['db']->store($c);
-            $config = [];
-        } else {
-            $config = $this->di['crypt']->decrypt($c->meta_value, $this->_getSalt());
-            $config = $this->di['tools']->decodeJ($config);
-        }
+        return $this->di['cache']->get("config_$ext", function (ItemInterface $item) use ($ext) {
+            $item->expiresAfter(60 * 60);
 
-        return $config;
+            $c = $this->di['db']->findOne('ExtensionMeta', 'extension = :ext AND meta_key = :key', [':ext' => $ext, ':key' => 'config']);
+            if (is_null($c)) {
+                $c = $this->di['db']->dispense('ExtensionMeta');
+                $c->extension = $ext;
+                $c->meta_key = 'config';
+                $c->meta_value = null;
+                $c->created_at = date('Y-m-d H:i:s');
+                $c->updated_at = date('Y-m-d H:i:s');
+                $this->di['db']->store($c);
+                $config = [];
+            } else {
+                $config = $this->di['crypt']->decrypt($c->meta_value, $this->_getSalt());
+                $config = $this->di['tools']->decodeJ($config);
+            }
+
+            return $config;
+        });
     }
 
     public function setConfig($data)
     {
-        $this->getConfig($data['ext']); // Creates new config if it does not exist in DB
+        $ext = $data['ext'];
+        $this->getConfig($ext); // Creates new config if it does not exist in DB
 
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminExtensionConfigSave', 'params' => $data]);
         $sql = "
@@ -599,12 +606,13 @@ class Service implements InjectionAwareInterface
         $config = $this->di['crypt']->encrypt($config, $this->_getSalt());
 
         $params = [
-            'ext' => $data['ext'],
+            'ext' => $ext,
             'config' => $config,
         ];
         $this->di['db']->exec($sql, $params);
         $this->di['events_manager']->fire(['event' => 'onAfterAdminExtensionConfigSave', 'params' => $data]);
-        $this->di['logger']->info('Updated extension "%s" configuration', $data['ext']);
+        $this->di['logger']->info('Updated extension "%s" configuration', $ext);
+        $this->di['cache']->delete("config_$ext");
 
         return true;
     }

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -643,7 +643,7 @@ class ServiceTest extends \BBTestCase {
         $di['crypt'] = $cryptMock;
         $di['tools'] = $toolsMock;
         $di['config'] = array('salt' => '');
-        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
 
         $this->service->setDi($di);
 
@@ -673,7 +673,7 @@ class ServiceTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
 
         $this->service->setDi($di);
         $result = $this->service->getConfig($data['ext']);
@@ -718,7 +718,7 @@ class ServiceTest extends \BBTestCase {
         $di['events_manager'] = $eventMock;
         $di['logger'] = new \Box_Log();
         $di['config'] = array('salt' => '');
-        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->setConfig($data);

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -643,6 +643,7 @@ class ServiceTest extends \BBTestCase {
         $di['crypt'] = $cryptMock;
         $di['tools'] = $toolsMock;
         $di['config'] = array('salt' => '');
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
 
         $this->service->setDi($di);
 
@@ -672,6 +673,7 @@ class ServiceTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
 
         $this->service->setDi($di);
         $result = $this->service->getConfig($data['ext']);
@@ -716,6 +718,7 @@ class ServiceTest extends \BBTestCase {
         $di['events_manager'] = $eventMock;
         $di['logger'] = new \Box_Log();
         $di['config'] = array('salt' => '');
+        $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->setConfig($data);


### PR DESCRIPTION
Relates to #1595.

This pull request adds a minor optimization to the app by caching extension configs, which saves the step of fetching it from the DB and then decoding the JSON. When the extension's config is updated, the cache is cleared.

Quite a few sections of the app use this data, although in this case I validated things are optimized by using the `/admin/support/kb` route which pulls the `support` module's config to see if the KB is enabled or not while it's registering it's routes.
Saves about 2ms in this testing.

## Before
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/577f6506-1c50-459d-bc6a-dfee88ff87a9)


## After
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/c63ec921-021c-4b24-8288-dbef4930ae61)
