### PR TITLE
Prevent undefined array key errors

### DIFF
--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -415,7 +415,7 @@ class Service implements InjectionAwareInterface
             $config = $this->getThemeConfig(true);
         }
 
-        if (is_array($config['markdown_attributes'])) {
+        if (isset($config['markdown_attributes']) && is_array($config['markdown_attributes'])) {
             $attributes = $config['markdown_attributes'];
             foreach ($attributes as $class => $defaults) {
                 if (!class_exists($class)) {


### PR DESCRIPTION
Missed this in the initial PR to add per-theme markdown attributes. Only matters for custom themes, but it's best not to fill up an error log :p