### PR TITLE
Ensure invoice authentication is on by default + bugfix

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -441,8 +441,8 @@ $di['loggedin_client'] = function () use ($di) {
     try {
         return $di['db']->getExistingModelById('Client', $client_id);
     } catch (Exception) {
-        // Either the account was deleted or the session is invalid. Either way, destroy it so they are forced to try and login again.
-        $di['session']->destroy('client');
+        // Either the account was deleted or the session is invalid. Either way, remove the ID from the session so the system doesn't consider someone logged in
+        $di['session']->delete('client_id');
 
         // Then either give an appropriate API response or redirect to the login page.
         $api_str = '/api/';
@@ -479,8 +479,8 @@ $di['loggedin_admin'] = function () use ($di) {
     try {
         return $di['db']->getExistingModelById('Admin', $admin['id']);
     } catch (Exception) {
-        // Either the account was deleted or the session is invalid. Either way, destroy it so they are forced to try and login again.
-        $di['session']->destroy('admin');
+        // Either the account was deleted or the session is invalid. Either way, remove the ID from the session so the system doesn't consider someone logged in
+        $di['session']->delete('admin');
 
         // Then either give an appropriate API response or redirect to the login page.
         $api_str = '/api/';

--- a/src/modules/Invoice/Controller/Client.php
+++ b/src/modules/Invoice/Controller/Client.php
@@ -52,7 +52,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         ];
         $invoice = $api->invoice_get($data);
         $systemService = $this->di['mod_service']('system');
-        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '1');
+        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '0');
 
         // If hash_access is not 0 or if a client is logged in, get the logged-in client
         if (!$this->di['auth']->isAdminLoggedIn() && $hash_access === '0') {
@@ -70,7 +70,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         ];
         $invoice = $api->invoice_get($data);
         $systemService = $this->di['mod_service']('system');
-        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '1');
+        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '0');
 
         // If hash_access is not 0 or if a client is logged in, get the logged-in client
         if (!$this->di['auth']->isAdminLoggedIn() && $hash_access === '0') {
@@ -115,7 +115,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         ];
         $invoice = $api->invoice_pdf($data);
         $systemService = $this->di['mod_service']('system');
-        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '1');
+        $hash_access = $systemService->getParamValue('invoice_accessible_from_hash', '0');
 
         // If hash_access is not 0 or if a client is logged in, get the logged-in client
         if (!$this->di['auth']->isAdminLoggedIn() && $hash_access === '0') {


### PR DESCRIPTION
This PR follows up from a previous PR to ensure invoice authentication is defaulting to on. People can still disable it if they'd desire, however.

Additionally, this fixes another bug that effected the redirection after login implementation where the system could destroy a session after the redirect URL was stored inside of it. Instead, the system will simply remove the stored ID from the session if there's an error when fetching the user from the DB. With this, the system still considers nobody to be logged in, but it won't destroy the previously saved redirect URL.