### PR TITLE
Added support for per-theme default markdown attributes

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -47,9 +47,11 @@ if ($url === '/run-patcher') {
 $di['session'];
 
 if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
+    define("ADMIN_AREA", true);
     $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));
     $app = new Box_AppAdmin([], $debugBar);
 } else {
+    define("ADMIN_AREA", false);
     $appUrl = $url;
     $app = new Box_AppClient([], $debugBar);
 }

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -54,13 +54,6 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% if is_subfolder %}
-                        <tr>
-                            <td>Subfolder detection</td>
-                            <td class="red">FAIL</td>
-                            <td>FOSSBilling does not support installing in a subfolder. Please move the application to your host document root. Refer to the <a href='https://fossbilling.org/docs/troubleshooting#subfolder-installations' data-tooltip="Opens in a new tab." target='_blank'>troubleshooting documentation</a> for more information.</td>
-                        </tr>
-                    {% endif %}
                     <tr>
                         <td>Operating system</td>
                         <td class="{{ os_ok ? 'green' : 'orange'}}">{{ os }}</td>

--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -54,6 +54,13 @@
                     </tr>
                 </thead>
                 <tbody>
+                    {% if is_subfolder %}
+                        <tr>
+                            <td>Subfolder detection</td>
+                            <td class="red">FAIL</td>
+                            <td>FOSSBilling does not support installing in a subfolder. Please move the application to your host document root. Refer to the <a href='https://fossbilling.org/docs/troubleshooting#subfolder-installations' data-tooltip="Opens in a new tab." target='_blank'>troubleshooting documentation</a> for more information.</td>
+                        </tr>
+                    {% endif %}
                     <tr>
                         <td>Operating system</td>
                         <td class="{{ os_ok ? 'green' : 'orange'}}">{{ os }}</td>

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -61,9 +61,9 @@ $loader->register();
 $protocol = FOSSBilling\Tools::isHTTPS() ? 'https' : 'http';
 
 // Detect if FOSSBilling is behind a proxy server
-if(!empty($_SERVER['HTTP_X_FORWARDED_HOST'])){
+if (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
     $host = $_SERVER['HTTP_X_FORWARDED_HOST'];
-}else{
+} else {
     $host = $_SERVER['HTTP_HOST'];
 }
 
@@ -181,8 +181,9 @@ final class FOSSBilling_Installer
                     'compatibility' => $compatibility,
                     'os' => PHP_OS,
                     'os_ok' => (str_starts_with(strtoupper(PHP_OS), 'WIN')) ? false : true,
+                    'is_subfolder' => $this->isSubfolder(),
                     'fossbilling_ver' => \FOSSBilling\Version::VERSION,
-                    'canInstall' => $compatibility['can_install'],
+                    'canInstall' => !$this->isSubfolder() && $compatibility['can_install'],
                     'alreadyInstalled' => $this->isAlreadyInstalled(),
                     'database_hostname' => $this->session->get('database_hostname'),
                     'database_name' => $this->session->get('database_name'),
@@ -302,6 +303,16 @@ final class FOSSBilling_Installer
         }
 
         return true;
