### PR TITLE
Improved backup patching

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -33,16 +33,12 @@ if ($url === '/run-patcher') {
     $patcher = new FOSSBilling\UpdatePatcher();
     $patcher->setDi($di);
 
-    if (!$patcher->isOutdated()) {
-        exit('There are no patches to apply');
-    }
-
     try {
         $patcher->applyConfigPatches();
         $patcher->applyCorePatches();
         $di['tools']->emptyFolder(PATH_CACHE);
 
-        exit('Patches have been applied');
+        exit('Any missing config migrations or database patches have been applied and the cache has been cleared');
     } catch (\Exception $e) {
         exit('An error occurred while attempting to apply patches: <br>' . $e->getMessage());
     }

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
@@ -28,13 +29,6 @@ class UpdatePatcher implements InjectionAwareInterface
     public function getDi(): ?\Pimple\Container
     {
         return $this->di;
-    }
-
-    public function isOutdated(): bool
-    {
-        $patchLevel = $this->getPatchLevel();
-        $patches = $this->getPatches($patchLevel);
-        return count($patches) !== 0;
     }
 
     /**
@@ -95,6 +89,10 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig = array_diff_key($newConfig, array_flip($depreciatedConfigKeys));
         foreach ($depreciatedConfigSubkeys as $key => $subkey) {
             unset($newConfig[$key][$subkey]);
+        }
+
+        if ($currentConfig === $newConfig) {
+            return;
         }
 
         $output = '<?php ' . PHP_EOL;
@@ -318,7 +316,7 @@ class UpdatePatcher implements InjectionAwareInterface
                 $ext_service = $this->di['mod_service']('extension');
                 if ($ext_service->isExtensionActive('mod', 'kb')) {
                     $support_ext_config = $ext_service->getConfig('mod_support');
-                    $support_ext_config['kb_enable'] ?: 'on';
+                    $support_ext_config['kb_enable'] = 'on';
                     $ext_service->setConfig($support_ext_config);
                 }
 


### PR DESCRIPTION
This pull request improves the backup patching method to allow any missing config migrations to be run even when the the DB patches are caught up.
It also fixes a patch step when migrating to account for the KB and Support modules being merged.