### PR TITLE
Fix knowledge base search

### DIFF
--- a/src/modules/Support/html_client/mod_support_kb_index.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_index.html.twig
@@ -33,7 +33,7 @@
                         </div>
                         <form method="get" action="" class="form-inline">
                             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
-                            <input name="_url" type="hidden" value="/kb">
+                            <input name="_url" type="hidden" value="/support/kb">
                             <div class="input-group">
                                 <input class="form-control" name="q" type="text" value="{{ request.q }}" placeholder="{{ 'What are you looking for?'|trans }}">
                                 <button class="btn btn-outline-secondary" type="submit">


### PR DESCRIPTION
The ``_url`` field in the search form had not been updated to account for the merge in #1180 and as a result the search form was trying to load the old "/kb" page and failing, it is now updated with the new location. 