### PR TITLE
Fix DebugBar error when rendering twig exceptions

### DIFF
--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -58,7 +58,10 @@ class Box_AppAdmin extends Box_App
 
         $profile = new Profile();
         $twig->addExtension(new ProfilerExtension($profile));
-        $this->debugBar->addCollector(new NamespacedTwigProfileCollector($profile));
+        $collector = new NamespacedTwigProfileCollector($profile);
+        if (!$this->debugBar->hasCollector($collector->getName())) {
+            $this->debugBar->addCollector($collector);
+        }
 
         $twig->addExtension(new DebugBar($this->getDebugBar()));
 

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -116,7 +116,10 @@ class Box_AppClient extends Box_App
 
         $profile = new Profile();
         $twig->addExtension(new ProfilerExtension($profile));
-        $this->debugBar->addCollector(new NamespacedTwigProfileCollector($profile));
+        $collector = new NamespacedTwigProfileCollector($profile);
+        if (!$this->debugBar->hasCollector($collector->getName())) {
+            $this->debugBar->addCollector($collector);
+        }
 
         $twig->addExtension(new DebugBar($this->getDebugBar()));
 


### PR DESCRIPTION
Presently if twig tries to render an exception (a 404 for example is a fast and easy way to trigger this), you'll get a fatal "'twig' is already a registered collector" error from DebugBar. This pull request fixes that