### PR TITLE
Fix TLD and registrar deletion

### DIFF
--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -438,9 +438,4 @@ class Admin extends \Api_Abstract
 
         return $s;
     }
-
-    public function findServiceDomain($tld)
-    {
-        return $this->di['db']->find('ServiceDomain', 'tld = ?', ['tld' => $tld]);
-    }
 }

--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -212,7 +212,7 @@ class Admin extends \Api_Abstract
             throw new \FOSSBilling\Exception('TLD not found');
         }
         // check if tld is used by any domain
-        $service_domains = $this->di['db']->find('ServiceDomain', 'tld = ?', ['tld' => $model->tld]);
+        $service_domains = $this->di['db']->find('ServiceDomain', 'tld = :tld', [':tld' => $data['tld']]);
         $count = is_countable($service_domains) ? count($service_domains) : 0;
         if ($count > 0) {
             throw new \FOSSBilling\InformationException('TLD is used by :count: domains', [':count:' => $count], 707);
@@ -349,16 +349,6 @@ class Admin extends \Api_Abstract
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
 
         $model = $this->di['db']->getExistingModelById('TldRegistrar', $data['id'], 'Registrar not found');
-
-        // check if registrar is used by any domain
-        $service_domains = $this->di['db']->find('ServiceDomain', 'tld_registrar_id = ?', ['tld_registrar_id' => $model->id]);
-
-        // Ensure $service_domains is an array before counting its elements
-        $count = is_array($service_domains) ? count($service_domains) : 0; // Handle the case where $service_domains might be null
-
-        if ($count > 0) {
-            throw new \FOSSBilling\InformationException('Registrar is used by :count: domains', [':count:' => $count], 707);
-        }
 
         return $this->getService()->registrarRm($model);
     }

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -1024,8 +1024,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function registrarRm(\Model_TldRegistrar $model)
     {
         $domains = $this->di['db']->find('ServiceDomain', 'tld_registrar_id = :registrar_id', [':registrar_id' => $model->id]);
-        if ((is_countable($domains) ? count($domains) : 0) > 0) {
-            throw new \FOSSBilling\InformationException('Can not remove registrar which has domains');
+        $count = is_countable($domains) ? count($domains) : 0;
+
+        if ($count > 0) {
+            throw new \FOSSBilling\InformationException('Registrar is used by :count: domains', [':count:' => $count], 707);
         }
 
         $name = $model->name;


### PR DESCRIPTION
This PR fixes two bugs introduced with #1492 that prevented TLD and registrars from being deleted.
It also removes a duplicated check when deleting a registrar & an added-in function that was unused