### PR TITLE
Added a basic blacklist for error reporting

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -375,7 +375,10 @@
         "reqs",
         "srcdoc",
         "iframes",
-        "borderless"
+        "borderless",
+        "serviceproxmox",
+        "servicegoogleworkspace",
+        "servicemulticraft"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -37,7 +37,7 @@ class SentryHelper
         'servicemulticraft'
     ];
 
-    // Array containing instance IDs that are blacklisted from error reporting and a unix timestap of when their blacklist expires.
+    // Array containing instance IDs that are blacklisted from error reporting and a unix timestamp of when their blacklist expires.
     private static array $blacklistedInstances = [
         '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1719829175
     ];


### PR DESCRIPTION
This pull request implements a simple blacklist for error reporting so we can exclude problematic instance IDs / modules from being reported. This saves a little bit of bandwidth for the instance & Sentry's sever alongside making it easier for us to only receive reports we actually care about. 