### PR TITLE
Increase WHM server manager HTTP client timeout

### DIFF
--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -389,7 +389,7 @@ class Server_Manager_Whm extends Server_Manager
         $client = $this->getHttpClient()->withOptions([
             'verify_peer'   => false,
             'verify_host'   => false,
-            'timeout'       => 30
+            'timeout'       => 90 // Account creation can timeout if set too low - see #1086.
         ]);
 
         $url =  ($this->_config['secure'] ? 'https' : 'http') . '://' . $this->_config['host'] . ':' . $this->_config['port'] . '/json-api/' . $action;


### PR DESCRIPTION
Increase WHM server manager HTTP client timeout to fix potential error when creating accounts. Resolves #1086.

This has been set to 90 seconds (3x current limit), which should be more than enough. However, if issues persist then it may be necessary to increase this further, though going much higher should be avoided. Longer term, such API calls should likely be executed in the background (perhaps by cron or some other method?) wherein a longer timeout could be acceptable. 