### PR TITLE
Improved logging functionality

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -114,8 +114,6 @@ return [
      */
     'path_data' => __DIR__ . '/data',
 
-    'log_to_db' => true,
-
     'db' => [
         /*
          * Database type. Don't change this if in doubt.

--- a/src/di.php
+++ b/src/di.php
@@ -50,25 +50,20 @@ $di['logger'] = function () use ($di) {
     $log = new Box_Log();
     $log->setDi($di);
 
-    $log_to_db = isset($di['config']['log_to_db']) && $di['config']['log_to_db'];
+    $activity_service = $di['mod_service']('activity');
+    $dbWriter = new Box_LogDb($activity_service);
+    $log->addWriter($dbWriter);
 
-    if ($log_to_db) {
-        $activity_service = $di['mod_service']('activity');
-        $writer2 = new Box_LogDb($activity_service);
-
-        if ($di['auth']->isAdminLoggedIn()) {
-            $admin = $di['loggedin_admin'];
-            $log->setEventItem('admin_id', $admin->id);
-        } elseif ($di['auth']->isClientLoggedIn()) {
-            $client = $di['loggedin_client'];
-            $log->setEventItem('client_id', $client->id);
-        }
-
-        $log->addWriter($writer2);
-    } else {
-        $monolog = new \FOSSBilling\Monolog();
-        $log->addWriter($monolog);
+    if ($di['auth']->isAdminLoggedIn()) {
+        $admin = $di['loggedin_admin'];
+        $log->setEventItem('admin_id', $admin->id);
+    } elseif ($di['auth']->isClientLoggedIn()) {
+        $client = $di['loggedin_client'];
+        $log->setEventItem('client_id', $client->id);
     }
+
+    $monolog = new \FOSSBilling\Monolog();
+    $log->addWriter($monolog);
 
     return $log;
 };

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -87,7 +87,7 @@ class Box_App
 
     public function show404(Exception $e)
     {
-        error_log($e->getMessage());
+        $this->di['logger']->setChannel('routing')->info($e->getMessage());   
         http_response_code(404);
 
         return $this->render('error', ['exception' => $e]);

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -68,7 +68,7 @@ class Box_AppClient extends Box_App
         }
         $e = new \FOSSBilling\InformationException('Page :url not found', [':url' => $this->url], 404);
 
-        error_log($e->getMessage());
+        $this->di['logger']->setChannel('routing')->info($e->getMessage());
         http_response_code(404);
 
         return $this->render('error', ['exception' => $e]);
@@ -82,7 +82,7 @@ class Box_AppClient extends Box_App
         try {
             $template = $this->getTwig()->load($fileName . '.' . $ext);
         } catch (Twig\Error\LoaderError $e) {
-            error_log($e->getMessage());
+            $this->di['logger']->setChannel('routing')->info($e->getMessage());
             http_response_code(404);
             throw new \FOSSBilling\InformationException('Page not found', null, 404);
         }

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -20,14 +20,14 @@
  */
 class Box_Log implements \FOSSBilling\InjectionAwareInterface
 {
-    final public const EMERG = 0;  // Emergency: system is unusable
-    final public const ALERT = 1;  // Alert: action must be taken immediately
-    final public const CRIT = 2;  // Critical: critical conditions
-    final public const ERR = 3;  // Error: error conditions
-    final public const WARN = 4;  // Warning: warning conditions
-    final public const NOTICE = 5;  // Notice: normal but significant condition
-    final public const INFO = 6;  // Informational: informational messages
-    final public const DEBUG = 7;  // Debug: debug messages
+    final public const EMERG  = 0; // Emergency: system is unusable
+    final public const ALERT  = 1; // Alert: action must be taken immediately
+    final public const CRIT   = 2; // Critical: critical conditions
+    final public const ERR    = 3; // Error: error conditions
+    final public const WARN   = 4; // Warning: warning conditions
+    final public const NOTICE = 5; // Notice: normal but significant condition
+    final public const INFO   = 6; // Informational: informational messages
+    final public const DEBUG  = 7; // Debug: debug messages
 
     protected array $_priorities = [
         self::EMERG => 'EMERG',

--- a/src/library/Box/LogDb.php
+++ b/src/library/Box/LogDb.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -10,6 +11,7 @@
 
 class Box_LogDb
 {
+    private array $ignoredChannels = ['billing', 'routing'];
     /**
      * Class constructor
      *
@@ -27,6 +29,11 @@ class Box_LogDb
      */
     public function write(array $event, string $channel = 'application'): void
     {
+        // TOOD: Temporary! Redo logging stuff in more depth for a major release.
+        if (in_array($channel, $this->ignoredChannels)) {
+            return;
+        }
+
         try {
             if (method_exists($this->service, 'logEvent')) {
                 $this->service->logEvent($event);
@@ -35,5 +42,4 @@ class Box_LogDb
             error_log($e);
         }
     }
-
 }

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -13,21 +15,25 @@ namespace FOSSBilling;
 use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
+use Monolog\Handler\RotatingFileHandler;
+use Symfony\Component\Filesystem\Path;
 
 class Monolog
 {
     protected $logger = null;
-    public string $dateFormat = "d-M-Y H:i:s e";
+    public string $dateFormat = 'd-M-Y H:i:s e';
     public string $outputFormat = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
 
     public array $channels = [
-        "application",
-        "cron",
-        "database",
-        "license",
-        "mail",
-        "event"
+        'activity',
+        'application',
+        'cron',
+        'database',
+        'license',
+        'mail',
+        'event',
+        'routing',
+        'billing'
     ];
 
     public function __construct()
@@ -36,11 +42,11 @@ class Monolog
 
         foreach ($channels as $channel) {
 
-            $path = PATH_LOG . DIRECTORY_SEPARATOR . $channel . '.log';
+            $path = Path::normalize(PATH_LOG . "/$channel/" . $channel . '.log');
 
             $this->logger[$channel] = new Logger($channel);
-            $stream = new StreamHandler($path, Level::Debug);
-            $this->logger[$channel]->pushHandler($stream);
+            $rotatingHandler = new RotatingFileHandler($path, 90, Level::Debug);
+            $this->logger[$channel]->pushHandler($rotatingHandler);
 
             $formatter = new LineFormatter($this->outputFormat, $this->dateFormat, true, true, true);
             $this->logger[$channel]->getHandlers()[0]->setFormatter($formatter);
@@ -64,14 +70,14 @@ class Monolog
     {
         // Map numeric priority to Monolog priority
         $map = [
-            \Box_Log::EMERG => Level::Emergency->value,
-            \Box_Log::ALERT => Level::Alert->value,
-            \Box_Log::CRIT => Level::Critical->value,
-            \Box_Log::ERR => Level::Error->value,
-            \Box_Log::WARN => Level::Warning->value,
+            \Box_Log::EMERG  => Level::Emergency->value,
+            \Box_Log::ALERT  => Level::Alert->value,
+            \Box_Log::CRIT   => Level::Critical->value,
+            \Box_Log::ERR    => Level::Error->value,
+            \Box_Log::WARN   => Level::Warning->value,
             \Box_Log::NOTICE => Level::Notice->value,
-            \Box_Log::INFO => Level::Info->value,
-            \Box_Log::DEBUG => Level::Debug->value,
+            \Box_Log::INFO   => Level::Info->value,
+            \Box_Log::DEBUG  => Level::Debug->value,
         ];
 
         return $map[$priority] ?? Level::Debug->value;

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -85,7 +85,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['info']['salt'] ??= $newConfig['salt'];
 
         // Remove depreciated config keys/subkeys.
-        $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone', 'sef_urls', 'salt', 'path_logs'];
+        $depreciatedConfigKeys = ['guzzle', 'locale', 'locale_date_format', 'locale_time_format', 'timezone', 'sef_urls', 'salt', 'path_logs', 'log_to_db'];
         $depreciatedConfigSubkeys = [
             'security' => 'cookie_lifespan',
         ];

--- a/src/library/Model/ActivityClientHistoryTable.php
+++ b/src/library/Model/ActivityClientHistoryTable.php
@@ -33,14 +33,14 @@ class Model_ActivityClientHistoryTable implements \FOSSBilling\InjectionAwareInt
 
         $extensionService = $this->di['mod_service']('extension');
         if ($extensionService->isExtensionActive('mod', 'demo')) {
-        $ip = null;
+            $ip = null;
         } else {
-        $ip = $data['ip'];
+            $ip = $data['ip'];
         }
 
         $entry = $this->di['db']->dispense('ActivityClientHistory');
         $entry->client_id       = $data['client_id'];
-        $entry->ip              = $data['ip'];
+        $entry->ip              = $ip;
         $entry->created_at      = date('Y-m-d H:i:s');
         $entry->updated_at      = date('Y-m-d H:i:s');
         $this->di['db']->store($entry);

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -561,7 +561,7 @@ class Service implements InjectionAwareInterface
 
         if (abs($balance - $required) < $epsilon) {
             if (DEBUG) {
-                error_log(sprintf('Setting invoice %s as paid with credits', $invoice->id));
+                $this->di['logger']->setChannel('billing')->info(sprintf('Setting invoice %s as paid with credits', $invoice->id));
             }
             $this->markAsPaid($invoice);
 
@@ -570,14 +570,14 @@ class Service implements InjectionAwareInterface
 
         if ($balance - $required > 0.00001) {
             if (DEBUG) {
-                error_log(sprintf('Setting invoice %s as paid with credits', $invoice->id));
+                $this->di['logger']->setChannel('billing')->info(sprintf('Setting invoice %s as paid with credits', $invoice->id));
             }
             $this->markAsPaid($invoice);
 
             return true;
         }
         if (DEBUG) {
-            error_log(sprintf('Invoice %s could not be paid with credits. Money in balance %s Required: %s', $invoice->id, $balance, $required));
+            $this->di['logger']->setChannel('billing')->info(sprintf('Invoice %s could not be paid with credits. Money in balance %s Required: %s', $invoice->id, $balance, $required));
         }
     }
 


### PR DESCRIPTION
This pull request improves our usage of logging with the following changes;

1. For simplicity going forward, the `log_to_db` option has been removed. Further refactoring will be done to this area of logging at later date as part of a major update.
2. Because `log_to_db` is no longer an option, monolog is now properly enabled at all times.
3. Enabled error rotation for monolog and changed the folder structure. Channels now get their own folder and logs are per-day and will be retained for 90 days (should probably respect the configured age once #1673 is done)
4. Some of the more spammy error log statements have been turned into their own channels.

These changes will help keep things better organized overall and make finding relevant info easier.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/32b0bae4-3d2a-4bd9-8c6d-fa7bc72f7b99)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/b553927e-c143-4100-b7b1-6746263fe4aa)

