### PR TITLE
Replaced the old IP address database

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -199,7 +199,7 @@ return [
 
     /**
      * You may override the default IP address database that FOSSBilling utilizes here if you desire.
-     * The 'included' arrays define what data types are included in that database. For exampple, the default ones for FOSSBilling would be ['country', 'asn']
+     * The 'included' arrays define what data types are included in that database. For example, the default ones for FOSSBilling would be ['country', 'asn']
      */
     'IPDatabase' => [
         'customIPv4' => '',

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -198,7 +198,7 @@ return [
     ],
 
     /**
-     * Use these options to override the default IP address database that FOSSBilling inlcudes which are free of licencing and also includes ASN data rather than just country data, however it does so at a loss to accuracy.
+     * Use these options to override the default IP address database that FOSSBilling includes which are free of licencing and also includes ASN data rather than just country data, however it does so at a loss to accuracy.
      * `custom_path` will define the local path to reference when loading the database.
      * `custom_url` can be set to have FOSSBilling update a database of your choosing from the provided URL once daily.
      * `included` defines what data types are included in that database. For example, the default ones for FOSSBilling would be ['country', 'asn']. This isn't strictly needed, but may be used by modules to enable / disable functionality.

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -196,4 +196,15 @@ return [
          */
         'rate_limit_whitelist' => [],
     ],
+
+    /**
+     * You may override the default IP address database that FOSSBilling utilizes here if you desire.
+     * The 'included' arrays define what data types are included in that database. For exampple, the default ones for FOSSBilling would be ['country', 'asn']
+     */
+    'IPDatabase' => [
+        'customIPv4' => '',
+        'includedIPv4' => [],
+        'customIPv6' => '',
+        'includedIPv6' => [],
+    ]
 ];

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -198,7 +198,7 @@ return [
     ],
 
     /**
-     * Use these options to override the default IP address database that FOSSBilling includes which are free of licencing and also includes ASN data rather than just country data, however it does so at a loss to accuracy.
+     * Use these options to override the default IP address database that FOSSBilling includes which are free of licensing and also includes ASN data rather than just country data, however it does so at a loss to accuracy.
      * `custom_path` will define the local path to reference when loading the database.
      * `custom_url` can be set to have FOSSBilling update a database of your choosing from the provided URL once daily.
      * `included` defines what data types are included in that database. For example, the default ones for FOSSBilling would be ['country', 'asn']. This isn't strictly needed, but may be used by modules to enable / disable functionality.

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -198,13 +198,14 @@ return [
     ],
 
     /**
-     * You may override the default IP address database that FOSSBilling utilizes here if you desire.
-     * The 'included' arrays define what data types are included in that database. For example, the default ones for FOSSBilling would be ['country', 'asn']
+     * Use these options to override the default IP address database that FOSSBilling inlcudes which are free of licencing and also includes ASN data rather than just country data, however it does so at a loss to accuracy.
+     * `custom_path` will define the local path to reference when loading the database.
+     * `custom_url` can be set to have FOSSBilling update a database of your choosing from the provided URL once daily.
+     * `included` defines what data types are included in that database. For example, the default ones for FOSSBilling would be ['country', 'asn']. This isn't strictly needed, but may be used by modules to enable / disable functionality.
      */
-    'IPDatabase' => [
-        'customIPv4' => '',
-        'includedIPv4' => [],
-        'customIPv6' => '',
-        'includedIPv6' => [],
+    'ip_database' => [
+        'custom_path'   => '',
+        'custom_url'    => '',
+        'included_data' => [],
     ]
 ];

--- a/src/di.php
+++ b/src/di.php
@@ -765,11 +765,13 @@ $di['license_server'] = function () use ($di) {
 };
 
 /*
- * @param void
- *
  * @return \GeoIp2\Database\Reader
+ * @deprecated You should instead invoke the IPDatabase class directly.
  */
