### PR TITLE
Improved Customer Mobile Navigation (#2031) + Auth Flow Design

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -375,7 +375,8 @@
         "reqs",
         "srcdoc",
         "iframes",
-        "borderless"
+        "borderless",
+        "passwordlength"
     ],
     "ignorePaths": [
         "tests/**",

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -315,7 +315,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','39',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','40',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -1079,6 +1079,7 @@ CREATE TABLE `service_hosting_server` (
   `username` text,
   `password` text,
   `accesshash` text,
+  `passwordlength` tinyint DEFAULT NULL,
   `port` varchar(20) DEFAULT NULL,
   `config` text,
   `secure` tinyint(1) DEFAULT NULL,

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -69,7 +69,7 @@ class Update implements InjectionAwareInterface
 
     /**
      * Builds a complete changelog for all updates between the the newest FOSSBilling version and an ending version number
-     * 
+     *
      * @param array $releases The GitHub API release info JSON represented as an array.
      * @param null|string $end What version number to end on. Defaults to the current version of this installation if `null` is passed.
      */
@@ -96,7 +96,7 @@ class Update implements InjectionAwareInterface
      *                       valid values are: 'preview' or 'release'.
      *
      * @param bool $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the latest info
-     * 
+     *
      * @throws Exception if there is an error downloading the latest
      *                        version information.
      *
@@ -174,6 +174,7 @@ class Update implements InjectionAwareInterface
      * Perform manual update - apply patches and update config.
      *
      * @return void
+     * @throws Exception
      */
     public function performManualUpdate(): void
     {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -362,11 +362,16 @@ class UpdatePatcher implements InjectionAwareInterface
             },
             39 => function () {
                 // The Serbian language was incorrectly placed into a folder named `srp` by Crowdin which is now corrected for via the locale repo and as such we need to delete the old directory.
-                // @see https://github.com/FOSSBilling/locale/issues/212 
+                // @see https://github.com/FOSSBilling/locale/issues/212
                 $fileActions = [
                     PATH_LANGS . DIRECTORY_SEPARATOR . 'srp' => 'unlink',
                 ];
                 $this->executeFileActions($fileActions);
+            },
+            40 => function () {
+                // Added `passwordlength` field to server managers
+                $q = "ALTER TABLE service_hosting_server ADD COLUMN `passwordlength` TINYINT DEFAULT NULL;";
+                $this->executeSql($q);
             }
         ];
         ksort($patches, SORT_NATURAL);

--- a/src/library/Model/ServiceHosting.php
+++ b/src/library/Model/ServiceHosting.php
@@ -10,4 +10,5 @@
 
 class Model_ServiceHosting extends \RedBeanPHP\SimpleModel
 {
+
 }

--- a/src/library/Server/Account.php
+++ b/src/library/Server/Account.php
@@ -15,9 +15,8 @@ class Server_Account
     private $domain     = NULL;
     private $ip         = NULL;
 
-    private ?\Server_Package $package    = NULL;
-
     private ?\Server_Client $client     = NULL;
+    private ?\Server_Package $package    = NULL;
     private ?bool $reseller   = NULL;
     private ?bool $suspended  = NULL;
     private $ns_1       = NULL;
@@ -25,7 +24,7 @@ class Server_Account
     private $ns_3       = NULL;
     private $ns_4       = NULL;
     private $note       = NULL;
-    
+
     public function setUsername($param)
     {
         $this->username = $param;
@@ -133,7 +132,7 @@ class Server_Account
     {
         return $this->suspended;
     }
-    
+
     public function setNs1($param)
     {
         $this->ns_1 = $param;
@@ -144,7 +143,7 @@ class Server_Account
     {
         return $this->ns_1;
     }
-    
+
     public function setNs2($param)
     {
         $this->ns_2 = $param;

--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -21,6 +21,7 @@ abstract class Server_Manager
         'accesshash' =>  NULL,
         'config'     =>  NULL,
         'port'       =>  NULL,
+        'passwordlength' => NULL,
     );
 
     /**
@@ -36,6 +37,7 @@ abstract class Server_Manager
      *                       - 'accesshash': Access hash for authenticating the connection. (API Key)
      *                       - 'config': Optional configuration for the server manager.
      *                       - 'port': Custom port number for the connection.
+     *                       - 'passwordlength': Password length for accounts.
      */
     public function __construct($options)
     {
@@ -61,6 +63,10 @@ abstract class Server_Manager
 
         if (isset($options['accesshash'])) {
             $this->_config['accesshash'] = $options['accesshash'];
+        }
+
+        if (isset($options['passwordlength'])) {
+            $this->_config['passwordlength'] = $options['passwordlength'];
         }
 
         if (isset($options['ssl'])) {
@@ -102,6 +108,17 @@ abstract class Server_Manager
     }
 
     /**
+     * This method is used to get the password length from the configuration.
+     * If the password length is not set in the configuration, it defaults to 10.
+     *
+     * @return int The password length.
+     */
+    public function getPasswordLength(): int
+    {
+        return $this->_config['passwordlength'] ?? 10;
+    }
+
+    /**
      * Sets the logger object.
      *
      * @param Box_Log $value The logger object.
@@ -138,10 +155,10 @@ abstract class Server_Manager
 
     /**
      * Initializes the object after construction.
-     * 
+     *
      * This function can be used to perform any necessary setup tasks that are required after the object has been constructed.
-     *  
-     * @return void 
+     *
+     * @return void
      */
     protected function init()
     {
@@ -149,27 +166,27 @@ abstract class Server_Manager
 
     /**
      * Returns the login URL for the server. (ex: panel.example.com)
-     * 
+     *
      * @param null|Server_Account $account Either the related `Server_Account` which can be used to generate an SSO link or `null`.
-     * 
+     *
      * @return string
      */
     abstract public function getLoginUrl(?Server_Account $account);
 
     /**
      * Returns the login URL for the server for reseller accounts.
-     * 
+     *
      * @param null|Server_Account $account Either the related `Server_Account` which can be used to generate an SSO link or `null`.
-     * 
+     *
      * @return string
      */
     abstract public function getResellerLoginUrl(?Server_Account $account);
 
     /**
      * Used to test the connection to the server and verify the server configuration is correct.
-     * 
+     *
      * @return bool
-     * 
+     *
      * @throws Server_Exception
      */
     abstract public function testConnection();
@@ -177,22 +194,22 @@ abstract class Server_Manager
     /**
      * Creates a new account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to create.
-     * 
+     * @param Server_Account $account Account object containing the details of the account to create.
+     *
      * @return bool True if the account was created successfully, if not the server manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while creating the account.
      */
-    abstract public function createAccount(Server_Account $a);
+    abstract public function createAccount(Server_Account $account);
 
 
     /**
      * Synchronizes the account status from the server.
      *
      * @param Server_Account $a Account object containing the details of the account to synchronize.
-     * 
+     *
      * @return Server_Account A new account object with the updated status.
-     * 
+     *
      * @throws Server_Exception If there was an error while synchronizing the account.
      */
     abstract public function synchronizeAccount(Server_Account $a);
@@ -202,9 +219,9 @@ abstract class Server_Manager
      * Suspends an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to suspend.
-     * 
+     *
      * @return bool True if the account was suspended successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while suspending the account.
      */
     abstract public function suspendAccount(Server_Account $a);
@@ -214,9 +231,9 @@ abstract class Server_Manager
      * Unsuspends an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to unsuspend.
-     * 
+     *
      * @return bool True if the account was unsuspended successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while unsuspending the account.
      */
     abstract public function unsuspendAccount(Server_Account $a);
@@ -226,9 +243,9 @@ abstract class Server_Manager
      * Cancels an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to cancel.
-     * 
+     *
      * @return bool True if the account was canceled successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while canceling the account.
      */
     abstract public function cancelAccount(Server_Account $a);
@@ -238,11 +255,11 @@ abstract class Server_Manager
      * Changes the password for an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to update.
-     * 
+     *
      * @param string $new_password The new password for the account.
-     * 
+     *
      * @return bool True if the password was changed successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while changing the password.
      */
     abstract public function changeAccountPassword(Server_Account $a, $new_password);
@@ -252,11 +269,11 @@ abstract class Server_Manager
      * Changes the username for an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to update.
-     * 
+     *
      * @param string $new_username The new username for the account.
-     * 
+     *
      * @return bool True if the username was changed successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while changing the username.
      */
     abstract public function changeAccountUsername(Server_Account $a, $new_username);
@@ -266,11 +283,11 @@ abstract class Server_Manager
      * Changes the domain for an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to update.
-     * 
+     *
      * @param string $new_domain The new domain for the account.
-     * 
+     *
      * @return bool True if the domain was changed successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while changing the domain.
      */
     abstract public function changeAccountDomain(Server_Account $a, $new_domain);
@@ -280,11 +297,11 @@ abstract class Server_Manager
      * Changes the IP address for an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to update.
-     * 
+     *
      * @param string $new_ip The new IP address for the account.
-     * 
+     *
      * @return bool True if the IP address was changed successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while changing the IP address.
      */
     abstract public function changeAccountIp(Server_Account $a, $new_ip);
@@ -294,11 +311,11 @@ abstract class Server_Manager
      * Changes the package for an account on the server.
      *
      * @param Server_Account $a Account object containing the details of the account to update.
-     * 
+     *
      * @param Server_Package $p New package for the account.
-     * 
+     *
      * @return bool True if the package was changed successfully, if not the sever manager should throw an exception
-     * 
+     *
      * @throws Server_Exception If there was an error while changing the package.
      */
     abstract public function changeAccountPackage(Server_Account $a, Server_Package $p);

--- a/src/library/Server/Manager/CWP.php
+++ b/src/library/Server/Manager/CWP.php
@@ -113,27 +113,27 @@ class Server_Manager_CWP extends Server_Manager
 	/**
 	 * Package name must match on both CWP and FOSSBilling!
 	 */
-	public function createAccount(Server_Account $a)
+	public function createAccount(Server_Account $account)
 	{
-		$this->getLog()->info('Creating account ' . $a->getUsername());
+		$this->getLog()->info('Creating account ' . $account->getUsername());
 
-		$client = $a->getClient();
-		$package = $a->getPackage()->getName();
+		$client = $account->getClient();
+		$package = $account->getPackage()->getName();
 
 		$ip = $this->_config['ip'];
 
 		$data = [
 			'action'       => 'add',
-			'domain'       => $a->getDomain(),
-			'user'         => $a->getUsername(),
-			'pass'         => base64_encode($a->getPassword()),
+			'domain'       => $account->getDomain(),
+			'user'         => $account->getUsername(),
+			'pass'         => base64_encode($account->getPassword()),
 			'email'        => $client->getEmail(),
 			'package'      => $package,
 			'server_ips'   => $ip,
 			'encodepass'   => true
 		];
 
-		if ($a->getReseller()) {
+		if ($account->getReseller()) {
 			$data['reseller'] = 1;
 		}
 

--- a/src/library/Server/Manager/Custom.php
+++ b/src/library/Server/Manager/Custom.php
@@ -12,16 +12,16 @@ class Server_Manager_Custom extends Server_Manager
 {
     /**
      * Method is called just after obejct contruct is complete.
-     * Add required parameters checks here. 
+     * Add required parameters checks here.
      */
 	public function init()
     {
-        
+
 	}
 
     /**
      * Return server manager parameters.
-     * @return type 
+     * @return type
      */
     public static function getForm()
     {
@@ -32,8 +32,8 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Returns link to account management page
-     * 
-     * @return string 
+     *
+     * @return string
      */
     public function getLoginUrl(?Server_Account $account = null)
     {
@@ -42,7 +42,7 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Returns link to reseller account management
-     * @return string 
+     * @return string
      */
     public function getResellerLoginUrl(?Server_Account $account = null)
     {
@@ -52,8 +52,8 @@ class Server_Manager_Custom extends Server_Manager
     /**
      * This method is called to check if configuration is correct
      * and class can connect to server
-     * 
-     * @return boolean 
+     *
+     * @return boolean
      */
     public function testConnection()
     {
@@ -61,10 +61,10 @@ class Server_Manager_Custom extends Server_Manager
     }
 
     /**
-     * MEthods retrieves information from server, assignes new values to
+     * Methods retrieves information from server, assigns new values to
      * cloned Server_Account object and returns it.
      * @param Server_Account $a
-     * @return Server_Account 
+     * @return Server_Account
      */
     public function synchronizeAccount(Server_Account $a)
     {
@@ -77,12 +77,12 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Create new account on server
-     * 
-     * @param Server_Account $a 
+     *
+     * @param Server_Account $account
      */
-	public function createAccount(Server_Account $a)
+	public function createAccount(Server_Account $account)
     {
-        if($a->getReseller()) {
+        if($account->getReseller()) {
             $this->getLog()->info('Creating reseller hosting account');
         } else {
             $this->getLog()->info('Creating shared hosting account');
@@ -91,7 +91,7 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Suspend account on server
-     * @param Server_Account $a 
+     * @param Server_Account $a
      */
 	public function suspendAccount(Server_Account $a)
     {
@@ -104,7 +104,7 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Unsuspend account on server
-     * @param Server_Account $a 
+     * @param Server_Account $a
      */
 	public function unsuspendAccount(Server_Account $a)
     {
@@ -117,7 +117,7 @@ class Server_Manager_Custom extends Server_Manager
 
     /**
      * Cancel account on server
-     * @param Server_Account $a 
+     * @param Server_Account $a
      */
 	public function cancelAccount(Server_Account $a)
     {
@@ -131,7 +131,7 @@ class Server_Manager_Custom extends Server_Manager
     /**
      * Change account package on server
      * @param Server_Account $a
-     * @param Server_Package $p 
+     * @param Server_Package $p
      */
 	public function changeAccountPackage(Server_Account $a, Server_Package $p)
     {
@@ -140,7 +140,7 @@ class Server_Manager_Custom extends Server_Manager
         } else {
             $this->getLog()->info('Updating shared hosting account');
         }
-        
+
         $p->getName();
         $p->getQuota();
         $p->getBandwidth();
@@ -150,7 +150,7 @@ class Server_Manager_Custom extends Server_Manager
         $p->getMaxFtp();
         $p->getMaxSql();
         $p->getMaxPop();
-        
+
         $p->getCustomValue('param_name');
 	}
 

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -8,24 +8,46 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
+use Random\RandomException;
+
+/**
+ * Class Server_Manager_Directadmin
+ * This class is responsible for managing the DirectAdmin server.
+ * It extends the Server_Manager class.
+ */
 class Server_Manager_Directadmin extends Server_Manager
 {
-    public function init()
+    /**
+     * Initialize the server manager.
+     * Checks if the host, username, and password are set in the configuration.
+     * Throws an exception if any of these are not set.
+     * @throws Server_Exception
+     */
+    public function init(): void
     {
+        // Check if host is set in the configuration
         if(empty($this->_config['host'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'hostname'], 2001);
         }
 
+        // Check if username is set in the configuration
         if(empty($this->_config['username'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'username'], 2001);
         }
 
+        // Check if password is set in the configuration
         if(empty($this->_config['password'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'password'], 2001);
         }
     }
 
-    public static function getForm()
+    /**
+     * Returns the form configuration for the DirectAdmin server manager.
+     * The form includes fields for username and password.
+     *
+     * @return array The form configuration.
+     */
+    public static function getForm(): array
     {
         return array(
             'label' => 'DirectAdmin',
@@ -52,23 +74,54 @@ class Server_Manager_Directadmin extends Server_Manager
         );
     }
 
-    public function _getPort()
+    /**
+     * Returns the port number for the DirectAdmin server.
+     * If the port is not set in the configuration, it defaults to '2222'.
+     *
+     * @return float|int|string The port number.
+     */
+    public function _getPort(): float|int|string
     {
         return is_numeric($this->_config['port']) ? $this->_config['port'] : '2222';
     }
 
+    /**
+     * Returns the login URL for the DirectAdmin server.
+     * The URL includes the host and port from the configuration.
+     * If the 'secure' configuration option is set, the URL uses the 'https' protocol.
+     * Otherwise, it uses the 'http' protocol.
+     *
+     * @param Server_Account|null $account The server account. This parameter is not used in this method.
+     * @return string The login URL.
+     */
     public function getLoginUrl(?Server_Account $account = null): string
     {
         $protocol = $this->_config['secure'] ? 'https://' : 'http://';
         return $protocol . $this->_config['host'] . ':'. $this -> _getPort();
     }
 
-    public function getResellerLoginUrl(?Server_Account $account = null)
+    /**
+     * Returns the login URL for a reseller account on the DirectAdmin server.
+     * This method simply calls the getLoginUrl method, as the URL is the same for reseller accounts.
+     *
+     * @param Server_Account|null $account The server account. This parameter is not used in this method.
+     * @return string The login URL.
+     */
+    public function getResellerLoginUrl(?Server_Account $account = null): string
     {
         return $this->getLoginUrl();
     }
 
-    public function generateUsername($domain_name)
+    /**
+     * Generates a username for a new account on the DirectAdmin server.
+     * The username is based on the domain name, but is sanitized to be alphanumeric and start with a letter.
+     * The username is also limited to 10 characters to avoid collisions.
+     *
+     * @param string $domain_name The domain name.
+     * @return string The generated username.
+     * @throws RandomException
+     */
+    public function generateUsername($domain_name): string
     {
         // Username must be alphanumeric.
         $username = preg_replace('/[^A-Za-z0-9]/', '', $domain_name);
@@ -76,111 +129,139 @@ class Server_Manager_Directadmin extends Server_Manager
         // Username must start with a-z.
         $username = is_numeric(substr($username, 0, 1)) ? substr_replace($username, chr(random_int(97,122)), 0, 1) : $username;
 
-        // Username must be at most 10 characters long, and sufficiently random to avoid collisons.
+        // Username must be at most 10 characters long, and sufficiently random to avoid collisions.
         $username = substr($username, 0, 7);
-        $randnum = random_int(0, 99);
-        return $username . $randnum;
+        $random_number = random_int(0, 99);
+        return $username . $random_number;
     }
 
-    public function testConnection()
+    /**
+     * Tests the connection to the DirectAdmin server.
+     * This method sends a request to the server and checks if the response is an array.
+     *
+     * @return bool True if the connection is successful, false otherwise.
+     * @throws Server_Exception
+     */
+    public function testConnection(): bool
     {
-        $results = $this->_request('CMD_API_SHOW_RESELLER_IPS');
-        return is_array($results);
+        // Makes login test connection. As we don't currently force JSON, DirectAdmin will return HTML on a failed attempt, which causes the request to throw an error.
+        $this->_request('API_LOGIN_TEST');
+        return true;
     }
 
-    public function synchronizeAccount(Server_Account $a)
+    /**
+     * Synchronizes the server account with the DirectAdmin server.
+     * This method currently does nothing and simply returns the account as is.
+     *
+     * @param Server_Account $a The server account.
+     * @return Server_Account The same server account.
+     */
+    public function synchronizeAccount(Server_Account $a): Server_Account
     {
-        return $a;
+        throw new Server_Exception(':type: does not support :action:', [':type:' => 'DirectAdmin', ':action:' => __trans('synchronizing the account')]);
     }
 
-    public function createAccount(Server_Account $a)
+    /**
+     * Creates a new account on the DirectAdmin server.
+     * This method sends a request to the server with the account details.
+     * If the account is a reseller account, additional fields are included in the request.
+     *
+     * @param Server_Account $account The server account.
+     * @return bool True if the account is created successfully, false otherwise.
+     * @throws Server_Exception
+     */
+    public function createAccount(Server_Account $account): bool
     {
+        throw new Server_Exception($account->getPassword());
+
         $ips = $this->getIps();
         if(empty($ips)) {
             throw new Server_Exception('There are no available IPs on this server.');
         }
+
         $ip = $ips[array_rand($ips)];
 
-        $package = $a->getPackage();
-        $client  = $a->getClient();
+        $package = $account->getPackage();
+        $client  = $account->getClient();
 
         $fields             = array();
         $fields['action']   = 'create';
         $fields['add']      = 'Submit';
-        $fields['username'] = $a->getUsername();
+        $fields['username'] = $account->getUsername();
         $fields['email']    = $client->getEmail();
-        $fields['passwd']   = $a->getPassword();
-        $fields['passwd2']  = $a->getPassword();
-        $fields['domain']   = $a->getDomain();
-
-        // do not create new package
-        //        $packages = $this->getPackages();
-        //        $fields['package'] = $package->getName();
-
+        $fields['passwd']   = $account->getPassword();
+        $fields['passwd2']  = $account->getPassword();
+        $fields['domain']   = $account->getDomain();
         $fields['ip']     = $ip;
         $fields['notify'] = 'no';
 
-        $fields['bandwidth'] = $package->getBandwidth(); //Amount of bandwidth User will be allowed to use. Number, in Megabytes
-        if($package->getBandwidth() == 'unlimited') {
-            $fields['ubandwidth'] = 'ON'; //ON or OFF. If ON, bandwidth is ignored and no limit is set
-        }
-        $fields['quota'] = $package->getQuota(); //Amount of disk space User will be allowed to use. Number, in Megabytes
-        if($package->getQuota() == 'unlimited') {
-            $fields['uquota'] = 'ON'; //ON or OFF. If ON, quota is ignored and no limit is set
-        }
-        $fields['vdomains'] = $package->getMaxDomains(); //Number of domains the User will be allowed to create
-        if($package->getMaxDomains() == 'unlimited') {
-            $fields['uvdomains'] = 'ON'; //ON or OFF. If ON, vdomains is ignored and no limit is set
-        }
-        $fields['nsubdomains'] = $package->getMaxSubdomains(); //Number of subdomains the User will be allowed to create
-        if($package->getMaxSubdomains() == 'unlimited') {
-            $fields['unsubdomains'] = 'ON'; //ON or OFF. If ON, nsubdomains is ignored and no limit is set
-        }
-        $fields['domainptr'] = $package->getMaxParkedDomains(); //Number of domain pointers the User will be allowed to create
-        if($package->getMaxParkedDomains() == 'unlimited') {
-            $fields['udomainptr'] = 'ON'; //ON or OFF Unlimited option for domainptr
-        }
-        $fields['nemails'] = $package->getMaxPop(); //Number of pop accounts the User will be allowed to create
-        if($package->getMaxPop() == 'unlimited') {
-            $fields['unemails'] = 'ON'; //ON or OFF Unlimited option for nemails
-        }
-        $fields['mysql'] = $package->getMaxSql(); //Number of MySQL databases the User will be allowed to create
-        if($package->getMaxSql() == 'unlimited') {
-            $fields['umysql'] = 'ON'; //ON or OFF Unlimited option for mysql
-        }
-        $fields['ftp'] = $package->getMaxFtp(); //Number of ftp accounts the User will be allowed to create
-        if($package->getMaxFtp() == 'unlimited') {
-            $fields['uftp'] = 'ON'; //ON or OFF Unlimited option for ftp
-        }
-        $fields['nemailf'] = $package->getCustomValue('nemailf'); //Number of forwarders the User will be allowed to create
-        if($fields['nemailf'] == 'unlimited') {
-            $fields['unemailf'] = 'ON'; //ON or OFF Unlimited option for nemailf
-        }
-        $fields['nemailml'] = $package->getCustomValue('nemailml'); //Number of mailing lists the User will be allowed to create
-        if($fields['nemailml'] == 'unlimited') {
-            $fields['unemailml'] = 'ON'; //ON or OFF Unlimited option for nemailml
-        }
-        $fields['nemailr'] = $package->getCustomValue('nemailr'); //Number of autoresponders the User will be allowed to create
-        if($fields['nemailr'] == 'unlimited') {
-            $fields['unemailr'] = 'ON'; //ON or OFF Unlimited option for nemailr
+        if (!empty($package->getCustomValue('package'))) {
+            $this->getLog()->info('Using DirectAdmin package name: ' . $package->getCustomValue('package') . ', ignoring package settings');
+            $fields['package'] = $package->getCustomValue('package');
+        } else {
+            $fields['bandwidth'] = $package->getBandwidth(); //Amount of bandwidth User will be allowed to use. Number, in Megabytes
+            if($package->getBandwidth() == 'unlimited') {
+                $fields['ubandwidth'] = 'ON'; //ON or OFF. If ON, bandwidth is ignored and no limit is set
+            }
+            $fields['quota'] = $package->getQuota(); //Amount of disk space User will be allowed to use. Number, in Megabytes
+            if($package->getQuota() == 'unlimited') {
+                $fields['uquota'] = 'ON'; //ON or OFF. If ON, quota is ignored and no limit is set
+            }
+            $fields['vdomains'] = $package->getMaxDomains(); //Number of domains the User will be allowed to create
+            if($package->getMaxDomains() == 'unlimited') {
+                $fields['uvdomains'] = 'ON'; //ON or OFF. If ON, vdomains is ignored and no limit is set
+            }
+            $fields['nsubdomains'] = $package->getMaxSubdomains(); //Number of subdomains the User will be allowed to create
+            if($package->getMaxSubdomains() == 'unlimited') {
+                $fields['unsubdomains'] = 'ON'; //ON or OFF. If ON, nsubdomains is ignored and no limit is set
+            }
+            $fields['domainptr'] = $package->getMaxParkedDomains(); //Number of domain pointers the User will be allowed to create
+            if($package->getMaxParkedDomains() == 'unlimited') {
+                $fields['udomainptr'] = 'ON'; //ON or OFF Unlimited option for domainptr
+            }
+            $fields['nemails'] = $package->getMaxPop(); //Number of pop accounts the User will be allowed to create
+            if($package->getMaxPop() == 'unlimited') {
+                $fields['unemails'] = 'ON'; //ON or OFF Unlimited option for nemails
+            }
+            $fields['mysql'] = $package->getMaxSql(); //Number of MySQL databases the User will be allowed to create
+            if($package->getMaxSql() == 'unlimited') {
+                $fields['umysql'] = 'ON'; //ON or OFF Unlimited option for mysql
+            }
+            $fields['ftp'] = $package->getMaxFtp(); //Number of ftp accounts the User will be allowed to create
+            if($package->getMaxFtp() == 'unlimited') {
+                $fields['uftp'] = 'ON'; //ON or OFF Unlimited option for ftp
+            }
+            $fields['nemailf'] = $package->getCustomValue('nemailf'); //Number of forwarders the User will be allowed to create
+            if($fields['nemailf'] == 'unlimited') {
+                $fields['unemailf'] = 'ON'; //ON or OFF Unlimited option for nemailf
+            }
+            $fields['nemailml'] = $package->getCustomValue('nemailml'); //Number of mailing lists the User will be allowed to create
+            if($fields['nemailml'] == 'unlimited') {
+                $fields['unemailml'] = 'ON'; //ON or OFF Unlimited option for nemailml
+            }
+            $fields['nemailr'] = $package->getCustomValue('nemailr'); //Number of autoresponders the User will be allowed to create
+            if($fields['nemailr'] == 'unlimited') {
+                $fields['unemailr'] = 'ON'; //ON or OFF Unlimited option for nemailr
+            }
+
+            $fields['aftp']       = $package->getCustomValue('aftp') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to have anonymous ftp accounts.
+            $fields['cgi']        = $package->getCustomValue('cgi') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
+            $fields['php']        = $package->getCustomValue('php') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run php scripts.
+            $fields['spam']       = $package->getCustomValue('spam') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
+            $fields['cron']       = $package->getCustomValue('cron') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to creat cronjobs.
+            $fields['catchall']   = $package->getCustomValue('catchall') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
+            $fields['ssl']        = $package->getCustomValue('ssl') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to access their websites through secure https://.
+            $fields['ssh']        = $package->getCustomValue('ssh') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have an ssh account.
+            $fields['sysinfo']    = $package->getCustomValue('sysinfo') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to a page that shows the system information.
+            $fields['login_keys'] = $package->getCustomValue('login_keys') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to the Login Key system for extra account passwords.
+            $fields['dnscontrol'] = $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to modify his/her dns records.
+            $fields['suspend_at_limit'] = $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be suspended if their User bandwidth limit is exceeded.
         }
 
-        $fields['aftp']       = $package->getCustomValue('aftp') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to have anonymous ftp accounts.
-        $fields['cgi']        = $package->getCustomValue('cgi') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-        $fields['php']        = $package->getCustomValue('php') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run php scripts.
-        $fields['spam']       = $package->getCustomValue('spam') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
-        $fields['cron']       = $package->getCustomValue('cron') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to creat cronjobs.
-        $fields['catchall']   = $package->getCustomValue('catchall') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
-        $fields['ssl']        = $package->getCustomValue('ssl') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to access their websites through secure https://.
-        $fields['ssh']        = $package->getCustomValue('ssh') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have an ssh account.
-        $fields['sysinfo']    = $package->getCustomValue('sysinfo') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to a page that shows the system information.
-        $fields['login_keys'] = $package->getCustomValue('login_keys') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to the Login Key system for extra account passwords.
-        $fields['dnscontrol'] = $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to modify his/her dns records.
-        $fields['suspend_at_limit'] = $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be suspended if their User bandwidth limit is exceeded.
-        $command              = 'CMD_API_ACCOUNT_USER';
+        $command = 'API_ACCOUNT_USER';
 
-        if($a->getReseller()) {
-            $command = 'CMD_ACCOUNT_RESELLER';
+        if($account->getReseller()) {
+            $command = 'ACCOUNT_RESELLER';
 
             $fields['ips'] = 1; //Number of ips that will be allocated to the Reseller upon account during account
             $fields['ip']  = 'assign';
@@ -216,10 +297,10 @@ class Server_Manager_Directadmin extends Server_Manager
         }
 
         $fields             = array();
-        $fields['location'] = 'CMD_USER_SHOW';
+        $fields['location'] = 'USER_SHOW';
         $fields['suspend']  = 'Suspend';
         $fields['select0']  = $a->getUsername();
-        $result             = $this->_request('CMD_API_SELECT_USERS', $fields);
+        $result             = $this->_request('API_SELECT_USERS', $fields);
 
         return true;
     }
@@ -232,10 +313,10 @@ class Server_Manager_Directadmin extends Server_Manager
         }
 
         $fields             = array();
-        $fields['location'] = 'CMD_USER_SHOW';
+        $fields['location'] = 'USER_SHOW';
         $fields['suspend']  = 'Unsuspend';
         $fields['select0']  = $a->getUsername();
-        $this->_request('CMD_API_SELECT_USERS', $fields);
+        $this->_request('API_SELECT_USERS', $fields);
         return true;
     }
 
@@ -245,7 +326,7 @@ class Server_Manager_Directadmin extends Server_Manager
         $fields['confirmed'] = 'Confirm';
         $fields['delete']    = 'yes';
         $fields['select0']   = $a->getUsername();
-        $this->_request('CMD_API_SELECT_USERS', $fields);
+        $this->_request('API_SELECT_USERS', $fields);
         return true;
     }
 
@@ -315,65 +396,80 @@ class Server_Manager_Directadmin extends Server_Manager
         $fields['ns1'] = $a->getNs1();
         $fields['ns2'] = $a->getNs2();
 
-        $this->_request('CMD_API_MODIFY_USER', $fields);
+        $this->_request('API_MODIFY_USER', $fields);
         return true;
     }
 
-    public function changeAccountPassword(Server_Account $a, $newPassword)
-    {
-        $fields             = array();
-        $fields['username'] = $a->getUsername();
-        $fields['passwd']   = $newPassword;
-        $fields['passwd2']  = $newPassword;
-        $this->_request('CMD_API_USER_PASSWD', $fields);
-        return true;
-    }
-
-    public function changeAccountUsername(Server_Account $a, $new): never
-    {
-        throw new Server_Exception(':type: does not support :action:', [':type:' => 'DirectAdmin', ':action:' => __trans('username changes')]);
-    }
-
-    public function changeAccountDomain(Server_Account $a, $new): never
+    public function changeAccountDomain(Server_Account $a, $new_domain): never
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'DirectAdmin', ':action:' => __trans('changing the account domain')]);
     }
 
-    public function changeAccountIp(Server_Account $a, $new): never
+    public function changeAccountIp(Server_Account $account, $new_ip): never
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'DirectAdmin', ':action:' => __trans('changing the account IP')]);
     }
 
-    public function changeAccountPackage(Server_Account $a, Server_Package $p)
+    public function changeAccountPackage(Server_Account $a, Server_Package $p): bool
     {
         $fields            = array();
         $fields['action']  = 'package';
         $fields['user']    = $a->getUsername();
         $fields['package'] = $a->getPackage()->getName();
-        $this->_request('CMD_API_MODIFY_USER', $fields);
+        $this->_request('API_MODIFY_USER', $fields);
         return true;
     }
 
-    private function getAccountInfo(Server_Account $a)
+    public function changeAccountPassword(Server_Account $a, $new_password)
+    {
+        $fields             = array();
+        $fields['username'] = $a->getUsername();
+        $fields['passwd']   = $new_password;
+        $fields['passwd2']  = $new_password;
+        $this->_request('API_USER_PASSWD', $fields);
+        return true;
+    }
+
+    public function changeAccountUsername(Server_Account $a, $new_username): never
+    {
+        throw new Server_Exception(':type: does not support :action:', [':type:' => 'DirectAdmin', ':action:' => __trans('username changes')]);
+    }
+
+    /**
+     * @throws Server_Exception
+     */
+    private function getAccountInfo(Server_Account $account): array
     {
         $fields           = array();
         $fields['action'] = 'create';
         $fields['add']    = 'Submit';
-        $fields['user']   = $a->getUsername();
-        return $this->_request('CMD_API_SHOW_USER_CONFIG', $fields);
+        $fields['user']   = $account->getUsername();
+        return $this->_request('API_SHOW_USER_CONFIG', $fields);
     }
 
-    private function getUserInfo(Server_Account $a)
+    /**
+     * @throws Server_Exception
+     */
+    private function getUserInfo(Server_Account $account)
     {
         $fields         = array();
-        $fields['user'] = $a->getUsername();
-        $result         = $this->_request('CMD_API_SHOW_USER_CONFIG', $fields);
+        $fields['user'] = $account->getUsername();
+        $result        = $this->_request('API_SHOW_USER_CONFIG', $fields);
         return;
     }
 
+    /**
+     * This method is used to verify the authentication credentials for the DirectAdmin server.
+     * It sends a request to the server with the 'API_VERIFY_PASSWORD' command and the username and password from the configuration.
+     * The response from the server is stored in the $response variable, but is not used in this method.
+     * The method always returns true, regardless of the server's response.
+     *
+     * @return bool Always returns true.
+     * @throws Server_Exception If there is an error while sending the request to the server.
+     */
     private function checkAuth()
     {
-        $r = $this->_request('CMD_API_VERIFY_PASSWORD', array(
+        $response = $this->_request('API_VERIFY_PASSWORD', array(
             'user' => $this->_config['username'],
             'passwd' => $this->_config['password']
         ));
@@ -381,55 +477,51 @@ class Server_Manager_Directadmin extends Server_Manager
         return true;
     }
 
-    private function getPackages()
-    {
-        return $this->_request('CMD_API_PACKAGES_USER');
-    }
-
+    /**
+     * @throws Server_Exception
+     */
     private function getIps()
     {
-        $results = $this->_request('CMD_API_SHOW_RESELLER_IPS');
+        $results = $this->_request('API_SHOW_RESELLER_IPS');
         return $results['list'] ?? array();
     }
 
     /**
      * @param string $command
+     * @param array $fields
+     * @param bool $post
+     * @return array
+     * @throws Server_Exception
      */
-    private function _request($command, $fields = array(), $post = true)
+    private function _request(string $command, array $fields = array(), bool $post = true): array
     {
         $host = $this->_config['host'];
         $protocol = $this->_config['secure'] ? 'https://' : 'http://';
 
-        $fieldstring = http_build_query($fields);
+        $field_string = http_build_query($fields);
 
-        $httpClient = $this->getHttpClient()->withOptions([
-            'verify_peer'   => false,
-            'verify_host'   => false,
-            'timeout'       => 60,
+        $http_client = $this->getHttpClient()->withOptions([
             'auth_basic'    => [ $this->_config['username'], $this->_config['password'] ],
+            'timeout'       => 60,
+            'verify_host'   => false,
+            'verify_peer'   => false,
         ]);
 
-        $url = $protocol . $host . ':'. $this -> _getPort().'/' . $command . '?' . $fieldstring;
+        $url = $protocol . $host . ':'. $this -> _getPort().'/CMD_' . $command . '?' . $field_string;
         $this->getLog()->debug($url);
 
         try {
-            if($post) {
-                $request = $httpClient->request('POST', $url, [
-                    'body'  => $fields,
-                ]);
-            } else {
-                $request = $httpClient->request('GET', $url);
-            }
-
+            // If it's a POST request, include the fields in the request body
+            $request = $http_client->request($post ? 'POST' : 'GET', $url, $post ? ['body' => $fields] : []);
             $data = $request->getContent();
         } catch (\Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface |
                  \Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface $error) {
-            $e = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
-            $this->getLog()->err($e);
-            throw $e;
+            $exception = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
+            $this->getLog()->err($exception);
+            throw $exception;
         }
 
-        if(strlen(strstr($data, 'DirectAdmin Login')) > 0) {
+        if(strlen(strstr($data, '<!doctype html>')) > 0 || strlen(strstr($data, 'DirectAdmin Login')) > 0) {
             throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'DirectAdmin']);
         }
 
@@ -437,30 +529,43 @@ class Server_Manager_Directadmin extends Server_Manager
             throw new Server_Exception('Server Manager DirectAdmin Error: "The request you have made cannot be executed because it does not exist in your authority level"');
         }
 
-        $r = $this->_parseResponse($data);
+        $response = $this->_parseResponse($data);
 
-        if(isset($r['error']) && $r['error'] == 1) {
-            $placeholders = [':action:' => $command, ':type:' => 'DirectAdmin'];
-            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        if(isset($response['error']) && $response['error'] == 1) {
+            $placeholders = [':action:' => $command, ':type:' => 'DirectAdmin', ':error:' => $response['text'] . ': ' . $response['details']];
+            throw new Server_Exception('Failed to :action: on the :type: server: :error:', $placeholders);
         }
 
-        $response = empty($r) ? array() : $r;
-        return $response;
+        return empty($response) ? array() : $response;
     }
 
-    private function _parseResponse($data)
+    /**
+     * This method is used to parse the response data from the DirectAdmin server.
+     * It first logs the raw response data for debugging purposes.
+     * Then it replaces certain HTML entities in the data with their corresponding characters.
+     * After that, it parses the data into an array using PHP's parse_str function.
+     * Finally, it logs the parsed response data and returns it.
+     *
+     * @param string $data The raw response data from the DirectAdmin server.
+     * @return array The parsed response data.
+     */
+    private function _parseResponse(string $data): array
     {
+        // Log the raw response data for debugging purposes
         $this->getLog()->debug('Raw Response: ' . $data);
 
-        // add more replacers if needed
+        // Replace certain HTML entities in the data with their corresponding characters
         $data = str_replace('&#39', '"', $data);
-
         $data = preg_replace('|(\&\#\d+)|', '$1;', $data);
         $data = html_entity_decode($data);
 
-        parse_str($data, $r);
+        // Parse the data into an array
+        parse_str($data, $response);
 
-        $this->getLog()->debug('Parsed Response: ' . print_r($r, 1));
-        return $r;
+        // Log the parsed response data for debugging purposes
+        $this->getLog()->debug('Parsed Response: ' . print_r($response, 1));
+
+        // Return the parsed response data
+        return $response;
     }
 }

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -510,7 +510,14 @@ class Server_Manager_Directadmin extends Server_Manager
 
         try {
             // If it's a POST request, include the fields in the request body
-            $request = $http_client->request($post ? 'POST' : 'GET', $url, $post ? ['body' => $fields] : []);
+            if($post) {
+                $request = $httpClient->request('POST', $url, [
+                    'body'  => $fields,
+                ]);
+            } else {
+                $request = $httpClient->request('GET', $url);
+            }
+
             $data = $request->getContent();
         } catch (\Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface |
                  \Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface $error) {
@@ -530,8 +537,8 @@ class Server_Manager_Directadmin extends Server_Manager
         $response = $this->_parseResponse($data);
 
         if(isset($response['error']) && $response['error'] == 1) {
-            $placeholders = [':action:' => $command, ':type:' => 'DirectAdmin', ':error:' => $response['text'] . ': ' . $response['details']];
-            throw new Server_Exception('Failed to :action: on the :type: server: :error:', $placeholders);
+            $this->getLog()->err('Failed to ' . $command . ' on the DirectAdmin server: ' . $response['text'] . ': ' . $response['details']);
+            throw new Server_Exception('Failed to complete the operation on the DirectAdmin server');
         }
 
         return empty($response) ? array() : $response;

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -498,7 +498,7 @@ class Server_Manager_Directadmin extends Server_Manager
 
         $field_string = http_build_query($fields);
 
-        $http_client = $this->getHttpClient()->withOptions([
+        $this->getHttpClient()->withOptions([
             'auth_basic'    => [ $this->_config['username'], $this->_config['password'] ],
             'timeout'       => 60,
             'verify_host'   => false,

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -172,8 +172,6 @@ class Server_Manager_Directadmin extends Server_Manager
      */
     public function createAccount(Server_Account $account): bool
     {
-        throw new Server_Exception($account->getPassword());
-
         $ips = $this->getIps();
         if(empty($ips)) {
             throw new Server_Exception('There are no available IPs on this server.');

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -162,14 +162,14 @@ class Server_Manager_Hestia extends Server_Manager
     /**
      * Create new account on server.
      *
-     * @param Server_Account $a
+     * @param Server_Account $account
      */
 
-    public function createAccount(Server_Account $a)
+    public function createAccount(Server_Account $account)
     {
-        $p = $a->getPackage();
+        $p = $account->getPackage();
         $packname = $this->_getPackageName($p);
-        $client = $a->getClient();
+        $client = $account->getClient();
         // Server credentials
         $vst_command = 'v-add-user';
         $vst_returncode = 'yes';
@@ -177,8 +177,8 @@ class Server_Manager_Hestia extends Server_Manager
         $postvars = [
             'returncode' => $vst_returncode,
             'cmd' => $vst_command,
-            'arg1' => $a->getUsername(),
-            'arg2' => $a->getPassword(),
+            'arg1' => $account->getUsername(),
+            'arg2' => $account->getPassword(),
             'arg3' => $client->getEmail(),
             'arg4' => $packname,
             'arg5' => trim($client->getFullName()),
@@ -190,8 +190,8 @@ class Server_Manager_Hestia extends Server_Manager
             $postvars2 = [
                 'returncode' => 'yes',
                 'cmd' => 'v-add-domain',
-                'arg1' => $a->getUsername(),
-                'arg2' => $a->getDomain(),
+                'arg1' => $account->getUsername(),
+                'arg2' => $account->getDomain(),
             ];
             $result2 = $this->_makeRequest($postvars2);
         } else {
@@ -202,7 +202,7 @@ class Server_Manager_Hestia extends Server_Manager
             $postvars3 = [
                 'returncode' => 'yes',
                 'cmd' => 'v-delete-user',
-                'arg1' => $a->getUsername(),
+                'arg1' => $account->getUsername(),
             ];
             $result3 = $this->_makeRequest($postvars3);
             if (0 !== intval($result3)) {

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -52,17 +52,17 @@ class Server_Manager_Plesk extends Server_Manager
 
         return true;
     }
-    
+
     public function synchronizeAccount(Server_Account $a): never
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'Plesk', ':action:' => __trans('account synchronization')]);
     }
 
-    public function createAccount(Server_Account $a)
+    public function createAccount(Server_Account $account)
     {
-    	$this->getLog()->info('Creating account ' . $a->getUsername());
+    	$this->getLog()->info('Creating account ' . $account->getUsername());
 
-    	if ($a->getReseller()) {
+    	if ($account->getReseller()) {
     		$ips = $this->_getIps();
     		foreach($ips['exclusive'] as $key => $ip) {
 	    		if (!$ip['empty']) {
@@ -79,19 +79,19 @@ class Server_Manager_Plesk extends Server_Manager
             if ((is_countable($ips['exclusive']) ? count($ips['exclusive']) : 0) > 0) {
                 $ips['exclusive'] = array_values($ips['exclusive']);
     		    $rand = array_rand($ips['exclusive']);
-    		    $a->setIp($ips['exclusive'][$rand]['ip']);
+    		    $account->setIp($ips['exclusive'][$rand]['ip']);
             }
     	}
 
-    	$id = $this->_createClient($a);
-        $client = $a->getClient();
+    	$id = $this->_createClient($account);
+        $client = $account->getClient();
     	if (!$id) {
     		$placeholders = [':action:' => __trans('create account'), ':type"' => 'Plesk'];
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
     	} else {
             $client->setId((string)$id);
     	}
-        $this->setSubscription($a);
+        $this->setSubscription($account);
 
         // We need to improve the way we handle the IP address before we should enable this.
         /*
@@ -116,7 +116,7 @@ class Server_Manager_Plesk extends Server_Manager
     // ??
     public function createServicePlan(Server_Account $a)
     {
-        
+
     }
 
     public function updateSubscription(Server_Account $a)
@@ -129,7 +129,7 @@ class Server_Manager_Plesk extends Server_Manager
     public function deleteSubscription(Server_Account $a)
     {
         $result = $this->_client->webspace()->delete('name', $a->getDomain());
-        
+
         return $result;
     }
 
@@ -204,7 +204,7 @@ class Server_Manager_Plesk extends Server_Manager
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'Plesk', ':action:' => __trans('username changes')]);
     }
-    
+
     public function changeAccountDomain(Server_Account $a, $new)
     {
         $this->getLog()->info('Updating domain for account ' . $a->getUsername());
@@ -236,7 +236,7 @@ class Server_Manager_Plesk extends Server_Manager
     	$response = $this->_client->ip()->get();
 
 		$ips = array('shared' => array(), 'exclusive' => array());
-		
+
         foreach($response as $ip) {
             $ips[(string)$ip->type][] = array(
 				'ip'		=>	(string)$ip->ipAddress,
@@ -410,7 +410,7 @@ class Server_Manager_Plesk extends Server_Manager
                                 'name'	=>	'max_site',
                                 'value'	=>	$p->getMaxDomains() ?: 0,
                             ),
-                        ), 
+                        ),
                     ),
                     'permissions'	=>	array(
                         'permission'	=>	array(

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -31,7 +31,7 @@ class Server_Manager_Whm extends Server_Manager
         }
 
         // If port not set, use WHM default.
-        $this->_config['port'] = empty($this->_config['port']) ? '2087' : $this->_config['port'];  
+        $this->_config['port'] = empty($this->_config['port']) ? '2087' : $this->_config['port'];
 	}
 
     public function getLoginUrl(?Server_Account $account = null)
@@ -45,7 +45,7 @@ class Server_Manager_Whm extends Server_Manager
         $host = $this->_config['host'];
         return 'http://'.$host.'/whm';
     }
-    
+
     public static function getForm()
     {
         return array(
@@ -100,47 +100,47 @@ class Server_Manager_Whm extends Server_Manager
         $new->setDomain($acc->domain);
         $new->setUsername($acc->user);
         $new->setIp($acc->ip);
-        
+
         return $new;
     }
 
-	public function createAccount(Server_Account $a)
+	public function createAccount(Server_Account $account)
     {
-        $this->getLog()->info('Creating account '.$a->getUsername());
+        $this->getLog()->info('Creating account '.$account->getUsername());
 
-        $client = $a->getClient();
-        $package = $a->getPackage();
+        $client = $account->getClient();
+        $package = $account->getPackage();
 
         $this->_checkPackageExists($package, true);
 
         $action = 'createacct';
         $var_hash = array(
-			'username'		=> $a->getUsername(),
-            'domain'		=> $a->getDomain(),
-			'password'		=> $a->getPassword(),
+			'username'		=> $account->getUsername(),
+            'domain'		=> $account->getDomain(),
+			'password'		=> $account->getPassword(),
 			'contactemail'  => $client->getEmail(),
 			'plan'			=> $this->_getPackageName($package),
         	'useregns'		=> 0,
         );
-            
-        if($a->getReseller()) {
+
+        if($account->getReseller()) {
             $var_hash['reseller'] = 1;
         }
-        
+
         $json = $this->_request($action, $var_hash);
         $result = ($json->result[0]->status == 1);
 
         // if this account is reseller account set ACL list
-        if($result && $a->getReseller()) {
+        if($result && $account->getReseller()) {
 
             $params = array(
-                'user'          =>  $a->getUsername(),
+                'user'          =>  $account->getUsername(),
                 'makeowner'     =>  0,
             );
             $this->_request('setupreseller', $params);
 
             $params = array(
-                'reseller'  =>  $a->getUsername(),
+                'reseller'  =>  $account->getUsername(),
                 'acllist'   =>  $package->getAcllist(),
             );
             $this->_request('setacls', $params);
@@ -194,7 +194,7 @@ class Server_Manager_Whm extends Server_Manager
     {
         $this->getLog()->info('Changing account '.$a->getUsername().' package');
         $this->_checkPackageExists($p, true);
-        
+
 		$var_hash = array(
 			'user'              => $a->getUsername(),
 			'pkg'               => $this->_getPackageName($p),
@@ -226,7 +226,7 @@ class Server_Manager_Whm extends Server_Manager
     public function changeAccountUsername(Server_Account $a, $new)
     {
         $this->getLog()->info('Changing account '.$a->getUsername().' username');
-        
+
         $action = 'modifyacct';
 		$var_hash = array(
             'user'      => $a->getUsername(),
@@ -236,7 +236,7 @@ class Server_Manager_Whm extends Server_Manager
 		$this->_request($action, $var_hash);
         return true;
     }
-    
+
     public function changeAccountDomain(Server_Account $a, $new)
     {
         $this->getLog()->info('Changing account '.$a->getUsername().' domain');
@@ -299,7 +299,7 @@ class Server_Manager_Whm extends Server_Manager
 			$var_hash['maxftp']			= $package->getMaxFtp();
 			$var_hash['maxsql']			= $package->getMaxSql();
 			$var_hash['maxpop']			= $package->getMaxPop();
-            
+
 			$var_hash['cgi']			= $package->getCustomValue('cgi');
             $var_hash['cpmod']			= $package->getCustomValue('cpmod');
 			$var_hash['maxlst']			= $package->getCustomValue('maxlst');
@@ -315,7 +315,7 @@ class Server_Manager_Whm extends Server_Manager
     {
         $name = $package->getName();
         $name = $this->_config['username'].'_'.$name;
-        
+
         return $name;
     }
 
@@ -396,11 +396,11 @@ class Server_Manager_Whm extends Server_Manager
         $username = $this->_config['username'];
         $accesshash = $this->_config['accesshash'];
         $password = $this->_config['password'];
-        $authstr = (!empty($accesshash)) ? 'WHM ' . $username . ':' . $accesshash  
+        $authstr = (!empty($accesshash)) ? 'WHM ' . $username . ':' . $accesshash
                                          : 'Basic ' . $username .':'. $password;
 
         $this->getLog()->debug(sprintf('Requesting WHM server action "%s" with params "%s" ', $action, print_r($params, true)));
-        
+
         try  {
             $response = $client->request('POST', $url, [
                 'headers'   => [ 'Authorization' => $authstr ],

--- a/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
+++ b/src/modules/Dashboard/html_client/mod_dashboard_index.html.twig
@@ -184,7 +184,7 @@
                             <a href="{{ 'order/service/manage'|link }}/{{ order.id }}">{{ order.title|truncate(30) }}</a>
                         </td>
                         <td>
-                            <span class="badge {% if order.status == 'active' %}badge-success{% elseif order.status == 'pending_setup' %}badge-warning{% endif %}">{{ mf.status_name(order.status) }}</span>
+                            <span class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% elseif order.status == 'canceled' %}bg-secondary{% endif %}">{{ mf.status_name(order.status) }}</span>
                         </td>
                     </tr>
                     {% else %}

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -206,7 +206,7 @@
     {% else %}
         <div class="row">
             <div class="col-md-6">
-                <div class="card mb-4bg-white">
+                <div class="card mb-4 bg-white">
                     <div class="card-header bg-white h6 py-3">{{ 'Profile'|trans }}</div>
                     <div class="card-body">
                         <p>{{ 'You are logged out'|trans }}</p>

--- a/src/modules/Index/html_client/mod_index_dashboard.html.twig
+++ b/src/modules/Index/html_client/mod_index_dashboard.html.twig
@@ -156,7 +156,7 @@
                                                 <span class="text-secondary small" title="{{ order.updated_at|format_date }}">{{ order.updated_at|timeago }} {{ 'ago'|trans }}</span>
                                             </div>
                                             <div>
-                                                <span class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% endif %}">{{ mf.status_name(order.status) }}</span>
+                                                <span class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% elseif order.status == 'canceled' %}bg-secondary{% endif %}">{{ mf.status_name(order.status) }}</span>
                                             </div>
                                         </a>
                                     {% endfor %}

--- a/src/modules/Order/html_client/mod_order_list.html.twig
+++ b/src/modules/Order/html_client/mod_order_list.html.twig
@@ -46,7 +46,7 @@
                                     <td>{% if order.expires_at %}{{ order.expires_at|format_date }}{% else %}-{% endif %}</td>
                                     <td>
                                     <span
-                                        class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% endif %}">{{ mf.status_name(order.status) }}</span>
+                                        class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% elseif order.status == 'canceled' %}bg-secondary{% endif %}">{{ mf.status_name(order.status) }}</span>
                                     </td>
                                     <td class="actions">
                                         <a class="btn btn-sm btn-outline-primary"

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -56,7 +56,7 @@
                         <tr>
                             <td><label>{{ 'Order status'|trans }}</label></td>
                             <td>
-                                <span class="badge {% if order.status == 'active' %} bg-success {% elseif order.status == 'pending_setup' %} bg-warning {% else %} bg-danger {% endif %}">{{ mf.status_name(order.status) }}</span>
+                                <span class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% elseif order.status == 'canceled' %}bg-secondary{% endif %}">{{ mf.status_name(order.status) }}</span>
                             </td>
                         </tr>
 

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -30,16 +30,17 @@
                         <button type="submit" class="btn btn-primary w-100 mb-3">{{ 'Login'|trans }}</button>
                     </form>
                     {% if settings.show_password_reset_link or settings.show_signup_link %}
-                        <div class="row justify-content-center">
-                            <div class="col-1"></div>
+                        <div class="row">
                             {% if settings.show_signup_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'signup'|link }}">{{ 'Create account'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'signup'|link }}">{{ 'Create account'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                             {% if settings.show_password_reset_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                         </div>
                     {% endif %}
                 </div>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -27,7 +27,7 @@
                         </div>
                         <button type="submit" class="btn btn-primary w-100 mb-3">{{ 'Reset password'|trans }}</button>
                     </form>
-                    <a class="btn btn-secondary btn-sm" href="{{ 'login'|link }}">{{ 'Back to login'|trans }}</a>
+                    <a class="btn btn-outline-primary w-100" href="{{ 'login'|link }}">{{ 'Back to login'|trans }}</a>
                 </div>
             </div>
         </div>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -165,14 +165,16 @@
                                 <button class="btn btn-primary w-100" type="submit">{{ 'Sign up'|trans }}</button>
                             </div>
                         </form>
-                        <div class="row justify-content-center">
-                            <div class="col-1"></div>
-                            <a class="btn btn-secondary btn-sm col" href="{{ 'login'|link }}">{{ 'Already a user?'|trans }}</a>
-                            <div class="col-1"></div>
+                        <div class="row">
+                            <div class="col">
+                                <a class="btn btn-outline-primary mb-2 w-100"
+                                   href="{{ 'login'|link }}">{{ 'Already a user?'|trans }}</a>
+                            </div>
                             {% if settings.show_password_reset_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                         </div>
                     </div>
                 </div>

--- a/src/modules/Servicehosting/Api/Admin.php
+++ b/src/modules/Servicehosting/Api/Admin.php
@@ -251,6 +251,7 @@ class Admin extends \Api_Abstract
      * @optional string $accesshash - server API login access hash
      * @optional string $userprefix - prefix for created user
      * @optional string $port - server API port
+     * @optional string $passwordlength - password length for generated accounts
      * @optional bool $secure - flag to define whether to use secure connection (https) to server or not (http)
      * @optional bool $active - flag to enable/disable server
      *

--- a/src/modules/Servicehosting/Api/Admin.php
+++ b/src/modules/Servicehosting/Api/Admin.php
@@ -170,6 +170,7 @@ class Admin extends \Api_Abstract
      * @optional string $password - server API login password
      * @optional string $accesshash - server API login access hash
      * @optional string $port - server API port
+     * @optional string $passwordlength - password length for generated accounts
      * @optional bool $secure - flag to define whether to use secure connection (https) to server or not (http)
      * @optional bool $active - flag to enable/disable server
      *

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -756,13 +756,13 @@ class Service implements InjectionAwareInterface
         $model->ns3 = $data['ns3'] ?? $model->ns3;
         $model->ns4 = $data['ns4'] ?? $model->ns4;
         $model->manager = $data['manager'] ?? $model->manager;
-        $model->port = is_numeric($data['port']) ? $data['port'] : 0;
+        $model->port = is_numeric($data['port']) ? $data['port'] : $model->port;
         $model->config = json_encode($data['config']) ?? $model->config;
         $model->secure = $data['secure'] ?? $model->secure;
         $model->username = $data['username'] ?? $model->username;
         $model->password = $data['password'] ?? $model->password;
         $model->accesshash = $data['accesshash'] ?? $model->accesshash;
-        $model->passwordlength = is_numeric($data['passwordlength']) ? $data['passwordlength'] : 10;
+        $model->passwordlength = is_numeric($data['passwordlength']) ? $data['passwordlength'] : $model->passwordlength;
         $model->updated_at = date('Y-m-d H:i:s');
 
         $this->di['db']->store($model);

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -526,6 +526,7 @@ class Service implements InjectionAwareInterface
             $result['password'] = $model->password;
             $result['accesshash'] = $model->accesshash;
             $result['port'] = $model->port;
+            $result['passwordlength'] = $model->passwordlength;
             $result['created_at'] = $model->created_at;
             $result['updated_at'] = $model->updated_at;
         }
@@ -597,12 +598,12 @@ class Service implements InjectionAwareInterface
 
     public function getServerManagers()
     {
-        $d = [];
-        foreach ($this->_getServerManagers() as $p) {
-            $d[$p] = $this->getServerManagerConfig($p);
+        $serverManagers = [];
+        foreach ($this->_getServerManagers() as $serverManager) {
+            $serverManagers[$serverManager] = $this->getServerManagerConfig($serverManager);
         }
 
-        return $d;
+        return $serverManagers;
     }
 
     private function _getServerManagers()
@@ -725,7 +726,6 @@ class Service implements InjectionAwareInterface
         $model->ns3 = $data['ns3'] ?? $model->ns3;
         $model->ns4 = $data['ns4'] ?? $model->ns4;
         $model->manager = $data['manager'] ?? $model->manager;
-        $model->accesshash = $data['accesshash'] ?? $model->accesshash;
         $model->port = $data['port'] ?? $model->port;
         $model->config = json_encode($data['config']) ?? $model->config;
         $model->secure = $data['secure'] ?? $model->secure;
@@ -742,6 +742,9 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
+    /**
+     * @throws Exception
+     */
     public function getServerManager(\Model_ServiceHostingServer $model)
     {
         if (empty($model->manager)) {
@@ -760,8 +763,8 @@ class Service implements InjectionAwareInterface
         $config['secure'] = $model->secure;
         $config['username'] = $model->username;
         $config['password'] = $model->password;
-        $config['passwordlength'] = $model->passwordlength;
         $config['accesshash'] = $model->accesshash;
+        $config['passwordlength'] = $model->passwordlength;
 
         $manager = $this->di['server_manager']($model->manager, $config);
 

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -507,7 +507,7 @@ class Service implements InjectionAwareInterface
 
     public function toHostingServerApiArray(\Model_ServiceHostingServer $model, $deep = false, $identity = null)
     {
-        [$cpanel_url, $whm_url] = $this->getMangerUrls($model);
+        [$cpanel_url, $whm_url] = $this->getManagerUrls($model);
         $result = [
             'name' => $model->name,
             'hostname' => $model->hostname,
@@ -970,14 +970,14 @@ class Service implements InjectionAwareInterface
      *
      * @return string[]|false[]
      */
-    public function getMangerUrls(\Model_ServiceHostingServer $model)
+    public function getManagerUrls(\Model_ServiceHostingServer $model)
     {
         try {
             $m = $this->getServerManager($model);
 
             return [$m->getLoginUrl(null), $m->getResellerLoginUrl(null)];
         } catch (\Exception $e) {
-            error_log('Error while retrieving cPanel url: ' . $e->getMessage());
+            error_log('Error while retrieving control panel url: ' . $e->getMessage());
         }
 
         return [false, false];

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -756,13 +756,13 @@ class Service implements InjectionAwareInterface
         $model->ns3 = $data['ns3'] ?? $model->ns3;
         $model->ns4 = $data['ns4'] ?? $model->ns4;
         $model->manager = $data['manager'] ?? $model->manager;
-        $model->port = $data['port'] ?? $model->port;
+        $model->port = is_numeric($data['port']) ? $data['port'] : 0;
         $model->config = json_encode($data['config']) ?? $model->config;
         $model->secure = $data['secure'] ?? $model->secure;
         $model->username = $data['username'] ?? $model->username;
         $model->password = $data['password'] ?? $model->password;
         $model->accesshash = $data['accesshash'] ?? $model->accesshash;
-        $model->passwordlength = $data['passwordlength'] ?? $model->passwordlength;
+        $model->passwordlength = is_numeric($data['passwordlength']) ? $data['passwordlength'] : 10;
         $model->updated_at = date('Y-m-d H:i:s');
 
         $this->di['db']->store($model);
@@ -785,10 +785,9 @@ class Service implements InjectionAwareInterface
         $config['ip'] = $model->ip;
         $config['host'] = $model->hostname;
         $config['port'] = $model->port;
+        $config['config'] = [];
         if (!is_null($model->config)) {
             $config['config'] = json_decode($model->config, 1);
-        } else {
-            $config['config'] = [];
         }
         $config['secure'] = $model->secure;
         $config['username'] = $model->username;

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -134,7 +134,7 @@ class Service implements InjectionAwareInterface
         }
 
         // Update the service's password to a placeholder value for security reasons
-        $model->pass = '*******';
+        $model->pass = '********';
 
         // Save the service
         $this->di['db']->store($model);
@@ -232,8 +232,23 @@ class Service implements InjectionAwareInterface
         $this->action_create($order);
         $orderService = $this->di['mod_service']('order');
         $model = $orderService->getOrderService($order);
+
+        // Retrieve the server manager for the order
+        $serverManager = $this->_getServerMangerForOrder($model);
+
+        // As we replace the password internally with asterisks, generate a new password
+        $pass = $this->di['tools']->generatePassword($serverManager->getPasswordLength(), 4);
+        $model->pass = $pass;
+
+        // Retrieve the adapter and account, then create the account on the server
         [$adapter, $account] = $this->_getAM($model);
         $adapter->createAccount($account);
+
+        // Update the service's password to a placeholder value for security reasons
+        $model->pass = '********';
+
+        // Save the service
+        $this->di['db']->store($model);
 
         return true;
     }

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -222,7 +222,7 @@
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                         <div class="col">
-                            <input class="form-control" type="number" name="passwordlength" min="1" max="100" value="10" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
+                            <input class="form-control" type="number" name="passwordlength" min="1" max="100" value="" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
                         </div>
                     </div>
                     <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -222,7 +222,7 @@
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                         <div class="col">
-                            <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                            <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
                         </div>
                     </div>
                     <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -216,13 +216,13 @@
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Connection port'|trans }}:</label>
                         <div class="col">
-                            <input class="form-control" type="text" name="port" value="" placeholder="{{ 'Custom port. Use blank to use default. Used to connect to the API'|trans }}">
+                            <input class="form-control" type="number" name="port" min="1" max="65535" value="" placeholder="{{ 'Custom port. Use blank to use default. Used to connect to the API'|trans }}">
                         </div>
                     </div>
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                         <div class="col">
-                            <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
+                            <input class="form-control" type="number" name="passwordlength" min="1" max="100" value="10" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
                         </div>
                     </div>
                     <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -222,7 +222,7 @@
                     <div class="mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                         <div class="col">
-                            <input class="form-control" type="text" name="passwordLength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                            <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
                         </div>
                     </div>
                     <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_index.html.twig
@@ -220,7 +220,13 @@
                         </div>
                     </div>
                     <div class="mb-3 row">
-                        <label class="form-label col-3 col-form-label">{{ 'Use Secure connection'|trans }}:</label>
+                        <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
+                        <div class="col">
+                            <input class="form-control" type="text" name="passwordLength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                        </div>
+                    </div>
+                    <div class="mb-3 row">
+                        <label class="form-label col-3 col-form-label">{{ 'Use secure connection'|trans }}:</label>
                         <div class="col">
                             <div class="form-check form-check-inline">
                                 <input class="form-check-input" id="radioSecureYes" type="radio" name="secure" value="1">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -89,7 +89,7 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                    <input class="form-control" type="text" name="passwordlength" value="{{ server.passwordlength }}" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
                 </div>
             </div>
             <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -87,7 +87,13 @@
                 </div>
             </div>
             <div class="mb-3 row">
-                <label class="form-label col-3 col-form-label">{{ 'Use Secure connection'|trans }}:</label>
+                <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
+                <div class="col">
+                    <input class="form-control" type="text" name="passwordLength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                </div>
+            </div>
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Use secure connection'|trans }}:</label>
                 <div class="col">
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" id="radioSecureConnectionYes" type="radio" name="secure" value="1"{% if server.secure %} checked{% endif %}>

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -89,7 +89,7 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="passwordlength" value="{{ server.passwordlength }}" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                    <input class="form-control" type="text" name="passwordlength" value="{{ server.passwordlength }}" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
                 </div>
             </div>
             <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -89,7 +89,7 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="passwordLength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
+                    <input class="form-control" type="text" name="passwordlength" value="" placeholder="{{ 'Generated password length. Use blank to use default (10). Used when creating user accounts'|trans }}">
                 </div>
             </div>
             <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -83,13 +83,13 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Connection port'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="port" value="{{ server.port }}" placeholder="{{ 'Custom port. Use blank to use default. Used to connect to the API'|trans }}">
+                    <input class="form-control" type="number" name="port" min="1" max="65535" value="{{ server.port }}" placeholder="{{ 'Custom port. Use blank to use default. Used to connect to the API'|trans }}">
                 </div>
             </div>
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Password length'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="passwordlength" value="{{ server.passwordlength }}" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
+                    <input class="form-control" type="number" name="passwordlength" min="1" max="100" value="{{ server.passwordlength }}" placeholder="{{ 'Length of generated passwords when creating user accounts. Defaults to 10'|trans }}">
                 </div>
             </div>
             <div class="mb-3 row">

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -4,7 +4,7 @@
         <h2>{{ 'Manage hosting account'|trans }}</h2>
     </div>
     <div class="card-body">
-        <ul class="nav nav-tabs mb-1">
+        <ul class="nav nav-tabs mb-2">
             <li class="nav-item">
                 <a class="nav-link active" data-bs-toggle="tab" href="#details">{{ 'Details'|trans }}</a>
             </li>

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -80,7 +80,7 @@
             </div>
             {# Hosting password #}
             <div class="tab-pane fade" role="tabpanel" id="password">
-                <h3>{{ 'Change your FTP/panel/SSH password'|trans }}</h3>
+                <h3>{{ 'Change your control panel/FTP/SSH password'|trans }}</h3>
                 <form class="api-form" action="{{ 'api/client/servicehosting/change_password'|link }}" method="post" data-api-msg="{{ 'Password changed'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <fieldset>

--- a/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/html_client/mod_servicehosting_manage.html.twig
@@ -80,7 +80,7 @@
             </div>
             {# Hosting password #}
             <div class="tab-pane fade" role="tabpanel" id="password">
-                <h3>{{ 'Change your control panel/FTP/SSH password'|trans }}</h3>
+                <h3>{{ 'Change your FTP/panel/SSH password'|trans }}</h3>
                 <form class="api-form" action="{{ 'api/client/servicehosting/change_password'|link }}" method="post" data-api-msg="{{ 'Password changed'|trans }}">
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <fieldset>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -80,19 +80,19 @@
                         {% endif %}
 
                         {% if settings.top_menu_dashboard %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 <a class="nav-link" href="{{ ''|link }}">{{ 'Dashboard'|trans }}</a>
                             </li>
                         {% endif %}
 
                         {% if settings.top_menu_order %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 <a class="nav-link" href="{{ '/order'|link }}">{{ 'Order'|trans }}</a>
                             </li>
                         {% endif %}
 
                         {% if settings.top_menu_profile %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 {% if not client %}
                                     <a class="nav-link" href="{{ 'login'|link }}">{{ 'Login'|trans }}</a>
                                 {% endif %}
@@ -100,7 +100,7 @@
                         {% endif %}
 
                         {% if settings.top_menu_signout %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 {% if client %}
                                     <div class="dropdown">
                                         <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -119,11 +119,15 @@
                                         </ul>
                                     </div>
                                 {% else %}
-                                    <a class="ms-2 btn btn-outline-primary"
+                                    <a class="ms-2 btn btn-outline-primary d-none d-md-block"
                                        href="{{ 'signup'|link }}">{{ 'Sign up'|trans }}</a>
                                 {% endif %}
                             </li>
                         {% endif %}
+
+                        <div class="d-md-none">
+                            {% include 'mobile_menu.html.twig' %}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/themes/huraga/html/mobile_menu.html.twig
+++ b/src/themes/huraga/html/mobile_menu.html.twig
@@ -1,0 +1,128 @@
+{% if settings.side_menu_dashboard %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19,5V7H15V5H19M9,5V11H5V5H9M19,13V19H15V13H19M9,17V19H5V17H9M21,3H13V9H21V3M11,3H3V13H11V3M21,11H13V21H21V11M11,15H3V21H11V15Z" /></svg>
+            {{ 'Dashboard'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_order %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/order'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17,18A2,2 0 0,1 19,20A2,2 0 0,1 17,22C15.89,22 15,21.1 15,20C15,18.89 15.89,18 17,18M1,2H4.27L5.21,4H20A1,1 0 0,1 21,5C21,5.17 20.95,5.34 20.88,5.5L17.3,11.97C16.96,12.58 16.3,13 15.55,13H8.1L7.2,14.63L7.17,14.75A0.25,0.25 0 0,0 7.42,15H19V17H7C5.89,17 5,16.1 5,15C5,14.65 5.09,14.32 5.24,14.04L6.6,11.59L3,4H1V2M7,18A2,2 0 0,1 9,20A2,2 0 0,1 7,22C5.89,22 5,21.1 5,20C5,18.89 5.89,18 7,18M16,11L18.78,6H6.14L8.5,11H16Z" /></svg>
+            {{ 'Order'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_support %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/support'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19.79,15.41C20.74,13.24 20.74,10.75 19.79,8.59L17.05,9.83C17.65,11.21 17.65,12.78 17.06,14.17L19.79,15.41M15.42,4.21C13.25,3.26 10.76,3.26 8.59,4.21L9.83,6.94C11.22,6.35 12.79,6.35 14.18,6.95L15.42,4.21M4.21,8.58C3.26,10.76 3.26,13.24 4.21,15.42L6.95,14.17C6.35,12.79 6.35,11.21 6.95,9.82L4.21,8.58M8.59,19.79C10.76,20.74 13.25,20.74 15.42,19.78L14.18,17.05C12.8,17.65 11.22,17.65 9.84,17.06L8.59,19.79M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,8A4,4 0 0,0 8,12A4,4 0 0,0 12,16A4,4 0 0,0 16,12A4,4 0 0,0 12,8Z" /></svg>
+            {{ 'Support'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_services %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/order/service'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M16.7 4.5L19.5 7.3L16.7 10.1L13.9 7.3L16.7 4.5M9 5V9H5V5H9M19 15V19H15V15H19M16.7 1.7L11 7.3L16.7 13H13V21H21V13H16.7L22.3 7.3L16.7 1.7M11 3H3V11H11V3M9 15V19H5V15H9M11 13H3V21H11V13Z" /></svg>
+            {{ 'Services'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_invoices %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/invoice'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19.5 3.5L18 2L16.5 3.5L15 2L13.5 3.5L12 2L10.5 3.5L9 2L7.5 3.5L6 2L4.5 3.5L3 2V22L4.5 20.5L6 22L7.5 20.5L9 22L10.5 20.5L12 22L13.5 20.5L15 22L16.5 20.5L18 22L19.5 20.5L21 22V2L19.5 3.5M19 19H5V5H19V19M6 15H18V17H6M6 11H18V13H6M6 7H18V9H6V7Z" /></svg>
+            {{ 'Invoices'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_emails %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/email'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.03 6.29L12 .64L2.97 6.29C2.39 6.64 2 7.27 2 8V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 7.27 21.61 6.64 21.03 6.29M20 18H4V10L12 15L20 10V18M12 13L4 8L12 3L20 8L12 13Z" /></svg>
+            {{ 'Email'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_payments %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/client/balance'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.5 15.5C16.33 15.5 17 14.83 17 14C17 13.17 16.33 12.5 15.5 12.5C14.67 12.5 14 13.17 14 14C14 14.83 14.67 15.5 15.5 15.5M7 3H17C18.11 3 19 3.9 19 5V7C20.11 7 21 7.9 21 9V19C21 20.11 20.11 21 19 21H7C4.79 21 3 19.21 3 17V7C3 4.79 4.79 3 7 3M17 7V5H7C5.9 5 5 5.9 5 7V7.54C5.59 7.2 6.27 7 7 7H17M5 17C5 18.11 5.9 19 7 19H19V9H7C5.9 9 5 9.9 5 11V17Z" /></svg>
+            {{ 'Wallet'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if (guest.extension_is_on({"mod":"news"}) and settings.side_menu_news) %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/news'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 5L20 19L4 19L4 5H20M20 3H4C2.89 3 2 3.89 2 5V19C2 20.11 2.89 21 4 21H20C21.11 21 22 20.11 22 19V5C22 3.89 21.11 3 20 3M18 15H6V17H18V15M10 7H6V13H10V7M12 9H18V7H12V9M18 11H12V13H18V11Z" /></svg>
+            {{ 'News'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if (guest.support_kb_enabled() and settings.side_menu_kb) %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ 'support/kb'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 1L14 6V17L19 12.5V1M21 5V18.5C19.9 18.15 18.7 18 17.5 18C15.8 18 13.35 18.65 12 19.5V6C10.55 4.9 8.45 4.5 6.5 4.5C4.55 4.5 2.45 4.9 1 6V20.65C1 20.9 1.25 21.15 1.5 21.15C1.6 21.15 1.65 21.1 1.75 21.1C3.1 20.45 5.05 20 6.5 20C8.45 20 10.55 20.4 12 21.5C13.35 20.65 15.8 20 17.5 20C19.15 20 20.85 20.3 22.25 21.05C22.35 21.1 22.4 21.1 22.5 21.1C22.75 21.1 23 20.85 23 20.6V6C22.4 5.55 21.75 5.25 21 5M10 18.41C8.75 18.09 7.5 18 6.5 18C5.44 18 4.18 18.19 3 18.5V7.13C3.91 6.73 5.14 6.5 6.5 6.5C7.86 6.5 9.09 6.73 10 7.13V18.41Z" /></svg>
+            {{ 'Knowledge base'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.sidebar_balance_enabled and client %}
+    <li class="pt-3 ps-3">
+        <h5 class="text-secondary d-block pb-1">{{ 'Account balance'|trans }}</h5>
+        <h4><strong>{{ profile.balance | money(profile.currency) }}</strong></h4>
+    </li>
+{% endif %}
+
+{% if settings.sidebar_note_enabled %}
+    <li class="pt-3 ps-3">
+        <h5 class="text-secondary d-block pb-1">{{ settings.sidebar_note_title }}</h5>
+        <span>{{ settings.sidebar_note_content }}</span>
+    </li>
+{% endif %}
+
+{% if settings.top_menu_signout %}
+    <li class="nav-item">
+        {% if client %}
+            <div class="dropdown">
+                <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <img class="img-fluid rounded-circle" alt="{{ profile.first_name }} {{ profile.last_name }} gravatar" src="{{ profile.email|gravatar(60) }}" height="25px" width="25px">
+                    {% if profile.company %}
+                        <span>{{ profile.first_name }} {{ profile.last_name }}|{{ profile.company }}</span>
+                    {% else %}
+                        <span>{{ profile.first_name }} {{ profile.last_name }}</span>
+                    {% endif %}
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item"
+                           href="{{ 'client/profile'|link }}">{{ 'Profile'|trans }}</a></li>
+                    <li><a class="dropdown-item"
+                           href="{{ 'client/logout'|link }}">{{ 'Sign out'|trans }}</a></li>
+                </ul>
+            </div>
+        {% else %}
+            <div class="row pt-2">
+                <div class="col">
+                    <a class="btn btn-outline-primary mb-2 w-100"
+                       href="{{ 'login'|link }}">{{ 'Sign in'|trans }}</a>
+                </div>
+                <div class="col">
+                    <a class="btn btn-outline-primary mb-2 w-100"
+                       href="{{ 'signup'|link }}">{{ 'Sign up'|trans }}</a>
+                </div>
+            </div>
+        {% endif %}
+    </li>
+{% endif %}

--- a/tests/modules/Servicehosting/ServiceTest.php
+++ b/tests/modules/Servicehosting/ServiceTest.php
@@ -1203,7 +1203,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertInstanceOf('\Server_Manager_Custom', $result);
     }
 
-    public function testgetMangerUrls()
+    public function testgetManagerUrls()
     {
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
@@ -1224,13 +1224,13 @@ class ServiceTest extends \BBTestCase {
             ->method('getServerManager')
             ->will($this->returnValue($serverManagerMock));
 
-        $result = $serviceMock->getMangerUrls($hostingServerModel);
+        $result = $serviceMock->getManagerUrls($hostingServerModel);
         $this->assertIsArray($result);
         $this->assertIsString($result[0]);
         $this->assertIsString($result[1]);
     }
 
-    public function testgetMangerUrlsException()
+    public function testgetManagerUrlsException()
     {
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
@@ -1243,7 +1243,7 @@ class ServiceTest extends \BBTestCase {
             ->method('getServerManager')
             ->will($this->throwException(new \Exception('Controlled unit test exception')));
 
-        $result = $serviceMock->getMangerUrls($hostingServerModel);
+        $result = $serviceMock->getManagerUrls($hostingServerModel);
         $this->assertIsArray($result);
         $this->assertFalse($result[0]);
         $this->assertFalse($result[1]);


### PR DESCRIPTION
This closes out #2031. I duplicated the sidebar menu items into a seperate template specifically for mobile (as re-using wouldn't work well), and only show the sidebar items in the top menu if the user is on mobile. I also hide the normal top menu items for mobile users, as the functionality is duplicated between the two menus.

I also took this as an opportunity to improve the design of the UI elements throughout the auth flow. While the move to Bootstrap 5 has drastically improved the customer dashboard, the buttons and badges don't align well (the colouring being one of the biggest issues). I figured I'd test the waters with moving the secondary buttons to use outlined buttons (as is consistent elsewhere), and see what you thought :) 

Thanks!