### PR TITLE
Fix how negative prices are formatted

### DIFF
--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -68,7 +68,7 @@ class Guest extends \Api_Abstract
         $convert = $data['convert'] ?? true;
         $without_currency = (bool) ($data['without_currency'] ?? false);
 
-        $p = $price;
+        $p = floatval($price);
         if ($convert) {
             $p = $price * $c['conversion_rate'];
         }
@@ -88,7 +88,7 @@ class Guest extends \Api_Abstract
         }
 
         $c['format'] = ($p >= 0) ? $c['format'] : '-' . $c['format'];
-        $p = $p >= 0 ? $p : '-' . $p;
+        $p = abs($p);
 
         return str_replace('{{price}}', $p, $c['format']);
     }

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -75,21 +75,31 @@ class Guest extends \Api_Abstract
 
         $p ??= 0;
 
-        $p = match (intval($c['price_format'])) {
+        $p = $this->select_format($p, $c['price_format']);
+
+        if ($without_currency) {
+            return $p;
+        }
+
+        if ($p < 0) {
+            // Price is negative, so we get a little creative to move the location of the negative symbol (ensuring -$5.00 instead of $-5.00)
+            $c['format'] = '-' . $c['format'];
+            $p = abs($p);
+            // Reformat the price to ensure it's displayed correctly after getting it's absolute value
+            $p = $this->select_format($p, $c['price_format']);
+        }
+
+        return str_replace('{{price}}', $p, $c['format']);
+    }
+
+    private function select_format($p, $format)
+    {
+        return match (intval($format)) {
             2 => number_format($p, 2, '.', ','),
             3 => number_format($p, 2, ',', '.'),
             4 => number_format($p, 0, '', ','),
             5 => number_format($p, 0, '', ''),
             default => number_format($p, 2, '.', ''),
         };
-
-        if ($without_currency) {
-            return $p;
-        }
-
-        $c['format'] = ($p >= 0) ? $c['format'] : '-' . $c['format'];
-        $p = abs($p);
-
-        return str_replace('{{price}}', $p, $c['format']);
     }
 }

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -73,19 +73,18 @@ class Guest extends \Api_Abstract
             $p = $price * $c['conversion_rate'];
         }
 
-        $p = $this->select_format($p, $c['price_format']);
-
         if ($without_currency) {
-            return $p;
+            return $this->select_format($p, $c['price_format']);;
         }
 
+        // Price is negative, so we place a negative symbol at the start of the format
         if ($p < 0) {
-            // Price is negative, so we get a little creative to move the location of the negative symbol (ensuring -$5.00 instead of $-5.00)
             $c['format'] = '-' . $c['format'];
-            $p = abs($p);
-            // Reformat the price to ensure it's displayed correctly after getting it's absolute value
-            $p = $this->select_format($p, $c['price_format']);
         }
+
+        // Get the absolute value of the price so it displays normally for both positive and negative prices and then properly format it
+        $p = abs($p);
+        $p = $this->select_format($p, $c['price_format']);
 
         return str_replace('{{price}}', $p, $c['format']);
     }

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -73,8 +73,6 @@ class Guest extends \Api_Abstract
             $p = $price * $c['conversion_rate'];
         }
 
-        $p ??= 0;
-
         $p = $this->select_format($p, $c['price_format']);
 
         if ($without_currency) {

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -83,8 +83,7 @@ class Guest extends \Api_Abstract
         }
 
         // Get the absolute value of the price so it displays normally for both positive and negative prices and then properly format it
-        $p = abs($p);
-        $p = $this->select_format($p, $c['price_format']);
+        $p = $this->select_format(abs($p), $c['price_format']);
 
         return str_replace('{{price}}', $p, $c['format']);
     }


### PR DESCRIPTION
Fixes an issue with how negative prices are formatted.
I think I had once resolved this, however then later on broke it once again to make PHPStan happy.
This should fix it properly.

## Before
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/9b1f3e4b-666c-447d-9d2d-ce600777af0c)

## After
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/dcd898a2-4ea2-48bd-819d-420252339e4a)
