### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [ spellcheck ]
     permissions:
       contents: read
-    uses: FOSSBilling/.workflows/.github/workflows/php-build.yml@main
+    uses: FOSSBilling/.workflows/.github/workflows/php-build.yml@b34d8a6da3a2f58848ff957befaf546eb9d5090d
     with:
       php-versions: '["8.1", "8.2", "8.3"]'
       upload-artifact: true
@@ -75,7 +75,7 @@ jobs:
     needs: [ php-build, prep-test ]
     permissions:
       contents: read
-    uses: FOSSBilling/.workflows/.github/workflows/php-test.yml@main  
+    uses: FOSSBilling/.workflows/.github/workflows/php-test.yml@b34d8a6da3a2f58848ff957befaf546eb9d5090d  
     with:
       php-versions: '["8.1", "8.2", "8.3"]'
       download-test-files: true


### PR DESCRIPTION
#1910 got merged while tests weren't running, and two checks were failing.

This PR fixes one of those tests, deletes the other which simply didn't work, and sets the workflows to run at the last commit SHA before changes were made that prevented them from running correctly.