### PR TITLE
Improvements to the update page / experience

### DIFF
--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -66,14 +68,25 @@ class Update implements InjectionAwareInterface
     }
 
     /**
-     * Gets what type of update is available (Major, minor, or patch)
-     *
-     * @return int And int from 0-2 representing the patch type
+     * Builds a complete changelog for all updates between the the newest FOSSBilling version and an ending version number
+     * 
+     * @param array $releases The GitHub API release info JSON represented as an array.
+     * @param null|string $end What version number to end on. Defaults to the current version of this installation if `null` is passed.
      */
-    public function getUpdateType(): int
+    private function buildCompleteChangelog(array $releases, ?string $end = null): string
     {
-        $updateBranch = $this->getUpdateBranch();
-        return $this->getLatestVersionInfo($updateBranch)['update_type'];
+        $end ??= Version::VERSION;
+        $completedChangelog = [];
+
+        foreach ($releases as $release) {
+            if (version_compare($release['tag_name'], $end, 'gt')) {
+                $completedChangelog[] = $release['body'];
+            } else {
+                break;
+            }
+        }
+
+        return implode(PHP_EOL, $completedChangelog);
     }
 
     /**
@@ -82,13 +95,16 @@ class Update implements InjectionAwareInterface
      * @param string $branch The branch to return the latest information for;
      *                       valid values are: 'preview' or 'release'.
      *
+     * @param bool $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the lastest info
+     * 
      * @throws Exception if there is an error downloading the latest
      *                        version information.
      *
      * @return array
      */
