### PR TITLE
4 bugfixes

### DIFF
--- a/src/install/install.php
+++ b/src/install/install.php
@@ -64,7 +64,7 @@ $current_url = pathinfo($url, PATHINFO_DIRNAME);
 $root_url = str_replace('/install', '', $current_url) . '/';
 define('SYSTEM_URL', $root_url);
 const URL_INSTALL = SYSTEM_URL . 'install/';
-const URL_ADMIN = SYSTEM_URL . 'index.php?_url=/admin';
+const URL_ADMIN = SYSTEM_URL . 'admin';
 
 // Load action and initialize the installer
 $action = $_GET['a'] ?? 'index';

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -315,7 +315,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','38',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','39',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/content_test.sql
+++ b/src/install/sql/content_test.sql
@@ -480,7 +480,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','38',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','39',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','FOSSBilling demo',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','demo@fossbilling.org',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -359,6 +359,14 @@ class UpdatePatcher implements InjectionAwareInterface
                     PATH_LIBRARY . DIRECTORY_SEPARATOR . 'Server' . DIRECTORY_SEPARATOR . 'Manager' . DIRECTORY_SEPARATOR . 'Virtualmin.php' => 'unlink',
                 ];
                 $this->executeFileActions($fileActions);
+            },
+            39 => function () {
+                // The Serbian language was incorrectly placed into a folder named `srp` by Crowdin which is now corrected for via the locale repo and as such we need to delete the old directory.
+                // @see https://github.com/FOSSBilling/locale/issues/212 
+                $fileActions = [
+                    PATH_LANGS . DIRECTORY_SEPARATOR . 'srp' => 'unlink',
+                ];
+                $this->executeFileActions($fileActions);
             }
         ];
         ksort($patches, SORT_NATURAL);

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -183,7 +183,7 @@ class Service implements InjectionAwareInterface
             throw new \FOSSBilling\InformationException('Invalid per page number');
         }
 
-        [$sql, $params] = $this->getSearchQuery($data, "SELECT c.id, IF(c.company <> '', CONCAT(c.first_name, ' ', c.last_name, ' (', c.company, ')'), CONCAT(c.first_name, ' ', c.last_name)) as client");
+        [$sql, $params] = $this->getSearchQuery($data, "SELECT c.id, IF(c.company <> '', CONCAT_WS(' ', c.first_name, c.last_name, ' (', c.company, ')'), CONCAT_WS(' ', c.first_name, c.last_name)) as client");
         $sql .= sprintf(' LIMIT %u', $limit);
 
         return $this->di['db']->getAssoc($sql, $params);

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_order_form.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_order_form.html.twig
@@ -118,6 +118,7 @@
         });
 
         $('#config-next').hide();
+        $( "#config-next" ).prop( "disabled", true );
 
         if ($(".addons").length) {
             $('.order-button').one('click', function () {
@@ -138,6 +139,7 @@
         $('#transfer-check').on('click', function (event) {
             var sld = $('input[name="transfer_sld"]').val();
             var tld = $('select[name="transfer_tld"]').val();
+            $('#domain-action').val('transfer');
             var domain = sld + tld;
 
             bb.post(
@@ -161,6 +163,7 @@
             sld = sld.toLowerCase();
             var tld = $('select[name="register_tld"]').val();
             var domain = sld + tld;
+            $('#domain-action').val('register');
             bb.post(
                 'guest/servicedomain/check',
                 {sld: sld, tld: tld},
@@ -189,6 +192,7 @@
                         s.append(new Option(i + "{{ ' Year/s @ '|trans }}" + price, i));
                     }
                     $('#config-next').show();
+                    $( "#config-next" ).prop( "disabled", false );
                 }
             );
         }
@@ -199,9 +203,9 @@
                 {tld: tld},
                 function (result) {
                     var price = bb.currency(result.price_transfer, {{ currency.conversion_rate }}, "{{ currency.code }}");
-
                     $('#transfer-price').text(price);
                     $('#config-next').show();
+                    $( "#config-next" ).prop( "disabled", false );
                 }
             );
         }


### PR DESCRIPTION
Resolves the following issues:

1. The client search would display `null` for a client which didn't have both a first and a last name.
2. The `action` parameter wasn't being updated when ordering a domain, making it impossible to perform a domain transfer from the order screen.
3. Now that https://github.com/FOSSBilling/locale/issues/212 is resolved, I've added a patch to auto-delete the old folder name to prevent duplicates / leftovers.
4. Updated the URL given after installing. Closes #1951