### PR TITLE
Enable custom domain area by default when domain registration is disabled

### DIFF
--- a/src/modules/Servicehosting/html_client/mod_servicehosting_order_form.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_order_form.html.twig
@@ -18,7 +18,7 @@
                 </div>
             {% endif %}
 
-            <div id="owndomain" class="mt-2 domain_action" style="display: none;">
+            <div id="owndomain" class="mt-2 domain_action" {% if tlds is not empty %} style="display: none;" {% endif %}>
                 <div class="row">
                     <div class="col-md-8">
                         <div class="d-flex gap-2">


### PR DESCRIPTION
Fix: [Forum#128](https://forum.fossbilling.org/d/128-domain-form-maybe-bug)

When domain registration is disabled, "I will use my existing domain and update nameservers" is automatically checked. The area to enter the domain is however hidden, so users need to click on the option again for the relevant text field to appear.

This PR addresses that by having the hiding rule be applied only when the TLD list is not empty (the check performed to see that domain registration is enabled).