-$di['geoip'] = fn () => new GeoIp2\Database\Reader(PATH_LIBRARY . '/GeoLite2-Country.mmdb');
+$di['geoip'] = function () {
+    error_log("Deprecated 'geoip' function called from the DI");
+    return FOSSBilling\IPDatabase::getReader(4);
+};
 
 /*
  * @param void

--- a/src/di.php
+++ b/src/di.php
@@ -770,7 +770,7 @@ $di['license_server'] = function () use ($di) {
  */
 $di['geoip'] = function () {
     error_log("Deprecated 'geoip' function called from the DI");
-    return FOSSBilling\IPDatabase::getReader(4);
+    return FOSSBilling\IPDatabase::getReader();
 };
 
 /*

--- a/src/library/FOSSBilling/IPDB.php
+++ b/src/library/FOSSBilling/IPDB.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2023 FOSSBilling
+ * Copyright 2011-2021 BoxBilling, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling;
+
+use GeoIp2\Database\Reader;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpClient\HttpClient;
+
+final class IPDatabase
+{
+    public const IPv4 = 4;
+    public const IPv6 = 6;
+    public const IPvUnknown = 0;
+
+    /**
+     * FOSSBilling uses databases that are licenced under the public domain (CC0 and PDDL).
+     * This is done to ensure that we have good enough data out of the box that's updated regularly and that can be used without a concern of licencing. 
+     * Below are the download URLs for both the IPv4 and IPv6 DBs we utilize.
+     * Both include ASN and Country information. 
+     */
+    public const DefaultIPv4DB = 'https://github.com/HostByBelle/IP-Geolocation-DB/releases/latest/download/cc0-pddl-country-asn-v4-variant-1.mmdb';
+    public const DefaultIPv6DB = 'https://github.com/HostByBelle/IP-Geolocation-DB/releases/latest/download/cc0-pddl-country-asn-v6-variant-1.mmdb';
+
+    /**
+     * Creates a new instance of the GeoIP2 reader for either a fixed address type or optionally will autodetect the correct type 
+     * 
+     * @param int $type The IP address type. Represented as `4`, `6`, or `0`. A zero should be passed to have the type automatically detected by providing the IP address used.
+     * @param null|string $ip (optional) The IP address to detect the type of.
+     * @throws Exception If the IP address or type given is invalid.
+     */
+    public static function getReader(int $type = self::IPvUnknown, ?string $ip = null): Reader
+    {
+        if ($type === self::IPvUnknown) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                $type = self::IPv4;
+            } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                $type = self::IPv6;
+            } else {
+                throw new Exception("The provided IP address is invalid");
+            }
+        }
+
+        [$IPv4, $IPv6] = self::getPaths();
+        error_log("$IPv4, $IPv6");
+
+        switch ($type) {
+            case self::IPv4:
+                return new Reader($IPv4);
+                break;
+            case self::IPv6:
+                return new Reader($IPv6);
+                break;
+            default:
+                throw new Exception("An invalid IP address type was given");
+        }
+    }
+
+    /**
+     * Updates the default databases that are included inside of FOSSBilling.
+     * If one of the databases have been replaced with an alternative, it won't be updated.
+     * 
+     * This function will only ever update one DB at a time as both an effort to spread out server load and to lessen any hangs that the fallback cron method may cause.
+     */
+    public static function update()
+    {
+        [$IPv4, $IPv6] = self::getPaths(true);
+        $IPv4Age = time() - filemtime($IPv4);
+        $IPv6Age = time() - filemtime($IPv6);
+
+        if (!defined('IPv4DB') && $IPv4Age >= 86400) {
+            self::performUpdate($IPv4, self::DefaultIPv4DB);
+            return;
+        }
+
+        if (!defined('IPv6DB') && $IPv6Age >= 86400) {
+            self::performUpdate($IPv6, self::DefaultIPv6DB);
+            return;
+        }
+    }
+
+    /**
+     * Returns an array containing what type of data is included in a given IP DB.
+     * Relies on the user to correctly set this information for DBs they provide on their own.
+     * 
+     * @return array 
+     */
+    public static function whatIsIncluded(): array
+    {
+        if (defined('includedIPv4')) {
+            $IPv4 = includedIPv4;
+        } else {
+            $IPv4 = ['country', 'asn'];
+        }
+
+        if (defined('includedIPv6')) {
+            $IPv6 = includedIPv6;
+        } else {
+            $IPv6 = ['country', 'asn'];
+        }
+
+        return [$IPv4, $IPv6];
+    }
+
+    /**
+     * Returns the correct paths for the actively used database.
+     * 
+     * @param bool $defaults Set to true to only have the default DB paths returned. 
+     */
+    public static function getPaths(bool $defaults = false): array
+    {
+        if (defined('IPv4DB') && !$defaults) {
+            $IPv4 = Path::canonicalize(IPv4DB);
+        } else {
+            //$IPv4 = Path::normalize(PATH_LIBRARY . '/IPv4.mmdb');
+            $IPv4 = Path::normalize(PATH_LIBRARY . '/GeoLite2-Country.mmdb');
+        }
+
+        if (defined('IPv6DB')  && !$defaults) {
+            $IPv6 = Path::canonicalize(IPv6DB);;
+        } else {
+            $IPv6 = Path::normalize(PATH_LIBRARY . '/IPv6.mmdb');
+        }
+
+        return [$IPv4, $IPv6];
+    }
+
+    private static function performUpdate(string $path, string $url)
+    {
+        try {
+            $httpClient = HttpClient::create();
+            $response = $httpClient->request('GET', $url);
+            if ($response->getStatusCode() === 200) {
+                file_put_contents($path, $response->getContent());
+            } else {
+                error_log("Got a " . $response->getStatusCode() . ' status code when attempting to download ' . $url);
+            }
+        } catch (\Exception $e) {
+            error_log("There was an error while updating one of the IP address databases: " . $e->getMessage());
+        }
+    }
+}

