### PR TITLE
Skip the queue when sending email verification emails

### DIFF
--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -612,6 +612,7 @@ class Service implements InjectionAwareInterface
             $email['code'] = 'mod_client_confirm';
             $email['require_email_confirmation'] = true;
             $email['email_confirmation_link'] = $this->generateEmailConfirmationLink($client->id);
+            $email['send_now'] = true;
 
             $emailService = $this->di['mod_service']('email');
             $emailService->sendTemplate($email);


### PR DESCRIPTION
As the title says.
Logically speaking this probably shouldn't be delayed and since it's only a single action being performed, we don't really need to worry about reaching a timeout limit. Plus the newer version of Huraga will display a spinner anyways, indicating something is happening.