### PR TITLE
Restructure the redirect after login functionality

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -345,6 +345,10 @@ $di['twig'] = $di->factory(function () use ($di) {
         $token = hash('md5', session_id());
     }
 
+    if (!empty($_SESSION["redirect_uri"])) {
+        $twig->addGlobal('redirect_uri', $_SESSION["redirect_uri"]);
+    }
+
     $twig->addGlobal('CSRFToken', $token);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);
@@ -494,15 +498,18 @@ $di['loggedin_admin'] = function () use ($di) {
 };
 
 $di['set_return_uri'] = function () use ($di) {
-    $url = $_GET['_url'] ?? ($_SERVER['PATH_INFO'] ?? '');
+    $url = $_GET['_url'] ?? $_SERVER['PATH_INFO'] ?? '';
     unset($_GET['_url']);
 
     if (str_starts_with($url, ADMIN_PREFIX)) {
         $url = substr($url, strlen(ADMIN_PREFIX));
     }
-    $redirectUri = $url . '?' . http_build_query($_GET);
 
-    $di['session']->set('redirect_uri', $redirectUri);
+    if($_GET){
+        $url .= '?' . http_build_query($_GET);
+    }
+
+    $di['session']->set('redirect_uri', $url);
 };
 
 /*

--- a/src/index.php
+++ b/src/index.php
@@ -11,8 +11,6 @@
 require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
 
-$di['session'];
-
 // Setting up the debug bar
 $debugBar = new \DebugBar\StandardDebugBar();
 $debugBar['request']->useHtmlVarDumper();
@@ -45,6 +43,8 @@ if ($url === '/run-patcher') {
         exit('An error occurred while attempting to apply patches: <br>' . $e->getMessage());
     }
 }
+
+$di['session'];
 
 if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
     $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));

--- a/src/index.php
+++ b/src/index.php
@@ -11,6 +11,8 @@
 require_once __DIR__ . '/load.php';
 $di = include __DIR__ . '/di.php';
 
+$di['session'];
+
 // Setting up the debug bar
 $debugBar = new \DebugBar\StandardDebugBar();
 $debugBar['request']->useHtmlVarDumper();

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -137,11 +137,7 @@ class Guest extends \Api_Abstract
         $this->di['session']->set('client_id', $client->id);
 
         $this->di['logger']->info('Client #%s logged in', $client->id);
-
-        $redirectUri = $this->di['session']->get('redirect_uri') ?? '';
         $this->di['session']->delete('redirect_uri');
-
-        $result['redirect_uri'] = $redirectUri;
 
         return $result;
     }

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -18,7 +18,7 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="text-center m-4">{{ 'Login to your account'|trans }}</h5>
-                    <form class="api-form auth" action="{{ 'api/guest/client/login'|link }}" method="post" data-api-redirect="{{ '/'|link }}">
+                    <form class="api-form auth" action="{{ 'api/guest/client/login'|link }}" method="post" data-api-redirect="{{ redirect_uri|default('/')|link }}">
                         <div class="mb-3">
                             <label class="form-label" for="email">{{ 'Email'|trans }}</label>
                             <input class="form-control" id="email" type="text" placeholder="{{ 'Enter your email address'|trans }}" name="email" value="{{ request.email }}" required="required" autofocus>

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -81,7 +81,10 @@ class Guest extends \Api_Abstract
             }
         }
 
-        return $this->getService()->login($data['email'], $data['password'], $this->getIp());
+        $result = $this->getService()->login($data['email'], $data['password'], $this->getIp());
+        $this->di['session']->delete('redirect_uri');
+
+        return $result;
     }
 
     public function update_password($data)

--- a/src/modules/Staff/Controller/Admin.php
+++ b/src/modules/Staff/Controller/Admin.php
@@ -64,10 +64,7 @@ class Admin implements InjectionAwareInterface
             return $app->redirect('');
         }
 
-        $redirect_uri = $this->di['session']->get('redirect_uri') ?: 'index';
-        $this->di['session']->delete('redirect_uri');
-
-        return $app->render('mod_staff_login', ['create_admin' => $create, 'redirect_uri' => $redirect_uri]);
+        return $app->render('mod_staff_login', ['create_admin' => $create]);
     }
 
     public function get_profile(\Box_App $app)

--- a/src/modules/Staff/html_admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login.html.twig
@@ -36,7 +36,7 @@
                 {% else %}
                 {% set params = guest.extension_settings({ 'ext': 'mod_staff' }) %}
                     <h2 class="h2 text-center mb-4">{{ 'Log into your account' | trans }}</h2>
-                    <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ redirect_uri|alink }}">
+                    <form class="api-form" action="{{ 'api/guest/staff/login'|link }}" method="post" data-api-redirect="{{ redirect_uri|default('/')|alink }}">
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3">
                             <label class="form-label" for="inputEmail">{{ 'Email' | trans }}</label>

--- a/tests/modules/Staff/Api/GuestTest.php
+++ b/tests/modules/Staff/Api/GuestTest.php
@@ -137,12 +137,17 @@ class GuestTest extends \BBTestCase
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
+        $sessionMock = $this->getMockBuilder('\\' . \FOSSBilling\Session::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
         $di['tools'] = $toolsMock;
+        $di['session'] = $sessionMock;
 
         $guestApi = new \Box\Mod\Staff\Api\Guest();
         $guestApi->setMod($modMock);


### PR DESCRIPTION
This PR restructures the code used to redirect the user back to the page they had originally access after logging in to simply the logic a little bit.

Additionally, it also fixes an issue where the session wasn't always available in the app by starting it within `index.php` as well as restoring the functionality for the client area as it was lost with the Huraga BS 5 migration. 

Builds on #1745