### PR TITLE
We shouldn't be converting the prices on PDFs

### DIFF
--- a/src/modules/Invoice/pdf_template/default-pdf.twig
+++ b/src/modules/Invoice/pdf_template/default-pdf.twig
@@ -71,8 +71,8 @@
 					<tr>
 						<td style='text-align: center; width:25px;'>{{ nr }}</td>
 						<td style='text-align: left'>{{ item.title }}</td>
-						<td style='text-align: right'>{{ item.quantity }}x {{ item.price|money_convert(currency_code) }}</td>
-						<td style='text-align: right'>{{ item.total|money_convert(currency_code) }}</td>
+						<td style='text-align: right'>{{ item.quantity }}x {{ item.price|money(currency_code) }}</td>
+						<td style='text-align: right'>{{ item.total|money(currency_code) }}</td>
 					</tr>
 				{% endfor %}
 				<tr>
@@ -82,18 +82,18 @@
 					<tr>
 						<th style='text-align: right' colspan='3'>{{ invoice.taxname }}
 							{{ invoice.taxrate }}% Tax:</th>
-						<th style='text-align: right'>{{ invoice.tax|money_convert(currency_code) }}</th>
+						<th style='text-align: right'>{{ invoice.tax|money(currency_code) }}</th>
 					</tr>
 				{% endif %}
 				{% if invoice.discount|default and invoice.discount > 0 %}
 					<tr>
 						<th style='text-align: right' colspan='3'>{{ 'Discount'|trans }}:</th>
-						<th style='text-align: right'>{{ invoice.discount|money_convert(currency_code) }}</th>
+						<th style='text-align: right'>{{ invoice.discount|money(currency_code) }}</th>
 					</tr>
 				{% endif %}
 				<tr>
 					<th style='text-align: right'  colspan='3'>{{ 'Total'|trans }}:</th>
-					<th style='text-align: right'>{{ invoice.total|money_convert(currency_code) }}</th>
+					<th style='text-align: right'>{{ invoice.total|money(currency_code) }}</th>
 				</tr>
 			</table>
 		<p>{{ footer.signature }}</p>


### PR DESCRIPTION
Follow up fixes to #2022 and #1461.
The pricing on invoices are already converted and the combined changes of the two PRs resulted in converting the price a 2nd time visually when rendering the PDF.
This PR fixes that by ensuring we are only *formatting* the price and not performing any conversions.