+    }
+
+    /**
+     * Attempt to detect if the application is under a subfolder.
+     *
+     * @return boolean
+     */
+    private function isSubfolder(): bool
+    {
+        return substr_count(URL_INSTALL, '/') > 4 ? true : false;
     }
 
     /**

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -181,9 +181,8 @@ final class FOSSBilling_Installer
                     'compatibility' => $compatibility,
                     'os' => PHP_OS,
                     'os_ok' => (str_starts_with(strtoupper(PHP_OS), 'WIN')) ? false : true,
-                    'is_subfolder' => $this->isSubfolder(),
                     'fossbilling_ver' => \FOSSBilling\Version::VERSION,
-                    'canInstall' => !$this->isSubfolder() && $compatibility['can_install'],
+                    'canInstall' => $compatibility['can_install'],
                     'alreadyInstalled' => $this->isAlreadyInstalled(),
                     'database_hostname' => $this->session->get('database_hostname'),
                     'database_name' => $this->session->get('database_name'),
@@ -303,16 +302,6 @@ final class FOSSBilling_Installer
         }
 
         return true;
-    }
-
-    /**
-     * Attempt to detect if the application is under a subfolder.
-     *
-     * @return boolean
-     */
-    private function isSubfolder(): bool
-    {
-        return substr_count(URL_INSTALL, '/') > 4 ? true : false;
     }
 
     /**

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -407,6 +407,27 @@ class Service implements InjectionAwareInterface
         return $encoreInfo;
     }
 
+    public function getDefaultMarkdownAttributes(): array
+    {
+        if (defined("ADMIN_AREA") && ADMIN_AREA == true) {
+            $config = $this->getThemeConfig(false);
+        } else {
+            $config = $this->getThemeConfig(true);
+        }
+
+        if (is_array($config['markdown_attributes'])) {
+            $attributes = $config['markdown_attributes'];
+            foreach ($attributes as $class => $defaults) {
+                if (!class_exists($class)) {
+                    unset($attributes[$class]);
+                }
+            }
+            return $attributes;
+        } else {
+            return [];
+        }
+    }
+
     protected function getEncoreJsonPath($filename): string
     {
         return $this->getThemesPath() . $this->getCurrentRouteTheme() . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . "{$filename}.json";

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -377,7 +377,7 @@ class Service implements InjectionAwareInterface
 
     public function getCurrentRouteTheme(): string
     {
-        if ($this->isRouteAdmin()) {
+        if (defined("ADMIN_AREA") && ADMIN_AREA == true) {
             return $this->getCurrentAdminAreaTheme()['code'];
         }
 
@@ -417,14 +417,5 @@ class Service implements InjectionAwareInterface
         $config = $this->getThemeConfig();
 
         return $config['use_admin_default_encore'] ?? false;
-    }
-
-    protected function isRouteAdmin()
-    {
-        if (str_starts_with($_SERVER['REQUEST_URI'] ?? $_SERVER['PATH_INFO'], ADMIN_PREFIX)) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/themes/admin_default/manifest.json
+++ b/src/themes/admin_default/manifest.json
@@ -1,8 +1,19 @@
 {
-    "name": "Admin area FOSSBilling Theme",
-    "version": "1.0.0",
-    "description": "Copy this theme and create your own admin area theme",
-    "icon": "screenshot.jpg",
-    "author": "FOSSBilling",
-    "author_url": "https://fossbilling.org/"
+  "name": "Admin area FOSSBilling Theme",
+  "version": "1.0.0",
+  "description": "Copy this theme and create your own admin area theme",
+  "icon": "screenshot.jpg",
+  "author": "FOSSBilling",
+  "author_url": "https://fossbilling.org/",
+  "markdown_attributes": {
+    "\\League\\CommonMark\\Extension\\Table\\Table": {
+      "class": "table table-hover"
+    },
+    "\\League\\CommonMark\\Extension\\CommonMark\\Node\\Inline\\Image": {
+      "class": "img-fluid"
+    },
+    "\\League\\CommonMark\\Extension\\CommonMark\\Node\\Block\\BlockQuote": {
+      "class": "blockquote"
+    }
+  }
 }

--- a/src/themes/huraga/manifest.json
+++ b/src/themes/huraga/manifest.json
@@ -1,8 +1,19 @@
 {
-    "name": "FOSSBilling Huraga",
-    "version": "1.0.0",
-    "description": "Default client area theme",
-    "icon": "screenshot.jpg",
-    "author": "FOSSBilling",
-    "author_url": "https://www.fossbilling.org/"
+  "name": "FOSSBilling Huraga",
+  "version": "1.0.0",
+  "description": "Default client area theme",
+  "icon": "screenshot.jpg",
+  "author": "FOSSBilling",
+  "author_url": "https://www.fossbilling.org/",
+  "markdown_attributes": {
+    "\\League\\CommonMark\\Extension\\Table\\Table": {
+      "class": "table table-hover"
+    },
+    "\\League\\CommonMark\\Extension\\CommonMark\\Node\\Inline\\Image": {
+      "class": "img-fluid"
+    },
+    "\\League\\CommonMark\\Extension\\CommonMark\\Node\\Block\\BlockQuote": {
+      "class": "blockquote"
+    }
+  }
 }


### PR DESCRIPTION
This pull request implements a simple method for each theme to set default attributes for rendered markdown.

In theory, the changes I have made have also resolved the longstanding issue with the admin panel on sub-folders, however when I tested it I found that everything in the application gave 404 errors, so I suspect one of the changes in #1075 further regressed the functionality, however I haven't investigated yet as it's both a low-priority and ultimately unrelated to this PR.

Closes #2007 and adds in the following defaults for our themes:
- Tables; `table table-hover`
- Images: `img-fluid`
- Quotes: `blockquote`

Now tables display more how one would expect:
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/29924c66-3d72-4957-9018-dd8e68104a73)