### PR TITLE
Rebuilt the requirements class

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -368,7 +368,8 @@
         "valuemin",
         "valuemax",
         "concat",
-        "debugbar"
+        "debugbar",
+        "reqs"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/di.php
+++ b/src/di.php
@@ -693,10 +693,8 @@ $di['server_manager'] = $di->protect(function ($manager, $config) use ($di) {
  *
  * @return \FOSSBilling\Requirements
  */
-$di['requirements'] = function () use ($di) {
+$di['requirements'] = function () {
     $r = new \FOSSBilling\Requirements();
-    $r->setDi($di);
-
     return $r;
 };
 

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -68,24 +68,26 @@
                     </tr>
                     <tr>
                         <td>PHP version</td>
-                        <td class="{{ php_ver_ok ? 'green' : 'red'}}">{{ php_ver }}</td>
-                        <td>{% if not php_ver_ok %}Required PHP version >{{ php_ver_req }}{% endif %}</td>
+                        <td class="{{ compatibility.php_version.isOk ? 'green' : 'red'}}">{{ compatibility.php_version.version }}</td>
+                        <td>{% if not compatibility.php_version.isOk %} Required PHP version >={{ compatibility.php_version.min_version }}{% endif %}</td>
                     </tr>
-                    {% if php_safe_mode %}
-                        <tr>
-                            <td>PHP safe mode</td>
-                            <td class="red">ON</td>
-                            <td>PHP safe mode should be OFF</td>
-                        </tr>
-                    {% endif %}
-                    {% for ext, loaded in extensions %}
+                    {% for ext, loaded in compatibility.required_extensions %}
                         <tr>
                             <td>PHP extension: <strong>{{ ext }}</strong></td>
                             <td class="{{ loaded ? 'green' : 'red'}}">{{ loaded ? 'OK' : 'FAIL'}}</td>
-                            <td>{% if not loaded %}Contact your server administrator to enable <strong>PHP {{ ext }} extension</strong>{% endif %}</td>
+                            <td>{% if not loaded %}Contact your server administrator to enable <strong>{{ ext }}</strong> PHP extension{% endif %}</td>
                         </tr>
                     {% endfor %}
-                    {% for file, writable in files %}
+                    {% for ext, loaded in compatibility.suggested_extensions %}
+                        {% if not loaded %}
+                            <tr>
+                                <td>PHP extension: <strong>{{ ext }}</strong></td>
+                                <td class="{{ loaded ? 'green' : 'orange'}}">{{ loaded ? 'OK' : 'WARN'}}</td>
+                                <td>{% if not loaded %}We recommend enabling the <strong>{{ ext }}</strong> PHP extension for improved performance / compatibility{% endif %}</td>
+                            </tr>
+                        {% endif %}
+                    {% endfor %}
+                    {% for file, writable in compatibility.files %}
                         {% if not writable %}
                             <tr>
                                 <td>{{ file }}</td>
@@ -94,7 +96,7 @@
                             </tr>
                         {% endif %}
                     {% endfor %}
-                    {% for folder, writable in folders %}
+                    {% for folder, writable in compatibility.folders %}
                         {% if not writable %}
                             <tr>
                                 <td>{{ folder }}</td>

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -449,7 +449,7 @@ class Service
         }
 
         $r = $this->di['requirements'];
-        $data = $r->getInfo();
+        $data = $r->checkCompat();
         $data['last_patch'] = $this->getParamValue('last_patch');
 
         return $data;


### PR DESCRIPTION
This pull request rebuilds the requirements to remove unneeded functionality, sync the requirements with those that have [recently been documented](https://fossbilling.org/docs/getting-started/requirements), and to also include the recommended PHP extensions as well.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/daaf84c6-892b-4073-abbc-4499de42b4df)

We also still had 8.0 listed as the required version, so that's also fixed in this PR