### PR TITLE
Fixed PDF invoices being locked to the default currency

### DIFF
--- a/src/modules/Invoice/pdf_template/default-pdf.twig
+++ b/src/modules/Invoice/pdf_template/default-pdf.twig
@@ -71,8 +71,8 @@
 					<tr>
 						<td style='text-align: center; width:25px;'>{{ nr }}</td>
 						<td style='text-align: left'>{{ item.title }}</td>
-						<td style='text-align: right'>{{ item.quantity }}x {{ item.price|money_convert }}</td>
-						<td style='text-align: right'>{{ item.total|money_convert }}</td>
+						<td style='text-align: right'>{{ item.quantity }}x {{ item.price|money_convert(currency_code) }}</td>
+						<td style='text-align: right'>{{ item.total|money_convert(currency_code) }}</td>
 					</tr>
 				{% endfor %}
 				<tr>
@@ -82,18 +82,18 @@
 					<tr>
 						<th style='text-align: right' colspan='3'>{{ invoice.taxname }}
 							{{ invoice.taxrate }}% Tax:</th>
-						<th style='text-align: right'>{{ invoice.tax|money_convert }}</th>
+						<th style='text-align: right'>{{ invoice.tax|money_convert(currency_code) }}</th>
 					</tr>
 				{% endif %}
 				{% if invoice.discount|default and invoice.discount > 0 %}
 					<tr>
 						<th style='text-align: right' colspan='3'>{{ 'Discount'|trans }}:</th>
-						<th style='text-align: right'>{{ invoice.discount|money_convert }}</th>
+						<th style='text-align: right'>{{ invoice.discount|money_convert(currency_code) }}</th>
 					</tr>
 				{% endif %}
 				<tr>
 					<th style='text-align: right'  colspan='3'>{{ 'Total'|trans }}:</th>
-					<th style='text-align: right'>{{ invoice.total|money_convert }}</th>
+					<th style='text-align: right'>{{ invoice.total|money_convert(currency_code) }}</th>
 				</tr>
 			</table>
 		<p>{{ footer.signature }}</p>


### PR DESCRIPTION
This PR resolves a regression introduced by #1461 which caused PDF invoices to only display values in the system default currency.

The below example is with the default being USD and the currency on the invoice being EUR with a conversion rate of 0.95

## Before
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/f29a4f71-3851-4fe2-936e-9fe3e15027de)


## After
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/6ffbe06b-9ed2-4a0b-b65d-c7dd140e5d8e)
