### PR TITLE
Use absolute URLs for the installer assets

### DIFF
--- a/src/install/assets/layout.html.twig
+++ b/src/install/assets/layout.html.twig
@@ -3,8 +3,8 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="./assets/css/pico.min.css" rel="stylesheet">
-        <script src="./assets/js/modal.js"></script>
+        <link href="{{ constant('URL_INSTALL') }}assets/css/pico.min.css" rel="stylesheet">
+        <script src="{{ constant('URL_INSTALL') }}assets/js/modal.js"></script>
         <title>FOSSBilling Installation</title>
         <base href="{{ constant('URL_INSTALL') }}"/>
         <style type="text/css">


### PR DESCRIPTION
I believe this will fix the issue that @John-S4 had, but let's not merge it until he can validate that's the case 
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/2e4765d6-28f0-482d-b3ad-d02b621a90c6)