-    private function getLatestVersionInfo(string $branch = 'release'): array
+    public function getLatestVersionInfo(?string $branch = null, bool $refetch = false): array
     {
+        $branch ??= $this->getUpdateBranch();
         $branch = (in_array($branch, ['release', 'preview'])) ? $branch : 'release';
 
         if ($branch === 'preview') {
@@ -97,31 +113,43 @@ class Update implements InjectionAwareInterface
             $downloadUrl = 'https://fossbilling.org/downloads/preview/';
 
             return [
-                'version' => Version::VERSION,
-                'download_url' => $downloadUrl,
+                'version'       => Version::VERSION,
+                'download_url'  => $downloadUrl,
                 'release_notes' => "Release notes are not available for the preview branch. You can check the latest changes on our [GitHub]($compareLink) repository.",
-                'update_type' => 0,
+                'update_type'   => 0,
+                'last_check'    => time(),
+                'next_check'    => time() + 3600,
             ];
         } else {
-            return $this->di['cache']->get("Update.latest_{$branch}_version_info", function (ItemInterface $item) {
-                $item->expiresAfter(24 * 60 * 60);
+            $key = "Update.latest_{$branch}_version_info";
+
+            // Delete the cached result to force a refetch
+            if ($refetch) {
+                $this->di['cache']->delete($key);
+            }
+
+            return $this->di['cache']->get($key, function (ItemInterface $item) {
+                $item->expiresAfter(3600);
 
                 try {
-                    $releaseInfoUrl = 'https://api.github.com/repos/FOSSBilling/FOSSBilling/releases/latest';
+                    $releaseInfoUrl = 'https://api.github.com/repos/FOSSBilling/FOSSBilling/releases';
                     $httpClient = HttpClient::create();
                     $response = $httpClient->request('GET', $releaseInfoUrl);
-                    $releaseInfo = $response->toArray();
+                    $releases = $response->toArray();
                 } catch (TransportExceptionInterface | HttpExceptionInterface $e) {
                     error_log($e->getMessage());
                     throw new Exception('Failed to download the latest version information. Further details are available in the error log.');
                 }
 
+                $releaseInfo = $releases[0];
                 return [
-                    'version' => $releaseInfo['tag_name'] ?: Version::VERSION,
-                    'download_url' => $releaseInfo['assets'][0]['browser_download_url'],
-                    'release_date' => $releaseInfo['published_at'],
-                    'release_notes' => $releaseInfo['body'] ?: '**Error: Release notes unavailable.**',
-                    'update_type' => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
+                    'version'       => $releaseInfo['tag_name'] ?: Version::VERSION,
+                    'download_url'  => $releaseInfo['assets'][0]['browser_download_url'],
+                    'release_date'  => $releaseInfo['published_at'],
+                    'release_notes' => $this->buildCompleteChangelog($releases) ?: '**Error: Release notes unavailable.**',
+                    'update_type'   => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
+                    'last_check'    => date('Y-m-d H:i:s'),
+                    'next_check'    => date('Y-m-d H:i:s', time() + 3600),
                 ];
             });
         }

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -119,6 +119,7 @@ class Update implements InjectionAwareInterface
                 'update_type'   => 0,
                 'last_check'    => time(),
                 'next_check'    => time() + 3600,
+                'branch'        => 'preview',
             ];
         } else {
             $key = "Update.latest_{$branch}_version_info";
@@ -128,7 +129,7 @@ class Update implements InjectionAwareInterface
                 $this->di['cache']->delete($key);
             }
 
-            return $this->di['cache']->get($key, function (ItemInterface $item) {
+            return $this->di['cache']->get($key, function (ItemInterface $item) use ($branch) {
                 $item->expiresAfter(3600);
 
                 try {
@@ -150,6 +151,7 @@ class Update implements InjectionAwareInterface
                     'update_type'   => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
                     'last_check'    => date('Y-m-d H:i:s'),
                     'next_check'    => date('Y-m-d H:i:s', time() + 3600),
+                    'branch'        => $branch,
                 ];
             });
         }

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -95,7 +95,7 @@ class Update implements InjectionAwareInterface
      * @param string $branch The branch to return the latest information for;
      *                       valid values are: 'preview' or 'release'.
      *
-     * @param bool $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the lastest info
+     * @param bool $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the latest info
      * 
      * @throws Exception if there is an error downloading the latest
      *                        version information.

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -147,27 +148,33 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Gets the latest release notes.
-     *
-     * @return string
+     * Used to check if there's an update available.
      */
-    public function release_notes()
+    public function update_available(): bool
     {
         $updater = $this->di['updater'];
 
-        return $updater->getLatestReleaseNotes();
+        return $updater->isUpdateAvailable();
     }
 
     /**
-     * Gets the update type.
-     *
-     * @return int
+     * Returns an array containing the update info
      */
-    public function update_type()
+    public function update_info(): array
     {
         $updater = $this->di['updater'];
 
-        return $updater->getUpdateType();
+        return $updater->getLatestVersionInfo();
+    }
+
+    /**
+     * Forces the system to clear out the update cache and re-fetch the latest info.
+     */
+    public function recheck_update(): bool
+    {
+        $updater = $this->di['updater'];
+        $updater->getLatestVersionInfo(null, true);
+        return true;
     }
 
     /**

--- a/src/modules/System/html_admin/mod_system_update.html.twig
+++ b/src/modules/System/html_admin/mod_system_update.html.twig
@@ -11,7 +11,7 @@
             <h1 class="card-title">{{ 'Update FOSSBilling'|trans }}</h1>
         </div>
         <div class="card-body">
-            {% if admin.system_update_available %}
+            {% if admin.system_update_available or update_info['branch'] == 'preview' %}
                 <h2 class="card-title">{{ 'Update release notes'|trans }} ({{ FOSSBillingVersion }} => {{ update_info['version'] }})</h2>
                 {% if update_info['update_type'] == 2 %}
                     <div class="alert alert-danger" role="alert">
@@ -32,7 +32,7 @@
             {% endif %}
         </div>
         <div class="card-footer">
-            {% if admin.system_update_available %}
+            {% if admin.system_update_available or update_info['branch'] == 'preview' %}
                 <a href="{{ 'api/admin/system/update_core'|link({ 'CSRFToken': CSRFToken }) }}"
                     class="btn btn-primary api-link"
                     data-api-reload="1"

--- a/src/modules/System/html_admin/mod_system_update.html.twig
+++ b/src/modules/System/html_admin/mod_system_update.html.twig
@@ -27,24 +27,33 @@
                     
                 {{ update_info['release_notes']|markdown }}
             {% else %}
-                <h2 class="card-title">{{ 'No update available'|trans }}</h2>
+                <h2 class="card-title">{{ 'There is no update available'|trans }}</h2>
+                <p>{{ 'You appear to be running the latest version of FOSSBilling, so no action is needed at the moment. If you think this is a mistake, you may use the button below to check again.'|trans }}</p>
             {% endif %}
         </div>
         <div class="card-footer">
-            <a href="{{ 'api/admin/system/update_core'|link({ 'CSRFToken': CSRFToken }) }}"
-                class="btn btn-primary api-link"
-                data-api-reload="1"
-                data-api-confirm="Proceed with automatic update?"
-                data-api-confirm-btn="Update"
-                data-api-confirm-content="Make sure that you have made database and files backups before proceeding with automatic update. You will automatically be redirected once the update is complete.">
-                <svg class="icon">
-                    <use xlink:href="#download" />
-                </svg>
-                {{ 'Update FOSSBilling'|trans }}
-                {% if not admin.system_update_available %}
-                    disabled
-                {% endif %}
-            </a>
+            {% if admin.system_update_available %}
+                <a href="{{ 'api/admin/system/update_core'|link({ 'CSRFToken': CSRFToken }) }}"
+                    class="btn btn-primary api-link"
+                    data-api-reload="1"
+                    data-api-confirm="Proceed with automatic update?"
+                    data-api-confirm-btn="Update"
+                    data-api-confirm-content="Make sure that you have made database and files backups before proceeding with automatic update. You will automatically be redirected once the update is complete.">
+                    <svg class="icon">
+                        <use xlink:href="#download" />
+                    </svg>
+                    {{ 'Update FOSSBilling'|trans }}
+                </a>
+            {% else %}
+                <a
+                    class="btn btn-primary disabled"
+                    aria-disabled="true">
+                    <svg class="icon">
+                        <use xlink:href="#download" />
+                    </svg>
+                    {{ 'Update FOSSBilling'|trans }}
+                </a>
+            {% endif %}
             <a href="{{ 'api/admin/system/recheck_update'|link({ 'CSRFToken': CSRFToken }) }}"
                 class="btn btn-primary api-link"
                 data-api-reload="1">
@@ -60,7 +69,7 @@
                 {{ 'Apply Patches & Update Configuration'|trans }}
             </a>
             <br />
-            <span class="text-muted">{{ "Applying patches and updating the configuration should be performed automatically, you don't need to use the button unless you are experiencing issues."|trans }}<br />
+            <span class="text-muted">{{ "Applying patches and updating the configuration should be performed automatically, you don't need to use that button unless you are experiencing issues."|trans }}<br />
             <span class="text-muted">{{ 'Last update check:'|trans }} {{ update_info['last_check']|format_datetime() }}.</span><br />
             <span class="text-muted"> {{ 'Next update check:'|trans }} {{ update_info['next_check']|format_datetime() }}.</span>
         </div>

--- a/src/modules/System/html_admin/mod_system_update.html.twig
+++ b/src/modules/System/html_admin/mod_system_update.html.twig
@@ -5,57 +5,64 @@
 {% block meta_title %}{{ 'Update'|trans }}{% endblock %}
 
 {% block content %}
-    {% set update_type = admin.system_update_type %}
+    {% set update_info = admin.system_update_info %}
     <div class="card">
         <div class="card-header">
-            <h3 class="card-title">Update</h3>
+            <h1 class="card-title">{{ 'Update FOSSBilling'|trans }}</h1>
         </div>
         <div class="card-body">
-            <h3 class="card-title">{{ 'Automatic Update'|trans }}</h3>
-            <p class="card-subtitle">{{ 'The automatic updater is a one-click tool for updating FOSSBilling. PHP must be able to write to the directory where FOSSBilling is installed.'|trans }}</p>
-
-            {% if update_type == 2 %}
-                <div class="alert alert-danger" role="alert">
-                    <span>{{ 'This update is considered to be a major update, you should check the release notes for any breaking changes.'|trans }}</span>
-                </div>
+            {% if admin.system_update_available %}
+                <h2 class="card-title">{{ 'Update release notes'|trans }} ({{ FOSSBillingVersion }} => {{ update_info['version'] }})</h2>
+                {% if update_info['update_type'] == 2 %}
+                    <div class="alert alert-danger" role="alert">
+                        <span>{{ 'This update is considered to be a major update, you should check the release notes for any breaking changes.'|trans }}</span>
+                    </div>
+                {% endif %}
+                
+                {% if update_info['update_type'] == 1 %}
+                    <div class="alert alert-warning" role="alert">
+                        <span>{{ 'This update is considered to be a minor update, there are low chances of incompatibilities.'|trans }}</span>
+                    </div>
+                {% endif %}
+                    
+                {{ update_info['release_notes']|markdown }}
+            {% else %}
+                <h2 class="card-title">{{ 'No update available'|trans }}</h2>
             {% endif %}
-
-            {% if update_type == 1 %}
-                <div class="alert alert-warning" role="alert">
-                    <span>{{ 'This update is considered to be a minor update, there are low chances of incompatibilities.'|trans }}</span>
-                </div>
-            {% endif %}
-
-            {{ admin.system_release_notes|markdown }}
+        </div>
+        <div class="card-footer">
             <a href="{{ 'api/admin/system/update_core'|link({ 'CSRFToken': CSRFToken }) }}"
-            class="btn btn-primary api-link"
-            data-api-reload="1"
-            data-api-confirm="Proceed with automatic update?"
-            data-api-confirm-btn="Update"
-            data-api-confirm-content="Make sure that you have made database and files backups before proceeding with automatic update. You will automatically be redirected once the update is complete.">
+                class="btn btn-primary api-link"
+                data-api-reload="1"
+                data-api-confirm="Proceed with automatic update?"
+                data-api-confirm-btn="Update"
+                data-api-confirm-content="Make sure that you have made database and files backups before proceeding with automatic update. You will automatically be redirected once the update is complete.">
+                <svg class="icon">
+                    <use xlink:href="#download" />
+                </svg>
+                {{ 'Update FOSSBilling'|trans }}
+                {% if not admin.system_update_available %}
+                    disabled
+                {% endif %}
+            </a>
+            <a href="{{ 'api/admin/system/recheck_update'|link({ 'CSRFToken': CSRFToken }) }}"
+                class="btn btn-primary api-link"
+                data-api-reload="1">
                 <svg class="icon">
                     <use xlink:href="#refresh" />
                 </svg>
-                {{ 'Update FOSSBilling'|trans }}
+                {{ 'Check for Updates'|trans }}
             </a>
-        </div>
-        <div class="card-body">
-            <h3 class="card-title">{{ 'Manual Update'|trans }}</h3>
-            <p class="card-subtitle">{{ 'If the auto updater is unable to function in your current installation environment, a manual update is available as an alternative solution.'|trans }}</p>
-            <ul>
-                <li>Download the latest release of FOSSBilling from GitHub at <a href="https://github.com/FOSSBilling/FOSSBilling/releases" target="_blank">https://github.com/FOSSBilling/FOSSBilling/releases</a>.</li>
-                <li>Extract the downloaded files to your computer.</li>
-                <li>Using an FTP client, upload (overwrite) the extracted files to your FOSSBilling installation directory at <strong>{{ constant('PATH_ROOT') }}</strong>.</li>
-                <li>Once the upload is complete, remove the <strong>install</strong> folder from the FOSSBilling installation directory.</li>
-                <li>Finally, run the manual patcher and configuration update tool below.</li>
-                <li>Your FOSSBilling installation is now up-to-date with the latest version!</li>
-            </ul>
             <a href="{{ 'api/admin/system/manual_update'|link({ 'CSRFToken': CSRFToken }) }}" class="btn btn-primary api-link" data-api-confirm="If you run into any issues, you can revert to the old config which will be saved as config.old.php." data-api-msg="Patches applied and configuration updated.">
                 <svg class="icon">
-                    <use xlink:href="#refresh" />
+                    <use xlink:href="#cog-play" />
                 </svg>
                 {{ 'Apply Patches & Update Configuration'|trans }}
             </a>
+            <br />
+            <span class="text-muted">{{ "Applying patches and updating the configuration should be performed automatically, you don't need to use the button unless you are experiencing issues."|trans }}<br />
+            <span class="text-muted">{{ 'Last update check:'|trans }} {{ update_info['last_check']|format_datetime() }}.</span><br />
+            <span class="text-muted"> {{ 'Next update check:'|trans }} {{ update_info['next_check']|format_datetime() }}.</span>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This pull request aims to resolve some of the most common complains / issues with the existing updating system in FOSSBilling with the following changes:

1. The system will now display the release notes for all versions between the current and the latest, which helps ensure people won't miss important changes / don't need to go pull up the website to find them.
2. The check cache has been reduced from 24 hours down to 1.
3. It now displays when a check was last performed, when it next will be performed, and also provides a button to check for updates now.
4. The page will properly display when there's no update available to reduce confusion.
5. I removed the "manual update" section as it's documented on our website and is realistically just a workaround method for updating.
6. I've changed the icons used for the buttons to be more sensible + to ensure each one has a unique icon. (Previously both utilized the `cog` icon)

## Update Available

Something to ask: Do we want to reverse the order of the changes so it's going in ascending order from older to newer?
This version is going from newer to older, but it should be very easy to reverse it.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/04bfcd68-96bb-459e-ac69-0d4f5b268855)

## Already up-to-date

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/3c5c0fd7-f2c5-4afd-9e26-df5c020cef65)

## Preview builds

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/205aa3b2-321e-46e6-9b66-0f4fc6827397)
