### PR TITLE
Fixed missing api-form class on order page registration form

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -49,7 +49,7 @@
                         </form>
                     </div>
                     <div class="tab-pane" id="sign-up" role="tabpanel" aria-labelledby="up-tab" tabindex="0">
-                        <form action="{{ 'api/guest/client/create'|link }}" method="post" data-api-jsonp="onAccountCreate">
+                        <form class="api-form" action="{{ 'api/guest/client/create'|link }}" method="post" data-api-jsonp="onAccountCreate">
                             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             {% set r = guest.client_required %}
                             <div class="row">


### PR DESCRIPTION
This class was missing from the registration form on the order screen, causing the browser to display the API calls result directly in the browser rather than properly passing it onto the `onAccountCreate` function