### PR TITLE
Smaller fixes

### DIFF
--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -280,12 +282,12 @@ class Tools
      * In a production environment, this will both check that the email address matches RFC standards as well as validating the domain.
      * In a testing / development environment it will only check the RFC standards.
      */
-    public function validateAndSanitizeEmail(string $email, bool $throw = true)
+    public function validateAndSanitizeEmail(string $email, bool $throw = true, bool $checkDNS = true)
     {
         $email = htmlspecialchars($email);
 
         $validator = new EmailValidator();
-        if (Environment::isProduction()) {
+        if (Environment::isProduction() && $checkDNS) {
             $validations = new MultipleValidationWithAnd([
                 new RFCValidation(),
                 new DNSCheckValidation()

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -115,7 +115,7 @@ class Guest extends \Api_Abstract
             'password' => 'Password required',
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
-        $this->di['tools']->validateAndSanitizeEmail($data['email']);
+        $this->di['tools']->validateAndSanitizeEmail($data['email'], true, false);
 
         $event_params = $data;
         $event_params['ip'] = $this->ip;

--- a/src/modules/Invoice/pdf_template/default-pdf.twig
+++ b/src/modules/Invoice/pdf_template/default-pdf.twig
@@ -4,6 +4,14 @@
 	{% set top = 325 + (25 * seller_lines) %}
 {% endif %}
 
+{% set address_lines = [] %}
+	{% for line in [footer.address_1, footer.address_2, footer.address_3] %}
+		{% if line|length > 0 %}
+			{% set address_lines = address_lines|merge([line]) %}
+		{% endif %}
+	{% endfor %}
+{% set address = address_lines|join(',') %}
+
 <!DOCTYPE html>
 <html>
 	<head>
@@ -91,12 +99,18 @@
 		<p>{{ footer.signature }}</p>
 		</div>
 		<div class='InvoiceFooter'>
-		{% if footer.display_bank_info == 1 %}
-			<b>{{ 'Payment details'|trans }}:</b><br >
-			<b>{{ 'Account Owner'|trans }}:</b> {{ footer.company_name }} | <b>{{ 'Bank'|trans }}:</b> {{ footer.bank_name }} | <b>{{ 'BIC / SWIFT Code'|trans }}:</b> {{ footer.bic }} | <b>{{ 'Account number'|trans }}:</b> {{ footer.account_number }}<br><br>
-		{% endif %}
-		<b>{{ footer.company_name }}</b> {{ footer.address_1 }}, {{ footer.address_2 }}, {{ footer.address_3 }} <br ><b>{{ 'Email'|trans }}:</b> {{ footer.email }} | <b>{{ 'Phone'|trans }}:</b> {{ footer.phone }}<br>
-		{% if footer.company_vat %}<b>{{ 'VAT ID'|trans }}:</b> {{ footer.company_vat }} | {% endif %} {% if footer.company_number %} <b>{{ 'Company Registration #:'|trans }}</b> {{ footer.company_number }} | {% endif %} <b>{{ 'Website'|trans }}: </b>{{ footer.www }}
+			{% if footer.display_bank_info == 1 %}
+				<b>{{ 'Payment details'|trans }}:</b><br >
+				<b>{{ 'Account Owner'|trans }}:</b> {{ footer.company_name }} | <b>{{ 'Bank'|trans }}:</b> {{ footer.bank_name }} | <b>{{ 'BIC / SWIFT Code'|trans }}:</b> {{ footer.bic }} | <b>{{ 'Account number'|trans }}:</b> {{ footer.account_number }}<br><br>
+			{% endif %}
+
+			<b>{{ footer.company_name }}</b>
+			{% if address %} {{ address }} <br> {% endif %}
+			<b>{{ 'Email'|trans }}:</b> {{ footer.email }} | <b>
+			{% if footer.phone %} {{ 'Phone'|trans }}:</b> {{ footer.phone }}<br> {% endif %}
+			{% if footer.company_vat %} <b>{{ 'VAT ID'|trans }}:</b> {{ footer.company_vat }} | {% endif %}
+			{% if footer.company_number %} <b>{{ 'Company Registration #:'|trans }}</b> {{ footer.company_number }} | {% endif %}
+			<b>{{ 'Website'|trans }}: </b>{{ footer.www }}
 		</div>
 	</body>
 </html>

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -66,7 +66,7 @@ class Guest extends \Api_Abstract
         ];
         $validator = $this->di['validator'];
         $validator->checkRequiredParamsForArray($required, $data);
-        $data['email'] = $this->di['tools']->validateAndSanitizeEmail($data['email']);
+        $data['email'] = $this->di['tools']->validateAndSanitizeEmail($data['email'], true, false);
 
         $config = $this->getMod()->getConfig();
 


### PR DESCRIPTION
1. Disables the DNS validation check for emails when logging in as otherwise that check may prevent someone from logging in and updating their email address in the event that their domain is changed / an email service is shutdown.
2. Modifies the PDF template to hide fields for more items that are unset. Closes #1998. Also replaced a sloppy portion of the footer which would display extra commas for companies which did not have 3 address lines.

## PDF Footer Before
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/e55b91a9-7aba-419d-a2dd-c34777f6f1ee)

## PDF Footer After
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/f18510aa-6e43-4a71-854b-308c5e03ceb0)
