### PR TITLE
Improved Customer Mobile Navigation (#2031) + Auth Flow Design

### DIFF
--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -30,16 +30,17 @@
                         <button type="submit" class="btn btn-primary w-100 mb-3">{{ 'Login'|trans }}</button>
                     </form>
                     {% if settings.show_password_reset_link or settings.show_signup_link %}
-                        <div class="row justify-content-center">
-                            <div class="col-1"></div>
+                        <div class="row">
                             {% if settings.show_signup_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'signup'|link }}">{{ 'Create account'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'signup'|link }}">{{ 'Create account'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                             {% if settings.show_password_reset_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                         </div>
                     {% endif %}
                 </div>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -27,7 +27,7 @@
                         </div>
                         <button type="submit" class="btn btn-primary w-100 mb-3">{{ 'Reset password'|trans }}</button>
                     </form>
-                    <a class="btn btn-secondary btn-sm" href="{{ 'login'|link }}">{{ 'Back to login'|trans }}</a>
+                    <a class="btn btn-outline-primary w-100" href="{{ 'login'|link }}">{{ 'Back to login'|trans }}</a>
                 </div>
             </div>
         </div>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -165,14 +165,16 @@
                                 <button class="btn btn-primary w-100" type="submit">{{ 'Sign up'|trans }}</button>
                             </div>
                         </form>
-                        <div class="row justify-content-center">
-                            <div class="col-1"></div>
-                            <a class="btn btn-secondary btn-sm col" href="{{ 'login'|link }}">{{ 'Already a user?'|trans }}</a>
-                            <div class="col-1"></div>
+                        <div class="row">
+                            <div class="col">
+                                <a class="btn btn-outline-primary mb-2 w-100"
+                                   href="{{ 'login'|link }}">{{ 'Already a user?'|trans }}</a>
+                            </div>
                             {% if settings.show_password_reset_link %}
-                                <a class="btn btn-secondary btn-sm col" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                <div class="col">
+                                    <a class="btn btn-outline-primary mb-2 w-100" href="{{ 'password-reset'|link }}">{{ 'Forgot password?'|trans }}</a>
+                                </div>
                             {% endif %}
-                            <div class="col-1"></div>
                         </div>
                     </div>
                 </div>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -80,19 +80,19 @@
                         {% endif %}
 
                         {% if settings.top_menu_dashboard %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 <a class="nav-link" href="{{ ''|link }}">{{ 'Dashboard'|trans }}</a>
                             </li>
                         {% endif %}
 
                         {% if settings.top_menu_order %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 <a class="nav-link" href="{{ '/order'|link }}">{{ 'Order'|trans }}</a>
                             </li>
                         {% endif %}
 
                         {% if settings.top_menu_profile %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 {% if not client %}
                                     <a class="nav-link" href="{{ 'login'|link }}">{{ 'Login'|trans }}</a>
                                 {% endif %}
@@ -100,7 +100,7 @@
                         {% endif %}
 
                         {% if settings.top_menu_signout %}
-                            <li class="nav-item">
+                            <li class="nav-item d-none d-md-block">
                                 {% if client %}
                                     <div class="dropdown">
                                         <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -119,11 +119,15 @@
                                         </ul>
                                     </div>
                                 {% else %}
-                                    <a class="ms-2 btn btn-outline-primary"
+                                    <a class="ms-2 btn btn-outline-primary d-none d-md-block"
                                        href="{{ 'signup'|link }}">{{ 'Sign up'|trans }}</a>
                                 {% endif %}
                             </li>
                         {% endif %}
+
+                        <div class="d-md-none">
+                            {% include 'mobile_menu.html.twig' %}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/themes/huraga/html/mobile_menu.html.twig
+++ b/src/themes/huraga/html/mobile_menu.html.twig
@@ -1,0 +1,128 @@
+{% if settings.side_menu_dashboard %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19,5V7H15V5H19M9,5V11H5V5H9M19,13V19H15V13H19M9,17V19H5V17H9M21,3H13V9H21V3M11,3H3V13H11V3M21,11H13V21H21V11M11,15H3V21H11V15Z" /></svg>
+            {{ 'Dashboard'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_order %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/order'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17,18A2,2 0 0,1 19,20A2,2 0 0,1 17,22C15.89,22 15,21.1 15,20C15,18.89 15.89,18 17,18M1,2H4.27L5.21,4H20A1,1 0 0,1 21,5C21,5.17 20.95,5.34 20.88,5.5L17.3,11.97C16.96,12.58 16.3,13 15.55,13H8.1L7.2,14.63L7.17,14.75A0.25,0.25 0 0,0 7.42,15H19V17H7C5.89,17 5,16.1 5,15C5,14.65 5.09,14.32 5.24,14.04L6.6,11.59L3,4H1V2M7,18A2,2 0 0,1 9,20A2,2 0 0,1 7,22C5.89,22 5,21.1 5,20C5,18.89 5.89,18 7,18M16,11L18.78,6H6.14L8.5,11H16Z" /></svg>
+            {{ 'Order'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_support %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/support'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19.79,15.41C20.74,13.24 20.74,10.75 19.79,8.59L17.05,9.83C17.65,11.21 17.65,12.78 17.06,14.17L19.79,15.41M15.42,4.21C13.25,3.26 10.76,3.26 8.59,4.21L9.83,6.94C11.22,6.35 12.79,6.35 14.18,6.95L15.42,4.21M4.21,8.58C3.26,10.76 3.26,13.24 4.21,15.42L6.95,14.17C6.35,12.79 6.35,11.21 6.95,9.82L4.21,8.58M8.59,19.79C10.76,20.74 13.25,20.74 15.42,19.78L14.18,17.05C12.8,17.65 11.22,17.65 9.84,17.06L8.59,19.79M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,8A4,4 0 0,0 8,12A4,4 0 0,0 12,16A4,4 0 0,0 16,12A4,4 0 0,0 12,8Z" /></svg>
+            {{ 'Support'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_services %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/order/service'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M16.7 4.5L19.5 7.3L16.7 10.1L13.9 7.3L16.7 4.5M9 5V9H5V5H9M19 15V19H15V15H19M16.7 1.7L11 7.3L16.7 13H13V21H21V13H16.7L22.3 7.3L16.7 1.7M11 3H3V11H11V3M9 15V19H5V15H9M11 13H3V21H11V13Z" /></svg>
+            {{ 'Services'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_invoices %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/invoice'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19.5 3.5L18 2L16.5 3.5L15 2L13.5 3.5L12 2L10.5 3.5L9 2L7.5 3.5L6 2L4.5 3.5L3 2V22L4.5 20.5L6 22L7.5 20.5L9 22L10.5 20.5L12 22L13.5 20.5L15 22L16.5 20.5L18 22L19.5 20.5L21 22V2L19.5 3.5M19 19H5V5H19V19M6 15H18V17H6M6 11H18V13H6M6 7H18V9H6V7Z" /></svg>
+            {{ 'Invoices'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_emails %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/email'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.03 6.29L12 .64L2.97 6.29C2.39 6.64 2 7.27 2 8V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 7.27 21.61 6.64 21.03 6.29M20 18H4V10L12 15L20 10V18M12 13L4 8L12 3L20 8L12 13Z" /></svg>
+            {{ 'Email'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.side_menu_payments %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/client/balance'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.5 15.5C16.33 15.5 17 14.83 17 14C17 13.17 16.33 12.5 15.5 12.5C14.67 12.5 14 13.17 14 14C14 14.83 14.67 15.5 15.5 15.5M7 3H17C18.11 3 19 3.9 19 5V7C20.11 7 21 7.9 21 9V19C21 20.11 20.11 21 19 21H7C4.79 21 3 19.21 3 17V7C3 4.79 4.79 3 7 3M17 7V5H7C5.9 5 5 5.9 5 7V7.54C5.59 7.2 6.27 7 7 7H17M5 17C5 18.11 5.9 19 7 19H19V9H7C5.9 9 5 9.9 5 11V17Z" /></svg>
+            {{ 'Wallet'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if (guest.extension_is_on({"mod":"news"}) and settings.side_menu_news) %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ '/news'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 5L20 19L4 19L4 5H20M20 3H4C2.89 3 2 3.89 2 5V19C2 20.11 2.89 21 4 21H20C21.11 21 22 20.11 22 19V5C22 3.89 21.11 3 20 3M18 15H6V17H18V15M10 7H6V13H10V7M12 9H18V7H12V9M18 11H12V13H18V11Z" /></svg>
+            {{ 'News'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if (guest.support_kb_enabled() and settings.side_menu_kb) %}
+    <li class="nav-item">
+        <a class="nav-link d-flex align-items-center gap-2" href="{{ 'support/kb'|link }}">
+            <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 1L14 6V17L19 12.5V1M21 5V18.5C19.9 18.15 18.7 18 17.5 18C15.8 18 13.35 18.65 12 19.5V6C10.55 4.9 8.45 4.5 6.5 4.5C4.55 4.5 2.45 4.9 1 6V20.65C1 20.9 1.25 21.15 1.5 21.15C1.6 21.15 1.65 21.1 1.75 21.1C3.1 20.45 5.05 20 6.5 20C8.45 20 10.55 20.4 12 21.5C13.35 20.65 15.8 20 17.5 20C19.15 20 20.85 20.3 22.25 21.05C22.35 21.1 22.4 21.1 22.5 21.1C22.75 21.1 23 20.85 23 20.6V6C22.4 5.55 21.75 5.25 21 5M10 18.41C8.75 18.09 7.5 18 6.5 18C5.44 18 4.18 18.19 3 18.5V7.13C3.91 6.73 5.14 6.5 6.5 6.5C7.86 6.5 9.09 6.73 10 7.13V18.41Z" /></svg>
+            {{ 'Knowledge base'|trans }}
+        </a>
+    </li>
+{% endif %}
+
+{% if settings.sidebar_balance_enabled and client %}
+    <li class="pt-3 ps-3">
+        <h5 class="text-secondary d-block pb-1">{{ 'Account balance'|trans }}</h5>
+        <h4><strong>{{ profile.balance | money(profile.currency) }}</strong></h4>
+    </li>
+{% endif %}
+
+{% if settings.sidebar_note_enabled %}
+    <li class="pt-3 ps-3">
+        <h5 class="text-secondary d-block pb-1">{{ settings.sidebar_note_title }}</h5>
+        <span>{{ settings.sidebar_note_content }}</span>
+    </li>
+{% endif %}
+
+{% if settings.top_menu_signout %}
+    <li class="nav-item">
+        {% if client %}
+            <div class="dropdown">
+                <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <img class="img-fluid rounded-circle" alt="{{ profile.first_name }} {{ profile.last_name }} gravatar" src="{{ profile.email|gravatar(60) }}" height="25px" width="25px">
+                    {% if profile.company %}
+                        <span>{{ profile.first_name }} {{ profile.last_name }}|{{ profile.company }}</span>
+                    {% else %}
+                        <span>{{ profile.first_name }} {{ profile.last_name }}</span>
+                    {% endif %}
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item"
+                           href="{{ 'client/profile'|link }}">{{ 'Profile'|trans }}</a></li>
+                    <li><a class="dropdown-item"
+                           href="{{ 'client/logout'|link }}">{{ 'Sign out'|trans }}</a></li>
+                </ul>
+            </div>
+        {% else %}
+            <div class="row pt-2">
+                <div class="col">
+                    <a class="btn btn-outline-primary mb-2 w-100"
+                       href="{{ 'login'|link }}">{{ 'Sign in'|trans }}</a>
+                </div>
+                <div class="col">
+                    <a class="btn btn-outline-primary mb-2 w-100"
+                       href="{{ 'signup'|link }}">{{ 'Sign up'|trans }}</a>
+                </div>
+            </div>
+        {% endif %}
+    </li>
+{% endif %}


### PR DESCRIPTION
This closes out https://github.com/FOSSBilling/FOSSBilling/issues/2031. I duplicated the sidebar menu items into a seperate template specifically for mobile (as re-using wouldn't work well), and only show the sidebar items in the top menu if the user is on mobile. I also hide the normal top menu items for mobile users, as the functionality is duplicated between the two menus.

I also took this as an opportunity to improve the design of the UI elements throughout the auth flow. While the move to Bootstrap 5 has drastically improved the customer dashboard, the buttons and badges don't align well (the colouring being one of the biggest issues). I figured I'd test the waters with moving the secondary buttons to use outlined buttons (as is consistent elsewhere), and see what you thought :)

Thanks!