### PR TITLE
Extend the language cookie expiration date

### DIFF
--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     localeSelector.on("change", (value) => {
-      bb.cookieCreate("BBLANG", value, 7);
+      bb.cookieCreate("BBLANG", value, 365);
       bb.reload();
     });
   }


### PR DESCRIPTION
When manually selecting a language from the dropdown menu, the resulting cookie was valid for only 7 days.
There's no reason for it to be that short as someone's language preference isn't going to just change after a week.
This pull request increases it to a full year for a small QoL improvement.