### PR TITLE
Added support for a html_custom folder

### DIFF
--- a/src/library/Box/TwigLoader.php
+++ b/src/library/Box/TwigLoader.php
@@ -50,6 +50,7 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
         $name_split = explode("_", $name);
 
         $paths = array();
+        $paths[] = $this->options["theme"] . DIRECTORY_SEPARATOR . "html_custom";
         $paths[] = $this->options["theme"] . DIRECTORY_SEPARATOR . "html";
         if (isset($name_split[1])) {
             $paths[] = $this->options["mods"] . DIRECTORY_SEPARATOR . ucfirst($name_split[1]) . DIRECTORY_SEPARATOR . "html_" . $this->options["type"];


### PR DESCRIPTION
Closes #1095 by adding a new path to our twig loader which will cause it to check under a theme's `html_custom` folder before it checks the `html` folder.
If there's no `html_custom` folder, nothing happens.

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/a64fe8aa-d8ef-4d8a-a23e-bd87a8722d19)