--- a/src/library/FOSSBilling/IPDatabase.php
+++ b/src/library/FOSSBilling/IPDatabase.php
@@ -121,8 +121,7 @@ final class IPDatabase
         if (defined('IPv4DB') && !$defaults) {
             $IPv4 = Path::canonicalize(IPv4DB);
         } else {
-            //$IPv4 = Path::normalize(PATH_LIBRARY . '/IPv4.mmdb');
-            $IPv4 = Path::normalize(PATH_LIBRARY . '/GeoLite2-Country.mmdb');
+            $IPv4 = Path::normalize(PATH_LIBRARY . '/IPv4.mmdb');
         }
 
         if (defined('IPv6DB')  && !$defaults) {

--- a/src/library/FOSSBilling/IPDatabase.php
+++ b/src/library/FOSSBilling/IPDatabase.php
@@ -23,8 +23,8 @@ final class IPDatabase
     public const IPvUnknown = 0;
 
     /**
-     * FOSSBilling uses databases that are licenced under the public domain (CC0 and PDDL).
-     * This is done to ensure that we have good enough data out of the box that's updated regularly and that can be used without a concern of licencing. 
+     * FOSSBilling uses databases that are licensed under the public domain (CC0 and PDDL).
+     * This is done to ensure that we have good enough data out of the box that's updated regularly and that can be used without a concern of licensing. 
      * Below are the download URLs for both the IPv4 and IPv6 DBs we utilize.
      * Both include ASN and Country information. 
      */
@@ -51,7 +51,6 @@ final class IPDatabase
         }
 
         [$IPv4, $IPv6] = self::getPaths();
-        error_log("$IPv4, $IPv6");
 
         switch ($type) {
             case self::IPv4:

--- a/src/library/FOSSBilling/IPDatabase.php
+++ b/src/library/FOSSBilling/IPDatabase.php
@@ -44,7 +44,7 @@ final class IPDatabase
             return;
         }
 
