### PR TITLE
Resolved certain PGs logging out clients

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -44,6 +44,14 @@ if ($url === '/run-patcher') {
     }
 }
 
+/**
+ * Workaround: Session IDs get reset when using PGs like PayPal because of the `samesite=strict` cookie attribute, resulting in the client getting logged out.
+ * Internally the return and cancel URLs get a restore_session GET parameter attached to them with the porper session ID to restore, so we do so here.
+ */
+if (!empty($_GET['restore_session'])) {
+    session_id($_GET['restore_session']);
+}
+
 $di['session'];
 
 if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {

--- a/src/index.php
+++ b/src/index.php
@@ -46,7 +46,7 @@ if ($url === '/run-patcher') {
 
 /**
  * Workaround: Session IDs get reset when using PGs like PayPal because of the `samesite=strict` cookie attribute, resulting in the client getting logged out.
- * Internally the return and cancel URLs get a restore_session GET parameter attached to them with the porper session ID to restore, so we do so here.
+ * Internally the return and cancel URLs get a restore_session GET parameter attached to them with the proper session ID to restore, so we do so here.
  */
 if (!empty($_GET['restore_session'])) {
     session_id($_GET['restore_session']);

--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -312,7 +312,7 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         $data['no_shipping']        = '1';
         $data['no_note']            = '1'; // Do not prompt payers to include a note with their payments. Allowable values for Subscribe buttons:
         $data['currency_code']      = $invoice['currency'];
-        $data['return']             = $this->config['return_url'];
+        $data['return']             = $this->config['thankyou_url'];
         $data['cancel_return']      = $this->config['cancel_url'];
         $data['notify_url']         = $this->config['notify_url'];
         $data['business']           = $this->config['email'];
@@ -361,7 +361,7 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         $data['no_note']            = '1';
         $data['currency_code']      = $invoice['currency'];
         $data['rm']                 = '2';
-        $data['return']             = $this->config['return_url'];
+        $data['return']             = $this->config['thankyou_url'];
         $data['cancel_return']      = $this->config['cancel_url'];
         $data['notify_url']         = $this->config['notify_url'];
         $data['business']           = $this->config['email'];

--- a/src/modules/Invoice/Controller/Client.php
+++ b/src/modules/Invoice/Controller/Client.php
@@ -34,6 +34,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         $app->post('/invoice/print/:hash', 'get_invoice_print', ['hash' => '[a-z0-9]+'], static::class);
         $app->get('/invoice/banklink/:hash/:id', 'get_banklink', ['id' => '[0-9]+', 'hash' => '[a-z0-9]+'], static::class);
         $app->get('/invoice/thank-you/:hash', 'get_thankyoupage', ['hash' => '[a-z0-9]+'], static::class);
+        $app->post('/invoice/thank-you/:hash', 'get_thankyoupage', ['hash' => '[a-z0-9]+'], static::class);
         $app->get('/invoice/pdf/:hash', 'get_pdf', ['hash' => '[a-z0-9]+'], static::class);
     }
 
@@ -87,7 +88,6 @@ class Client implements \FOSSBilling\InjectionAwareInterface
             'hash' => $hash,
         ];
         $invoice = $api->invoice_get($data);
-
         return $app->render('mod_invoice_thankyou', ['invoice' => $invoice]);
     }
 

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -361,10 +361,10 @@ class ServicePayGateway implements InjectionAwareInterface
     private function getReturnUrl(\Model_PayGateway $pg, $model = null)
     {
         if ($model instanceof \Model_Invoice) {
-            return $this->di['url']->link('/invoice/' . $model->hash, ['status' => 'ok']);
+            return $this->di['url']->link('/invoice/' . $model->hash, ['status' => 'ok', 'restore_session' => session_id()]);
         }
 
-        return $this->di['url']->link('/invoice', ['status' => 'ok']);
+        return $this->di['url']->link('/invoice', ['status' => 'ok', 'restore_session' => session_id()]);
     }
 
     /**
@@ -373,10 +373,10 @@ class ServicePayGateway implements InjectionAwareInterface
     private function getCancelUrl(\Model_PayGateway $pg, $model = null)
     {
         if ($model instanceof \Model_Invoice) {
-            return $this->di['url']->link('/invoice/' . $model->hash, ['status' => 'cancel']);
+            return $this->di['url']->link('/invoice/' . $model->hash, ['status' => 'cancel', 'restore_session' => session_id()]);
         }
 
-        return $this->di['url']->link('/invoice', ['status' => 'cancel']);
+        return $this->di['url']->link('/invoice', ['status' => 'cancel', 'restore_session' => session_id()]);
     }
 
     /**

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -240,7 +240,7 @@ class ServicePayGateway implements InjectionAwareInterface
         $defaults['continue_shopping_url'] = $this->di['tools']->url('/order');
         $defaults['single_page'] = true;
         if ($model instanceof \Model_Invoice) {
-            $defaults['thankyou_url'] = $this->di['tools']->url('/invoice/thank-you/' . $model->hash);
+            $defaults['thankyou_url'] = $this->di['url']->link('/invoice/thank-you/' . $model->hash, ['restore_session' => session_id()]);
             $defaults['invoice_url'] = $this->di['tools']->url('/invoice/' . $model->hash);
         }
 

--- a/src/modules/Invoice/html_client/mod_invoice_thankyou.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_thankyou.html.twig
@@ -8,16 +8,19 @@
     <div class="card ms-0 ms-md-3 w-100">
         <div class="card-header">
             <h1>{{ 'Thank you'|trans }}</h1>
-            <p>{{ 'Your payment is being processed right now. It can take up 5 minutes to complete.'|trans }}</p>
+            <p>{{ 'Your payment has been submitted and will be processed shortly. It may take a little bit of time for your invoice to be marked as paid.'|trans }}</p>
         </div>
         <div class="card-body">
             <p>{{ 'Payment for invoice received'|trans }}</p>
-            <p>{{ 'You will be automatically redirected to invoice page after 5 minutes.'|trans }}</p>
+            <p>{{ 'You will be automatically redirected to the invoice page after 1 minute.'|trans }}</p>
+            <div class="progress">
+                <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
+            </div>
 
             <script type="text/javascript">
                 setTimeout(function() {
                     bb.redirect("{{ ('/invoice/'~invoice.hash)|link }}");
-                }, 5 * 60 * 1000);
+                }, 1 * 60 * 1000);
             </script>
         </div>
     </div>


### PR DESCRIPTION
Closes #1223

The issue stemms from how we set `samesite=strict` to cookies as a way to improve security, resulting in the session ID getting lost and then on the return back to FOSSBilling the system generates them a new session ID and effectively being logged out.

The two potential workarounds would be to reduce the security by setting `samesite=lax` or to add the proper session ID to the return URLs and restore the session, which has to be done via `index.php` due to how early the sessions are started.

I've opted with the choice that doesn't reduce security.

Additionally, I've switched the PayPal gateway to display the "thank you" page instead of going directly back to the invoice as I've noticed it can take a few moments to be marked as paid within FOSSBilling. I've also made some minor adjustments to the thank you page just to make it a little less rough around the edges.

The thank you page route is also now registered for `post` as as PayPal would return to it via a `post` request rather than `get`.

![Animation](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/f3eb1c84-9309-4a36-9444-e5027c70a36a)
