### PR TITLE
Fix password confirmation field in order form

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -132,7 +132,7 @@
                             <div class="row">
                                 <div class="col-md-7 mb-3">
                                     <label for="password-confirm" class="visually-hidden">{{ 'Confirm password'|trans }}</label>
-                                    <input class="form-control form-control-sm" type="password" name="password-confirm" id="password-confirm"
+                                    <input class="form-control form-control-sm" type="password" name="password_confirm" id="password-confirm"
                                            required="required"
                                            placeholder="{{ 'Confirm password'|trans }}">
                                 </div>


### PR DESCRIPTION
Fix: #1982 

During the migration of Huraga to Bootstrap 4 (#1602), it appears that the name of the password confirmation field in the order form was accidentally changed from `password_confirm` to `password-confirm`. This may have occured because, prior to the migration, the input field wrongly contained two name fields: https://github.com/FOSSBilling/FOSSBilling/blob/dfcabdd80becae87210e90d8fc162d729650e07e/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig#L118

The ``create`` function in https://github.com/FOSSBilling/FOSSBilling/blob/be36d68f61a5d405e5f43a290290058e4a3956e9/src/modules/Client/Api/Guest.php currently expects the `name` parameter to be named `password_confirm`, as can be seen in line 66:
https://github.com/FOSSBilling/FOSSBilling/blob/be36d68f61a5d405e5f43a290290058e4a3956e9/src/modules/Client/Api/Guest.php#L66

Changing the ``name`` property back to ``password_confirm`` should be all that's needed.

