### PR TITLE
Include an empty cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .vagrant*
 src/config.php
 src/data/log/*
-src/data/cache/*
+#src/data/cache/*
 src/vendor/*
 build
 composer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .vagrant*
 src/config.php
 src/data/log/*
-#src/data/cache/*
+src/data/cache/*
 src/vendor/*
 build
 composer.phar


### PR DESCRIPTION
The installer fails the requirement check if this directory doesn't exist.
Previously the preview workflow would add it in for us, but that step was removed in #1915.

We could add the missing step back in, but I've opted to add it to the git repo as that change also covers locally created builds.