### PR TITLE
Fix the issue John noticed

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -152,7 +152,7 @@ final class FOSSBilling_Installer
                         // Delete install directory only if debug mode is NOT enabled.
                         $config = require PATH_CONFIG;
                         if (!$config['debug_and_monitoring']['debug']) {
-                            $this->removeDirectory('..' . DIRECTORY_SEPARATOR . 'install');
+                            unlink(__DIR__ . DIRECTORY_SEPARATOR . 'install.php');
                         }
                     } catch (Exception) {
                         // Do nothing and fail silently. New warnings are presented on the installation completed page for a leftover install directory.
@@ -442,29 +442,5 @@ final class FOSSBilling_Installer
         $emailService->setDi($di);
 
         return $emailService->templateBatchGenerate();
-    }
-
-    /**
-     * Recursively remove a directory at a specific path.
-     *
-     * @param string $dir
-     * @return void
-     */
-    public function removeDirectory($dir)
-    {
-        if (is_dir($dir)) {
-            $contents = scandir($dir);
-            foreach ($contents as $content) {
-                if ('.' !== $content && '..' !== $content) {
-                    if ('dir' === filetype($dir . DIRECTORY_SEPARATOR . $content)) {
-                        $this->removeDirectory($dir . DIRECTORY_SEPARATOR . $content);
-                    } else {
-                        unlink($dir . DIRECTORY_SEPARATOR . $content);
-                    }
-                }
-            }
-            reset($contents);
-            rmdir($dir);
-        }
     }
 }

--- a/src/load.php
+++ b/src/load.php
@@ -51,15 +51,24 @@ function checkConfig()
  */
 function checkInstaller()
 {
+    if (!Environment::isProduction()) {
+        return;
+    }
+
     $filesystem = new Filesystem();
 
     // Check if /install directory still exists after installation has been completed.
-    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install/install.php') && Environment::isProduction()) {
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install/install.php')) {
         // Throw exception only if debug mode is NOT enabled.
         $config = require PATH_CONFIG;
         if (!$config['debug_and_monitoring']['debug']) {
             throw new Exception('For security reasons, you have to delete the install directory before you can use FOSSBilling.', 2);
         }
+    }
+
+    // If the config file exists and not install.php, but the install folder does, perform some cleanup.
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install')) {
+        $filesystem->remove('install');
     }
 }
 

--- a/src/load.php
+++ b/src/load.php
@@ -67,7 +67,7 @@ function checkInstaller()
     }
 
     // If the config file exists and not install.php, but the install folder does, perform some cleanup.
-    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install')) {
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists('install') && !DEBUG) {
         $filesystem->remove('install');
     }
 }

--- a/src/modules/Support/html_client/mod_support_kb_article.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_article.html.twig
@@ -29,7 +29,7 @@
                 </div>
             </div>
             <div class="card-footer">
-                <a href="{{ 'support/kb'|link }}" class="btn btn-primary btn-sm" type="button">{{ 'Back to all knowedge base articles'|trans }}</a>
+                <a href="{{ 'support/kb'|link }}" class="btn btn-primary btn-sm" type="button">{{ 'Back to all knowledge base articles'|trans }}</a>
 
                 <a href="{{ 'support/kb'|link }}/{{ article.category.slug }}" class="btn btn-primary btn-sm" type="button">{{ 'Similar articles'|trans }}</a>
             </div>


### PR DESCRIPTION
This pull request resolves an issue that @John-S4 had post-install where the CSS wasn't loaded. 
Issue seemed to stem from the installer deleting the `install` folder and then rendering the page to the client.

My solution was to instead have the installer delete `install.php` instead of the entire directory and instead of have our loader delete the entire directory for us.

Another option would be to use a CDN for the CSS, but I know we generally avoid relying on external services