-        $localDb = self::getPath(true);
+        $localDb = self::getPath(false, true);
         if (file_exists($localDb)) {
             $dbAge = time() - filemtime($localDb);
         } else {
@@ -78,7 +78,8 @@ final class IPDatabase
     /**
      * Returns the correct path for the actively used database.
      * 
-     * @param bool $defaults Set to true to only have the default DB paths returned. 
+     * @param bool $default set to true to only have the default DB paths returned
+     * @param bool $skipUpdate set to true to have the system skip trying to call our updater do download the DB if it doesn't exist 
      */
     public static function getPath(bool $default = false, bool $skipUpdate = false): string
     {
@@ -94,7 +95,7 @@ final class IPDatabase
             $path = self::defaultDBPath;
         }
 
-        if (file_exists(self::customDBDownloadedPath) && !$skipUpdate) {
+        if (!file_exists(self::customDBDownloadedPath) && !$skipUpdate) {
             self::update();
         }
 

--- a/src/library/FOSSBilling/IPDatabase.php
+++ b/src/library/FOSSBilling/IPDatabase.php
@@ -40,6 +40,7 @@ final class IPDatabase
      */
     public static function update()
     {
+        $custom_path = Config::getProperty('ip_database.custom_path', '');
         if (!empty($custom_path)) {
             return;
         }
@@ -101,7 +102,7 @@ final class IPDatabase
 
         return $path;
     }
-    public function getDownloadUrl(bool $default = false)
+    public static function getDownloadUrl(bool $default = false)
     {
         $custom_url = Config::getProperty('ip_database.custom_url', '');
         if (!$default && !empty($custom_url)) {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -82,6 +82,13 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['info']['instance_id'] ??= Uuid::uuid4()->toString();
         $newConfig['info']['salt'] ??= $newConfig['salt'];
 
+        $newConfig['IPDatabase'] ??= [
+            'customIPv4' => '',
+            'includedIPv4' => [],
+            'customIPv6' => '',
+            'includedIPv6' => [],
+        ];
+
         // Remove depreciated config keys/subkeys.
         $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone', 'sef_urls', 'salt', 'path_logs', 'log_to_db'];
         $depreciatedConfigSubkeys = [

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -82,11 +82,10 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['info']['instance_id'] ??= Uuid::uuid4()->toString();
         $newConfig['info']['salt'] ??= $newConfig['salt'];
 
-        $newConfig['IPDatabase'] ??= [
-            'customIPv4' => '',
-            'includedIPv4' => [],
-            'customIPv6' => '',
-            'includedIPv6' => [],
+        $newConfig['ip_database'] ??= [
+            'custom_path'   => '',
+            'custom_url'    => '',
+            'included_data' => [],
         ];
 
         // Remove depreciated config keys/subkeys.

--- a/src/load.php
+++ b/src/load.php
@@ -253,16 +253,6 @@ define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
 define('SYSTEM_URL', Config::getProperty('url'));
 define('INSTANCE_ID', Config::getProperty('info.instance_id', 'Unknown'));
 
-if (!empty($config['IPDatabase']['customIPv4']) && isset($config['IPDatabase']['includedIPv4'])) {
-    define('IPv4DB', $config['IPDatabase']['customIPv4']);
-    define('includedIPv4', $config['IPDatabase']['includedIPv4']);
-}
-
-if (!empty($config['IPDatabase']['customIPv6']) && isset($config['IPDatabase']['includedIPv6'])) {
-    define('IPv6DB', $config['IPDatabase']['customIPv6']);
-    define('includedIPv6', $config['IPDatabase']['includedIPv6']);
-}
-
 // Initial setup and checks passed, now we setup our custom autoloader.
 require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'Autoloader.php';
 $loader = new FOSSBilling\AutoLoader();

--- a/src/load.php
+++ b/src/load.php
@@ -253,6 +253,16 @@ define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
 define('SYSTEM_URL', Config::getProperty('url'));
 define('INSTANCE_ID', Config::getProperty('info.instance_id', 'Unknown'));
 
+if (!empty($config['IPDatabase']['customIPv4']) && isset($config['IPDatabase']['includedIPv4'])) {
+    define('IPv4DB', $config['IPDatabase']['customIPv4']);
+    define('includedIPv4', $config['IPDatabase']['includedIPv4']);
+}
+
+if (!empty($config['IPDatabase']['customIPv6']) && isset($config['IPDatabase']['includedIPv6'])) {
+    define('IPv6DB', $config['IPDatabase']['customIPv6']);
+    define('includedIPv6', $config['IPDatabase']['includedIPv6']);
+}
+
 // Initial setup and checks passed, now we setup our custom autoloader.
 require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR . 'Autoloader.php';
 $loader = new FOSSBilling\AutoLoader();

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1713,6 +1713,9 @@ class Service
             if ($cache->prune()) {
                 $di['logger']->setChannel('cron')->info('Pruned the filesystem cache');
             }
+
+            // Update the IP address database
+            \FOSSBilling\IPDatabase::update();
         } catch (\Exception $e) {
             error_log($e->getMessage());
         }


### PR DESCRIPTION
Draft while a WIP.
Closes #1922 and relates to #1678.

Replaces the existing MaxMind database which is outdated and not correctly attributed with ones that are built automatically and are available under the public domain while also generally expanding the functionality of it.

## Database choice
There's quite a few [different variants](https://github.com/HostByBelle/IP-Geolocation-DB#variants) of databases available we can use (possibly another in the near future). The one I have chosen gives us both Country and ASN data, which means we can both display the country associated with an IP address as well as what organization that IP address is associated with.

The MaxMind database only included country data, so we technically have more info available to us with this choice, although I would assume that data is otherwise a bit less accurate.

## Enhancements
 - Automatic & daily updating of the database.
 - The ability to override the database in use via the config file.
 - Others to come as it's still WIP.