### PR TITLE
Fix updating from previous releases

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -78,6 +78,9 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['debug_and_monitoring']['log_stacktrace'] ??= $newConfig['log_stacktrace'] ?? true;
         $newConfig['debug_and_monitoring']['stacktrace_length'] ??= $newConfig['stacktrace_length'] ?? 25;
         $newConfig['debug_and_monitoring']['report_errors'] ??= false;
+        if (!class_exists('Uuid')) {
+            $this->registerFallbackAutoloader();
+        }
         $newConfig['info']['instance_id'] ??= Uuid::uuid4()->toString();
         $newConfig['info']['salt'] ??= $newConfig['salt'];
 
@@ -353,5 +356,16 @@ class UpdatePatcher implements InjectionAwareInterface
         ksort($patches, SORT_NATURAL);
 
         return array_filter($patches, fn ($key) => $key > $patchLevel, ARRAY_FILTER_USE_KEY);
+    }
+
+    private function registerFallbackAutoloader()
+    {
+        $loader = new \AntCMS\AntLoader([
+            'mode' => 'filesystem',
+            'path' => PATH_CACHE . DIRECTORY_SEPARATOR . 'fallbackClassMap.php',
+        ]);
+        $loader->addNamespace('', PATH_VENDOR);
+        $loader->checkClassMap();
+        $loader->register(true);
     }
 }


### PR DESCRIPTION
This pull request implements a workaround to allow us to perform upgrades from the 0.5.X releases to the latest preview (soon to be 0.6.0).
Issue came from the fact that we introduced the UUID package and are attempting to use it in the same step. We can't reload the composer autoloader, which results in the UUID class not existing as far as PHP is concerned.

The workaround I came up with is to use AntLoader and point it at the vendor directory. Using the classmap generator with it, we don't actually need to know what packages are PSR0 / PSR4 (if either) as the generator simply finds classes and registers them in the classmap, which also makes this a fairly universal fix for any cases where we run into the issue.

Cache is cleared after the patching steps, so the `fallbackClassMap.php` will also automatically get cleared.

I've validated that using these changes we are able to upgrade from 0.5.6 to the preview builds (0.6.0). No errors occur and the instance ID is correctly set.