### PR TITLE
Fix product configuration page

### DIFF
--- a/src/modules/Order/html_client/mod_order_product.html.twig
+++ b/src/modules/Order/html_client/mod_order_product.html.twig
@@ -13,16 +13,13 @@
 {% block content %}
 <div class="row">
     <div class="col-md-12">
-
         <div class="card">
             <div class="card-header">
                 <h2>{{ 'Select Product'|trans }}</h2>
                 <p>{{ 'Choose products we offer for selling'|trans }}</p>
             </div>
-                <section>
-                    <img id="loader-image" src="{{ loader_url|mod_asset_url('orderbutton') }}" style="display: block; margin-left: auto; margin-right: auto; position: relative; top: 50%"  alt="Loader"/>
-                    <iframe style="width: 100%;" frameborder="0" allowtransparency="true" onload="resizeIframe(this);" src="{{ 'orderbutton'|link }}&theme_color={{ settings.color_scheme|default('green') }}{% if product %}&order={{ product.id }}{% endif %}{% if request.show_custom_form_values %}&show_custom_form_values=1{% endif %}&loader=3" id="popup-iframe"></iframe>
-                </section>
+            <div class="card-body overflow-hidden">
+                {% include 'mod_orderbutton_index.html.twig' %}
             </div>
         </div>
     </div>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_currency.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_currency.html.twig
@@ -2,7 +2,7 @@
 
 {% if currencies|length > 1 %}
         <label for="currency" class="mt-2">
-            <select id="currency" name="currency" class="currency_selector form-select">
+            <select id="currency" name="currency" class="currency_selector form-select ms-2">
                 {% set selected = guest.cart_get_currency.code %}
                 {% for code,title in currencies %}
                 <option value="{{ code }}" class="currency_{{ code }}"{% if code == selected %} selected="selected"{% endif %}>{{ code }} - {{ title }}</option>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
@@ -39,7 +39,6 @@
                     </div>
 
                 </div>
-                {% include 'mod_orderbutton_currency.html.twig' %}
                 {% if guest.extension_is_on({"mod":'branding'}) %}
                     <div class="d-flex justify-content-center small text-muted pt-3 pb-2">
                         <span>{{ 'Powered by'|trans }}</span>&nbsp;<a href="https://fossbilling.org"

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -1,4 +1,6 @@
-{% set product = request.product ? guest.product_get({"id":request.product}) : null %}
+{% if not product %}
+    {% set product = request.product ? guest.product_get({"id":request.product}) : null %}
+{% endif %}
 <div class="accordion-item">
     <h2 class="accordion-header">
         <button class="accordion-button {% if not product %}collapsed{%endif%}" type="button" data-bs-toggle="collapse" data-bs-target="#order" aria-expanded="true" aria-controls="order">


### PR DESCRIPTION
Fix: #1993

---

``src/modules/Order/html_client/mod_order_product.html.twig``:
Replace iframes with Twig include as done [in the migration to Bootstrap 5 in #1612](https://github.com/FOSSBilling/FOSSBilling/pull/1612/commits/5454f17bd46974a19fcb7afd0bb0472fe09616b5). 

Previously, the template was trying to load an iframe with the old configuration (more specifically, using the ``order`` parameter for the product ID which has been replaced with ``product``), and failing to load properly as a result.

---

``src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig``:
Check if the ``product`` variable has already been set before setting it to a value that has been passed as a query parameter.

Currently, the following configuration is set in place:
https://github.com/FOSSBilling/FOSSBilling/blob/e4b871d2597d95b8d103a8a5e94f3db2915db212/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig#L1

A ``product`` query parameter is expected to be always supplied, setting the ``product`` variable to its value or ``null`` if it is not provided. This overrides the ``product`` variable the render calls of ``get_configure_product_by_slug`` and ``get_configure_product`` pass to the template in [Order/Controller/Client.php](https://github.com/FOSSBilling/FOSSBilling/blob/fefbcd21b0ff9e7ea04c5f0b9b1d12d215f20c5e/src/modules/Order/Controller/Client.php), and causes them to "fail" (not select the product) as a result.

I have added a condition that sets ``product`` from the query parameter only if it does not already hold a value.  

---

The following URL structures have been tested to work as intended with the proposed changes:
* domain/order?product=ID
* domain/order/ID
* domain/order/slug