### PR TITLE
Update CI and release workflow to fix Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       contents: read
     needs: [ preview-build ]
     if: ${{ github.ref == 'refs/heads/main' }}
-    uses: FOSSBilling/.workflows/.github/workflows/docker-build-push.yml@fa4a4a4882e1ac5a78980aa2dc852b2879cd9d54
+    uses: FOSSBilling/.workflows/.github/workflows/docker-build-push.yml@8cdd61a976263ca52e1d53580c4d421d5f518369
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -47,7 +47,7 @@ jobs:
     permissions: 
       contents: read
     needs: [ release-build, check-latest ]
-    uses: FOSSBilling/.workflows/.github/workflows/docker-build-push.yml@fa4a4a4882e1ac5a78980aa2dc852b2879cd9d54
+    uses: FOSSBilling/.workflows/.github/workflows/docker-build-push.yml@8cdd61a976263ca52e1d53580c4d421d5f518369
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Due to changes in actions/upload-artifact@v4, the preview and release Docker builds were broken - this works around the new limitations in the action. Resolves #1987.