### PR TITLE
Rector & PHP-CS-Fixer Improvements

### DIFF
--- a/.github/workflows/rectorAndCs.yml
+++ b/.github/workflows/rectorAndCs.yml
@@ -1,59 +1,78 @@
 name: Rector and Code Styling
 
 on:
-  schedule:
-    - cron: '0 12 * * 2,4' # Runs once every Tuesday and Thursday
+    schedule:
+        - cron: "0 12 * * 2,4" # Runs once every Tuesday and Thursday
 
 jobs:
-  php-cs-fixer:
-    name: Rector & PHP-CS-Fixer
-    runs-on: ubuntu-latest
+    php-cs-fixer:
+        name: Rector & PHP-CS-Fixer
+        runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v4
+        steps:
+            - uses: actions/checkout@v4
 
-    - name: Validate composer.json and composer.lock
-      uses: php-actions/composer@v6
-      with:
-        command: validate
+            - name: Validate composer.json and composer.lock
+              uses: php-actions/composer@v6
+              with:
+                  command: validate
 
-    - name: Cache Composer Dependencies
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: ./src/vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
+            - name: Cache Composer Dependencies
+              id: composer-cache
+              uses: actions/cache@v3
+              with:
+                  path: ./src/vendor
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
 
-    - name: Install Composer Dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      uses: php-actions/composer@v6
-      with:
-        php_version: 8.2
+            - run: |
+                  echo "MONTH=$(date '+%h')" >> ${GITHUB_ENV}
+                  mkdir cache/rector
+                  mkdir cache/rector-tests
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
+            - name: Install Composer Dependencies
+              if: steps.composer-cache.outputs.cache-hit != 'true'
+              uses: php-actions/composer@v6
+              with:
+                  php_version: 8.2
 
-    - name: Run Reactor
-      run: |
-        php src/vendor/bin/rector
-        php src/vendor/bin/rector --config=rectorTests.php
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.2"
 
-    - name: Run PHP CS Fixer
-      run: php src/vendor/bin/php-cs-fixer fix
+            - name: Restore Rector Cache
+              uses: actions/cache@v3
+              with:
+                  path: ./var/cache/rector
+                  key: ${{ runner.os }}-rector-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-rector-
 
-    - name: Create a Pull Request
-      uses: peter-evans/create-pull-request@v5
-      with:
-        title: Apply PHP Code Styling & Quality Changes
-        commit-message: Apply PHP Code Styling & Quality Changes
-        branch: rector-and-CS
-        body: Automated run of PHP-CS-Fixer and Rector to ensure code styling, quality, and modern practices.
-        delete-branch: true
-        token: ${{ secrets.BOT_TOKEN }}
-        committer: FOSSBilling Bot <fossbilling-bot>
-        author: FOSSBilling Bot <fossbilling-bot>
-        labels: skip-changelog
+            - name: Restore Rector Cache for the Tests
+              uses: actions/cache@v3
+              with:
+                  path: ./var/cache/rector
+                  key: ${{ runner.os }}-rector-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-rector-
+
+            - name: Run Reactor
+              run: |
+                  php src/vendor/bin/rector
+                  php src/vendor/bin/rector --config=rectorTests.php
+
+            - name: Run PHP CS Fixer
+              run: php src/vendor/bin/php-cs-fixer fix
+
+            - name: Create a Pull Request
+              uses: peter-evans/create-pull-request@v5
+              with:
+                  title: Apply PHP Code Styling & Quality Changes
+                  commit-message: Apply PHP Code Styling & Quality Changes
+                  branch: rector-and-CS
+                  body: Automated run of PHP-CS-Fixer and Rector to ensure code styling, quality, and modern practices.
+                  delete-branch: true
+                  token: ${{ secrets.BOT_TOKEN }}
+                  committer: FOSSBilling Bot <fossbilling-bot>
+                  author: FOSSBilling Bot <fossbilling-bot>
+                  labels: skip-changelog

--- a/.github/workflows/rectorAndCs.yml
+++ b/.github/workflows/rectorAndCs.yml
@@ -46,15 +46,22 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ./var/cache/rector
-                  key: ${{ runner.os }}-rector-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-rector-
+                  key: ${{ env.MONTH }}-rector
+                  restore-keys: ${{ env.MONTH }}-rector
 
             - name: Restore Rector Cache for the Tests
               uses: actions/cache@v3
               with:
-                  path: ./var/cache/rector
-                  key: ${{ runner.os }}-rector-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-rector-
+                  path: ./var/cache/rector_tests
+                  key: ${{ env.MONTH }}-rector_tests
+                  restore-keys: ${{ env.MONTH }}-rector_tests
+
+            - name: Restore CS-Fixer Cache
+              uses: actions/cache@v3
+              with:
+                  path: .php-cs-fixer.cache
+                  key: ${{ env.MONTH }}-csfixer
+                  restore-keys: ${{ env.MONTH }}-csfixer
 
             - name: Run Reactor
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ report/*
 DOCKER_ENV
 docker_tag
 src/themes/*/config/settings_data.json
+cache
 
 ### Cypress ###
 tests/cypress/videos/*

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -33,19 +34,14 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setFinder(
         (new PhpCsFixer\Finder())
-            ->in(__DIR__ . '/src')
+            ->in([__DIR__ . '/src', __DIR__ . '/tests'])
             ->exclude([
                 'data',
-                'library',
                 'locale',
                 'themes',
                 'vendor',
-                'install',
-                'modules/Wysiwyg',
-                'modules/Spamchecker'
             ])
             ->notPath(
                 'config-sample.php'
             )
-    )
-;
+    );

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -21,8 +22,11 @@ return static function (RectorConfig $rectorConfig): void {
         NullToStrictStringFuncCallArgRector::class,
     ]);
 
-    
+
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
     ]);
+
+    $rectorConfig->cacheClass(FileCacheStorage::class);
+    $rectorConfig->cacheDirectory('./cache/rector');
 };

--- a/rectorTests.php
+++ b/rectorTests.php
@@ -8,6 +8,7 @@ use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -20,9 +21,12 @@ return static function (RectorConfig $rectorConfig): void {
         NullToStrictStringFuncCallArgRector::class,
     ]);
 
-    
+
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
         PHPUnitSetList::PHPUNIT_100,
     ]);
+
+    $rectorConfig->cacheClass(FileCacheStorage::class);
+    $rectorConfig->cacheDirectory('./cache/rector_tests');
 };

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -1,7 +1,8 @@
 <?php
+
 if (version_compare(PHP_VERSION, '8.1.0', '<')) {
     echo 'Error: PHP version 8.1.0 or higher is required. You have version ' . PHP_VERSION;
-    exit();
+    exit;
 }
-header("Location: " . pathinfo($_SERVER["PHP_SELF"], PATHINFO_DIRNAME) . "/install.php");
-exit();
+header('Location: ' . pathinfo($_SERVER['PHP_SELF'], PATHINFO_DIRNAME) . '/install.php');
+exit;

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -3,7 +3,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -11,9 +11,9 @@
 
 use Box\Mod\Email\Service;
 use FOSSBilling\Environment;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpClient\HttpClient;
 use Twig\Loader\FilesystemLoader;
-use Ramsey\Uuid\Uuid;
 
 date_default_timezone_set('UTC');
 error_reporting(E_ALL);
@@ -100,7 +100,6 @@ final class FOSSBilling_Installer
      * Action router.
      *
      * @param string $action
-     * @return void
      */
     public function run($action): void
     {
@@ -109,7 +108,7 @@ final class FOSSBilling_Installer
                 // Make sure this is a POST request
                 if ($_SERVER['REQUEST_METHOD'] != 'POST') {
                     header('Location: ' . URL_INSTALL);
-                    die;
+                    exit;
                 }
 
                 // Installer validation
@@ -173,17 +172,18 @@ final class FOSSBilling_Installer
                         'message' => $e->getMessage(),
                     ]);
                 }
+
                 break;
             case 'index':
             default:
-                $requirements = new \FOSSBilling\Requirements();
+                $requirements = new FOSSBilling\Requirements();
                 $compatibility = $requirements->checkCompat();
                 $vars = [
                     'compatibility' => $compatibility,
                     'os' => PHP_OS,
                     'os_ok' => (str_starts_with(strtoupper(PHP_OS), 'WIN')) ? false : true,
                     'is_subfolder' => $this->isSubfolder(),
-                    'fossbilling_ver' => \FOSSBilling\Version::VERSION,
+                    'fossbilling_ver' => FOSSBilling\Version::VERSION,
                     'canInstall' => !$this->isSubfolder() && $compatibility['can_install'],
                     'alreadyInstalled' => $this->isAlreadyInstalled(),
                     'database_hostname' => $this->session->get('database_hostname'),
@@ -204,6 +204,7 @@ final class FOSSBilling_Installer
                     'domain' => pathinfo(SYSTEM_URL, PATHINFO_BASENAME),
                 ];
                 echo $this->render(PAGE_INSTALL, $vars);
+
                 break;
         }
     }
@@ -212,8 +213,7 @@ final class FOSSBilling_Installer
      * Render a page with Twig.
      *
      * @param string $name
-     * @param array $vars
-     * @return string
+     * @param array  $vars
      */
     private function render($name, $vars = []): string
     {
@@ -229,15 +229,13 @@ final class FOSSBilling_Installer
         $loader = new FilesystemLoader($options['paths']);
         $twig = new Twig\Environment($loader, $options);
         $twig->addGlobal('request', $_REQUEST);
-        $twig->addGlobal('version', \FOSSBilling\Version::VERSION);
+        $twig->addGlobal('version', FOSSBilling\Version::VERSION);
 
         return $twig->render($name, $vars);
     }
 
     /**
      * Attempt to open the database connection.
-     *
-     * @return void
      */
     private function connectDatabase(): void
     {
@@ -263,19 +261,17 @@ final class FOSSBilling_Installer
 
         // Attempt to create the database.
         try {
-            $this->pdo->exec("CREATE DATABASE `" .  $this->session->get('database_name') . "` CHARACTER SET utf8 COLLATE utf8_general_ci;");
+            $this->pdo->exec('CREATE DATABASE `' . $this->session->get('database_name') . '` CHARACTER SET utf8 COLLATE utf8_general_ci;');
         } catch (PDOException) {
             // Silently fail if the database already exists.
         }
 
         // Select the database as default for future queries
-        $this->pdo->query("USE `" .  $this->session->get('database_name') . "`;");
+        $this->pdo->query('USE `' . $this->session->get('database_name') . '`;');
     }
 
     /**
      * Validate admin information meets all required parameters.
-     *
-     * @return boolean
      */
     private function validateAdmin(): bool
     {
@@ -287,15 +283,15 @@ final class FOSSBilling_Installer
             throw new Exception('Minimum admin password length is 8 characters.');
         }
 
-        if (!preg_match("#[0-9]+#", $this->session->get('admin_password'))) {
+        if (!preg_match('#[0-9]+#', $this->session->get('admin_password'))) {
             throw new Exception('Admin password must include at least one number.');
         }
 
-        if (!preg_match("#[a-z]+#", $this->session->get('admin_password'))) {
+        if (!preg_match('#[a-z]+#', $this->session->get('admin_password'))) {
             throw new Exception('Admin password must include at least one lowercase letter.');
         }
 
-        if (!preg_match("#[A-Z]+#", $this->session->get('admin_password'))) {
+        if (!preg_match('#[A-Z]+#', $this->session->get('admin_password'))) {
             throw new Exception('Admin password must include at least one uppercase letter.');
         }
 
@@ -308,8 +304,6 @@ final class FOSSBilling_Installer
 
     /**
      * Attempt to detect if the application is under a subfolder.
-     *
-     * @return boolean
      */
     private function isSubfolder(): bool
     {
@@ -318,8 +312,6 @@ final class FOSSBilling_Installer
 
     /**
      * Check if we are already installed.
-     *
-     * @return boolean
      */
     public function isAlreadyInstalled(): bool
     {
@@ -328,8 +320,6 @@ final class FOSSBilling_Installer
 
     /**
      * Installation processor.
-     *
-     * @return boolean
      */
     private function install(): bool
     {
@@ -363,17 +353,17 @@ final class FOSSBilling_Installer
         // Delete default currency from content file and use currency passed in the installer
         $stmt = $this->pdo->prepare("DELETE FROM currency WHERE code='USD'");
         $stmt->execute();
-        $stmt = $this->pdo->prepare("INSERT INTO currency (id, title, code, is_default, conversion_rate, format, price_format, created_at, updated_at) VALUES(1, :currency_title, :currency_code, 1, 1.000000, :currency_format, 1,  NOW(), NOW());");
+        $stmt = $this->pdo->prepare('INSERT INTO currency (id, title, code, is_default, conversion_rate, format, price_format, created_at, updated_at) VALUES(1, :currency_title, :currency_code, 1, 1.000000, :currency_format, 1,  NOW(), NOW());');
         $stmt->execute([
             'currency_title' => $this->session->get('currency_title'),
             'currency_code' => $this->session->get('currency_code'),
             'currency_format' => $this->session->get('currency_format'),
         ]);
 
-        $stmt = $this->pdo->prepare("INSERT INTO setting (param, value, created_at, updated_at) VALUES (:param, :value, NOW(), NOW())");
+        $stmt = $this->pdo->prepare('INSERT INTO setting (param, value, created_at, updated_at) VALUES (:param, :value, NOW(), NOW())');
         $stmt->execute([
             ':param' => 'last_error_reporting_nudge',
-            ':value' => \FOSSBilling\Version::VERSION,
+            ':value' => FOSSBilling\Version::VERSION,
         ]);
 
         // Copy config templates when applicable
@@ -388,7 +378,7 @@ final class FOSSBilling_Installer
                 $response = $client->request('GET', 'https://raw.githubusercontent.com/FOSSBilling/FOSSBilling/main/src/.htaccess');
                 file_put_contents(PATH_HTACCESS, $response->getContent());
             } catch (Exception $e) {
-                throw new Exception("Unable to write required .htaccess file to " . PATH_HTACCESS . ". Check file and folder permissions.", $e->getCode());
+                throw new Exception('Unable to write required .htaccess file to ' . PATH_HTACCESS . '. Check file and folder permissions.', $e->getCode());
             }
         }
 
@@ -404,19 +394,17 @@ final class FOSSBilling_Installer
 
     /**
      * Generate the `config.php` file using the `config-sample.php` as a template.
-     *
-     * @return string
      */
     private function getConfigOutput(): string
     {
-        $updateBranch = \FOSSBilling\Version::isPreviewVersion() ? "preview" : "release";
+        $updateBranch = FOSSBilling\Version::isPreviewVersion() ? 'preview' : 'release';
 
         // Load default sample config
         $data = require PATH_CONFIG_SAMPLE;
 
         // Handle dynamic configs
         $data['security']['force_https'] = FOSSBilling\Tools::isHTTPS();
-        $data['debug_and_monitoring']['report_errors'] = (bool)$this->session->get('error_reporting');
+        $data['debug_and_monitoring']['report_errors'] = (bool) $this->session->get('error_reporting');
         $data['update_branch'] = $updateBranch;
         $data['info']['salt'] = bin2hex(random_bytes(16));
         $data['info']['instance_id'] = Uuid::uuid4()->toString();
@@ -435,13 +423,12 @@ final class FOSSBilling_Installer
         // Build and return data
         $output = '<?php ' . PHP_EOL;
         $output .= 'return ' . var_export($data, true) . ';';
+
         return $output;
     }
 
     /**
      * Generate the default email templates.
-     *
-     * @return boolean
      */
     private function generateEmailTemplates(): bool
     {

--- a/src/install/session.php
+++ b/src/install/session.php
@@ -2,7 +2,7 @@
 
 class Session
 {
-    private $_handler = null;
+    private $_handler;
 
     public function __construct()
     {
@@ -23,7 +23,7 @@ class Session
     {
         return $this->_handler->get($key);
     }
-    
+
     public function set($key, $value)
     {
         $this->_handler->set($key, $value);
@@ -37,8 +37,8 @@ class Session
 
 class Box_SessionFile
 {
-    final public const SESSION_STARTED       = TRUE;
-    final public const SESSION_NOT_STARTED   = FALSE;
+    final public const SESSION_STARTED = true;
+    final public const SESSION_NOT_STARTED = false;
 
     protected $sessionState = self::SESSION_NOT_STARTED;
 
@@ -46,14 +46,14 @@ class Box_SessionFile
 
     public static function getInstance()
     {
-        if ( !isset(self::$instance))
-        {
-            self::$instance = new self;
-            if(!self::$instance->sessionExists() && !headers_sent()) {
+        if (!isset(self::$instance)) {
+            self::$instance = new self();
+            if (!self::$instance->sessionExists() && !headers_sent()) {
                 session_name('BOXSID');
                 self::$instance->sessionState = session_start();
             }
         }
+
         return self::$instance;
     }
 
@@ -64,22 +64,23 @@ class Box_SessionFile
 
     public function destroy()
     {
-        if(self::$instance->sessionExists()) {
+        if (self::$instance->sessionExists()) {
             session_destroy();
         }
     }
 
     public function delete($key)
     {
-        if(isset($_SESSION[$key])) {
+        if (isset($_SESSION[$key])) {
             unset($_SESSION[$key]);
         }
-        return TRUE;
+
+        return true;
     }
 
     private function sessionExists()
     {
-        if(!isset($_SESSION)) {
+        if (!isset($_SESSION)) {
             return false;
         }
 
@@ -104,7 +105,7 @@ class Box_SessionFile
 
     public function __get($key)
     {
-        return $_SESSION[$key] ?? NULL;
+        return $_SESSION[$key] ?? null;
     }
 
     public function __set($key, $value)
@@ -112,13 +113,13 @@ class Box_SessionFile
         $_SESSION[$key] = $value;
     }
 
-    public function __isset( $name )
+    public function __isset($name)
     {
         return isset($_SESSION[$name]);
     }
 
-    public function __unset( $name )
+    public function __unset($name)
     {
-        unset( $_SESSION[$name] );
+        unset($_SESSION[$name]);
     }
 }

--- a/src/library/Api/Abstract.php
+++ b/src/library/Api/Abstract.php
@@ -2,42 +2,42 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
 
 class Api_Abstract implements InjectionAwareInterface
 {
     /**
      * @var string - request ip
      */
-    protected $ip = null;
+    protected $ip;
 
     /**
-     * @var \Box_Mod
+     * @var Box_Mod
      */
-    protected $mod  = null;
+    protected $mod;
 
     // TODO: Find a way to correctly set the type. Maybe a module's service should extend a "Service" class?
-    protected $service  = null;
+    protected $service;
 
     /**
      * @var Model_Admin|Model_Client|Model_Guest
      */
-    protected $identity = null;
+    protected $identity;
 
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -58,6 +58,7 @@ class Api_Abstract implements InjectionAwareInterface
         if (!$this->mod) {
             throw new FOSSBilling\Exception('Mod object is not set for the service');
         }
+
         return $this->mod;
     }
 

--- a/src/library/Api/Handler.php
+++ b/src/library/Api/Handler.php
@@ -2,23 +2,23 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
 
 final class Api_Handler implements InjectionAwareInterface
 {
-    protected $type     = NULL;
-    protected $ip       = NULL;
+    protected $type;
+    protected $ip;
     protected ?\Pimple\Container $di = null;
 
-    private   bool $_enable_cache    = FALSE;
-    private   array $_cache           = array();
-    private   bool $_acl_exception    = FALSE;
+    private bool $_enable_cache = false;
+    private array $_cache = [];
+    private bool $_acl_exception = false;
 
     public function __construct(protected $identity)
     {
@@ -26,23 +26,23 @@ final class Api_Handler implements InjectionAwareInterface
         $this->type = $role;
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
 
     public function __call($method, $arguments)
     {
-        if(!str_contains($method, '_')) {
-            throw new \FOSSBilling\Exception("Method :method must contain underscore", array(':method'=>$method), 710);
+        if (!str_contains($method, '_')) {
+            throw new FOSSBilling\Exception('Method :method must contain underscore', [':method' => $method], 710);
         }
 
-        if(isset($arguments[0])) {
+        if (isset($arguments[0])) {
             $arguments = $arguments[0];
         }
 
@@ -51,43 +51,44 @@ final class Api_Handler implements InjectionAwareInterface
         unset($e[0]);
         $method_name = implode('_', $e);
 
-        if(empty($mod)) {
-            throw new \FOSSBilling\Exception('Invalid module name', null, 714);
+        if (empty($mod)) {
+            throw new FOSSBilling\Exception('Invalid module name', null, 714);
         }
 
-        //cache
-        $cache_key = md5($this->type.$mod.$method_name.serialize($arguments));
-        if($this->_enable_cache && isset($this->_cache[$cache_key])) {
+        // cache
+        $cache_key = md5($this->type . $mod . $method_name . serialize($arguments));
+        if ($this->_enable_cache && isset($this->_cache[$cache_key])) {
             return $this->_cache[$cache_key];
         }
 
         $service = $this->di['mod']('extension')->getService();
 
-        if(!$service->isExtensionActive('mod',$mod)) {
-            throw new \FOSSBilling\Exception('FOSSBilling module :mod is not installed/activated',array(':mod'=>$mod), 715);
+        if (!$service->isExtensionActive('mod', $mod)) {
+            throw new FOSSBilling\Exception('FOSSBilling module :mod is not installed/activated', [':mod' => $mod], 715);
         }
 
         // permissions check
-        if($this->type == 'admin') {
+        if ($this->type == 'admin') {
             $staff_service = $this->di['mod_service']('Staff');
-            if(!$staff_service->hasPermission($this->identity, $mod)) {
-                if($this->_acl_exception) {
-                    throw new \FOSSBilling\Exception('You do not have access to :mod module', array(':mod'=>$mod), 725);
+            if (!$staff_service->hasPermission($this->identity, $mod)) {
+                if ($this->_acl_exception) {
+                    throw new FOSSBilling\Exception('You do not have access to :mod module', [':mod' => $mod], 725);
                 } else {
-                    if(DEBUG) {
-                        error_log('You do not have access to '.$mod. ' module');
+                    if (DEBUG) {
+                        error_log('You do not have access to ' . $mod . ' module');
                     }
+
                     return null;
                 }
             }
         }
 
-        $api_class = '\Box\Mod\\'.ucfirst($mod).'\\Api\\'.ucfirst($this->type);
+        $api_class = '\Box\Mod\\' . ucfirst($mod) . '\\Api\\' . ucfirst($this->type);
 
         $api = new $api_class();
 
-        if(!$api instanceof Api_Abstract ) {
-            throw new \FOSSBilling\Exception('Api class must be instance of Api_Abstract', null, 730);
+        if (!$api instanceof Api_Abstract) {
+            throw new FOSSBilling\Exception('Api class must be instance of Api_Abstract', null, 730);
         }
 
         $bb_mod = $this->di['mod']($mod);
@@ -96,20 +97,21 @@ final class Api_Handler implements InjectionAwareInterface
         $api->setMod($bb_mod);
         $api->setIdentity($this->identity);
         $api->setIp($this->di['request']->getClientAddress());
-        if($bb_mod->hasService()) {
+        if ($bb_mod->hasService()) {
             $api->setService($this->di['mod_service']($mod));
         }
 
-        if(!method_exists($api, $method_name) || !is_callable(array($api, $method_name))) {
+        if (!method_exists($api, $method_name) || !is_callable([$api, $method_name])) {
             $reflector = new ReflectionClass($api);
-            if(!$reflector->hasMethod('__call')) {
-                throw new \FOSSBilling\Exception(':type API call :method does not exist in module :module', array(':type'=>ucfirst($this->type), ':method'=>$method_name,':module'=>$mod), 740);
+            if (!$reflector->hasMethod('__call')) {
+                throw new FOSSBilling\Exception(':type API call :method does not exist in module :module', [':type' => ucfirst($this->type), ':method' => $method_name, ':module' => $mod], 740);
             }
         }
         $res = $api->{$method_name}($arguments);
-        if($this->_enable_cache){
+        if ($this->_enable_cache) {
             $this->_cache[$cache_key] = $res;
         }
+
         return $res;
     }
 }

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -3,17 +3,17 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use Twig\Profiler\Profile;
-use Twig\Extension\ProfilerExtension;
 use DebugBar\Bridge\NamespacedTwigProfileCollector;
-use FOSSBilling\TwigExtensions\DebugBar;
 use FOSSBilling\Environment;
+use FOSSBilling\TwigExtensions\DebugBar;
+use Twig\Extension\ProfilerExtension;
+use Twig\Profiler\Profile;
 
 class Box_AppAdmin extends Box_App
 {
@@ -32,7 +32,7 @@ class Box_AppAdmin extends Box_App
 
         if ($this->mod !== 'extension' && $this->di['auth']->isAdminLoggedIn() && !$service->hasPermission(null, $this->mod)) {
             http_response_code(403);
-            $e = new \FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
+            $e = new FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
             echo $this->render('error', ['exception' => $e]);
             exit;
         }

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -3,17 +3,17 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use Twig\Profiler\Profile;
-use Twig\Extension\ProfilerExtension;
 use DebugBar\Bridge\NamespacedTwigProfileCollector;
-use FOSSBilling\TwigExtensions\DebugBar;
 use FOSSBilling\Environment;
+use FOSSBilling\TwigExtensions\DebugBar;
+use Twig\Extension\ProfilerExtension;
+use Twig\Profiler\Profile;
 
 class Box_AppClient extends Box_App
 {
@@ -22,7 +22,7 @@ class Box_AppClient extends Box_App
         $m = $this->di['mod']($this->mod);
         $m->registerClientRoutes($this);
 
-        if ('api' == $this->mod) {
+        if ($this->mod == 'api') {
             define('API_MODE', true);
 
             // Prevent errors from being displayed in API mode as it can cause invalid JSON to be returned.
@@ -59,6 +59,7 @@ class Box_AppClient extends Box_App
         }
         $page = str_replace('/', '_', $page);
         $tpl = 'mod_page_' . $page;
+
         try {
             return $this->render($tpl, ['post' => $_POST], $ext);
         } catch (Exception $e) {
@@ -66,7 +67,7 @@ class Box_AppClient extends Box_App
                 error_log($e);
             }
         }
-        $e = new \FOSSBilling\InformationException('Page :url not found', [':url' => $this->url], 404);
+        $e = new FOSSBilling\InformationException('Page :url not found', [':url' => $this->url], 404);
 
         $this->di['logger']->setChannel('routing')->info($e->getMessage());
         http_response_code(404);
@@ -84,7 +85,8 @@ class Box_AppClient extends Box_App
         } catch (Twig\Error\LoaderError $e) {
             $this->di['logger']->setChannel('routing')->info($e->getMessage());
             http_response_code(404);
-            throw new \FOSSBilling\InformationException('Page not found', null, 404);
+
+            throw new FOSSBilling\InformationException('Page not found', null, 404);
         }
 
         if ($fileName . '.' . $ext == 'mod_page_sitemap.xml') {

--- a/src/library/Box/Authorization.php
+++ b/src/library/Box/Authorization.php
@@ -2,51 +2,52 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_Authorization
 {
-    private $session = null;
+    private $session;
 
-    public function __construct(private \Pimple\Container $di)
+    public function __construct(private Pimple\Container $di)
     {
         $this->session = $di['session'];
     }
 
     public function isClientLoggedIn()
     {
-        return (bool)($this->session->get('client_id'));
+        return (bool) $this->session->get('client_id');
     }
 
     public function isAdminLoggedIn()
     {
-        return (bool)($this->session->get('admin'));
+        return (bool) $this->session->get('admin');
     }
 
     public function authorizeUser($user, $plainTextPassword)
     {
         $user = $this->passwordBackwardCompatibility($user, $plainTextPassword);
-        if ($this->di['password']->verify($plainTextPassword, $user->pass)){
-            if ($this->di['password']->needsRehash($user->pass)){
+        if ($this->di['password']->verify($plainTextPassword, $user->pass)) {
+            if ($this->di['password']->needsRehash($user->pass)) {
                 $user->pass = $this->di['password']->hashIt($plainTextPassword);
                 $this->di['db']->store($user);
             }
+
             return $user;
         }
+
         return null;
     }
 
     public function passwordBackwardCompatibility($user, $plainTextPassword)
     {
-        if (sha1($plainTextPassword) == $user->pass){
+        if (sha1($plainTextPassword) == $user->pass) {
             $user->pass = $this->di['password']->hashIt($plainTextPassword);
             $this->di['db']->store($user);
         }
+
         return $user;
     }
-
 }

--- a/src/library/Box/BeanHelper.php
+++ b/src/library/Box/BeanHelper.php
@@ -2,31 +2,30 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_BeanHelper extends \RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper implements \FOSSBilling\InjectionAwareInterface
+class Box_BeanHelper extends RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
 
     /** @phpstan-ignore-next-line (No matter what I put for the return type of this function, PHPStan is unhappy) */
-    public function getModelForBean(\RedBeanPHP\OODBBean $bean): ?object 
+    public function getModelForBean(RedBeanPHP\OODBBean $bean): ?object
     {
-        $prefix    = '\\Model_';
-        $model     = $bean->getMeta('type');
+        $prefix = '\\Model_';
+        $model = $bean->getMeta('type');
         $modelName = $prefix . $this->underscoreToCamelCase($model);
 
         if (!class_exists($modelName)) {
@@ -34,7 +33,7 @@ class Box_BeanHelper extends \RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper imple
         }
 
         $model = new $modelName();
-        if ($model instanceof \FOSSBilling\InjectionAwareInterface) {
+        if ($model instanceof FOSSBilling\InjectionAwareInterface) {
             $model->setDi($this->di);
         }
 
@@ -49,6 +48,7 @@ class Box_BeanHelper extends \RedBeanPHP\BeanHelper\SimpleFacadeBeanHelper imple
             $string[0] = strtoupper($string[0]);
         }
         $func = fn ($c) => strtoupper($c[1]);
+
         return preg_replace_callback('/_([a-z])/', $func, $string);
     }
 }

--- a/src/library/Box/Crypt.php
+++ b/src/library/Box/Crypt.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_Crypt implements \FOSSBilling\InjectionAwareInterface
+class Box_Crypt implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
@@ -21,12 +20,12 @@ class Box_Crypt implements \FOSSBilling\InjectionAwareInterface
         }
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -51,7 +50,7 @@ class Box_Crypt implements \FOSSBilling\InjectionAwareInterface
 
     public function decrypt($text, $pass = null)
     {
-        if (is_null($text)){
+        if (is_null($text)) {
             return false;
         }
         $key = $this->_getSalt($pass);
@@ -77,9 +76,10 @@ class Box_Crypt implements \FOSSBilling\InjectionAwareInterface
 
     private function _getSalt($pass = null)
     {
-        if (null == $pass) {
+        if ($pass == null) {
             $pass = $this->di['config']['info']['salt'];
         }
+
         return pack('H*', hash('md5', $pass));
     }
 }

--- a/src/library/Box/Database.php
+++ b/src/library/Box/Database.php
@@ -2,31 +2,30 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
 
 class Box_Database implements InjectionAwareInterface
 {
-
     protected ?\Pimple\Container $di = null;
-    protected $orm = null;
+    protected $orm;
 
     public function setDataMapper($orm)
     {
         $this->orm = $orm;
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -38,40 +37,42 @@ class Box_Database implements InjectionAwareInterface
         if ($type == $modelName) {
             return $bean;
         }
+
         return $bean->box();
     }
 
     public function store($modelOrBean)
     {
-        if ($modelOrBean instanceof \RedBeanPHP\SimpleModel) {
+        if ($modelOrBean instanceof RedBeanPHP\SimpleModel) {
             $bean = $modelOrBean->unbox();
         } else {
             $bean = $modelOrBean;
         }
+
         return $this->orm->store($bean);
     }
 
-    public function getAll($sql, $values = array())
+    public function getAll($sql, $values = [])
     {
         return $this->orm->getAll($sql, $values);
     }
 
-    public function getCell($sql, $values = array())
+    public function getCell($sql, $values = [])
     {
         return $this->orm->getCell($sql, $values);
     }
 
-    public function getRow($sql, $values = array())
+    public function getRow($sql, $values = [])
     {
         return $this->orm->getRow($sql, $values);
     }
 
-    public function getAssoc($sql, $values = array())
+    public function getAssoc($sql, $values = [])
     {
         return $this->orm->getAssoc($sql, $values);
     }
 
-    public function findOne($modelName, $sql = null, $values = array())
+    public function findOne($modelName, $sql = null, $values = [])
     {
         $type = $this->_getTypeFromModelName($modelName);
         $bean = $this->orm->findOne($type, $sql, $values);
@@ -81,10 +82,11 @@ class Box_Database implements InjectionAwareInterface
         if ($bean && $bean->id) {
             return $bean->box();
         }
+
         return null;
     }
 
-    public function find($modelName, $sql = null, $values = array())
+    public function find($modelName, $sql = null, $values = [])
     {
         $type = $this->_getTypeFromModelName($modelName);
         $beans = $this->orm->find($type, $sql, $values);
@@ -109,7 +111,7 @@ class Box_Database implements InjectionAwareInterface
 
     /**
      * @param string $modelName
-     * @param integer $id
+     * @param int    $id
      */
     public function load($modelName, $id)
     {
@@ -134,21 +136,23 @@ class Box_Database implements InjectionAwareInterface
 
     /**
      * @param string $sql
-     * @param array $values
+     * @param array  $values
+     *
      * @return int - affected rows
      */
-    public function exec($sql, $values = array())
+    public function exec($sql, $values = [])
     {
         return $this->orm->exec($sql, $values);
     }
 
     public function trash($modelOrBean)
     {
-        if ($modelOrBean instanceof \RedBeanPHP\SimpleModel) {
+        if ($modelOrBean instanceof RedBeanPHP\SimpleModel) {
             $bean = $modelOrBean->unbox();
         } else {
             $bean = $modelOrBean;
         }
+
         return $this->orm->trash($bean);
     }
 
@@ -164,26 +168,29 @@ class Box_Database implements InjectionAwareInterface
 
     public function toArray($modelOrBean)
     {
-        if ($modelOrBean instanceof \RedBeanPHP\SimpleModel) {
+        if ($modelOrBean instanceof RedBeanPHP\SimpleModel) {
             $bean = $modelOrBean->unbox();
         } else {
             $bean = $modelOrBean;
         }
+
         return $bean->export();
     }
 
     /**
      * @param string $modelName
-     * @param int $id
+     * @param int    $id
      * @param string $message
-     * @return \RedBeanPHP\SimpleModel
-     * @throws \FOSSBilling\Exception
+     *
+     * @return RedBeanPHP\SimpleModel
+     *
+     * @throws FOSSBilling\Exception
      */
-    public function getExistingModelById($modelName, $id, $message = "Model :name not found in the database")
+    public function getExistingModelById($modelName, $id, $message = 'Model :name not found in the database')
     {
-        $model = $this->load($modelName, (int)$id);
-        if (null === $model) {
-            throw new \FOSSBilling\Exception($message, [':name' => $modelName]);
+        $model = $this->load($modelName, (int) $id);
+        if ($model === null) {
+            throw new FOSSBilling\Exception($message, [':name' => $modelName]);
         }
 
         return $model;
@@ -200,6 +207,7 @@ class Box_Database implements InjectionAwareInterface
         foreach ($ret as &$match) {
             $match = $match == strtoupper($match) ? strtolower($match) : lcfirst($match);
         }
+
         return implode('_', $ret);
     }
 }

--- a/src/library/Box/DbLoggedPDOStatement.php
+++ b/src/library/Box/DbLoggedPDOStatement.php
@@ -2,17 +2,17 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_DbLoggedPDOStatement extends PDOStatement
 {
-    public function execute ($input_parameters = null): bool
+    public function execute($input_parameters = null): bool
     {
         error_log($this->queryString);
+
         return parent::execute($input_parameters);
     }
 }

--- a/src/library/Box/Event.php
+++ b/src/library/Box/Event.php
@@ -2,16 +2,15 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_Event implements ArrayAccess, \FOSSBilling\InjectionAwareInterface
+class Box_Event implements ArrayAccess, FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
-    protected $value = null;
+    protected $value;
     protected $processed = false;
 
     /**
@@ -25,12 +24,12 @@ class Box_Event implements ArrayAccess, \FOSSBilling\InjectionAwareInterface
     {
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }

--- a/src/library/Box/EventDispatcher.php
+++ b/src/library/Box/EventDispatcher.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_EventDispatcher
 {
     protected $listeners = [];
@@ -47,6 +46,7 @@ class Box_EventDispatcher
                 unset($this->listeners[$name][$i]);
             }
         }
+
         return null;
     }
 
@@ -67,6 +67,7 @@ class Box_EventDispatcher
         foreach ($this->listeners[$name] as $i => $callable) {
             unset($this->listeners[$name][$i]);
         }
+
         return null;
     }
 
@@ -98,6 +99,7 @@ class Box_EventDispatcher
         foreach ($this->getListeners($event->getName()) as $listener) {
             if (call_user_func($listener, $event)) {
                 $event->setProcessed(true);
+
                 break;
             }
         }

--- a/src/library/Box/EventManager.php
+++ b/src/library/Box/EventManager.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_EventManager implements \FOSSBilling\InjectionAwareInterface
+class Box_EventManager implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }

--- a/src/library/Box/Exception.php
+++ b/src/library/Box/Exception.php
@@ -2,28 +2,27 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_Exception extends FOSSBilling\Exception
 {
-	/**
-	 * Creates a new translated exception.
-	 * 
-	 * @deprecated 0.6.0, you should use FOSSBilling\Exception instead which is a drop in replacement.
-	 *
-	 * @param string $message error message
-	 * @param array|null $variables translation variables
-	 * @param int $code The exception code.
-	 * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace. 
-	 */
-	public function __construct(string $message, ?array $variables = null, int $code = 0, bool $protected = false)
-	{
+    /**
+     * Creates a new translated exception.
+     *
+     * @deprecated 0.6.0, you should use FOSSBilling\Exception instead which is a drop in replacement.
+     *
+     * @param string     $message   error message
+     * @param array|null $variables translation variables
+     * @param int        $code      the exception code
+     * @param bool       $protected if the variables in this should be considered protect, if so, hide them from the stack trace
+     */
+    public function __construct(string $message, array $variables = null, int $code = 0, bool $protected = false)
+    {
         // Pass the message to the parent
-		trigger_error('Box_Exception is deprectated and soon to be removed.', E_USER_DEPRECATED);
+        trigger_error('Box_Exception is deprectated and soon to be removed.', E_USER_DEPRECATED);
         parent::__construct($message, $variables, $code, $protected);
-	}
+    }
 }

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -18,16 +18,16 @@
  * @method void info(string $message)
  * @method void debug(string $message)
  */
-class Box_Log implements \FOSSBilling\InjectionAwareInterface
+class Box_Log implements FOSSBilling\InjectionAwareInterface
 {
-    final public const EMERG  = 0; // Emergency: system is unusable
-    final public const ALERT  = 1; // Alert: action must be taken immediately
-    final public const CRIT   = 2; // Critical: critical conditions
-    final public const ERR    = 3; // Error: error conditions
-    final public const WARN   = 4; // Warning: warning conditions
+    final public const EMERG = 0; // Emergency: system is unusable
+    final public const ALERT = 1; // Alert: action must be taken immediately
+    final public const CRIT = 2; // Critical: critical conditions
+    final public const ERR = 3; // Error: error conditions
+    final public const WARN = 4; // Warning: warning conditions
     final public const NOTICE = 5; // Notice: normal but significant condition
-    final public const INFO   = 6; // Informational: informational messages
-    final public const DEBUG  = 7; // Debug: debug messages
+    final public const INFO = 6; // Informational: informational messages
+    final public const DEBUG = 7; // Debug: debug messages
 
     protected array $_priorities = [
         self::EMERG => 'EMERG',
@@ -41,27 +41,24 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
     ];
 
     protected ?\Pimple\Container $di = null;
-    protected $_min_priority = null;
+    protected $_min_priority;
 
     protected array $_writers = [];
     protected array $_extras = [];
     protected string $_channel = 'application';
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
 
     /**
-     * @param $method
-     * @param $params
-     * @return void
-     * @throws \FOSSBilling\Exception
+     * @throws FOSSBilling\Exception
      */
     public function __call($method, $params): void
     {
@@ -69,10 +66,11 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
         if (($priority = array_search($priority, $this->_priorities)) !== false) {
             switch (is_countable($params) ? count($params) : 0) {
                 case 0:
-                    throw new \FOSSBilling\Exception('Missing log message');
+                    throw new FOSSBilling\Exception('Missing log message');
                 case 1:
                     $message = array_shift($params);
                     $extras = null;
+
                     break;
                 default:
                     $message = array_shift($params);
@@ -80,20 +78,17 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
                     if (!$message) {
                         throw new LogicException('Number of placeholders does not match number of variables');
                     }
+
                     break;
             }
             $this->log($message, $priority, $params);
         } else {
-            throw new \FOSSBilling\Exception('Bad log priority');
+            throw new FOSSBilling\Exception('Bad log priority');
         }
     }
 
     /**
-     * @param $message
-     * @param $priority
-     * @param $extras
-     * @return void
-     * @throws \FOSSBilling\Exception
+     * @throws FOSSBilling\Exception
      */
     public function log($message, $priority, $extras = null): void
     {
@@ -103,7 +98,7 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
         }
 
         if (!isset($this->_priorities[$priority])) {
-            throw new \FOSSBilling\Exception('Bad log priority');
+            throw new FOSSBilling\Exception('Bad log priority');
         }
 
         if ($this->_min_priority && $priority > $this->_min_priority) {
@@ -131,7 +126,7 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
             }
         }
 
-        //do not log debug level messages if debug is OFF
+        // do not log debug level messages if debug is OFF
         if (!DEBUG && $event['priority'] > self::INFO) {
             return;
         }
@@ -149,22 +144,26 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
 
     /**
      * @param Box_LogDb|FOSSBilling\Monolog $writer
+     *
      * @return $this The Box_Log instance
      */
     public function addWriter($writer): static
     {
         $this->_writers[] = $writer;
+
         return $this;
     }
 
     /**
-     * @param $name string
+     * @param $name  string
      * @param $value mixed
+     *
      * @return $this The Box_Log instance
      */
     public function setEventItem(string $name, mixed $value): static
     {
         $this->_extras = array_merge($this->_extras, [$name => $value]);
+
         return $this;
     }
 
@@ -172,21 +171,23 @@ class Box_Log implements \FOSSBilling\InjectionAwareInterface
      * Set the channel name for the logger.
      *
      * @param string $channel Channel name
+     *
      * @return $this The Box_Log instance
      */
     public function setChannel(string $channel): static
     {
         $this->_channel = $channel;
+
         return $this;
     }
 
     /**
-     * @param $priority
      * @return $this The Box_Log instance
      */
     public function setMinPriority($priority): static
     {
         $this->_min_priority = $priority;
+
         return $this;
     }
 }

--- a/src/library/Box/LogDb.php
+++ b/src/library/Box/LogDb.php
@@ -3,17 +3,17 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_LogDb
 {
     private array $ignoredChannels = ['billing', 'routing'];
+
     /**
-     * Class constructor
+     * Class constructor.
      *
      * @param object $service - module service class object
      */
@@ -23,9 +23,6 @@ class Box_LogDb
 
     /**
      * Write a message to the log.
-     *
-     *
-     * @return void
      */
     public function write(array $event, string $channel = 'application'): void
     {

--- a/src/library/Box/Mod.php
+++ b/src/library/Box/Mod.php
@@ -2,19 +2,18 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_Mod
 {
     private ?string $mod = null;
 
     private ?\Pimple\Container $di = null;
 
-    private array $core = array(
+    private array $core = [
         'api',
         'activity',
         'cart',
@@ -42,21 +41,21 @@ class Box_Mod
         'theme',
         'orderbutton',
         'formbuilder',
-    );
+    ];
 
     /**
      * @param string $mod
      */
     public function __construct($mod)
     {
-        if(!preg_match('#[a-zA-Z]#', $mod)) {
-            throw new \FOSSBilling\Exception('Invalid module name');
+        if (!preg_match('#[a-zA-Z]#', $mod)) {
+            throw new FOSSBilling\Exception('Invalid module name');
         }
 
         $this->mod = strtolower($mod);
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
@@ -68,39 +67,39 @@ class Box_Mod
 
     public function getManifest()
     {
-        if(!$this->hasManifest()) {
-            throw new \FOSSBilling\Exception('Module :mod manifest file is missing', array(':mod'=>$this->mod), 5897);
+        if (!$this->hasManifest()) {
+            throw new FOSSBilling\Exception('Module :mod manifest file is missing', [':mod' => $this->mod], 5897);
         }
         $file = $this->_getModPath() . 'manifest.json';
         $json = json_decode(file_get_contents($file), true);
-        if(empty ($json)) {
-            throw new \FOSSBilling\Exception('Module :mod manifest file is invalid. Check file syntax and permissions.', array(':mod'=>$this->mod));
+        if (empty($json)) {
+            throw new FOSSBilling\Exception('Module :mod manifest file is invalid. Check file syntax and permissions.', [':mod' => $this->mod]);
         }
 
-        //default module info if some fields are missing
-        $info = array(
-            'id'            => $this->mod,
-            'type'          => 'mod',
-            'name'          => $this->mod,
-            'description'   => NULL,
-            'homepage_url'  => 'https://fossbilling.org/',
-            'author'        => 'FOSSBilling',
-            'author_url'    => 'https://extensions.fossbilling.org/',
-            'license'       => 'N/A',
-            'version'       => '1.0',
-            'icon_url'      => NULL,
-            'download_url'  => NULL,
-            'project_url'   => 'https://extensions.fossbilling.org/',
-            "minimum_boxbilling_version" => NULL,
-            "maximum_boxbilling_version" => NULL,
-        );
+        // default module info if some fields are missing
+        $info = [
+            'id' => $this->mod,
+            'type' => 'mod',
+            'name' => $this->mod,
+            'description' => null,
+            'homepage_url' => 'https://fossbilling.org/',
+            'author' => 'FOSSBilling',
+            'author_url' => 'https://extensions.fossbilling.org/',
+            'license' => 'N/A',
+            'version' => '1.0',
+            'icon_url' => null,
+            'download_url' => null,
+            'project_url' => 'https://extensions.fossbilling.org/',
+            'minimum_boxbilling_version' => null,
+            'maximum_boxbilling_version' => null,
+        ];
 
         $info = array_merge($info, $json);
         $info['id'] = $this->mod;
         $info['type'] = 'mod';
 
-        if(!empty($info['icon_url'])) {
-            $info['icon_url'] = '/modules/'.ucfirst($this->mod).'/'.$info['icon_url'];
+        if (!empty($info['icon_url'])) {
+            $info['icon_url'] = '/modules/' . ucfirst($this->mod) . '/' . $info['icon_url'];
         }
 
         return $info;
@@ -109,19 +108,21 @@ class Box_Mod
     public function hasService($sub = '')
     {
         $filename = sprintf('Service%s.php', ucfirst($sub));
+
         return file_exists($this->_getModPath() . $filename);
     }
 
     public function getService($sub = '')
     {
-        if(!$this->hasService($sub)) {
-            throw new \FOSSBilling\Exception('Module :mod does not have service class', array(':mod'=>$this->mod), 5898);
+        if (!$this->hasService($sub)) {
+            throw new FOSSBilling\Exception('Module :mod does not have service class', [':mod' => $this->mod], 5898);
         }
-        $class = 'Box\\Mod\\'.ucfirst($this->mod).'\\Service'.ucfirst($sub);
-    	$service = new $class();
-        if(method_exists($service, 'setDi')) {
+        $class = 'Box\\Mod\\' . ucfirst($this->mod) . '\\Service' . ucfirst($sub);
+        $service = new $class();
+        if (method_exists($service, 'setDi')) {
             $service->setDi($this->di);
         }
+
         return $service;
     }
 
@@ -132,21 +133,22 @@ class Box_Mod
 
     public function getClientController()
     {
-        if(!$this->hasClientController()) {
-            throw new \FOSSBilling\Exception('Module :mod Client controller class was not found', array(':mod'=>$this->mod));
+        if (!$this->hasClientController()) {
+            throw new FOSSBilling\Exception('Module :mod Client controller class was not found', [':mod' => $this->mod]);
         }
 
-        $class = 'Box\\Mod\\'.ucfirst($this->mod).'\\Controller\\Client';
+        $class = 'Box\\Mod\\' . ucfirst($this->mod) . '\\Controller\\Client';
         $service = new $class();
-        if(method_exists($service, 'setDi')) {
+        if (method_exists($service, 'setDi')) {
             $service->setDi($this->di);
         }
-    	return $service;
+
+        return $service;
     }
 
     public function hasSettingsPage()
     {
-        return file_exists($this->_getModPath() . 'html_admin/mod_'.$this->mod.'_settings.html.twig');
+        return file_exists($this->_getModPath() . 'html_admin/mod_' . $this->mod . '_settings.html.twig');
     }
 
     public function hasAdminController()
@@ -156,27 +158,29 @@ class Box_Mod
 
     public function getAdminController()
     {
-        if(!$this->hasAdminController()) {
+        if (!$this->hasAdminController()) {
             return null;
         }
-        $class = 'Box\\Mod\\'.ucfirst($this->mod).'\\Controller\\Admin';
+        $class = 'Box\\Mod\\' . ucfirst($this->mod) . '\\Controller\\Admin';
         $service = new $class();
-        if(method_exists($service, 'setDi')) {
+        if (method_exists($service, 'setDi')) {
             $service->setDi($this->di);
         }
-    	return $service;
+
+        return $service;
     }
 
     public function install()
     {
-        if($this->isCore()) {
+        if ($this->isCore()) {
             return true;
         }
 
-        if($this->hasService()) {
+        if ($this->hasService()) {
             $s = $this->getService();
-            if(method_exists($s, 'install')) {
+            if (method_exists($s, 'install')) {
                 $s->install();
+
                 return true;
             }
         }
@@ -186,34 +190,38 @@ class Box_Mod
 
     public function uninstall()
     {
-        if($this->isCore()) {
+        if ($this->isCore()) {
             return true;
         }
 
-        if($this->hasService()) {
+        if ($this->hasService()) {
             $s = $this->getService();
-            if(method_exists($s, 'uninstall')) {
+            if (method_exists($s, 'uninstall')) {
                 $s->uninstall();
+
                 return true;
             }
         }
+
         return false;
     }
 
     public function update()
     {
-        if($this->isCore()) {
-            throw new \FOSSBilling\InformationException('Core module can not be updated');
+        if ($this->isCore()) {
+            throw new FOSSBilling\InformationException('Core module can not be updated');
         }
 
-        if($this->hasService()) {
+        if ($this->hasService()) {
             $s = $this->getService();
-            if(method_exists($s, 'update')) {
+            if (method_exists($s, 'update')) {
                 $manifest = $this->getManifest();
                 $s->update($manifest);
+
                 return true;
             }
         }
+
         return false;
     }
 
@@ -231,14 +239,15 @@ class Box_Mod
     {
         $db = $this->di['db'];
         $bb_config = $this->di['config'];
-        $config = array();
+        $config = [];
 
-        $modName = 'mod_'.strtolower($this->mod);
-        $c = $db->findOne('extension_meta', 'extension = :ext AND meta_key = :key', array(':ext'=>$modName, ':key'=>'config'));
-        if($c) {
+        $modName = 'mod_' . strtolower($this->mod);
+        $c = $db->findOne('extension_meta', 'extension = :ext AND meta_key = :key', [':ext' => $modName, ':key' => 'config']);
+        if ($c) {
             $config = $this->di['crypt']->decrypt($c->meta_value, $bb_config['info']['salt']);
             $config = $this->di['tools']->decodeJ($config);
         }
+
         return $config;
     }
 
@@ -249,13 +258,15 @@ class Box_Mod
 
     public function registerClientRoutes(Box_App &$app)
     {
-        if($this->hasClientController()) {
+        if ($this->hasClientController()) {
             $cc = $this->getClientController();
-            if(method_exists($cc, 'register')) {
+            if (method_exists($cc, 'register')) {
                 $cc->register($app);
+
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/library/Box/Pagination.php
+++ b/src/library/Box/Pagination.php
@@ -2,25 +2,25 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
 
 class Box_Pagination implements InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
     protected $per_page = 100;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -33,18 +33,18 @@ class Box_Pagination implements InjectionAwareInterface
         return $this->per_page;
     }
 
-    public function getSimpleResultSet($q, $values, ?int $per_page = 100, ?int $page = null)
+    public function getSimpleResultSet($q, $values, ?int $per_page = 100, int $page = null)
     {
-        if (is_null($page)){
+        if (is_null($page)) {
             $page = $_GET['page'] ?? 1;
         }
         $per_page = $_GET['per_page'] ?? $per_page ?? 100;
 
-        if (!is_numeric($page) || $page < 1 ){
-           throw new \FOSSBilling\InformationException('Invalid page number');
+        if (!is_numeric($page) || $page < 1) {
+            throw new FOSSBilling\InformationException('Invalid page number');
         }
-        if (!is_numeric($per_page) || $per_page < 1 ){
-           throw new \FOSSBilling\InformationException('Invalid per page number');
+        if (!is_numeric($per_page) || $per_page < 1) {
+            throw new FOSSBilling\InformationException('Invalid per page number');
         }
 
         $offset = ($page - 1) * $per_page;
@@ -55,16 +55,17 @@ class Box_Pagination implements InjectionAwareInterface
 
         $exploded = explode('FROM', $q);
         $sql = 'SELECT count(1) FROM ' . $exploded[1];
-        $total = $this->di['db']->getCell($sql , $values);
+        $total = $this->di['db']->getCell($sql, $values);
 
-        $pages = ($per_page > 1) ? (int)ceil($total / $per_page) : 1;
-        return array(
-            "pages"             => $pages,
-            "page"              => $page,
-            "per_page"          => $per_page,
-            "total"             => $total,
-            "list"              => $result,
-        );
+        $pages = ($per_page > 1) ? (int) ceil($total / $per_page) : 1;
+
+        return [
+            'pages' => $pages,
+            'page' => $page,
+            'per_page' => $per_page,
+            'total' => $total,
+            'list' => $result,
+        ];
     }
 
     public function getAdvancedResultSet($q, $values, ?int $per_page = 100)
@@ -72,11 +73,11 @@ class Box_Pagination implements InjectionAwareInterface
         $page = $_GET['page'] ?? 1;
         $per_page = $_GET['per_page'] ?? $per_page ?? 100;
 
-        if (!is_numeric($page) || $page < 1 ){
-           throw new \FOSSBilling\InformationException('Invalid page number');
+        if (!is_numeric($page) || $page < 1) {
+            throw new FOSSBilling\InformationException('Invalid page number');
         }
-        if (!is_numeric($per_page) || $per_page < 1 ){
-           throw new \FOSSBilling\InformationException('Invalid per page number');
+        if (!is_numeric($per_page) || $per_page < 1) {
+            throw new FOSSBilling\InformationException('Invalid per page number');
         }
 
         $offset = ($page - 1) * $per_page;
@@ -85,13 +86,14 @@ class Box_Pagination implements InjectionAwareInterface
         $result = $this->di['db']->getAll($q, $values);
         $total = $this->di['db']->getCell('SELECT FOUND_ROWS();');
 
-        $pages = ($per_page > 1) ? (int)ceil($total / $per_page) : 1;
-        return array(
-            "pages"             => $pages,
-            "page"              => $page,
-            "per_page"          => $per_page,
-            "total"             => $total,
-            "list"              => $result,
-        );
+        $pages = ($per_page > 1) ? (int) ceil($total / $per_page) : 1;
+
+        return [
+            'pages' => $pages,
+            'page' => $page,
+            'per_page' => $per_page,
+            'total' => $total,
+            'list' => $result,
+        ];
     }
 }

--- a/src/library/Box/Paginator.php
+++ b/src/library/Box/Paginator.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * Class to paginate a list of items in a old digg style
- * 
+ * Class to paginate a list of items in a old digg style.
+ *
  * @see https://github.com/gigo6000/Symfony2-Pagination-Class
+ *
  * @author Darko Goleš
  * @author Carlos Mafla <gigo6000@hotmail.com>
+ *
  * @www.inchoo.net
  */
-class Box_Paginator extends Paginator {}
+class Box_Paginator extends Paginator
+{
+}
 
-class Paginator {
-
+class Paginator
+{
     /**
      * @var int total number of pages
      */
@@ -39,13 +43,13 @@ class Paginator {
      */
     public function __construct(protected $itemsCount = 0, protected $currentPage = 1, protected $limit = 20, protected $midRange = 7)
     {
-        //Set defaults
+        // Set defaults
         $this->setDefaults();
 
-        //Calculate number of pages total
+        // Calculate number of pages total
         $this->getInternalNumPages();
 
-        //Calculate first shown item on current page
+        // Calculate first shown item on current page
         $this->calculateOffset();
         $this->calculateRange();
     }
@@ -53,7 +57,7 @@ class Paginator {
     private function calculateRange()
     {
         $startRange = $this->currentPage - floor($this->midRange / 2);
-        $endRange   = $this->currentPage + floor($this->midRange / 2);
+        $endRange = $this->currentPage + floor($this->midRange / 2);
 
         if ($startRange <= 0) {
             $endRange += abs($startRange) + 1;
@@ -61,7 +65,7 @@ class Paginator {
         }
 
         if ($endRange > $this->numPages) {
-            $endRange   = $this->numPages;
+            $endRange = $this->numPages;
             $startRange = $endRange - $this->numPages + 1;
         }
 
@@ -70,47 +74,40 @@ class Paginator {
 
     private function setDefaults()
     {
-        //If currentPage is set to null or is set to 0 or less
-        //set it to default (1)
-        if ($this->currentPage == null || $this->currentPage < 1)
-        {
+        // If currentPage is set to null or is set to 0 or less
+        // set it to default (1)
+        if ($this->currentPage == null || $this->currentPage < 1) {
             $this->currentPage = 1;
         }
-        //if limit is set to null set it to default (20)
-        if ($this->limit == null)
-        {
+        // if limit is set to null set it to default (20)
+        if ($this->limit == null) {
             $this->limit = 20;
-            //if limit is any number less than 1 then set it to 0 for displaying
-            //items without limit
-        }
-        else if ($this->limit < 1)
-        {
+        // if limit is any number less than 1 then set it to 0 for displaying
+        // items without limit
+        } elseif ($this->limit < 1) {
             $this->limit = 0;
         }
     }
 
     private function getInternalNumPages()
     {
-        //If limit is set to 0 or set to number bigger then total items count
-        //display all in one page
-        if ($this->limit < 1 || $this->limit > $this->itemsCount)
-        {
+        // If limit is set to 0 or set to number bigger then total items count
+        // display all in one page
+        if ($this->limit < 1 || $this->limit > $this->itemsCount) {
             $this->numPages = 1;
-        }
-        else
-        {
-            //Calculate rest numbers from dividing operation so we can add one
-            //more page for this items
+        } else {
+            // Calculate rest numbers from dividing operation so we can add one
+            // more page for this items
             $restItemsNum = $this->itemsCount % $this->limit;
-            //if rest items > 0 then add one more page else just divide items
-            //by limit
+            // if rest items > 0 then add one more page else just divide items
+            // by limit
             $this->numPages = $restItemsNum > 0 ? intval($this->itemsCount / $this->limit) + 1 : intval($this->itemsCount / $this->limit);
         }
     }
 
     private function calculateOffset()
     {
-        //Calculet offset for items based on current page number
+        // Calculet offset for items based on current page number
         $this->offset = ($this->currentPage - 1) * $this->limit;
     }
 
@@ -173,24 +170,26 @@ class Paginator {
     public function getStartingPoint()
     {
         $arr = $this->getRange();
+
         return reset($arr);
     }
 
     public function getEndingPoint()
     {
         $arr = $this->getRange();
+
         return end($arr);
     }
 
     public function toArray()
     {
-        return array(
-            'currentpage'   => $this->getCurrentPage(),
-            'numpages'      => $this->getNumPages(),
-            'midrange'      => $this->getMidRange(),
-            'range'         => $this->getRange(),
-            'start'         => $this->getStartingPoint(),
-            'end'           => $this->getEndingPoint(),
-        );
+        return [
+            'currentpage' => $this->getCurrentPage(),
+            'numpages' => $this->getNumPages(),
+            'midrange' => $this->getMidRange(),
+            'range' => $this->getRange(),
+            'start' => $this->getStartingPoint(),
+            'end' => $this->getEndingPoint(),
+        ];
     }
 }

--- a/src/library/Box/Password.php
+++ b/src/library/Box/Password.php
@@ -2,18 +2,17 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_Password {
-
+class Box_Password
+{
     private string $algo = PASSWORD_DEFAULT;
-    private array $options = array();
+    private array $options = [];
 
-    public function setAlgo ($algo)
+    public function setAlgo($algo)
     {
         $this->algo = $algo;
     }
@@ -23,7 +22,7 @@ class Box_Password {
         return $this->algo;
     }
 
-    public function setOptions($options = array())
+    public function setOptions($options = [])
     {
         $this->options = $options;
     }
@@ -41,7 +40,7 @@ class Box_Password {
         return password_hash($password, $this->algo, $this->options);
     }
 
-    public function verify ($password, $hash)
+    public function verify($password, $hash)
     {
         return password_verify((string) $password, $hash);
     }

--- a/src/library/Box/Period.php
+++ b/src/library/Box/Period.php
@@ -2,38 +2,37 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_Period
 {
-    final public const UNIT_DAY          = 'D';
-    final public const UNIT_WEEK         = 'W';
-    final public const UNIT_MONTH        = 'M';
-    final public const UNIT_YEAR         = 'Y';
+    final public const UNIT_DAY = 'D';
+    final public const UNIT_WEEK = 'W';
+    final public const UNIT_MONTH = 'M';
+    final public const UNIT_YEAR = 'Y';
 
-    final public const PERIOD_WEEK       = '1W';
-    final public const PERIOD_MONTH      = '1M';
-    final public const PERIOD_QUARTER    = '3M';
-    final public const PERIOD_BIANNUAL   = '6M';
-    final public const PERIOD_ANNUAL     = '1Y';
-    final public const PERIOD_BIENNIAL    = '2Y';
-    final public const PERIOD_TRIENNIAL    = '3Y';
+    final public const PERIOD_WEEK = '1W';
+    final public const PERIOD_MONTH = '1M';
+    final public const PERIOD_QUARTER = '3M';
+    final public const PERIOD_BIANNUAL = '6M';
+    final public const PERIOD_ANNUAL = '1Y';
+    final public const PERIOD_BIENNIAL = '2Y';
+    final public const PERIOD_TRIENNIAL = '3Y';
 
     /**
-     * Predefined periods
+     * Predefined periods.
      */
-    protected $_multiplier = array(
-        self::PERIOD_MONTH      =>  1,
-        self::PERIOD_QUARTER    =>  3,
-        self::PERIOD_BIANNUAL   =>  6,
-        self::PERIOD_ANNUAL     =>  12,
-        self::PERIOD_BIENNIAL    =>    24,
-        self::PERIOD_TRIENNIAL    =>    36,
-    );
+    protected $_multiplier = [
+        self::PERIOD_MONTH => 1,
+        self::PERIOD_QUARTER => 3,
+        self::PERIOD_BIANNUAL => 6,
+        self::PERIOD_ANNUAL => 12,
+        self::PERIOD_BIENNIAL => 24,
+        self::PERIOD_TRIENNIAL => 36,
+    ];
 
     private readonly string $unit;
     private int $qty;
@@ -41,26 +40,27 @@ class Box_Period
     public function __construct($code)
     {
         if (strlen($code) != 2) {
-            throw new \FOSSBilling\Exception("Invalid period code. Period definition must be 2 chars length");
+            throw new FOSSBilling\Exception('Invalid period code. Period definition must be 2 chars length');
         }
 
         [$qty, $unit] = str_split($code);
 
         $units = $this->getUnits();
-        $qty = (int)$qty;
+        $qty = (int) $qty;
         $unit = strtoupper($unit);
         if (!array_key_exists($unit, $units)) {
-            throw new \FOSSBilling\Exception("Period Error. Unit :unit is not defined", array(':unit' => $unit));
+            throw new FOSSBilling\Exception('Period Error. Unit :unit is not defined', [':unit' => $unit]);
         }
 
         if ($qty < $units[$unit][0] || $qty > $units[$unit][1]) {
-            $d = array(
-                ':qty'  =>  $qty,
-                ':unit'  =>  $unit,
-                ':from'  =>  $units[$unit][0],
-                ':to'  =>  $units[$unit][1],
-            );
-            throw new \FOSSBilling\Exception("Invalid period quantity :qty for unit :unit. Allowed range is from :from to :to", $d);
+            $d = [
+                ':qty' => $qty,
+                ':unit' => $unit,
+                ':from' => $units[$unit][0],
+                ':to' => $units[$unit][1],
+            ];
+
+            throw new FOSSBilling\Exception('Invalid period quantity :qty for unit :unit. Allowed range is from :from to :to', $d);
         }
 
         $this->unit = $unit;
@@ -69,33 +69,34 @@ class Box_Period
 
     private function getUnits()
     {
-        return array(
-            self::UNIT_DAY      => array(1, 90),
-            self::UNIT_WEEK     => array(1, 52),
-            self::UNIT_MONTH    => array(1, 24),
-            self::UNIT_YEAR     => array(1, 5),
-        );
+        return [
+            self::UNIT_DAY => [1, 90],
+            self::UNIT_WEEK => [1, 52],
+            self::UNIT_MONTH => [1, 24],
+            self::UNIT_YEAR => [1, 5],
+        ];
     }
 
     public static function getPredefined($simple = true)
     {
-        $periods = array(
-            self::PERIOD_WEEK       =>  array('rec_qty' => 1, 'title' => __trans('Every week'), 'code' => self::PERIOD_WEEK, 'rec_unit' => self::UNIT_WEEK),
-            self::PERIOD_MONTH      =>  array('rec_qty' => 1, 'title' => __trans('Every month'), 'code' => self::PERIOD_MONTH, 'rec_unit' => self::UNIT_MONTH),
-            self::PERIOD_QUARTER    =>  array('rec_qty' => 3, 'title' => __trans('Every 3 months'), 'code' => self::PERIOD_QUARTER, 'rec_unit' => self::UNIT_MONTH),
-            self::PERIOD_BIANNUAL   =>  array('rec_qty' => 6, 'title' => __trans('Every 6 months'), 'code' => self::PERIOD_BIANNUAL, 'rec_unit' => self::UNIT_MONTH),
-            self::PERIOD_ANNUAL     =>  array('rec_qty' => 1, 'title' => __trans('Every year'), 'code' => self::PERIOD_ANNUAL, 'rec_unit' => self::UNIT_YEAR),
-            self::PERIOD_BIENNIAL    =>    array('rec_qty' => 2, 'title' => __trans('Every 2 years'), 'code' => self::PERIOD_BIENNIAL, 'rec_unit' => self::UNIT_YEAR),
-            self::PERIOD_TRIENNIAL    =>    array('rec_qty' => 3, 'title' => __trans('Every 3 years'), 'code' => self::PERIOD_TRIENNIAL, 'rec_unit' => self::UNIT_YEAR),
-        );
+        $periods = [
+            self::PERIOD_WEEK => ['rec_qty' => 1, 'title' => __trans('Every week'), 'code' => self::PERIOD_WEEK, 'rec_unit' => self::UNIT_WEEK],
+            self::PERIOD_MONTH => ['rec_qty' => 1, 'title' => __trans('Every month'), 'code' => self::PERIOD_MONTH, 'rec_unit' => self::UNIT_MONTH],
+            self::PERIOD_QUARTER => ['rec_qty' => 3, 'title' => __trans('Every 3 months'), 'code' => self::PERIOD_QUARTER, 'rec_unit' => self::UNIT_MONTH],
+            self::PERIOD_BIANNUAL => ['rec_qty' => 6, 'title' => __trans('Every 6 months'), 'code' => self::PERIOD_BIANNUAL, 'rec_unit' => self::UNIT_MONTH],
+            self::PERIOD_ANNUAL => ['rec_qty' => 1, 'title' => __trans('Every year'), 'code' => self::PERIOD_ANNUAL, 'rec_unit' => self::UNIT_YEAR],
+            self::PERIOD_BIENNIAL => ['rec_qty' => 2, 'title' => __trans('Every 2 years'), 'code' => self::PERIOD_BIENNIAL, 'rec_unit' => self::UNIT_YEAR],
+            self::PERIOD_TRIENNIAL => ['rec_qty' => 3, 'title' => __trans('Every 3 years'), 'code' => self::PERIOD_TRIENNIAL, 'rec_unit' => self::UNIT_YEAR],
+        ];
 
         if ($simple) {
-            $new = array();
+            $new = [];
             foreach ($periods as $pp) {
                 $new[$pp['code']] = $pp['title'];
             }
             $periods = $new;
         }
+
         return $periods;
     }
 
@@ -124,12 +125,11 @@ class Box_Period
             self::UNIT_WEEK => __pluralTrans('Every :number week', 'Every :number weeks', $qty, $placeholders),
             self::UNIT_MONTH => __pluralTrans('Every :number month', 'Every :number months', $qty, $placeholders),
             self::UNIT_YEAR => __pluralTrans('Every :number year', 'Every :number years', $qty, $placeholders),
-            default => throw new \FOSSBilling\Exception('Unit not defined'),
+            default => throw new FOSSBilling\Exception('Unit not defined'),
         };
 
         return $shift;
     }
-
 
     public function getDays()
     {
@@ -137,7 +137,8 @@ class Box_Period
     }
 
     /**
-     * How many months $this->unit consists of
+     * How many months $this->unit consists of.
+     *
      * @return int
      */
     public function getMonths()
@@ -149,15 +150,15 @@ class Box_Period
             self::UNIT_WEEK => $this->qty / 4,
             self::UNIT_MONTH => $this->qty,
             self::UNIT_YEAR => $this->qty * 12,
-            default => throw new \FOSSBilling\Exception('Unable to get the number of months for :unit',[':unit' => $this->unit]),
+            default => throw new FOSSBilling\Exception('Unable to get the number of months for :unit', [':unit' => $this->unit]),
         };
 
         return $qty;
     }
 
-    public function getExpirationTime($now = NULL)
+    public function getExpirationTime($now = null)
     {
-        if (NULL === $now) {
+        if ($now === null) {
             $now = time();
         }
 
@@ -166,8 +167,9 @@ class Box_Period
             self::UNIT_WEEK => 'weeks',
             self::UNIT_MONTH => 'months',
             self::UNIT_YEAR => 'years',
-            default => throw new \FOSSBilling\Exception('Unit not defined'),
+            default => throw new FOSSBilling\Exception('Unit not defined'),
         };
+
         return strtotime("+$this->qty $shift", $now);
     }
 }

--- a/src/library/Box/Translate.php
+++ b/src/library/Box/Translate.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_Translate implements \FOSSBilling\InjectionAwareInterface
+class Box_Translate implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
@@ -26,20 +25,22 @@ class Box_Translate implements \FOSSBilling\InjectionAwareInterface
 
     /**
      * @param string $locale
+     *
      * @return Box_Translate
      */
     public function setLocale($locale)
     {
         $this->locale = $locale;
+
         return $this;
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -49,12 +50,12 @@ class Box_Translate implements \FOSSBilling\InjectionAwareInterface
         PhpMyAdmin\MoTranslator\Loader::loadFunctions();
 
         $locale = $this->getLocale();
-        if(empty($locale)){
-            //We are using the standard PHP Exception here rather than our custom one as ours requires translations to be setup, which we cannot do without the locale being defined.
-            throw new Exception("Unable to setup FOSSBilling translation functionality, locale was undefined.");
+        if (empty($locale)) {
+            // We are using the standard PHP Exception here rather than our custom one as ours requires translations to be setup, which we cannot do without the locale being defined.
+            throw new Exception('Unable to setup FOSSBilling translation functionality, locale was undefined.');
         }
 
-        $codeset = "UTF-8";
+        $codeset = 'UTF-8';
         @putenv('LANG=' . $locale . '.' . $codeset);
         @putenv('LANGUAGE=' . $locale . '.' . $codeset);
         // set locale
@@ -102,16 +103,16 @@ class Box_Translate implements \FOSSBilling\InjectionAwareInterface
     }
 
     /**
-     * @param $domain
      * @return Box_Translate
      */
     public function setDomain($domain)
     {
         $this->domain = $domain;
+
         return $this;
     }
 
-    public function __($msgid, array $values = NULL)
+    public function __($msgid, array $values = null)
     {
         return __trans($msgid, $values);
     }

--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -2,27 +2,26 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use \FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\InjectionAwareInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(?\Pimple\Container $di): void
+    public function setDi(?Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -105,7 +104,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_bb_client_link_filter($link, $params = null)
     {
-        if (null === $this->di['url']) {
+        if ($this->di['url'] === null) {
             return null;
         }
 
@@ -117,7 +116,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         return $this->di['url']->adminLink($link, $params);
     }
 
-    function twig_period_title(Twig\Environment $env, $period)
+    public function twig_period_title(Twig\Environment $env, $period)
     {
         $globals = $env->getGlobals();
         $api_guest = $globals['guest'];
@@ -191,23 +190,24 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_script_tag($path)
     {
-        return sprintf('<script type="text/javascript" src="%s?%s"></script>', $path, \FOSSBilling\Version::VERSION);
+        return sprintf('<script type="text/javascript" src="%s?%s"></script>', $path, FOSSBilling\Version::VERSION);
     }
 
     public function twig_stylesheet_tag($path, $media = 'screen')
     {
-        return sprintf('<link rel="stylesheet" type="text/css" href="%s?v=%s" media="%s" />', $path, \FOSSBilling\Version::VERSION, $media);
+        return sprintf('<link rel="stylesheet" type="text/css" href="%s?v=%s" media="%s" />', $path, FOSSBilling\Version::VERSION, $media);
     }
 
     public function twig_gravatar_filter($email, $size = 20)
     {
-        if(empty($email)){
+        if (empty($email)) {
             return '';
         }
 
         $url = 'https://www.gravatar.com/avatar/';
         $url .= md5(strtolower(trim($email)));
         $url .= "?s=$size&d=mp&r=g";
+
         return $url;
     }
 
@@ -234,6 +234,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         if (is_null($number)) {
             $number = '0';
         }
+
         return number_format(floatval($number), $decimals, $dec_point, $thousands_sep);
     }
 
@@ -263,7 +264,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
         $no = floor($no);
 
-        if (1 != $no) {
+        if ($no != 1) {
             $pds[$v] .= 's';
         }
         $x = sprintf('%d %s ', $no, $pds[$v]);
@@ -353,13 +354,13 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
             return;
         }
 
-        if ($array instanceof \Traversable) {
+        if ($array instanceof Traversable) {
             $array = iterator_to_array($array);
         } elseif (!\is_array($array)) {
             return $array;
         }
 
-        if (null !== $arrow) {
+        if ($arrow !== null) {
             uasort($array, $arrow);
         } else {
             asort($array);

--- a/src/library/Box/TwigLoader.php
+++ b/src/library/Box/TwigLoader.php
@@ -2,15 +2,14 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_TwigLoader extends Twig\Loader\FilesystemLoader
 {
-    protected $options = array();
+    protected $options = [];
 
     /**
      * Constructor.
@@ -21,22 +20,21 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
     {
         parent::__construct();
         if (!isset($options['mods'])) {
-            throw new \FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'mods']);
+            throw new FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'mods']);
         }
 
         if (!isset($options['theme'])) {
-            throw new \FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'theme']);
+            throw new FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'theme']);
         }
 
         if (!isset($options['type'])) {
-            throw new \FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'type']);
+            throw new FOSSBilling\Exception('Missing :missing: param for Box_TwigLoader', ['missing' => 'type']);
         }
 
         $this->options = $options;
-        $paths_arr = array($options['mods'], $options['theme']);
+        $paths_arr = [$options['mods'], $options['theme']];
         $this->setPaths($paths_arr);
     }
-
 
     protected function findTemplate($name, $throw = true)
     {
@@ -47,13 +45,13 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
             return $this->cache[$name];
         }
 
-        $name_split = explode("_", $name);
+        $name_split = explode('_', $name);
 
-        $paths = array();
-        $paths[] = $this->options["theme"] . DIRECTORY_SEPARATOR . "html_custom";
-        $paths[] = $this->options["theme"] . DIRECTORY_SEPARATOR . "html";
+        $paths = [];
+        $paths[] = $this->options['theme'] . DIRECTORY_SEPARATOR . 'html_custom';
+        $paths[] = $this->options['theme'] . DIRECTORY_SEPARATOR . 'html';
         if (isset($name_split[1])) {
-            $paths[] = $this->options["mods"] . DIRECTORY_SEPARATOR . ucfirst($name_split[1]) . DIRECTORY_SEPARATOR . "html_" . $this->options["type"];
+            $paths[] = $this->options['mods'] . DIRECTORY_SEPARATOR . ucfirst($name_split[1]) . DIRECTORY_SEPARATOR . 'html_' . $this->options['type'];
         }
 
         foreach ($paths as $path) {
@@ -66,6 +64,6 @@ class Box_TwigLoader extends Twig\Loader\FilesystemLoader
             }
         }
 
-        throw new \Twig\Error\LoaderError(sprintf('Unable to find template "%s" (looked into: %s).', $name,  implode(', ', $paths)));
+        throw new Twig\Error\LoaderError(sprintf('Unable to find template "%s" (looked into: %s).', $name, implode(', ', $paths)));
     }
 }

--- a/src/library/Box/Url.php
+++ b/src/library/Box/Url.php
@@ -2,23 +2,22 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Box_Url implements \FOSSBilling\InjectionAwareInterface
+class Box_Url implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
     protected $baseUri;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -29,7 +28,7 @@ class Box_Url implements \FOSSBilling\InjectionAwareInterface
     }
 
     /**
-     * Generates a URL
+     * Generates a URL.
      */
     public function get($uri)
     {
@@ -39,7 +38,7 @@ class Box_Url implements \FOSSBilling\InjectionAwareInterface
     /**
      * @param string $uri
      */
-    public function link($uri = null, $params = array())
+    public function link($uri = null, $params = [])
     {
         $uri = trim($uri, '/');
         $link = $this->baseUri . $uri;
@@ -47,14 +46,14 @@ class Box_Url implements \FOSSBilling\InjectionAwareInterface
             $link .= '?' . http_build_query($params);
         }
 
-
         return $link;
     }
 
-    public function adminLink($uri, $params = array())
+    public function adminLink($uri, $params = [])
     {
         $uri = trim($uri, '/');
         $uri = ADMIN_PREFIX . '/' . $uri;
+
         return $this->link($uri, $params);
     }
 }

--- a/src/library/Box/UrlHelper.php
+++ b/src/library/Box/UrlHelper.php
@@ -3,15 +3,14 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Box_UrlHelper
 {
-    public $params = array();
+    public $params = [];
     public $match = false;
 
     /**
@@ -19,7 +18,6 @@ class Box_UrlHelper
      */
     public function __construct(private $method, $url, private $conditions, $requestUri)
     {
-
         $requestMethod = $_SERVER['REQUEST_METHOD'];
 
         // Respond identically to a HEAD request as if it's a GET request
@@ -28,9 +26,8 @@ class Box_UrlHelper
         }
 
         if (strtoupper($method) == $requestMethod) {
-
-            $paramNames = array();
-            $paramValues = array();
+            $paramNames = [];
+            $paramValues = [];
 
             preg_match_all('@:([a-zA-Z]+)@', $url, $paramNames, PREG_PATTERN_ORDER);                    // get param names
             $paramNames = $paramNames[1];                                                               // we want the set of matches
@@ -38,7 +35,7 @@ class Box_UrlHelper
             if (preg_match('@^' . $regexedUrl . '$@', $requestUri, $paramValues)) {                            // determine match and get param values
                 array_shift($paramValues);                                                              // remove the complete text match
                 $counted = count($paramNames);
-                for ($i = 0; $i < $counted; $i++) {
+                for ($i = 0; $i < $counted; ++$i) {
                     $this->params[$paramNames[$i]] = $paramValues[$i];
                 }
                 $this->match = true;

--- a/src/library/FOSSBilling/Autoloader.php
+++ b/src/library/FOSSBilling/Autoloader.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -25,7 +26,7 @@ class AutoLoader
     /**
      * Creates a new instance of AntLoader and then loads the classmap.
      * The instance is configured for filesystem caching within the FOSSBilling cache directory.
-     * 
+     *
      * @param bool $registerFOSSBillingDefaults (optional) Set to true if you want the autoloader to be shipped with the default paths and namespaces for FOSSBilling. Defaults to true.
      */
     public function __construct(bool $registerFOSSBillingDefaults = true)
@@ -45,7 +46,7 @@ class AutoLoader
 
     /**
      * Registers the autoloader with PHP.
-     * 
+     *
      * @param bool $prepend (optional) Set to true to have this autoloader be placed before others currently registered, meaning it will be checked first. Defaults to true.
      */
     public function register(bool $prepend = true): void

--- a/src/library/FOSSBilling/CentralAlerts.php
+++ b/src/library/FOSSBilling/CentralAlerts.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -42,6 +44,7 @@ class CentralAlerts implements InjectionAwareInterface
      * The alerts are **never** displayed to the clients.
      *
      * @return array The alerts
+     *
      * @throws Exception
      */
     public function getAlerts(): array
@@ -56,12 +59,13 @@ class CentralAlerts implements InjectionAwareInterface
     }
 
     /**
-     * Filter the cached alerts by type and version
+     * Filter the cached alerts by type and version.
      *
-     * @param array $type The alert types to filter by (e.g. ['info', 'warning']) - defaults to all types
+     * @param array  $type    The alert types to filter by (e.g. ['info', 'warning']) - defaults to all types
      * @param string $version The version to filter by (e.g. 0.4.2) - defaults to the current version of FOSSBilling
      *
      * @return array The filtered alerts
+     *
      * @throws Exception
      */
     public function filterAlerts(array $type = [], string $version = Version::VERSION): array
@@ -69,14 +73,14 @@ class CentralAlerts implements InjectionAwareInterface
         $alerts = $this->getAlerts();
 
         if (is_array($type) && !empty($type)) {
-            $alerts = array_filter($alerts, fn($alert) => in_array($alert['type'], $type));
+            $alerts = array_filter($alerts, fn ($alert) => in_array($alert['type'], $type));
         }
 
         if ($version) {
             if ($this->di['config']['update_branch'] === 'preview') {
-                $alerts = array_filter($alerts, fn($alert) => $alert['include_preview_branch']);
+                $alerts = array_filter($alerts, fn ($alert) => $alert['include_preview_branch']);
             } else {
-                $alerts = array_filter($alerts, function($alert) use ($version) {
+                $alerts = array_filter($alerts, function ($alert) use ($version) {
                     $overThanTheMinimum = version_compare(strtolower($version), strtolower($alert['min_fossbilling_version']), '>=');
                     $lessThanTheMaximum = version_compare(strtolower($version), strtolower($alert['max_fossbilling_version']), '<=');
 
@@ -89,17 +93,19 @@ class CentralAlerts implements InjectionAwareInterface
     }
 
     /**
-     * Make a request to the FOSSBilling Central Alerts System API
+     * Make a request to the FOSSBilling Central Alerts System API.
      *
      * @param string $endpoint The API endpoint to call (e.g. list)
-     * @param array $params The array of parameters to pass to the API endpoint
+     * @param array  $params   The array of parameters to pass to the API endpoint
      *
      * @return array The API response
+     *
      * @throws Exception
      */
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
+
         try {
             $httpClient = HttpClient::create();
             $response = $httpClient->request('GET', $url, [
@@ -107,8 +113,9 @@ class CentralAlerts implements InjectionAwareInterface
                 'query' => [...$params, 'fossbilling_version' => Version::VERSION],
             ]);
             $json = $response->toArray();
-        } catch (TransportExceptionInterface | HttpExceptionInterface $e) {
+        } catch (TransportExceptionInterface|HttpExceptionInterface $e) {
             error_log($e->getMessage());
+
             throw new Exception('Unable to fetch alerts from Central Alerts System. See error log for more information.', null);
         }
 

--- a/src/library/FOSSBilling/Environment.php
+++ b/src/library/FOSSBilling/Environment.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -23,8 +25,6 @@ class Environment
     /**
      * Get the current environment of the application.
      * The environment variable set in the operating system will have priority over the environment variable set in the .env file.
-     * 
-     * @return string
      */
     public static function getCurrentEnvironment(): string
     {
@@ -33,7 +33,6 @@ class Environment
 
     /**
      * Check if the current environment is a production environment.
-     * @return bool
      */
     public static function isProduction(): bool
     {
@@ -42,7 +41,6 @@ class Environment
 
     /**
      * Check if the current environment is a development environment.
-     * @return bool
      */
     public static function isDevelopment(): bool
     {
@@ -51,7 +49,6 @@ class Environment
 
     /**
      * Check if the current environment is a testing environment.
-     * @return bool
      */
     public static function isTesting(): bool
     {
@@ -60,10 +57,9 @@ class Environment
 
     /**
      * Check if the current environment is a CLI environment.
-     * @return bool
      */
     public static function isCLI(): bool
     {
-        return (php_sapi_name() === 'cli' || !http_response_code());
+        return php_sapi_name() === 'cli' || !http_response_code();
     }
 }

--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -16,8 +16,6 @@ class ErrorPage
 {
     /**
      * Returns the list of error codes and their specialized messages. All Error code parameters are optional.
-     *
-     * @return array
      */
     private static function getCodes(): array
     {
@@ -58,10 +56,10 @@ class ErrorPage
                 'report' => false,
             ],
             '5' => [
-                'title' => "Missing .htaccess file",
-                'message' => "You appear to be running an Apache or LiteSpeed based webserver without a valid <b><em>.htaccess</em></b> file. Please create one using the default FOSSBilling .htaccess file.",
+                'title' => 'Missing .htaccess file',
+                'message' => 'You appear to be running an Apache or LiteSpeed based webserver without a valid <b><em>.htaccess</em></b> file. Please create one using the default FOSSBilling .htaccess file.',
                 'link' => [
-                    'label' => "Check the default .htaccess",
+                    'label' => 'Check the default .htaccess',
                     'href' => 'https://github.com/FOSSBilling/FOSSBilling/blob/main/src/.htaccess',
                 ],
                 'report' => false,
@@ -77,7 +75,7 @@ class ErrorPage
             // Incomplete payment gateway configuration. Is listed here so it's not forwarded to Sentry.io
             4001 => [
                 'report' => false,
-            ]
+            ],
         ];
     }
 
@@ -95,23 +93,22 @@ class ErrorPage
         ],
         'Server Managers' => [
             'start' => 2000,
-            'end'   => 2999,
+            'end' => 2999,
         ],
         'Domain Registration' => [
             'start' => 3000,
-            'end'   => 3999,
+            'end' => 3999,
         ],
         'Payment Gateway' => [
             'start' => 4000,
-            'end'   => 4999,
-        ]
+            'end' => 4999,
+        ],
     ];
 
     /**
      * Gets info for a specified error code, using placeholders for anything undefined.
      *
      * @param int $code The error code
-     * @return array
      */
     public static function getCodeInfo(int $code): array
     {
@@ -136,6 +133,7 @@ class ErrorPage
         foreach (self::$codeCategories as $categoryName => $categoryRange) {
             if ($code >= $categoryRange['start'] && $code <= $categoryRange['end']) {
                 $errorDetails['category'] = $categoryName;
+
                 break;
             }
         }
@@ -144,9 +142,8 @@ class ErrorPage
     }
 
     /**
-     * @param int $code Error code
+     * @param int    $code    Error code
      * @param string $message The original exception message
-     * @return never
      */
     public function generatePage(int $code, string $message): never
     {
@@ -279,7 +276,7 @@ class ErrorPage
                     <ul class="list-horizontal">
                         <li>' . "Instance ID: $instanceID" . '</li>
                         <li>' . "Error Code: #$code" . '</li>
-                        <li>' . 'Component: '. $error['category'] . '</li>
+                        <li>Component: ' . $error['category'] . '</li>
                     </ul>
 
                     <p class="error-message" id="specialized">' . $error['message'] . '</p>
@@ -322,6 +319,6 @@ class ErrorPage
             </body>
         </html>';
         echo $page;
-        die();
+        exit;
     }
 }

--- a/src/library/FOSSBilling/Exception.php
+++ b/src/library/FOSSBilling/Exception.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,81 +12,81 @@ namespace FOSSBilling;
 
 /**
  * The base FOSSBilling exception class. Implements translation and stacktrace logging.
- *
- * @package FOSSBilling
  */
 class Exception extends \Exception
 {
-	/**
-	 * Creates a new translated exception.
-	 *
-	 * @param string $message error message
-	 * @param array|null $variables translation variables
-	 * @param int $code The exception code.
-	 * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace.
-	 */
-	public function __construct(string $message, ?array $variables = null, int $code = 0, bool $protected = false)
-	{
-		$config = include PATH_CONFIG;
-		$logStack = $config['debug_and_monitoring']['log_stacktrace'] ?? true;
-		$stackLength = $config['debug_and_monitoring']['stacktrace_length'] ?? 25;
+    /**
+     * Creates a new translated exception.
+     *
+     * @param string     $message   error message
+     * @param array|null $variables translation variables
+     * @param int        $code      the exception code
+     * @param bool       $protected if the variables in this should be considered protect, if so, hide them from the stack trace
+     */
+    public function __construct(string $message, array $variables = null, int $code = 0, bool $protected = false)
+    {
+        $config = include PATH_CONFIG;
+        $logStack = $config['debug_and_monitoring']['log_stacktrace'] ?? true;
+        $stackLength = $config['debug_and_monitoring']['stacktrace_length'] ?? 25;
 
-		if (DEBUG && $logStack) {
-			error_log('An exception has been thrown. Stacktrace:');
-			error_log($this->stackTrace($stackLength, $protected));
-		}
+        if (DEBUG && $logStack) {
+            error_log('An exception has been thrown. Stacktrace:');
+            error_log($this->stackTrace($stackLength, $protected));
+        }
 
-		// Translate the exception
-		if (function_exists('__trans')) {
-			$message = __trans($message, $variables);
-		} elseif (is_array($variables)) {
-			$message = strtr($message, $variables);
-		}
+        // Translate the exception
+        if (function_exists('__trans')) {
+            $message = __trans($message, $variables);
+        } elseif (is_array($variables)) {
+            $message = strtr($message, $variables);
+        }
 
-		// Pass the message to the parent
-		parent::__construct($message, $code);
-	}
+        // Pass the message to the parent
+        parent::__construct($message, $code);
+    }
 
+    /**
+     * Big thank you to jhurliman and jambroseclarke on Stack Overflow for this backtrace formatter.
+     * We have slightly modified it for our purposes
+     * https://stackoverflow.com/a/32365961.
+     */
+    private function stackTrace($Length = 25, $protected = false)
+    {
+        $stack = debug_backtrace($Length);
+        $output = '';
 
-	/**
-	 * Big thank you to jhurliman and jambroseclarke on Stack Overflow for this backtrace formatter.
-	 * We have slightly modified it for our purposes
-	 * https://stackoverflow.com/a/32365961
-	 */
-	private function stackTrace($Length = 25, $protected = false)
-	{
-		$stack = debug_backtrace($Length);
-		$output = '';
+        $stackLen = count($stack);
+        for ($i = 1; $i < $stackLen; ++$i) {
+            $entry = $stack[$i];
 
-		$stackLen = count($stack);
-		for ($i = 1; $i < $stackLen; $i++) {
-			$entry = $stack[$i];
+            $func = $entry['function'] . '(';
+            if (isset($entry['args'])) {
+                $argsLen = count($entry['args']);
+                for ($j = 0; $j < $argsLen; ++$j) {
+                    $my_entry = $entry['args'][$j];
+                    if ($protected) {
+                        $func .= '***';
+                    } elseif (is_string($my_entry)) {
+                        $func .= $my_entry;
+                    }
+                    if ($j < $argsLen - 1) {
+                        $func .= ', ';
+                    }
+                }
+            }
+            $func .= ')';
 
-			$func = $entry['function'] . '(';
-			if (isset($entry['args'])) {
-				$argsLen = count($entry['args']);
-				for ($j = 0; $j < $argsLen; $j++) {
-					$my_entry = $entry['args'][$j];
-					if ($protected) {
-						$func .= "***";
-					} else if (is_string($my_entry)) {
-						$func .= $my_entry;
-					}
-					if ($j < $argsLen - 1) $func .= ', ';
-				}
-			}
-			$func .= ')';
+            $entry_file = 'NO_FILE';
+            if (array_key_exists('file', $entry)) {
+                $entry_file = str_replace(PATH_ROOT, '', $entry['file']);
+            }
+            $entry_line = 'NO_LINE';
+            if (array_key_exists('line', $entry)) {
+                $entry_line = $entry['line'];
+            }
+            $output .= $entry_file . ':' . $entry_line . ' - ' . $func . PHP_EOL;
+        }
 
-			$entry_file = 'NO_FILE';
-			if (array_key_exists('file', $entry)) {
-				$entry_file = str_replace(PATH_ROOT, '', $entry['file']);
-			}
-			$entry_line = 'NO_LINE';
-			if (array_key_exists('line', $entry)) {
-				$entry_line = $entry['line'];
-			}
-			$output .= $entry_file . ':' . $entry_line . ' - ' . $func . PHP_EOL;
-		}
-		return $output;
-	}
+        return $output;
+    }
 }

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -38,13 +39,14 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Fetch extension details from the FOSSBilling extension directory
+     * Fetch extension details from the FOSSBilling extension directory.
      *
      * @param string $id The extension identifier (e.g. Example)
      *
      * @return array The extension details
+     *
      * @example https://extensions.fossbilling.org/api/extension/Example An example of the API response
-     * 
+     *
      * @throws Exception
      */
     public function getExtension(string $id): array
@@ -59,13 +61,14 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Fetch the list of releases of an extension from the FOSSBilling extension directory
+     * Fetch the list of releases of an extension from the FOSSBilling extension directory.
      *
      * @param string $id The extension identifier (e.g. Example)
      *
      * @return array The list of releases of the extension
+     *
      * @example https://extensions.fossbilling.org/api/extension/Example An example of the API response (the "releases" array)
-     * 
+     *
      * @throws Exception
      */
     public function getExtensionReleases(string $id): array
@@ -80,13 +83,14 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Fetch the latest release of an extension from the FOSSBilling extension directory
+     * Fetch the latest release of an extension from the FOSSBilling extension directory.
      *
      * @param string $id The extension identifier (e.g. Example)
      *
      * @return array The latest release of the extension
+     *
      * @example https://extensions.fossbilling.org/api/extension/Example An example of the API response (the first element in the "releases" array)
-     * 
+     *
      * @throws Exception
      */
     public function getLatestExtensionRelease(string $id): array
@@ -102,11 +106,12 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Fetch the list of extensions from the FOSSBilling extension directory
+     * Fetch the list of extensions from the FOSSBilling extension directory.
      *
      * @param string $type The extension type (e.g. mod) - optional
      *
      * @return array The list of extensions
+     *
      * @example https://extensions.fossbilling.org/api/list An example of the API response
      */
     public function getExtensionList($type = null): array
@@ -121,7 +126,7 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Check if the latest version of an extension is compatible with the current FOSSBilling version
+     * Check if the latest version of an extension is compatible with the current FOSSBilling version.
      *
      * @param string $extension The extension identifier (e.g. Example)
      *
@@ -141,13 +146,13 @@ class ExtensionManager implements InjectionAwareInterface
     }
 
     /**
-     * Make a request to the FOSSBilling extension directory
+     * Make a request to the FOSSBilling extension directory.
      *
      * @param string $endpoint The API endpoint to call (e.g. list)
-     * @param array $params The array of parameters to pass to the API endpoint
+     * @param array  $params   The array of parameters to pass to the API endpoint
      *
      * @return array The API response
-     * 
+     *
      * @throws Exception
      */
     public function makeRequest(string $endpoint, array $params = []): array
@@ -161,7 +166,7 @@ class ExtensionManager implements InjectionAwareInterface
             $httpClient = \Symfony\Component\HttpClient\HttpClient::create();
             $response = $httpClient->request('GET', $url, [
                 'timeout' => 5,
-                'query' => [...$params, 'fossbilling_version' => \FOSSBilling\Version::VERSION],
+                'query' => [...$params, 'fossbilling_version' => Version::VERSION],
             ]);
 
             $json = $response->toArray();

--- a/src/library/FOSSBilling/Fingerprint.php
+++ b/src/library/FOSSBilling/Fingerprint.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -19,7 +20,7 @@ class Fingerprint
     {
         $agentDetails = $this->extractAgentInfo();
 
-        /**
+        /*
          * Sets up the fingerprint info for the existing request.
          * 'weight' is used to weigh specific parameters.
          *      Example: The agent string has a weight of 2, one failure from it equal as 2 failures of other properties.
@@ -83,7 +84,7 @@ class Fingerprint
     }
 
     /**
-     * Generates a fingerprint for the device that made the request to the server
+     * Generates a fingerprint for the device that made the request to the server.
      */
     public function fingerprint(): array
     {
@@ -104,8 +105,8 @@ class Fingerprint
      *      - Each property can define a weight. For example, if the IP address doesn't match and the weight is set to 3, 3 will be selected from the total.
      *          - This means with a total of 9 properties, the IP address being wrong would effectively be weighted as 3 properties and only two more differing properties will make it fail the check.
      *      - If any property is found in one of the fingerprints and not the other, the baseline is incremented and the final score is decreased by it's weight.
-     * 
-     * @return bool `true` if the fingerprint passes, `false` if it's considered invalid. 
+     *
+     * @return bool `true` if the fingerprint passes, `false` if it's considered invalid
      */
     public function checkFingerprint(array $fingerprint): bool
     {
@@ -117,13 +118,13 @@ class Fingerprint
             $exitsInCurrentFingerprint = !empty($properties['source']);
 
             if ((!$exitsInFingerprint && $exitsInCurrentFingerprint) || ($exitsInFingerprint && !$exitsInCurrentFingerprint)) {
-                //The property exists in one fingerprint and not the other, so we increment the total count and deduct from the score.
-                $itemCount++;
+                // The property exists in one fingerprint and not the other, so we increment the total count and deduct from the score.
+                ++$itemCount;
                 $scoreSubtract += $properties['weight'];
             } elseif (!$exitsInFingerprint && !$exitsInCurrentFingerprint) {
                 // Do nothing in this case, as the property isn't in either fingerprint.
             } else {
-                $itemCount++;
+                ++$itemCount;
                 $hashedData = hash('md5', $properties['source']);
 
                 if ($fingerprint[$name] !== $hashedData) {
@@ -135,19 +136,18 @@ class Fingerprint
         /**
          * Here we calculate how confident we are in our ability to fingerprint a device without causing issues for legitimate sessions.
          * The less confident we are, the more wrong the current fingerprint needs to be when compared against the session's before it is invalidated.
-         * 
+         *
          * In the event that less that 70% of the possible values are in the fingerprint, we use the percentage off we are to calculate a higher percentage before failure.
          * For example:
          *  If we have 13 possible fingerprint properties and only 9 are available, that's only 69% of the possible properties and the failure threshold will be calculated as follows.
          *  Negative weight: (1 - 0.69) / 1.25 = `0.24`
          *  Failure threshold: 0.5 + 0.24 = `0.74`
-         *  
+         *
          *  So in this example, the percentage wrong needs to be at or above 74% (nearly 75%) before the session is declared invalid.
          *  If there's only 6 of 13 available that moves to 93% and at 5 of 13 it's 99%.
          *  By doing this, we can effectively give additional headroom in situations where we are less-confident than we'd like to be and effectively completely disable the check in a worst-case situation.
-         *  
+         *
          *  Keep in mind, this method does not prevent changes such as the OS or browser from invalidating a session as those are weighted so heavily to always be considered more than 100% wrong.
-         *  
          */
         $percentOfOverallItems = $itemCount / count($this->fingerprintProperties);
         if ($percentOfOverallItems >= 0.70) {
@@ -159,6 +159,7 @@ class Fingerprint
 
         // Here we calculate the "percentage wrong" (weighted, not a true percent) and return true (indicating no issues) if it's less then the failure threshold.
         $percentageWrong = $scoreSubtract / $itemCount;
+
         return $percentageWrong < $failureThreshold;
     }
 

--- a/src/library/FOSSBilling/InformationException.php
+++ b/src/library/FOSSBilling/InformationException.php
@@ -3,7 +3,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -16,12 +16,12 @@ class InformationException extends Exception
     /**
      * Creates a new translated information exception.
      *
-     * @param string $message error message
+     * @param string     $message   error message
      * @param array|null $variables translation variables
-     * @param int $code The exception code.
-     * @param bool $protected If the variables in this should be considered protect, if so, hide them from the stack trace. 
+     * @param int        $code      the exception code
+     * @param bool       $protected if the variables in this should be considered protect, if so, hide them from the stack trace
      */
-    public function __construct(string $message, ?array $variables = null, int $code = 0, bool $protected = false)
+    public function __construct(string $message, array $variables = null, int $code = 0, bool $protected = false)
     {
         // Pass the message to the parent
         parent::__construct($message, $variables, $code, $protected);

--- a/src/library/FOSSBilling/InjectionAwareInterface.php
+++ b/src/library/FOSSBilling/InjectionAwareInterface.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,14 +14,7 @@ namespace FOSSBilling;
 
 interface InjectionAwareInterface
 {
-    /**
-     * @param \Pimple\Container $di
-     * @return void
-     */
     public function setDi(\Pimple\Container $di): void;
 
-    /**
-     * @return \Pimple\Container|null
-     */
     public function getDi(): ?\Pimple\Container;
 }

--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -10,11 +12,11 @@
 
 namespace FOSSBilling;
 
-use Symfony\Component\Mailer\Mailer;
-use Symfony\Component\Mime\Email;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 
 class Mail implements InjectionAwareInterface
 {
@@ -37,16 +39,16 @@ class Mail implements InjectionAwareInterface
     /**
      * Constructor for creating an email message. The custom DSN will be used if you either don't provide a transport or use 'custom' for it.
      *
-     * @param array|string $from      The sender's email and name (optional) as an associative array with keys 'email' and 'name', a string representing the email address, or an array of email addresses.
-     * @param array|string $to        The recipient's email and name (optional) as an associative array with keys 'email' and 'name', a string representing the email address, or an array of email addresses.
-     * @param string $subject         The subject line of the email.
-     * @param string $bodyHTML        The HTML content of the email body.
-     * @param string|null $transport  (optional) The name of the transport to use for sending the email.
-     * @param string|null $dsn        (optional) The DSN to use for sending the email. (See: https://symfony.com/doc/current/mailer.html#using-a-3rd-party-transport)
+     * @param array|string $from      the sender's email and name (optional) as an associative array with keys 'email' and 'name', a string representing the email address, or an array of email addresses
+     * @param array|string $to        the recipient's email and name (optional) as an associative array with keys 'email' and 'name', a string representing the email address, or an array of email addresses
+     * @param string       $subject   the subject line of the email
+     * @param string       $bodyHTML  the HTML content of the email body
+     * @param string|null  $transport (optional) The name of the transport to use for sending the email
+     * @param string|null  $dsn       (optional) The DSN to use for sending the email. (See: https://symfony.com/doc/current/mailer.html#using-a-3rd-party-transport)
      *
      * @return void
      */
-    public function __construct(array|string $from, array|string $to, string $subject, string $bodyHTML, string|null $transport, string|null $dsn = null)
+    public function __construct(array|string $from, array|string $to, string $subject, string $bodyHTML, string|null $transport, string $dsn = null)
     {
         if (isset($from['email']) && isset($from['name'])) {
             $fromAddress = new Address($from['email'], $from['name']);
@@ -77,8 +79,6 @@ class Mail implements InjectionAwareInterface
      * Add one or more email addresses to the email's "To" field.
      *
      * @param string|array $toAddresses The email address(es) to add to the "To" field. Can be a string for a single address or an array for multiple addresses.
-     *
-     * @return void
      */
     public function addTo(string|array $toAddresses): void
     {
@@ -89,8 +89,6 @@ class Mail implements InjectionAwareInterface
      * Adds one or more Carbon Copy (Cc) email addresses to the message.
      *
      * @param string|array $ccAddresses The email address(es) to add. Can be a string with a single email address, or an array with multiple email addresses.
-     *
-     * @return void
      */
     public function addCc(string|array $ccAddresses): void
     {
@@ -100,9 +98,7 @@ class Mail implements InjectionAwareInterface
     /**
      * Add one or more Bcc addresses to the email.
      *
-     * @param string|array $bccAddresses A single email address or an array of email addresses to add as Bcc recipients.
-     *
-     * @return void
+     * @param string|array $bccAddresses a single email address or an array of email addresses to add as Bcc recipients
      */
     public function addBcc(string|array $bccAddresses): void
     {
@@ -112,9 +108,7 @@ class Mail implements InjectionAwareInterface
     /**
      * Add reply-to addresses to the email.
      *
-     * @param string|array $replyToAddresses The email address(es) to add as reply-to.
-     *
-     * @return void
+     * @param string|array $replyToAddresses the email address(es) to add as reply-to
      */
     public function addReplyTo(string|array $replyToAddresses): void
     {
@@ -123,53 +117,55 @@ class Mail implements InjectionAwareInterface
 
     /**
      * Set the priority of the email message. Can be an integer between 1 and 5, with 1 being the highest priority.
-     * It's recommended to use Symfony's pre-defined constants instead of a specific integer, but either should work. (Example: Email::PRIORITY_HIGH)
+     * It's recommended to use Symfony's pre-defined constants instead of a specific integer, but either should work. (Example: Email::PRIORITY_HIGH).
      *
-     * @param int $priority The priority of the email message, represented as an integer between 1 and 5.
+     * @param int $priority the priority of the email message, represented as an integer between 1 and 5
      *
-     * @throws InformationException if the provided priority is invalid.
-     *
-     * @return void
+     * @throws InformationException if the provided priority is invalid
      */
     public function setPriority(int $priority): void
     {
         if (is_int($priority) && $priority >= Email::PRIORITY_HIGHEST && $priority <= Email::PRIORITY_LOWEST) {
             $this->email->priority($priority);
         } else {
-            throw new InformationException("Provided priority (:priority) is invalid. Please provide an integer between 1 and 5 or use the pre-defined symfony constants.", [':priority' => $priority]);
+            throw new InformationException('Provided priority (:priority) is invalid. Please provide an integer between 1 and 5 or use the pre-defined symfony constants.', [':priority' => $priority]);
         }
     }
 
     /**
-     * Sends the email that was created and configured when the class was constructed
+     * Sends the email that was created and configured when the class was constructed.
      *
-     * @param array|null $options An optional array of options specific to the chosen transport method.
-     * 
+     * @param array|null $options an optional array of options specific to the chosen transport method
+     *
      * @throws InformationException If the transport method is unknown or if required options for the selected transport aren't defined
      */
-    public function send(array|null $options = null): void
+    public function send(array $options = null): void
     {
         switch ($this->transport) {
             case 'sendmail':
                 $dsn = 'sendmail://default';
                 if (!function_exists('proc_open')) {
-                    throw new InformationException("FOSSBilling requires the proc_open PHP function to be enabled when using the sendmail transport");
+                    throw new InformationException('FOSSBilling requires the proc_open PHP function to be enabled when using the sendmail transport');
                 }
+
                 break;
             case 'smtp':
                 $dsn = $this->__smtpDsn($options);
+
                 break;
             case 'sendgrid':
                 if (empty($options['sendgrid_key'])) {
-                    throw new InformationException("A Sendgrid API key is required to send emails via Sendgrid");
+                    throw new InformationException('A Sendgrid API key is required to send emails via Sendgrid');
                 }
                 $dsn = 'sendgrid://' . $options['sendgrid_key'] . '@default';
+
                 break;
             case 'custom':
                 if (empty($this->dsn)) {
                     throw new InformationException("Unable to send email: 'Custom' transport method was selected without a custom DSN");
                 }
                 $dsn = $this->dsn;
+
                 break;
             default:
                 throw new InformationException('Unknown mail transport: :transport', [':transport' => $this->transport]);
@@ -180,18 +176,18 @@ class Mail implements InjectionAwareInterface
             $mailer = new Mailer($transport);
             $mailer->send($this->email);
         } catch (TransportExceptionInterface $e) {
-            throw new Exception("Failed to send email via :transport with the exception :e", [':transport' => $this->transport, ':e' => $e]);
+            throw new Exception('Failed to send email via :transport with the exception :e', [':transport' => $this->transport, ':e' => $e]);
         }
     }
 
     /**
      * Create a DSN string for SMTP transport based on given options.
      *
-     * @param array $options An associative array of SMTP options including 'smtp_host', 'smtp_port', 'smtp_username', and 'smtp_password'.
+     * @param array $options an associative array of SMTP options including 'smtp_host', 'smtp_port', 'smtp_username', and 'smtp_password'
      *
-     * @throws InformationException if the SMTP host or port is not configured.
+     * @return string a string representing the DSN for the SMTP transport
      *
-     * @return string A string representing the DSN for the SMTP transport.
+     * @throws InformationException if the SMTP host or port is not configured
      */
     private function __smtpDsn(array $options): string
     {
@@ -206,9 +202,10 @@ class Mail implements InjectionAwareInterface
             $pass = urlencode(trim($options['smtp_password'] ?? ''));
 
             $authString = !empty($pass) ? $username . ':' . $pass : $username;
-            return "smtp://$authString@" . $host . ":" . $options['smtp_port'];
+
+            return "smtp://$authString@" . $host . ':' . $options['smtp_port'];
         } else {
-            return "smtp://" . $host . ":" . $options['smtp_port'];
+            return 'smtp://' . $host . ':' . $options['smtp_port'];
         }
     }
 }

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,15 +12,15 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
-use Monolog\Level;
-use Monolog\Logger;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\RotatingFileHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use Symfony\Component\Filesystem\Path;
 
 class Monolog
 {
-    protected $logger = null;
+    protected $logger;
     public string $dateFormat = 'd-M-Y H:i:s e';
     public string $outputFormat = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
 
@@ -33,7 +33,7 @@ class Monolog
         'mail',
         'event',
         'routing',
-        'billing'
+        'billing',
     ];
 
     public function __construct()
@@ -41,7 +41,6 @@ class Monolog
         $channels = $this->channels;
 
         foreach ($channels as $channel) {
-
             $path = Path::normalize(PATH_LOG . "/$channel/" . $channel . '.log');
 
             $this->logger[$channel] = new Logger($channel);
@@ -54,7 +53,7 @@ class Monolog
     }
 
     /**
-     * @return \Monolog\Logger The logger for the specified channel. If the channel does not exist, the default logger (the 'application' channel) is returned.
+     * @return Logger The logger for the specified channel. If the channel does not exist, the default logger (the 'application' channel) is returned.
      */
     public function getChannel(string $channel = 'application'): Logger
     {
@@ -62,22 +61,20 @@ class Monolog
     }
 
     /**
-     * Convert numeric FOSSBilling priority to Monolog priority
-     *
-     * @return int
+     * Convert numeric FOSSBilling priority to Monolog priority.
      */
     public function parsePriority(int $priority): int
     {
         // Map numeric priority to Monolog priority
         $map = [
-            \Box_Log::EMERG  => Level::Emergency->value,
-            \Box_Log::ALERT  => Level::Alert->value,
-            \Box_Log::CRIT   => Level::Critical->value,
-            \Box_Log::ERR    => Level::Error->value,
-            \Box_Log::WARN   => Level::Warning->value,
+            \Box_Log::EMERG => Level::Emergency->value,
+            \Box_Log::ALERT => Level::Alert->value,
+            \Box_Log::CRIT => Level::Critical->value,
+            \Box_Log::ERR => Level::Error->value,
+            \Box_Log::WARN => Level::Warning->value,
             \Box_Log::NOTICE => Level::Notice->value,
-            \Box_Log::INFO   => Level::Info->value,
-            \Box_Log::DEBUG  => Level::Debug->value,
+            \Box_Log::INFO => Level::Info->value,
+            \Box_Log::DEBUG => Level::Debug->value,
         ];
 
         return $map[$priority] ?? Level::Debug->value;

--- a/src/library/FOSSBilling/Request.php
+++ b/src/library/FOSSBilling/Request.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -26,9 +27,10 @@ class Request implements InjectionAwareInterface
     }
 
     /**
-     * Gets most possible client IPv4 Address. This method search in $_SERVER[‘REMOTE_ADDR’] and optionally in $_SERVER[‘HTTP_X_FORWARDED_FOR’]
+     * Gets most possible client IPv4 Address. This method search in $_SERVER[‘REMOTE_ADDR’] and optionally in $_SERVER[‘HTTP_X_FORWARDED_FOR’].
+     *
      * @param bool $trustForwardedHeader - No by default because this can be changed to anything extremely easy, making it unreliable for tracking and adding a potential source for external data to be executed.
-     * Please see: https://stackoverflow.com/questions/3003145/how-to-get-the-client-ip-address-in-php
+     *                                   Please see: https://stackoverflow.com/questions/3003145/how-to-get-the-client-ip-address-in-php
      */
     public function getClientAddress(bool $trustForwardedHeader = false): null|string|array
     {
@@ -44,11 +46,13 @@ class Request implements InjectionAwareInterface
                 [$address] = explode(',', $address);
             }
         }
+
         return $address;
     }
 
     /**
-     * Checks whether request includes attached files
+     * Checks whether request includes attached files.
+     *
      * @return int - number of files
      */
     public function hasFiles($onlySuccessful = true)
@@ -56,23 +60,25 @@ class Request implements InjectionAwareInterface
         $number_of_files = 0;
         $number_of_successful_files = 0;
         foreach ($_FILES as $file) {
-            $number_of_files++;
+            ++$number_of_files;
             if (isset($file['error']) && $file['error'] == 0) {
-                $number_of_successful_files++;
+                ++$number_of_successful_files;
             }
         }
-        return ($onlySuccessful)  ? $number_of_successful_files : $number_of_files;
+
+        return ($onlySuccessful) ? $number_of_successful_files : $number_of_files;
     }
 
     /**
-     * Gets attached files as SplFileInfo collection
+     * Gets attached files as SplFileInfo collection.
+     *
      * @return array
      */
     public function getUploadedFiles($onlySuccessful = true)
     {
-        $files = array();
+        $files = [];
         foreach ($_FILES as $file) {
-            $f = new \FOSSBilling\RequestFile($file);
+            $f = new RequestFile($file);
             if ($onlySuccessful) {
                 if ($file['error'] == 0) {
                     $files[] = $f;
@@ -81,6 +87,7 @@ class Request implements InjectionAwareInterface
                 $files[] = $f;
             }
         }
+
         return $files;
     }
 }

--- a/src/library/FOSSBilling/RequestFile.php
+++ b/src/library/FOSSBilling/RequestFile.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0

--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -25,7 +25,7 @@ class Requirements
             'dom',
             'iconv',
             'json',
-            'zlib'
+            'zlib',
         ],
         'suggested_extensions' => [
             'curl',
@@ -35,7 +35,7 @@ class Requirements
             'gd',
             'bz2',
             'simplexml',
-            'xml'
+            'xml',
         ],
         'min_version' => '8.1',
     ];
@@ -58,6 +58,7 @@ class Requirements
         if (!$ok) {
             $this->isOk = false;
         }
+
         return $ok;
     }
 
@@ -66,7 +67,7 @@ class Requirements
         $writable = false;
         if (is_writable($path)) {
             $writable = true;
-        } else if (!file_exists($path)) {
+        } elseif (!file_exists($path)) {
             $written = @file_put_contents($path, 'Test?');
             if ($written) {
                 $writable = true;
@@ -77,6 +78,7 @@ class Requirements
         } else {
             $this->isOk = false;
         }
+
         return $writable;
     }
 
@@ -88,6 +90,7 @@ class Requirements
         } else {
             $this->isOk = false;
         }
+
         return $writable;
     }
 
@@ -115,6 +118,7 @@ class Requirements
             if ($ext === 'opcache') {
                 if (!function_exists('opcache_get_status')) {
                     $result['suggested_extensions'][$ext] = false;
+
                     continue;
                 }
                 $status = opcache_get_status();
@@ -131,6 +135,7 @@ class Requirements
         ];
 
         $result['can_install'] = $this->isOk;
+
         return $result;
     }
 }

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -39,7 +39,7 @@ class SentryHelper
 
     // Array containing instance IDs that are blacklisted from error reporting and a unix timestamp of when their blacklist expires.
     private static array $blacklistedInstances = [
-        '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1719829175
+        '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1_719_829_175
     ];
 
     /**

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,12 +12,12 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
-use \Sentry\Event;
-use \Sentry\EventHint;
-use \Sentry\HttpClient\HttpClientInterface;
-use \Sentry\HttpClient\Request;
-use \Sentry\HttpClient\Response;
-use \Sentry\Options;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\HttpClient\HttpClientInterface;
+use Sentry\HttpClient\Request;
+use Sentry\HttpClient\Response;
+use Sentry\Options;
 use Symfony\Component\HttpClient\HttpClient;
 
 class SentryHelper
@@ -31,28 +31,27 @@ class SentryHelper
 
     // Errors for blacklisted modules are discarded from error reporting
     private static array $blacklistedModules = [
-        'serviceproxmox', // Remove once it's officially ready for more than just dev work 
+        'serviceproxmox', // Remove once it's officially ready for more than just dev work
         'forum',
         'servicegoogleworkspace',
-        'servicemulticraft'
+        'servicemulticraft',
     ];
 
     // Array containing instance IDs that are blacklisted from error reporting and a unix timestamp of when their blacklist expires.
     private static array $blacklistedInstances = [
-        '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1_719_829_175
+        '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1_719_829_175,
     ];
 
     /**
      * Registers Sentry for error reporting. Skips the steps to enable Sentry if error reporting is not enabled.
      *
-     * @param array $config The FOSSBilling config.
+     * @param array $config the FOSSBilling config
      */
     public static function registerSentry(array $config): void
     {
         $sentryDSN = '--replace--this--during--release--process--';
 
-        $httpClient = new class() implements HttpClientInterface
-        {
+        $httpClient = new class() implements HttpClientInterface {
             public function sendRequest(Request $request, Options $options): Response
             {
                 $dsn = $options->getDsn();
@@ -72,7 +71,7 @@ class SentryHelper
                     $dsn->getEnvelopeApiEndpointUrl(),
                     [
                         'headers' => $requestHeaders,
-                        'body'    => $requestData,
+                        'body' => $requestData,
                     ]
                 );
 
@@ -103,7 +102,7 @@ class SentryHelper
                     if (str_starts_with($exceptionPath, PATH_MODS)) {
                         $module = self::getModule($exceptionPath);
                         $event->setTag('module.name', $module);
-                    } else if (str_starts_with($exceptionPath, PATH_LIBRARY)) {
+                    } elseif (str_starts_with($exceptionPath, PATH_LIBRARY)) {
                         $event->setTag('library.class', self::getLibrary($exceptionPath));
                     }
                 }
@@ -113,6 +112,7 @@ class SentryHelper
                 }
 
                 $event->setTag('webserver.used', self::estimateWebServer());
+
                 return $event;
             },
 
@@ -128,13 +128,13 @@ class SentryHelper
             'attach_stacktrace' => true,
         ];
 
-        /**
+        /*
          * Here we validate that the DSN is correctly set and that error reporting is enabled before passing it off to the Sentry SDK.
          * It may look a bit odd, but the DSN placeholder value here is split into two strings and concatenated so we can easily perform a `sed` replacement of the placeholder without it effecting this check
          *
          * @phpstan-ignore-next-line (The value is replaced during release and the check is written with this in mind.)
          */
-        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== '--replace--this--' . 'during--release--process--' && !empty($sentryDSN)) {
+        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== '--replace--this--during--release--process--' && !empty($sentryDSN)) {
             // Per Sentry documentation, not setting this results in the SDK simply not sending any information.
             $options['dsn'] = $sentryDSN;
         }
@@ -150,12 +150,14 @@ class SentryHelper
         $module = 'Unknown';
 
         while ($level <= 10) {
-            if (dirname($strippedPath, ($level + 1)) === DIRECTORY_SEPARATOR) {
+            if (dirname($strippedPath, $level + 1) === DIRECTORY_SEPARATOR) {
                 $module = trim(dirname($strippedPath, $level), DIRECTORY_SEPARATOR);
+
                 break;
             }
-            $level++;
+            ++$level;
         }
+
         return $module;
     }
 
@@ -172,9 +174,9 @@ class SentryHelper
         $serverSoftware = $_SERVER['SERVER_SOFTWARE'] ?? '';
         if (function_exists('apache_get_version') || (stripos(strtolower($serverSoftware), 'apache') !== false)) {
             return 'Apache';
-        } else if (stripos(strtolower($serverSoftware), 'litespeed') !== false) {
+        } elseif (stripos(strtolower($serverSoftware), 'litespeed') !== false) {
             return 'Litespeed';
-        } else if (stripos(strtolower($serverSoftware), 'nginx') !== false) {
+        } elseif (stripos(strtolower($serverSoftware), 'nginx') !== false) {
             return 'NGINX';
         } else {
             return 'Unknown';
@@ -182,7 +184,7 @@ class SentryHelper
     }
 
     // Checks if either the module producing the error or the instance ID of this installation is blacklisted
-    public static function isBlacklisted(?string $module = null): bool
+    public static function isBlacklisted(string $module = null): bool
     {
         if (INSTANCE_ID === 'Unknown') {
             return true;

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -42,6 +42,9 @@ class SentryHelper
         '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1_719_829_175,
     ];
 
+    private static string $placholderFirstHalf = '--replace--this--';
+    private static string $placholderSecondHalf = 'during--release--process--';
+
     /**
      * Registers Sentry for error reporting. Skips the steps to enable Sentry if error reporting is not enabled.
      *
@@ -134,7 +137,7 @@ class SentryHelper
          *
          * @phpstan-ignore-next-line (The value is replaced during release and the check is written with this in mind.)
          */
-        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== '--replace--this--during--release--process--' && !empty($sentryDSN)) {
+        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== self::$placholderFirstHalf . self::$placholderSecondHalf && !empty($sentryDSN)) {
             // Per Sentry documentation, not setting this results in the SDK simply not sending any information.
             $options['dsn'] = $sentryDSN;
         }

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -42,8 +42,8 @@ class SentryHelper
         '82766452-ff2f-43ff-953a-3cbe3c3973ea' => 1_719_829_175,
     ];
 
-    private static string $placholderFirstHalf = '--replace--this--';
-    private static string $placholderSecondHalf = 'during--release--process--';
+    private static string $placeholderFirstHalf = '--replace--this--';
+    private static string $placeholderSecondHalf = 'during--release--process--';
 
     /**
      * Registers Sentry for error reporting. Skips the steps to enable Sentry if error reporting is not enabled.
@@ -137,7 +137,7 @@ class SentryHelper
          *
          * @phpstan-ignore-next-line (The value is replaced during release and the check is written with this in mind.)
          */
-        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== self::$placholderFirstHalf . self::$placholderSecondHalf && !empty($sentryDSN)) {
+        if ($config['debug_and_monitoring']['report_errors'] && $sentryDSN !== self::$placeholderFirstHalf . self::$placeholderSecondHalf && !empty($sentryDSN)) {
             // Per Sentry documentation, not setting this results in the SDK simply not sending any information.
             $options['dsn'] = $sentryDSN;
         }

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -11,9 +12,7 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
-use FOSSBilling\Environment;
-
-class Session implements \FOSSBilling\InjectionAwareInterface
+class Session implements InjectionAwareInterface
 {
     private ?\Pimple\Container $di = null;
 
@@ -51,16 +50,16 @@ class Session implements \FOSSBilling\InjectionAwareInterface
         }
 
         $currentCookieParams = session_get_cookie_params();
-        $currentCookieParams["httponly"] = true;
-        $currentCookieParams["lifetime"] = 0;
-        $currentCookieParams["secure"] = $this->secure;
+        $currentCookieParams['httponly'] = true;
+        $currentCookieParams['lifetime'] = 0;
+        $currentCookieParams['secure'] = $this->secure;
 
         $cookieParams = [
-            'lifetime' => $currentCookieParams["lifetime"],
-            'path' => $currentCookieParams["path"],
-            'domain' => $currentCookieParams["domain"],
-            'secure' => $currentCookieParams["secure"],
-            'httponly' => $currentCookieParams["httponly"]
+            'lifetime' => $currentCookieParams['lifetime'],
+            'path' => $currentCookieParams['path'],
+            'domain' => $currentCookieParams['domain'],
+            'secure' => $currentCookieParams['secure'],
+            'httponly' => $currentCookieParams['httponly'],
         ];
 
         if ($this->securityMode == 'strict') {
@@ -98,10 +97,12 @@ class Session implements \FOSSBilling\InjectionAwareInterface
         switch ($type) {
             case 'admin':
                 $this->delete('admin');
+
                 break;
             case 'client':
                 $this->delete('client');
                 $this->delete('client_id');
+
                 break;
         }
 
@@ -121,7 +122,7 @@ class Session implements \FOSSBilling\InjectionAwareInterface
         $sessionID = $_COOKIE['PHPSESSID'];
         $maxAge = time() - $this->di['config']['security']['session_lifespan'];
 
-        $fingerprint = new Fingerprint;
+        $fingerprint = new Fingerprint();
         /** @var \RedBeanPHP\OODBBean $session */
         $session = $this->di['db']->findOne('session', 'id = :id', [':id' => $sessionID]);
 
@@ -129,7 +130,7 @@ class Session implements \FOSSBilling\InjectionAwareInterface
             return;
         }
 
-        if(empty($session->created_at)){
+        if (empty($session->created_at)) {
             $session->created_at = time();
             $this->di['db']->store($session);
         }
@@ -150,7 +151,7 @@ class Session implements \FOSSBilling\InjectionAwareInterface
 
         // Fix for the installer which temporarily uses FS sessions before FOSSBilling is completely setup.
         if (!is_null($session)) {
-            $fingerprint = new Fingerprint;
+            $fingerprint = new Fingerprint();
             $session->fingerprint = json_encode($fingerprint->fingerprint());
             $this->di['db']->store($session);
         }

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -38,36 +38,31 @@ class Tools
         if ($fp) {
             $bytes = fwrite($fp, $content);
             fclose($fp);
+
             return $bytes;
         } else {
             $error = error_get_last();
 
-            throw new \RuntimeException(
-                sprintf(
-                    'Could not write to %s: %s',
-                    $target,
-                    substr(
-                        $error['message'],
-                        strpos($error['message'], ':') + 2
-                    )
-                )
-            );
+            throw new \RuntimeException(sprintf('Could not write to %s: %s', $target, substr($error['message'], strpos($error['message'], ':') + 2)));
         }
     }
 
     /**
-     * Return site url
+     * Return site url.
+     *
      * @return string
      */
     public function url($link = null)
     {
         $link = trim($link, '/');
+
         return SYSTEM_URL . $link;
     }
 
     public function hasService($type)
     {
         $file = PATH_MODS . '/mod_' . $type . '/Service.php';
+
         return file_exists($file);
     }
 
@@ -76,9 +71,10 @@ class Tools
         $class = 'Box_Mod_' . ucfirst($type) . '_Service';
         $file = PATH_MODS . '/mod_' . $type . '/Service.php';
         if (!file_exists($file)) {
-            throw new Exception('Service class :class was not found in :path', array(':class' => $class, ':path' => $file));
+            throw new Exception('Service class :class was not found in :path', [':class' => $class, ':path' => $file]);
         }
         require_once $file;
+
         return new $class();
     }
 
@@ -86,14 +82,15 @@ class Tools
     {
         clearstatcache();
         $configmod = substr(sprintf('%o', fileperms($path)), -4);
-        $int = (int)$configmod;
+        $int = (int) $configmod;
         if ($configmod == $perm) {
             return true;
         }
 
-        if ((int)$configmod < (int)$perm) {
+        if ((int) $configmod < (int) $perm) {
             return true;
         }
+
         return false;
     }
 
@@ -106,15 +103,17 @@ class Tools
             $di = new \RecursiveDirectoryIterator($folder, \FilesystemIterator::SKIP_DOTS);
             $ri = new \RecursiveIteratorIterator($di, \RecursiveIteratorIterator::CHILD_FIRST);
             foreach ($ri as $file) {
-                $file->isDir() ?  rmdir($file->getRealPath()) : unlink($file->getRealPath());
+                $file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
             }
         }
     }
 
     /**
-     * Generates random password
+     * Generates random password.
+     *
      * @param int $length
      * @param int $strength
+     *
      * @return string
      */
     public function generatePassword($length = 8, $strength = 3)
@@ -130,58 +129,64 @@ class Tools
         $symbols = '!@#$%&?()+-_';
 
         switch ($strength) {
-                //lowercase + uppercase + numeric
+            // lowercase + uppercase + numeric
             case 3:
                 $lower = random_int(1, $length - 2);
                 $upper = random_int(1, $length - $lower - 1);
                 $numeric = $length - $lower - $upper;
+
                 break;
-                //lowercase + uppercase + numeric + symbols
+                // lowercase + uppercase + numeric + symbols
             case 4:
             default:
                 $lower = random_int(1, $length - 3);
                 $upper = random_int(1, $length - $lower - 2);
                 $numeric = random_int(1, $length - $lower - $upper - 1);
                 $other = $length - $lower - $upper - $numeric;
+
                 break;
         }
 
-        $passOrder = array();
+        $passOrder = [];
 
-        for ($i = 0; $i < $upper; $i++) {
+        for ($i = 0; $i < $upper; ++$i) {
             $passOrder[] = $upper_letters[random_int(0, mt_getrandmax()) % strlen($upper_letters)];
         }
-        for ($i = 0; $i < $lower; $i++) {
+        for ($i = 0; $i < $lower; ++$i) {
             $passOrder[] = $lower_letters[random_int(0, mt_getrandmax()) % strlen($lower_letters)];
         }
-        for ($i = 0; $i < $numeric; $i++) {
+        for ($i = 0; $i < $numeric; ++$i) {
             $passOrder[] = $numbers[random_int(0, mt_getrandmax()) % strlen($numbers)];
         }
-        for ($i = 0; $i < $other; $i++) {
+        for ($i = 0; $i < $other; ++$i) {
             $passOrder[] = $symbols[random_int(0, mt_getrandmax()) % strlen($symbols)];
         }
 
         shuffle($passOrder);
+
         return implode('', $passOrder);
     }
 
     public function autoLinkText($text)
     {
-        $pattern  = '#\b(([\w-]+://?|www[.])[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))#';
+        $pattern = '#\b(([\w-]+://?|www[.])[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))#';
         $callback = function ($matches) {
-            $url       = array_shift($matches);
+            $url = array_shift($matches);
             $url_parts = parse_url($url);
-            if (!isset($url_parts["scheme"])) {
-                $url = "http://" . $url;
+            if (!isset($url_parts['scheme'])) {
+                $url = 'http://' . $url;
             }
+
             return sprintf('<a target="_blank" href="%s">%s</a>', $url, $url);
         };
+
         return preg_replace_callback($pattern, $callback, $text);
     }
 
     public function getResponseCode($theURL)
     {
         $headers = get_headers($theURL);
+
         return substr($headers[0], 9, 3);
     }
 
@@ -189,14 +194,16 @@ class Tools
     {
         $str = strtolower(trim($str));
         $str = preg_replace('/[^a-z0-9-]/', '-', $str);
-        $str = preg_replace('/-+/', "-", $str);
+        $str = preg_replace('/-+/', '-', $str);
         $str = trim($str, '-');
+
         return $str;
     }
 
     public function escape($string)
     {
         $string = htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+
         return stripslashes($string);
     }
 
@@ -206,13 +213,15 @@ class Tools
             $str[0] = strtoupper($str[0]);
         }
         $func = fn ($c) => strtoupper($c[1]);
+
         return preg_replace_callback('/-([a-z])/', $func, $str);
     }
 
     public function from_camel_case($str)
     {
         $str[0] = strtolower($str[0]);
-        $func = fn ($c) => "-" . strtolower($c[1]);
+        $func = fn ($c) => '-' . strtolower($c[1]);
+
         return preg_replace_callback('/([A-Z])/', $func, $str);
     }
 
@@ -220,17 +229,18 @@ class Tools
     {
         if (isset($json_str) && is_string($json_str)) {
             $config = json_decode($json_str, true);
-            return is_array($config) ? $config : array();
+
+            return is_array($config) ? $config : [];
         } else {
-            return array();
+            return [];
         }
     }
 
     public function sortByOneKey(array $array, $key, $asc = true)
     {
-        $result = array();
+        $result = [];
 
-        $values = array();
+        $values = [];
         foreach ($array as $id => $value) {
             $values[$id] = $value[$key] ?? '';
         }
@@ -253,23 +263,24 @@ class Tools
         $class = 'Model_' . ucfirst($type) . 'Table';
         $file = PATH_LIBRARY . '/Model/' . $type . 'Table.php';
         if (!file_exists($file)) {
-            throw new Exception('Service class :class was not found in :path', array(':class' => $class, ':path' => $file));
+            throw new Exception('Service class :class was not found in :path', [':class' => $class, ':path' => $file]);
         }
         require_once $file;
+
         return new $class();
     }
 
     public function getPairsForTableByIds($table, $ids)
     {
         if (empty($ids)) {
-            return array();
+            return [];
         }
 
-        $slots = (is_countable($ids) ? count($ids) : 0) ? implode(',', array_fill(0, is_countable($ids) ? count($ids) : 0, '?')) : ''; //same as RedBean genSlots() method
+        $slots = (is_countable($ids) ? count($ids) : 0) ? implode(',', array_fill(0, is_countable($ids) ? count($ids) : 0, '?')) : ''; // same as RedBean genSlots() method
 
         $rows = $this->di['db']->getAll('SELECT id, title FROM ' . $table . ' WHERE id in (' . $slots . ')', $ids);
 
-        $result = array();
+        $result = [];
         foreach ($rows as $record) {
             $result[$record['id']] = $record['title'];
         }
@@ -290,7 +301,7 @@ class Tools
         if (Environment::isProduction() && $checkDNS) {
             $validations = new MultipleValidationWithAnd([
                 new RFCValidation(),
-                new DNSCheckValidation()
+                new DNSCheckValidation(),
             ]);
         } else {
             $validations = new RFCValidation();
@@ -299,6 +310,7 @@ class Tools
         if (!$validator->isValid($email, $validations)) {
             if ($throw) {
                 $friendlyName = ucfirst(__trans('Email address'));
+
                 throw new Exception(':friendlyName: is invalid', [':friendlyName:' => $friendlyName]);
             } else {
                 return false;
@@ -313,6 +325,6 @@ class Tools
         $protocol = $_SERVER['HTTPS'] ?? $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? $_SERVER['REQUEST_SCHEME'] ?? '';
 
         // $_SERVER['HTTPS'] will be set to `on` to indicate HTTPS and the other to will be set to `https`, so either one means we are connected via HTTPS.
-        return (strcasecmp($protocol, 'on') === 0 || strcasecmp($protocol, 'https') === 0);
+        return strcasecmp($protocol, 'on') === 0 || strcasecmp($protocol, 'https') === 0;
     }
 }

--- a/src/library/FOSSBilling/TwigExtensions/DebugBar.php
+++ b/src/library/FOSSBilling/TwigExtensions/DebugBar.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 /**
  * Copyright 2023 FOSSBilling
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -13,9 +13,9 @@ namespace FOSSBilling\TwigExtensions;
 
 use DebugBar\JavascriptRenderer;
 use DebugBar\StandardDebugBar;
+use FOSSBilling\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use FOSSBilling\Environment;
 
 class DebugBar extends AbstractExtension
 {
@@ -31,7 +31,7 @@ class DebugBar extends AbstractExtension
     {
         return [
             new TwigFunction('DebugBar_renderHead', $this->renderHead(...), ['is_safe' => ['html']]),
-            new TwigFunction('DebugBar_render', $this->render(...), ['is_safe' => ['html']])
+            new TwigFunction('DebugBar_render', $this->render(...), ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -38,7 +38,7 @@ class Update implements InjectionAwareInterface
     /**
      * Get the branch configured to update from.
      *
-     * @return string Branch to update from.
+     * @return string branch to update from
      */
     public function getUpdateBranch(): string
     {
@@ -48,32 +48,34 @@ class Update implements InjectionAwareInterface
     /**
      * Get latest release notes for the configured update branch.
      *
-     * @return string Release notes for the latest version.
+     * @return string release notes for the latest version
      */
     public function getLatestReleaseNotes(): string
     {
         $updateBranch = $this->getUpdateBranch();
+
         return $this->getLatestVersionInfo($updateBranch)['release_notes'];
     }
 
     /**
      * Get latest version number for the configured update branch.
      *
-     * @return string Version number of the latest version.
+     * @return string version number of the latest version
      */
     public function getLatestVersion(): string
     {
         $updateBranch = $this->getUpdateBranch();
+
         return $this->getLatestVersionInfo($updateBranch)['version'];
     }
 
     /**
-     * Builds a complete changelog for all updates between the the newest FOSSBilling version and an ending version number
-     * 
-     * @param array $releases The GitHub API release info JSON represented as an array.
-     * @param null|string $end What version number to end on. Defaults to the current version of this installation if `null` is passed.
+     * Builds a complete changelog for all updates between the the newest FOSSBilling version and an ending version number.
+     *
+     * @param array       $releases the GitHub API release info JSON represented as an array
+     * @param string|null $end      What version number to end on. Defaults to the current version of this installation if `null` is passed.
      */
-    private function buildCompleteChangelog(array $releases, ?string $end = null): string
+    private function buildCompleteChangelog(array $releases, string $end = null): string
     {
         $end ??= Version::VERSION;
         $completedChangelog = [];
@@ -92,17 +94,14 @@ class Update implements InjectionAwareInterface
     /**
      * Returns information about the latest version of the specified branch.
      *
-     * @param string $branch The branch to return the latest information for;
-     *                       valid values are: 'preview' or 'release'.
+     * @param string $branch  the branch to return the latest information for;
+     *                        valid values are: 'preview' or 'release'
+     * @param bool   $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the latest info
      *
-     * @param bool $refetch Set to `true` to have FOSSBilling invalidate the update cache and fetch the latest info
-     * 
      * @throws Exception if there is an error downloading the latest
-     *                        version information.
-     *
-     * @return array
+     *                   version information
      */
-    public function getLatestVersionInfo(?string $branch = null, bool $refetch = false): array
+    public function getLatestVersionInfo(string $branch = null, bool $refetch = false): array
     {
         $branch ??= $this->getUpdateBranch();
         $branch = (in_array($branch, ['release', 'preview'])) ? $branch : 'release';
@@ -113,13 +112,13 @@ class Update implements InjectionAwareInterface
             $downloadUrl = 'https://fossbilling.org/downloads/preview/';
 
             return [
-                'version'       => Version::VERSION,
-                'download_url'  => $downloadUrl,
+                'version' => Version::VERSION,
+                'download_url' => $downloadUrl,
                 'release_notes' => "Release notes are not available for the preview branch. You can check the latest changes on our [GitHub]($compareLink) repository.",
-                'update_type'   => 0,
-                'last_check'    => time(),
-                'next_check'    => time() + 3600,
-                'branch'        => 'preview',
+                'update_type' => 0,
+                'last_check' => time(),
+                'next_check' => time() + 3600,
+                'branch' => 'preview',
             ];
         } else {
             $key = "Update.latest_{$branch}_version_info";
@@ -137,21 +136,23 @@ class Update implements InjectionAwareInterface
                     $httpClient = HttpClient::create();
                     $response = $httpClient->request('GET', $releaseInfoUrl);
                     $releases = $response->toArray();
-                } catch (TransportExceptionInterface | HttpExceptionInterface $e) {
+                } catch (TransportExceptionInterface|HttpExceptionInterface $e) {
                     error_log($e->getMessage());
+
                     throw new Exception('Failed to download the latest version information. Further details are available in the error log.');
                 }
 
                 $releaseInfo = $releases[0];
+
                 return [
-                    'version'       => $releaseInfo['tag_name'] ?: Version::VERSION,
-                    'download_url'  => $releaseInfo['assets'][0]['browser_download_url'],
-                    'release_date'  => $releaseInfo['published_at'],
+                    'version' => $releaseInfo['tag_name'] ?: Version::VERSION,
+                    'download_url' => $releaseInfo['assets'][0]['browser_download_url'],
+                    'release_date' => $releaseInfo['published_at'],
                     'release_notes' => $this->buildCompleteChangelog($releases) ?: '**Error: Release notes unavailable.**',
-                    'update_type'   => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
-                    'last_check'    => date('Y-m-d H:i:s'),
-                    'next_check'    => date('Y-m-d H:i:s', time() + 3600),
-                    'branch'        => $branch,
+                    'update_type' => Version::getUpdateType($releaseInfo['tag_name'] ?: Version::VERSION),
+                    'last_check' => date('Y-m-d H:i:s'),
+                    'next_check' => date('Y-m-d H:i:s', time() + 3600),
+                    'branch' => $branch,
                 ];
             });
         }
@@ -160,25 +161,24 @@ class Update implements InjectionAwareInterface
     /**
      * Check if an update is available for the current FOSSBilling version.
      *
-     * @return bool True if update is available, false if not.
+     * @return bool true if update is available, false if not
      */
     public function isUpdateAvailable(): bool
     {
         $version = $this->getLatestVersion();
         $result = Version::compareVersion($version);
-        $result = (Version::isPreviewVersion() && $this->getUpdateBranch() === "release") ? 1 : $result;
-        return ($result > 0);
+        $result = (Version::isPreviewVersion() && $this->getUpdateBranch() === 'release') ? 1 : $result;
+
+        return $result > 0;
     }
 
     /**
      * Perform manual update - apply patches and update config.
-     *
-     * @return void
      */
     public function performManualUpdate(): void
     {
         // Apply system patches and migrate configuration file.
-        $patcher = new UpdatePatcher;
+        $patcher = new UpdatePatcher();
         $patcher->setDi($this->di);
         $patcher->applyCorePatches();
         $patcher->applyConfigPatches();
@@ -187,11 +187,9 @@ class Update implements InjectionAwareInterface
     /**
      * Perform system update.
      *
-     * @throws InformationException if latest version already installed.
-     * @throws Exception if unable to download the update archive.
-     * @throws Exception if unable to extract the update archive.
-     *
-     * @return void
+     * @throws InformationException if latest version already installed
+     * @throws Exception            if unable to download the update archive
+     * @throws Exception            if unable to extract the update archive
      */
     public function performUpdate(): void
     {
@@ -208,7 +206,7 @@ class Update implements InjectionAwareInterface
         try {
             $httpClient = HttpClient::create([
                 'timeout' => 30,
-                'max_duration' => 120
+                'max_duration' => 120,
             ]);
             $response = $httpClient->request('GET', $this->getLatestVersionInfo($updateBranch)['download_url']);
 
@@ -217,8 +215,9 @@ class Update implements InjectionAwareInterface
                 fwrite($fileHandler, $chunk->getContent());
             }
             fclose($fileHandler);
-        } catch (TransportExceptionInterface | HttpExceptionInterface $e) {
+        } catch (TransportExceptionInterface|HttpExceptionInterface $e) {
             error_log($e->getMessage());
+
             throw new Exception('Failed to download the update archive. Further details are available in the error log.');
         }
 
@@ -232,11 +231,12 @@ class Update implements InjectionAwareInterface
             $zip->close();
         } catch (ZipException $e) {
             error_log($e->getMessage());
+
             throw new Exception('Failed to extract file, please check file and folder permissions. Further details are available in the error log.');
         }
 
         // Apply system patches and migrate configuration file.
-        $patcher = new UpdatePatcher;
+        $patcher = new UpdatePatcher();
         $patcher->setDi($this->di);
         $patcher->applyCorePatches();
 
@@ -250,7 +250,8 @@ class Update implements InjectionAwareInterface
             $filesystem->mkdir(PATH_CACHE, 0777);
         } catch (IOException $e) {
             error_log($e->getMessage());
-            throw new Exception("Unable to clear cache and/or remove install folder. Further details are available in the error log.");
+
+            throw new Exception('Unable to clear cache and/or remove install folder. Further details are available in the error log.');
         }
 
         // Log off the current user and destroy the session.

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Ramsey\Uuid\Uuid;
 
 class UpdatePatcher implements InjectionAwareInterface
 {
@@ -33,8 +33,6 @@ class UpdatePatcher implements InjectionAwareInterface
 
     /**
      * Apply configuration file patches.
-     *
-     * @return void
      */
     public function applyConfigPatches(): void
     {
@@ -49,7 +47,7 @@ class UpdatePatcher implements InjectionAwareInterface
         // Create backup of current configuration.
         try {
             $filesystem->copy(PATH_CONFIG, substr(PATH_CONFIG, 0, -4) . '.old.php');
-        } catch (FileNotFoundException | IOException) {
+        } catch (FileNotFoundException|IOException) {
             throw new Exception('Unable to create backup of configuration file');
         }
 
@@ -111,8 +109,6 @@ class UpdatePatcher implements InjectionAwareInterface
 
     /**
      * Apply all relevant patches to current FOSSBilling instance.
-     *
-     * @return void
      */
     public function applyCorePatches(): void
     {
@@ -131,8 +127,6 @@ class UpdatePatcher implements InjectionAwareInterface
      *
      * @param array $files Array containing files and directories to perform action on and
      *                     the actions to perform. Valid options are 'rename' and 'unlink'.
-     *
-     * @return void
      */
     private function executeFileActions(array $files): void
     {
@@ -154,18 +148,18 @@ class UpdatePatcher implements InjectionAwareInterface
     /**
      * Execute the given SQL statement.
      *
-     * @param $sql The SQL statement to execute.
-     *
-     * @return void
+     * @param $sql The SQL statement to execute
      */
     private function executeSql($sql): void
     {
         $statement = $this->di['pdo']->prepare($sql);
+
         try {
             $statement->execute();
         } catch (\Exception $e) {
             // Log the error and then throw a user-friendly exception to prevent further patches from being applied.
             error_log($e->getMessage());
+
             throw new Exception('There was an error while applying database patches. Please check the error log for information on the error, correct it, and then perform the backup patching method to complete the update.');
         }
     }
@@ -173,7 +167,7 @@ class UpdatePatcher implements InjectionAwareInterface
     /**
      * Get the current patch level of FOSSBilling.
      *
-     * @return int|null The current patch level.
+     * @return int|null the current patch level
      */
     private function getPatchLevel(): int|null
     {
@@ -181,6 +175,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $sqlStatement = $this->di['pdo']->prepare($sql);
         $sqlStatement->execute(['param' => 'last_patch']);
         $result = $sqlStatement->fetchColumn();
+
         return intval($result) ?: null;
     }
 
@@ -188,8 +183,6 @@ class UpdatePatcher implements InjectionAwareInterface
      * Set the current patch level of FOSSBilling.
      *
      * @param int $patchLevel The last executed patch level
-     *
-     * @return void
      */
     private function setPatchLevel(int $patchLevel): void
     {
@@ -207,9 +200,9 @@ class UpdatePatcher implements InjectionAwareInterface
     /**
      * Get patches to be applied.
      *
-     * @param int|null $patchLevel The current patch level of FOSSBilling.
+     * @param int|null $patchLevel the current patch level of FOSSBilling
      *
-     * @return array Array containing the patches to be executed, in order.
+     * @return array array containing the patches to be executed, in order
      */
     private function getPatches($patchLevel = 0): array
     {
@@ -229,7 +222,7 @@ class UpdatePatcher implements InjectionAwareInterface
             },
             27 => function () {
                 // Migration steps to create table to allow admin users to do password reset.
-                $q = "CREATE TABLE `admin_password_reset` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `admin_id` bigint(20) DEFAULT NULL, `hash` varchar(100) DEFAULT NULL, `ip` varchar(45) DEFAULT NULL, `created_at` datetime DEFAULT NULL, `updated_at` datetime DEFAULT NULL, PRIMARY KEY (`id`), KEY `admin_id_idx` (`admin_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
+                $q = 'CREATE TABLE `admin_password_reset` ( `id` bigint(20) NOT NULL AUTO_INCREMENT, `admin_id` bigint(20) DEFAULT NULL, `hash` varchar(100) DEFAULT NULL, `ip` varchar(45) DEFAULT NULL, `created_at` datetime DEFAULT NULL, `updated_at` datetime DEFAULT NULL, PRIMARY KEY (`id`), KEY `admin_id_idx` (`admin_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8;';
                 $this->executeSql($q);
             },
             28 => function () {
@@ -299,12 +292,12 @@ class UpdatePatcher implements InjectionAwareInterface
             },
             34 => function () {
                 // Adds the new "fingerprint" to the session table, to allow us to fingerprint devices and help prevent against attacks such as session hijacking.
-                $q = "ALTER TABLE session ADD fingerprint TEXT;";
+                $q = 'ALTER TABLE session ADD fingerprint TEXT;';
                 $this->executeSql($q);
             },
             35 => function () {
                 // Adds the new "created_at" to the session table, to ensure sessions are destroyed after they reach their maximum age.
-                $q = "ALTER TABLE session ADD created_at int(11);";
+                $q = 'ALTER TABLE session ADD created_at int(11);';
                 $this->executeSql($q);
             },
             36 => function () {
@@ -312,7 +305,7 @@ class UpdatePatcher implements InjectionAwareInterface
                 // @see https://github.com/FOSSBilling/FOSSBilling/pull/1180
 
                 // Renames the "kb_article" and "kb_article_category" tables to "support_kb_article" and "support_kb_article_category", respectively.
-                $q = "RENAME TABLE kb_article TO support_kb_article, kb_article_category TO support_kb_article_category;";
+                $q = 'RENAME TABLE kb_article TO support_kb_article, kb_article_category TO support_kb_article_category;';
                 $this->executeSql($q);
 
                 // If the Kb extension is currently active, set enabled in Support settings.
@@ -362,12 +355,12 @@ class UpdatePatcher implements InjectionAwareInterface
             },
             39 => function () {
                 // The Serbian language was incorrectly placed into a folder named `srp` by Crowdin which is now corrected for via the locale repo and as such we need to delete the old directory.
-                // @see https://github.com/FOSSBilling/locale/issues/212 
+                // @see https://github.com/FOSSBilling/locale/issues/212
                 $fileActions = [
                     PATH_LANGS . DIRECTORY_SEPARATOR . 'srp' => 'unlink',
                 ];
                 $this->executeFileActions($fileActions);
-            }
+            },
         ];
         ksort($patches, SORT_NATURAL);
 

--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -1,8 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -27,44 +29,40 @@ class Validate
     /**
      * Check if second level domain (SLD) is valid.
      */
-    public function isSldValid(string $sld) : bool
+    public function isSldValid(string $sld): bool
     {
         // allow punnycode
-        if(str_starts_with($sld, 'xn--')) {
+        if (str_starts_with($sld, 'xn--')) {
             return true;
         }
 
-        if(preg_match('/^[a-z0-9]+[a-z0-9\-]*[a-z0-9]+$/i', $sld) && strlen($sld) < 64 && substr($sld, 2, 2) != '--') {
+        if (preg_match('/^[a-z0-9]+[a-z0-9\-]*[a-z0-9]+$/i', $sld) && strlen($sld) < 64 && substr($sld, 2, 2) != '--') {
             return true;
         } else {
             return false;
         }
     }
 
-    /**
-     *
-     *
-     */
-    public function isPasswordStrong($pwd) : bool
+    public function isPasswordStrong($pwd): bool
     {
-        if( strlen($pwd) < 8 ) {
-            throw new InformationException("Minimum password length is 8 characters.");
+        if (strlen($pwd) < 8) {
+            throw new InformationException('Minimum password length is 8 characters.');
         }
 
-        if( strlen($pwd) > 256 ) {
-            throw new InformationException("Maximum password length is 256 characters.");
+        if (strlen($pwd) > 256) {
+            throw new InformationException('Maximum password length is 256 characters.');
         }
 
-        if( !preg_match("#[0-9]+#", $pwd) ) {
-            throw new InformationException("Password must include at least one number.");
+        if (!preg_match('#[0-9]+#', $pwd)) {
+            throw new InformationException('Password must include at least one number.');
         }
 
-        if( !preg_match("#[a-z]+#", $pwd) ) {
-            throw new InformationException("Password must include at least one lowercase letter.");
+        if (!preg_match('#[a-z]+#', $pwd)) {
+            throw new InformationException('Password must include at least one lowercase letter.');
         }
 
-        if( !preg_match("#[A-Z]+#", $pwd) ) {
-            throw new InformationException("Password must include at least one uppercase letter.");
+        if (!preg_match('#[A-Z]+#', $pwd)) {
+            throw new InformationException('Password must include at least one uppercase letter.');
         }
 
         /*
@@ -76,26 +74,25 @@ class Validate
     }
 
     /**
-     * @param array $required - Array with required keys and messages to show if the key is not found
-     * @param array $data - Array to search for keys
+     * @param array $required  - Array with required keys and messages to show if the key is not found
+     * @param array $data      - Array to search for keys
      * @param array $variables - Array of variables for message placeholders (:placeholder)
-     * @param integer $code - Exception code
-     * 
+     * @param int   $code      - Exception code
+     *
      * @throws InformationException
      */
-    public function checkRequiredParamsForArray(array $required, array $data, array $variables = NULL, $code = 0)
+    public function checkRequiredParamsForArray(array $required, array $data, array $variables = null, $code = 0)
     {
         foreach ($required as $key => $msg) {
-
-            if(!isset($data[$key])){
+            if (!isset($data[$key])) {
                 throw new InformationException($msg, $variables, $code);
             }
 
-            if (is_string($data[$key]) && strlen(trim($data[$key])) === 0){
+            if (is_string($data[$key]) && strlen(trim($data[$key])) === 0) {
                 throw new InformationException($msg, $variables, $code);
             }
 
-            if (!is_numeric($data[$key]) && empty($data[$key])){
+            if (!is_numeric($data[$key]) && empty($data[$key])) {
                 throw new InformationException($msg, $variables, $code);
             }
         }
@@ -105,8 +102,10 @@ class Validate
     {
         if (strlen(trim($birthday)) > 0 && strtotime($birthday) === false) {
             $friendlyName = ucfirst(__trans('Birthdate'));
+
             throw new Exception(':friendlyName: is invalid', [':friendlyName:' => $friendlyName]);
         }
+
         return true;
     }
 }

--- a/src/library/FOSSBilling/Version.php
+++ b/src/library/FOSSBilling/Version.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -24,11 +24,11 @@ final class Version
      * Compare the specified FOSSBilling version string $version
      * with the current \FOSSBilling\Version::VERSION of FOSSBilling.
      *
-     * @param   string  $version  A version string (e.g. "0.7.1").
-     * @return  integer           -1 if the $version is older,
-     *                            0 if they are the same,
-     *                            and +1 if $version is newer.
+     * @param string $version A version string (e.g. "0.7.1").
      *
+     * @return int -1 if the $version is older,
+     *             0 if they are the same,
+     *             and +1 if $version is newer
      */
     public static function compareVersion(string $version): int
     {
@@ -37,12 +37,13 @@ final class Version
 
     /**
      * Used to compare two different FOSSBilling versions to determine if updating between them is considered a major, minor, or a patch update.
-     * 
-     * @param string $new The new FOSSBilling version to compare against
-     * @param null|string $current (optional) Defaults to the current version, however you can override it if you wanted / needed
-     * @return int 0-2 to indicate the type of update.
+     *
+     * @param string      $new     The new FOSSBilling version to compare against
+     * @param string|null $current (optional) Defaults to the current version, however you can override it if you wanted / needed
+     *
+     * @return int 0-2 to indicate the type of update
      */
-    public static function getUpdateType(string $new, ?string $current = null): int
+    public static function getUpdateType(string $new, string $current = null): int
     {
         // Report patch as a dummy value as we can't properly compare version numbers when the current version is a preview build
         if (self::isPreviewVersion()) {
@@ -73,6 +74,6 @@ final class Version
 
     public static function isPreviewVersion(): bool
     {
-        return (preg_match(self::semverRegex, \FOSSBilling\Version::VERSION, $matches) !== 0) ? false : true;
+        return (preg_match(self::semverRegex, Version::VERSION, $matches) !== 0) ? false : true;
     }
 }

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -17,16 +17,16 @@ class i18n
     /**
      * Attempts to get the correct locale for the current user, or a suitable fallback option if it's unavailable.
      *
-     * @param bool $autoDetect Indicates if the user's Accept-Language header should be used to select the correct locale for them.
+     * @param bool $autoDetect indicates if the user's Accept-Language header should be used to select the correct locale for them
      *
-     * @return string The locale code to use for the system.
+     * @return string the locale code to use for the system
      */
     public static function getActiveLocale(bool $autoDetect = true): string
     {
         $config = include PATH_CONFIG;
         $locale = null;
 
-        /**
+        /*
          * If the locale cookie is set and it's one of the enabled locales, use that.
          * Otherwise, fallback to auto-detection when enable.
          */
@@ -47,11 +47,12 @@ class i18n
     /**
      * Retrieves the user's preferred language/locale based on the browser's Accept-Language header.
      *
-     * @return string|null The user's preferred language/locale or null if not found.
+     * @return string|null the user's preferred language/locale or null if not found
      */
     private static function getBrowserLocale(): ?string
     {
         $header = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
+
         try {
             $detectedLocale = @\Locale::acceptFromHttp($header);
             $detectedLocale = @\Locale::canonicalize($detectedLocale . '.utf8');
@@ -81,15 +82,16 @@ class i18n
             foreach (self::getLocales() as $locale) {
                 if (str_starts_with($locale, substr($detectedLocale, 0, 2))) {
                     if (!headers_sent()) {
-                        setcookie("BBLANG", $locale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+                        setcookie('BBLANG', $locale, ['expires' => strtotime('+1 month'), 'path' => '/']);
                     }
+
                     return $locale;
                 }
             }
         }
 
         if (!headers_sent()) {
-            setcookie("BBLANG", $matchingLocale, ['expires' => strtotime("+1 month"), 'path' => "/"]);
+            setcookie('BBLANG', $matchingLocale, ['expires' => strtotime('+1 month'), 'path' => '/']);
         }
 
         return $matchingLocale;
@@ -99,14 +101,13 @@ class i18n
      * Retrieve a list of available locales, optionally including their details.
      *
      * @param bool $includeLocaleDetails (optional) Whether to include locale details or not. Defaults to false.
-     *
-     * @param bool $disabled Set to true if you want it to return a list of the disabled locales, defaults to false which will return the enabled locales.
+     * @param bool $disabled             set to true if you want it to return a list of the disabled locales, defaults to false which will return the enabled locales
      *
      * @return array An array of locales, sorted alphabetically. If `$includeLocaleDetails` is true, the array will contain
      *               subarrays with the following keys: `locale` (string), `title` (string), `name` (string).
      *               If `$includeLocaleDetails` is false, the array will only contain the locale codes (strings).
      */
-    public static function getLocales(bool $includeLocaleDetails  = false, bool $disabled = false): array
+    public static function getLocales(bool $includeLocaleDetails = false, bool $disabled = false): array
     {
         $locales = self::getLocaleList($disabled);
         if (!$includeLocaleDetails) {
@@ -122,6 +123,7 @@ class i18n
                 'name' => $array[$locale] ?? $locale,
             ];
         }
+
         return $details;
     }
 
@@ -148,6 +150,7 @@ class i18n
             return unlink($disablePath);
         } else {
             file_put_contents($disablePath, '');
+
             return file_exists($disablePath);
         }
     }
@@ -158,7 +161,7 @@ class i18n
      *
      * @param string $locale The locale ID (Example: `en_US`)
      *
-     * @return int The percentage complete for the specified locale.
+     * @return int the percentage complete for the specified locale
      */
     public static function getLocaleCompletionPercent(string $locale): int
     {
@@ -172,6 +175,7 @@ class i18n
         }
 
         $completion = include $completionFile;
+
         return intval($completion[$locale] ?? 0);
     }
 
@@ -180,7 +184,7 @@ class i18n
      *
      * @param bool $disabled Set to true to get the list of disabled locales. True returns the list of enabled locales.
      *
-     * @return array The list of locale codes, sorted alphabetically.
+     * @return array the list of locale codes, sorted alphabetically
      */
     private static function getLocaleList(bool $disabled = false): array
     {

--- a/src/library/Model/ActivityAdminHistory.php
+++ b/src/library/Model/ActivityAdminHistory.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ActivityAdminHistory extends \RedBeanPHP\SimpleModel
+class Model_ActivityAdminHistory extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ActivityClientEmail.php
+++ b/src/library/Model/ActivityClientEmail.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ActivityClientEmail extends \RedBeanPHP\SimpleModel
+class Model_ActivityClientEmail extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ActivityClientHistory.php
+++ b/src/library/Model/ActivityClientHistory.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ActivityClientHistory extends \RedBeanPHP\SimpleModel
+class Model_ActivityClientHistory extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ActivityClientHistoryTable.php
+++ b/src/library/Model/ActivityClientHistoryTable.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ActivityClientHistoryTable implements \FOSSBilling\InjectionAwareInterface
+class Model_ActivityClientHistoryTable implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -27,8 +26,8 @@ class Model_ActivityClientHistoryTable implements \FOSSBilling\InjectionAwareInt
      */
     public function logEvent($data)
     {
-        if(!isset($data['client_id']) || !isset($data['ip'])) {
-            return ;
+        if (!isset($data['client_id']) || !isset($data['ip'])) {
+            return;
         }
 
         $extensionService = $this->di['mod_service']('extension');
@@ -39,19 +38,18 @@ class Model_ActivityClientHistoryTable implements \FOSSBilling\InjectionAwareInt
         }
 
         $entry = $this->di['db']->dispense('ActivityClientHistory');
-        $entry->client_id       = $data['client_id'];
-        $entry->ip              = $ip;
-        $entry->created_at      = date('Y-m-d H:i:s');
-        $entry->updated_at      = date('Y-m-d H:i:s');
+        $entry->client_id = $data['client_id'];
+        $entry->ip = $ip;
+        $entry->created_at = date('Y-m-d H:i:s');
+        $entry->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($entry);
     }
 
     public function rmByClient(Model_Client $client)
     {
-        $models = $this->di['db']->find('ActivityClientHistory', 'client_id = ?', array($client->id));
-        foreach($models as $model){
+        $models = $this->di['db']->find('ActivityClientHistory', 'client_id = ?', [$client->id]);
+        foreach ($models as $model) {
             $this->di['db']->trash($model);
         }
     }
-
 }

--- a/src/library/Model/ActivitySystem.php
+++ b/src/library/Model/ActivitySystem.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ActivitySystem extends \RedBeanPHP\SimpleModel
+class Model_ActivitySystem extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Admin.php
+++ b/src/library/Model/Admin.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Admin extends \RedBeanPHP\SimpleModel
+class Model_Admin extends RedBeanPHP\SimpleModel
 {
     final public const ROLE_ADMIN = 'admin';
     final public const ROLE_STAFF = 'staff';
@@ -24,13 +23,14 @@ class Model_Admin extends \RedBeanPHP\SimpleModel
 
     public function getStatus($status = '')
     {
-        $statusArray = array(
+        $statusArray = [
             self::STATUS_ACTIVE,
-            self::STATUS_INACTIVE
-        );
-        if (in_array($status, $statusArray)){
+            self::STATUS_INACTIVE,
+        ];
+        if (in_array($status, $statusArray)) {
             return strtolower($status);
         }
+
         return self::STATUS_INACTIVE;
     }
 }

--- a/src/library/Model/AdminGroup.php
+++ b/src/library/Model/AdminGroup.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_AdminGroup extends \RedBeanPHP\SimpleModel
+class Model_AdminGroup extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/AdminPasswordReset.php
+++ b/src/library/Model/AdminPasswordReset.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_AdminPasswordReset extends \RedBeanPHP\SimpleModel
+class Model_AdminPasswordReset extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ApiRequest.php
+++ b/src/library/Model/ApiRequest.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ApiRequest extends \RedBeanPHP\SimpleModel
+class Model_ApiRequest extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ApiRequestTable.php
+++ b/src/library/Model/ApiRequestTable.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ApiRequestTable implements \FOSSBilling\InjectionAwareInterface
+class Model_ApiRequestTable implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -38,9 +37,9 @@ class Model_ApiRequestTable implements \FOSSBilling\InjectionAwareInterface
         $sql = 'SELECT count(id) as cc
                 WHERE created_at > :since';
 
-        $params = array(':since' => $sinceIso);
+        $params = [':since' => $sinceIso];
 
-        if(NULL !== $ip) {
+        if ($ip !== null) {
             $sql .= ' AND ip = :ip';
             $params[':ip'] = $ip;
         }

--- a/src/library/Model/Cart.php
+++ b/src/library/Model/Cart.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Cart extends \RedBeanPHP\SimpleModel
+class Model_Cart extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/CartProduct.php
+++ b/src/library/Model/CartProduct.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_CartProduct extends \RedBeanPHP\SimpleModel
+class Model_CartProduct extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Client.php
+++ b/src/library/Model/Client.php
@@ -2,20 +2,19 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Client extends \RedBeanPHP\SimpleModel
+class Model_Client extends RedBeanPHP\SimpleModel
 {
-    final public const ACTIVE                    = 'active';
-    final public const SUSPENDED                 = 'suspended';
-    final public const CANCELED                  = 'canceled';
+    final public const ACTIVE = 'active';
+    final public const SUSPENDED = 'suspended';
+    final public const CANCELED = 'canceled';
 
     public function getFullName()
     {
-        return $this->first_name .' '.$this->last_name;
+        return $this->first_name . ' ' . $this->last_name;
     }
 }

--- a/src/library/Model/ClientBalance.php
+++ b/src/library/Model/ClientBalance.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientBalance extends \RedBeanPHP\SimpleModel
+class Model_ClientBalance extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ClientGroup.php
+++ b/src/library/Model/ClientGroup.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientGroup extends \RedBeanPHP\SimpleModel
+class Model_ClientGroup extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ClientOrder.php
+++ b/src/library/Model/ClientOrder.php
@@ -2,27 +2,26 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientOrder extends \RedBeanPHP\SimpleModel
+class Model_ClientOrder extends RedBeanPHP\SimpleModel
 {
-	final public const STATUS_PENDING_SETUP = "pending_setup";
-	final public const STATUS_FAILED_SETUP = "failed_setup";
-    final public const STATUS_FAILED_RENEW = "failed_renew";
-	final public const STATUS_ACTIVE = "active";
-	final public const STATUS_CANCELED = "canceled";
-	final public const STATUS_SUSPENDED = "suspended";
+    final public const STATUS_PENDING_SETUP = 'pending_setup';
+    final public const STATUS_FAILED_SETUP = 'failed_setup';
+    final public const STATUS_FAILED_RENEW = 'failed_renew';
+    final public const STATUS_ACTIVE = 'active';
+    final public const STATUS_CANCELED = 'canceled';
+    final public const STATUS_SUSPENDED = 'suspended';
 
-    final public const ACTION_CREATE     = 'create';
-    final public const ACTION_ACTIVATE   = 'activate';
-    final public const ACTION_RENEW      = 'renew';
-    final public const ACTION_SUSPEND    = 'suspend';
-    final public const ACTION_UNSUSPEND  = 'unsuspend';
-    final public const ACTION_CANCEL     = 'cancel';
-    final public const ACTION_UNCANCEL   = 'uncancel';
-    final public const ACTION_DELETE     = 'delete';
+    final public const ACTION_CREATE = 'create';
+    final public const ACTION_ACTIVATE = 'activate';
+    final public const ACTION_RENEW = 'renew';
+    final public const ACTION_SUSPEND = 'suspend';
+    final public const ACTION_UNSUSPEND = 'unsuspend';
+    final public const ACTION_CANCEL = 'cancel';
+    final public const ACTION_UNCANCEL = 'uncancel';
+    final public const ACTION_DELETE = 'delete';
 }

--- a/src/library/Model/ClientOrderMeta.php
+++ b/src/library/Model/ClientOrderMeta.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientOrderMeta extends \RedBeanPHP\SimpleModel
+class Model_ClientOrderMeta extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ClientOrderStatus.php
+++ b/src/library/Model/ClientOrderStatus.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientOrderStatus extends \RedBeanPHP\SimpleModel
+class Model_ClientOrderStatus extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ClientPasswordReset.php
+++ b/src/library/Model/ClientPasswordReset.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientPasswordReset extends \RedBeanPHP\SimpleModel
+class Model_ClientPasswordReset extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ClientPasswordResetTable.php
+++ b/src/library/Model/ClientPasswordResetTable.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ClientPasswordResetTable implements \FOSSBilling\InjectionAwareInterface
+class Model_ClientPasswordResetTable implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -25,15 +24,15 @@ class Model_ClientPasswordResetTable implements \FOSSBilling\InjectionAwareInter
     public function generate(Model_Client $client, $ip)
     {
         $r = $this->di['db']->findOne('ClientPasswordReset', 'client_id', $client->id);
-        if(!$r instanceof Model_ClientPasswordReset) {
+        if (!$r instanceof Model_ClientPasswordReset) {
             $r = $this->di['db']->dispense('ClientPasswordReset');
-            $r->created_at  = date('Y-m-d H:i:s');
-            $r->client_id   = $client->id;
+            $r->created_at = date('Y-m-d H:i:s');
+            $r->client_id = $client->id;
         }
 
-        $r->ip          = $ip;
-        $r->hash        = hash('sha256', random_int(50, random_int(10, 99)));
-        $r->updated_at  = date('Y-m-d H:i:s');
+        $r->ip = $ip;
+        $r->hash = hash('sha256', random_int(50, random_int(10, 99)));
+        $r->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($r);
 
         return $r;
@@ -41,10 +40,9 @@ class Model_ClientPasswordResetTable implements \FOSSBilling\InjectionAwareInter
 
     public function rmByClient(Model_Client $client)
     {
-        $models = $this->di['db']->find('ClientPasswordReset', 'client_id = ?', array($client->id));
-        foreach($models as $model){
+        $models = $this->di['db']->find('ClientPasswordReset', 'client_id = ?', [$client->id]);
+        foreach ($models as $model) {
             $this->di['db']->trash($model);
         }
     }
-
 }

--- a/src/library/Model/Currency.php
+++ b/src/library/Model/Currency.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Currency extends \RedBeanPHP\SimpleModel
+class Model_Currency extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/EmailTemplate.php
+++ b/src/library/Model/EmailTemplate.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_EmailTemplate extends \RedBeanPHP\SimpleModel
+class Model_EmailTemplate extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Extension.php
+++ b/src/library/Model/Extension.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Extension extends \RedBeanPHP\SimpleModel
+class Model_Extension extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ExtensionMeta.php
+++ b/src/library/Model/ExtensionMeta.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ExtensionMeta extends \RedBeanPHP\SimpleModel
+class Model_ExtensionMeta extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Form.php
+++ b/src/library/Model/Form.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Form extends \RedBeanPHP\SimpleModel
+class Model_Form extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/FormField.php
+++ b/src/library/Model/FormField.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_FormField extends \RedBeanPHP\SimpleModel
+class Model_FormField extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Guest.php
+++ b/src/library/Model/Guest.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Model_Guest
 {
-
 }

--- a/src/library/Model/Invoice.php
+++ b/src/library/Model/Invoice.php
@@ -2,15 +2,14 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Invoice extends \RedBeanPHP\SimpleModel
+class Model_Invoice extends RedBeanPHP\SimpleModel
 {
-    final public const STATUS_PAID   = 'paid';
+    final public const STATUS_PAID = 'paid';
     final public const STATUS_UNPAID = 'unpaid';
     final public const STATUS_REFUNDED = 'refunded';
     final public const STATUS_CANCELED = 'canceled';

--- a/src/library/Model/InvoiceItem.php
+++ b/src/library/Model/InvoiceItem.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_InvoiceItem extends \RedBeanPHP\SimpleModel
+class Model_InvoiceItem extends RedBeanPHP\SimpleModel
 {
-    final public const TYPE_DEPOSIT  = 'deposit'; // this type of item can not be charged with credits
-    final public const TYPE_CUSTOM   = 'custom';
-    final public const TYPE_ORDER    = 'order';
-    final public const TYPE_HOOK_CALL= 'hook_call';
+    final public const TYPE_DEPOSIT = 'deposit'; // this type of item can not be charged with credits
+    final public const TYPE_CUSTOM = 'custom';
+    final public const TYPE_ORDER = 'order';
+    final public const TYPE_HOOK_CALL = 'hook_call';
 
-    final public const TASK_VOID     = 'void';
+    final public const TASK_VOID = 'void';
     final public const TASK_ACTIVATE = 'activate';
-    final public const TASK_RENEW    = 'renew';
+    final public const TASK_RENEW = 'renew';
 
     final public const STATUS_PENDING_PAYMENT = 'pending_payment';
     final public const STATUS_PENDING_SETUP = 'pending_setup';

--- a/src/library/Model/MassmailerMessage.php
+++ b/src/library/Model/MassmailerMessage.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_MassmailerMessage extends \RedBeanPHP\SimpleModel
+class Model_MassmailerMessage extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/ModEmailQueue.php
+++ b/src/library/Model/ModEmailQueue.php
@@ -2,17 +2,15 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-
 /**
- * Class Model_ModEmailQueue
+ * Class Model_ModEmailQueue.
  */
-class Model_ModEmailQueue extends \RedBeanPHP\SimpleModel
+class Model_ModEmailQueue extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/PayGateway.php
+++ b/src/library/Model/PayGateway.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_PayGateway extends \RedBeanPHP\SimpleModel
+class Model_PayGateway extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Post.php
+++ b/src/library/Model/Post.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Post extends \RedBeanPHP\SimpleModel
+class Model_Post extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Product.php
+++ b/src/library/Model/Product.php
@@ -2,55 +2,55 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Product extends \RedBeanPHP\SimpleModel implements \FOSSBilling\InjectionAwareInterface
+class Model_Product extends RedBeanPHP\SimpleModel implements FOSSBilling\InjectionAwareInterface
 {
-    final public const STATUS_ENABLED    = 'enabled';
-    final public const STATUS_DISABLED   = 'disabled';
+    final public const STATUS_ENABLED = 'enabled';
+    final public const STATUS_DISABLED = 'disabled';
 
-    final public const CUSTOM            = 'custom';
-    final public const LICENSE           = 'license';
-    final public const ADDON             = 'addon';
-    final public const DOMAIN            = 'domain';
-    final public const DOWNLOADABLE      = 'downloadable';
-    final public const HOSTING           = 'hosting';
-    final public const MEMBERSHIP        = 'membership';
-    final public const VPS               = 'vps';
+    final public const CUSTOM = 'custom';
+    final public const LICENSE = 'license';
+    final public const ADDON = 'addon';
+    final public const DOMAIN = 'domain';
+    final public const DOWNLOADABLE = 'downloadable';
+    final public const HOSTING = 'hosting';
+    final public const MEMBERSHIP = 'membership';
+    final public const VPS = 'vps';
 
-    final public const SETUP_AFTER_ORDER     = 'after_order';
-    final public const SETUP_AFTER_PAYMENT   = 'after_payment';
-    final public const SETUP_MANUAL          = 'manual';
+    final public const SETUP_AFTER_ORDER = 'after_order';
+    final public const SETUP_AFTER_PAYMENT = 'after_payment';
+    final public const SETUP_MANUAL = 'manual';
 
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
 
     public function getTable()
     {
-        $tableName = 'Model_Product'. ucfirst($this->type). 'Table';
-        if(!class_exists($tableName)) {
+        $tableName = 'Model_Product' . ucfirst($this->type) . 'Table';
+        if (!class_exists($tableName)) {
             $tableName = 'Model_ProductTable';
         }
-        $productTable = new $tableName;
+        $productTable = new $tableName();
         $productTable->setDi($this->di);
+
         return $productTable;
     }
 
     public function getService()
     {
-        return $this->di['mod_service']('service'.$this->type);
+        return $this->di['mod_service']('service' . $this->type);
     }
 }

--- a/src/library/Model/ProductCategory.php
+++ b/src/library/Model/ProductCategory.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductCategory extends \RedBeanPHP\SimpleModel
+class Model_ProductCategory extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/ProductCustom.php
+++ b/src/library/Model/ProductCustom.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductCustom extends \RedBeanPHP\SimpleModel
+class Model_ProductCustom extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ProductDomain.php
+++ b/src/library/Model/ProductDomain.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Model_ProductDomain extends Model_Product
 {
-
 }

--- a/src/library/Model/ProductDomainTable.php
+++ b/src/library/Model/ProductDomainTable.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Model_ProductDomainTable extends Model_ProductTable
 {
     public function getUnit(Model_Product $model)
@@ -17,11 +16,12 @@ class Model_ProductDomainTable extends Model_ProductTable
 
     protected function getStartingFromPrice(Model_Product $model)
     {
-        $p = array();
+        $p = [];
         $prices = $this->getPricingArray($model);
         foreach ($prices as $tld) {
             $p[] = $tld['price_registration'];
         }
+
         return empty($p) ? 0 : min($p);
     }
 
@@ -31,28 +31,29 @@ class Model_ProductDomainTable extends Model_ProductTable
     }
 
     /**
-     * Determine discount for items in cart (Hosting and related domain discount)
-     * @param array $items Array of cart products
+     * Determine discount for items in cart (Hosting and related domain discount).
+     *
+     * @param array         $items   Array of cart products
      * @param Model_Product $product current product in iteration
-     * @param array $config configurations specified in product config
+     * @param array         $config  configurations specified in product config
+     *
      * @return number discount
-     * 
      */
     public function getRelatedDiscount(array $items, Model_Product $product, array $config)
     {
-        /**For each cart product, 
+        /**For each cart product,
          * Compare it with other items in the cart
          * If a domain has related hosting package, determine discount configured.
          */
         foreach ($items as $addon) {
-
             if (
-                $this->isActionNameSet($addon, 'register') &&
-                $this->_isFreeDomainSet($addon) &&
-                $this->registerDomainMatch($addon, $config)
+                $this->isActionNameSet($addon, 'register')
+                && $this->_isFreeDomainSet($addon)
+                && $this->registerDomainMatch($addon, $config)
             ) {
                 if ($this->_hasFreePeriod($addon)) {
-                    $factor = $this->discountFactor($addon, $config["period"]);
+                    $factor = $this->discountFactor($addon, $config['period']);
+
                     return $factor * $this->getProductPrice($product, $config);
                 } else {
                     return 0;
@@ -60,9 +61,9 @@ class Model_ProductDomainTable extends Model_ProductTable
             }
 
             if (
-                $this->isActionNameSet($addon, 'transfer') &&
-                $this->isFreeTransferSet($addon) &&
-                $this->transferDomainMatch($addon, $config)
+                $this->isActionNameSet($addon, 'transfer')
+                && $this->isFreeTransferSet($addon)
+                && $this->transferDomainMatch($addon, $config)
             ) {
                 return $this->getProductPrice($product, $config);
             }
@@ -73,8 +74,8 @@ class Model_ProductDomainTable extends Model_ProductTable
 
     private function _hasFreePeriod($addon)
     {
-        $free_domain_periods    = $addon['config']['free_domain_periods'];
-        $addon_period      = $addon['config']['period'];
+        $free_domain_periods = $addon['config']['free_domain_periods'];
+        $addon_period = $addon['config']['period'];
         if (in_array($addon_period, $free_domain_periods) || sizeof($free_domain_periods) > 0) {
             return true;
         } else {
@@ -82,32 +83,28 @@ class Model_ProductDomainTable extends Model_ProductTable
         }
     }
 
-
     /**
-     * Determine the number of years configured for free domain      
-     * 
+     * Determine the number of years configured for free domain.
      */
     private function discountFactor($addon, $period)
     {
         $ref_item_period = $this->di['period']($period);
         $ref_item_qty = $ref_item_period->getQty();
 
-        $addon_period      = $addon['config']['period'];
+        $addon_period = $addon['config']['period'];
         $addon_sys_period = $this->di['period']($addon_period);
         $addon_qty = $addon_sys_period->getQty();
 
-        $free_domain_periods    = $addon['config']['free_domain_periods'];
+        $free_domain_periods = $addon['config']['free_domain_periods'];
         if ((is_countable($free_domain_periods) ? count($free_domain_periods) : 0) > 0) {
             // if hosting and domain periods are equal, return domain quantity (year)
             if ($addon_period == $period) {
-
                 if (in_array($addon_period, $free_domain_periods)) {
                     return $ref_item_qty;
                 }
             }
 
             if (str_contains($addon_period, 'Y')) {
-
                 if (min($ref_item_qty, $addon_qty) == 1) {
                     return 1;
                 }
@@ -142,9 +139,9 @@ class Model_ProductDomainTable extends Model_ProductTable
 
     private function _isFreeDomainSet($item)
     {
-        $free_domain            = $item['config']['free_domain'] ?? false;
-        $tld                    = $item['config']['tld'] ?? null;
-        $free_tlds              = $item['config']['free_tlds'] ?? [];
+        $free_domain = $item['config']['free_domain'] ?? false;
+        $tld = $item['config']['tld'] ?? null;
+        $free_tlds = $item['config']['free_tlds'] ?? [];
 
         if ($tld != null && !$free_domain && is_array($free_tlds) && in_array($tld, $free_tlds)) {
             return true;
@@ -158,6 +155,7 @@ class Model_ProductDomainTable extends Model_ProductTable
         if (!isset($item['config']['domain']['register_sld'])) {
             return false;
         }
+
         return $item['config']['domain']['register_sld'] == $config['register_sld'] && $item['config']['domain']['register_tld'] == $config['register_tld'];
     }
 
@@ -166,6 +164,7 @@ class Model_ProductDomainTable extends Model_ProductTable
         if (!isset($item['config']['domain']['transfer_sld'])) {
             return false;
         }
+
         return $item['config']['domain']['transfer_sld'] == $config['transfer_sld'] && $item['config']['domain']['transfer_tld'] == $config['transfer_tld'];
     }
 
@@ -176,33 +175,33 @@ class Model_ProductDomainTable extends Model_ProductTable
 
     public function getPricingArray(Model_Product $product)
     {
-        $pricing = array();
+        $pricing = [];
 
-        $sql = "
+        $sql = '
             SELECT t.*, r.name
             FROM tld t
             LEFT JOIN tld_registrar r ON (r.id = t.tld_registrar_id)
             WHERE t.active = 1
             ORDER BY t.id ASC
-        ";
+        ';
         $stmt = $this->di['pdo']->prepare($sql);
         $stmt->execute();
 
         foreach ($stmt->fetchAll() as $tld) {
-            $pricing[$tld['tld']] = array(
-                'tld'                   => $tld['tld'],
-                'price_registration'    => $tld['price_registration'],
-                'price_renew'           => $tld['price_renew'],
-                'price_transfer'        => $tld['price_transfer'],
-                'active'                => $tld['active'],
-                'allow_register'        => $tld['allow_register'],
-                'allow_transfer'        => $tld['allow_transfer'],
-                'min_years'             => $tld['min_years'],
-                'registrar'             => array(
-                    'id'                =>  $tld['tld_registrar_id'],
-                    'title'             =>  $tld['name'],
-                ),
-            );
+            $pricing[$tld['tld']] = [
+                'tld' => $tld['tld'],
+                'price_registration' => $tld['price_registration'],
+                'price_renew' => $tld['price_renew'],
+                'price_transfer' => $tld['price_transfer'],
+                'active' => $tld['active'],
+                'allow_register' => $tld['allow_register'],
+                'allow_transfer' => $tld['allow_transfer'],
+                'min_years' => $tld['min_years'],
+                'registrar' => [
+                    'id' => $tld['tld_registrar_id'],
+                    'title' => $tld['name'],
+                ],
+            ];
         }
 
         return $pricing;
@@ -214,7 +213,7 @@ class Model_ProductDomainTable extends Model_ProductTable
         $tld = '';
 
         if (!isset($config['action'])) {
-            throw new \FOSSBilling\Exception('Could not determine domain price. Domain action is missing', null, 498);
+            throw new FOSSBilling\Exception('Could not determine domain price. Domain action is missing', null, 498);
         }
 
         if ($config['action'] == 'owndomain') {
@@ -231,7 +230,7 @@ class Model_ProductDomainTable extends Model_ProductTable
 
         $tld = $rtable->findOneByTld($tld);
         if (!$tld instanceof Model_Tld) {
-            throw new \FOSSBilling\Exception('Unknown TLD. Could not determine registration price');
+            throw new FOSSBilling\Exception('Unknown TLD. Could not determine registration price');
         }
 
         if ($config['action'] == 'register') {
@@ -252,6 +251,6 @@ class Model_ProductDomainTable extends Model_ProductTable
 
     public function rm(Model_Product $product): never
     {
-        throw new \FOSSBilling\Exception('Domain product can not be removed.');
+        throw new FOSSBilling\Exception('Domain product can not be removed.');
     }
 }

--- a/src/library/Model/ProductDownloadable.php
+++ b/src/library/Model/ProductDownloadable.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductDownloadable extends \RedBeanPHP\SimpleModel
+class Model_ProductDownloadable extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ProductHosting.php
+++ b/src/library/Model/ProductHosting.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductHosting extends \RedBeanPHP\SimpleModel
+class Model_ProductHosting extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ProductLicense.php
+++ b/src/library/Model/ProductLicense.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductLicense extends \RedBeanPHP\SimpleModel
+class Model_ProductLicense extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ProductMembership.php
+++ b/src/library/Model/ProductMembership.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductMembership extends \RedBeanPHP\SimpleModel
+class Model_ProductMembership extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ProductPayment.php
+++ b/src/library/Model/ProductPayment.php
@@ -2,15 +2,14 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductPayment extends \RedBeanPHP\SimpleModel
+class Model_ProductPayment extends RedBeanPHP\SimpleModel
 {
-    final public const FREE      = 'free';
-    final public const ONCE      = 'once';
+    final public const FREE = 'free';
+    final public const ONCE = 'once';
     final public const RECURRENT = 'recurrent';
 }

--- a/src/library/Model/ProductTable.php
+++ b/src/library/Model/ProductTable.php
@@ -2,35 +2,34 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
+class Model_ProductTable implements FOSSBilling\InjectionAwareInterface
 {
-    public const CUSTOM            = 'custom';
-    public const LICENSE           = 'license';
-    public const ADDON             = 'addon';
-    public const DOMAIN            = 'domain';
-    public const DOWNLOADABLE      = 'downloadable';
-    public const HOSTING           = 'hosting';
-    public const MEMBERSHIP        = 'membership';
-    public const VPS               = 'vps';
+    public const CUSTOM = 'custom';
+    public const LICENSE = 'license';
+    public const ADDON = 'addon';
+    public const DOMAIN = 'domain';
+    public const DOWNLOADABLE = 'downloadable';
+    public const HOSTING = 'hosting';
+    public const MEMBERSHIP = 'membership';
+    public const VPS = 'vps';
 
-    public const SETUP_AFTER_ORDER     = 'after_order';
-    public const SETUP_AFTER_PAYMENT   = 'after_payment';
-    public const SETUP_MANUAL          = 'manual';
+    public const SETUP_AFTER_ORDER = 'after_order';
+    public const SETUP_AFTER_PAYMENT = 'after_payment';
+    public const SETUP_MANUAL = 'manual';
 
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -46,18 +45,19 @@ class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
     private function _getPeriodKey(Box_Period $period)
     {
         $code = $period->getCode();
+
         try {
             return match ($code) {
-                '1W'  => 'w',
-                '1M'  => 'm',
-                '3M'  => 'q',
-                '6M'  => 'b',
+                '1W' => 'w',
+                '1M' => 'm',
+                '3M' => 'q',
+                '6M' => 'b',
                 '12M' => 'a',
-                '1Y'  => 'a',
-                '2Y'  => 'bia',
-                '3Y'  => 'tria'
+                '1Y' => 'a',
+                '2Y' => 'bia',
+                '3Y' => 'tria'
             };
-        } catch (\UnhandledMatchError) {
+        } catch (UnhandledMatchError) {
             throw new FOSSBilling\Exception('Unknown period selected ' . $code);
         }
     }
@@ -67,17 +67,16 @@ class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
         if ($model->product_payment_id) {
             $service = $this->di['mod_service']('product');
             $productPayment = $this->di['db']->load('ProductPayment', $model->product_payment_id);
+
             return $service->toProductPaymentApiArray($productPayment);
         }
 
-        throw new \FOSSBilling\Exception('Product pricing could not be determined. ' . static::class);
+        throw new FOSSBilling\Exception('Product pricing could not be determined. ' . static::class);
     }
 
     /**
-     * Price for one unit
+     * Price for one unit.
      *
-     * @param Model_Product $product
-     * @param array $config
      * @return float
      */
     public function getProductSetupPrice(Model_Product $product, array $config = null)
@@ -89,27 +88,25 @@ class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
         }
 
         if ($pp->type == Model_ProductPayment::ONCE) {
-            $price = (float)$pp->once_setup_price;
+            $price = (float) $pp->once_setup_price;
         }
 
         if ($pp->type == Model_ProductPayment::RECURRENT) {
             $period = new Box_Period($config['period']);
             $key = $this->_getPeriodKey($period);
-            $price = (float)$pp->{$key . '_setup_price'};
+            $price = (float) $pp->{$key . '_setup_price'};
         }
 
         if (isset($price)) {
             return $price;
         }
 
-        throw new \FOSSBilling\Exception('Unknown period selected for setup price');
+        throw new FOSSBilling\Exception('Unknown period selected for setup price');
     }
 
     /**
-     * Price for one unit
+     * Price for one unit.
      *
-     * @param Model_Product $product
-     * @param array $config
      * @return float
      */
     public function getProductPrice(Model_Product $product, array $config = null)
@@ -126,7 +123,7 @@ class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
 
         if ($pp->type == Model_ProductPayment::RECURRENT) {
             if (!isset($config['period'])) {
-                throw new \FOSSBilling\Exception('Product :id payment type is recurrent, but period was not selected', array(':id' => $product->id));
+                throw new FOSSBilling\Exception('Product :id payment type is recurrent, but period was not selected', [':id' => $product->id]);
             }
 
             $period = new Box_Period($config['period']);
@@ -138,6 +135,6 @@ class Model_ProductTable implements \FOSSBilling\InjectionAwareInterface
             return $price;
         }
 
-        throw new \FOSSBilling\Exception('Unknown Period selected for price');
+        throw new FOSSBilling\Exception('Unknown Period selected for price');
     }
 }

--- a/src/library/Model/Promo.php
+++ b/src/library/Model/Promo.php
@@ -2,14 +2,13 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Promo extends \RedBeanPHP\SimpleModel
+class Model_Promo extends RedBeanPHP\SimpleModel
 {
-	final public const PERCENTAGE    = 'percentage';
-	final public const ABSOLUTE      = 'absolute';
+    final public const PERCENTAGE = 'percentage';
+    final public const ABSOLUTE = 'absolute';
 }

--- a/src/library/Model/ServiceApiKey.php
+++ b/src/library/Model/ServiceApiKey.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceApiKey extends \RedBeanPHP\SimpleModel
+class Model_ServiceApiKey extends RedBeanPHP\SimpleModel
 {
     public int $id;
     public int $client_id;

--- a/src/library/Model/ServiceCustom.php
+++ b/src/library/Model/ServiceCustom.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceCustom extends \RedBeanPHP\SimpleModel
+class Model_ServiceCustom extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ServiceDomain.php
+++ b/src/library/Model/ServiceDomain.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceDomain extends \RedBeanPHP\SimpleModel
+class Model_ServiceDomain extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ServiceDownloadable.php
+++ b/src/library/Model/ServiceDownloadable.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceDownloadable extends \RedBeanPHP\SimpleModel
+class Model_ServiceDownloadable extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ServiceHosting.php
+++ b/src/library/Model/ServiceHosting.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceHosting extends \RedBeanPHP\SimpleModel
+class Model_ServiceHosting extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/ServiceHostingHp.php
+++ b/src/library/Model/ServiceHostingHp.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceHostingHp extends \RedBeanPHP\SimpleModel
+class Model_ServiceHostingHp extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ServiceHostingServer.php
+++ b/src/library/Model/ServiceHostingServer.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceHostingServer extends \RedBeanPHP\SimpleModel
+class Model_ServiceHostingServer extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/ServiceLicense.php
+++ b/src/library/Model/ServiceLicense.php
@@ -2,21 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceLicense extends \RedBeanPHP\SimpleModel
+class Model_ServiceLicense extends RedBeanPHP\SimpleModel
 {
     private function _decodeJson($j)
     {
-        if(isset($j)){
+        if (isset($j)) {
             $config = json_decode($j, true);
-            return is_array($config) ? $config : array();
+
+            return is_array($config) ? $config : [];
         } else {
-            return array();
+            return [];
         }
     }
 
@@ -39,5 +39,4 @@ class Model_ServiceLicense extends \RedBeanPHP\SimpleModel
     {
         return $this->_decodeJson($this->paths);
     }
-
 }

--- a/src/library/Model/ServiceMembership.php
+++ b/src/library/Model/ServiceMembership.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_ServiceMembership extends \RedBeanPHP\SimpleModel
+class Model_ServiceMembership extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Session.php
+++ b/src/library/Model/Session.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Session extends \RedBeanPHP\SimpleModel
+class Model_Session extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Setting.php
+++ b/src/library/Model/Setting.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Setting extends \RedBeanPHP\SimpleModel
+class Model_Setting extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Subscription.php
+++ b/src/library/Model/Subscription.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Subscription extends \RedBeanPHP\SimpleModel
+class Model_Subscription extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/SupportHelpdesk.php
+++ b/src/library/Model/SupportHelpdesk.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportHelpdesk extends \RedBeanPHP\SimpleModel
+class Model_SupportHelpdesk extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/SupportKbArticle.php
+++ b/src/library/Model/SupportKbArticle.php
@@ -2,14 +2,13 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportKbArticle extends \RedBeanPHP\SimpleModel
+class Model_SupportKbArticle extends RedBeanPHP\SimpleModel
 {
-    final public const ACTIVE    = 'active';
-    final public const DRAFT     = 'draft';
+    final public const ACTIVE = 'active';
+    final public const DRAFT = 'draft';
 }

--- a/src/library/Model/SupportKbArticleCategory.php
+++ b/src/library/Model/SupportKbArticleCategory.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportKbArticleCategory extends \RedBeanPHP\SimpleModel
+class Model_SupportKbArticleCategory extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/SupportPTicket.php
+++ b/src/library/Model/SupportPTicket.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportPTicket extends \RedBeanPHP\SimpleModel
+class Model_SupportPTicket extends RedBeanPHP\SimpleModel
 {
     final public const OPENED = 'open';
     final public const ONHOLD = 'on_hold';

--- a/src/library/Model/SupportPTicketMessage.php
+++ b/src/library/Model/SupportPTicketMessage.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportPTicketMessage extends \RedBeanPHP\SimpleModel
+class Model_SupportPTicketMessage extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/SupportPr.php
+++ b/src/library/Model/SupportPr.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportPr extends \RedBeanPHP\SimpleModel
+class Model_SupportPr extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/SupportPrCategory.php
+++ b/src/library/Model/SupportPrCategory.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportPrCategory extends \RedBeanPHP\SimpleModel
+class Model_SupportPrCategory extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/SupportTicket.php
+++ b/src/library/Model/SupportTicket.php
@@ -2,23 +2,22 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportTicket extends \RedBeanPHP\SimpleModel
+class Model_SupportTicket extends RedBeanPHP\SimpleModel
 {
     final public const OPENED = 'open';
     final public const ONHOLD = 'on_hold';
     final public const CLOSED = 'closed';
 
-    final public const REL_TYPE_ORDER   = 'order';
+    final public const REL_TYPE_ORDER = 'order';
 
-    final public const REL_STATUS_PENDING        = 'pending';
-    final public const REL_STATUS_COMPLETE       = 'complete';
+    final public const REL_STATUS_PENDING = 'pending';
+    final public const REL_STATUS_COMPLETE = 'complete';
 
-    final public const REL_TASK_CANCEL   = 'cancel';
-    final public const REL_TASK_UPGRADE  = 'upgrade';
+    final public const REL_TASK_CANCEL = 'cancel';
+    final public const REL_TASK_UPGRADE = 'upgrade';
 }

--- a/src/library/Model/SupportTicketMessage.php
+++ b/src/library/Model/SupportTicketMessage.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportTicketMessage extends \RedBeanPHP\SimpleModel
+class Model_SupportTicketMessage extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/SupportTicketNote.php
+++ b/src/library/Model/SupportTicketNote.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_SupportTicketNote extends \RedBeanPHP\SimpleModel
+class Model_SupportTicketNote extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Tax.php
+++ b/src/library/Model/Tax.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Tax extends \RedBeanPHP\SimpleModel
+class Model_Tax extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Tld.php
+++ b/src/library/Model/Tld.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Tld extends \RedBeanPHP\SimpleModel
+class Model_Tld extends RedBeanPHP\SimpleModel
 {
 }

--- a/src/library/Model/TldRegistrar.php
+++ b/src/library/Model/TldRegistrar.php
@@ -2,13 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_TldRegistrar extends \RedBeanPHP\SimpleModel
+class Model_TldRegistrar extends RedBeanPHP\SimpleModel
 {
-
 }

--- a/src/library/Model/Transaction.php
+++ b/src/library/Model/Transaction.php
@@ -2,16 +2,15 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Model_Transaction extends \RedBeanPHP\SimpleModel
+class Model_Transaction extends RedBeanPHP\SimpleModel
 {
-    final public const STATUS_RECEIVED        = 'received';
-    final public const STATUS_APPROVED        = 'approved';
-    final public const STATUS_PROCESSED       = 'processed';
-    final public const STATUS_ERROR           = 'error';
+    final public const STATUS_RECEIVED = 'received';
+    final public const STATUS_APPROVED = 'approved';
+    final public const STATUS_PROCESSED = 'processed';
+    final public const STATUS_ERROR = 'error';
 }

--- a/src/library/Payment/Adapter/ClientBalance.php
+++ b/src/library/Payment/Adapter/ClientBalance.php
@@ -2,43 +2,41 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterface
+class Payment_Adapter_ClientBalance implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
 
     public function __construct()
     {
-
     }
 
     public static function getConfig()
     {
-        return array(
-            'logo' => array(
+        return [
+            'logo' => [
                 'logo' => 'clientbalance.png',
                 'height' => '50px',
                 'width' => '50px',
-            ),
-        );
+            ],
+        ];
     }
 
-    public function enoughInBalanceToCoverInvoice(\Model_Invoice $invoice)
+    public function enoughInBalanceToCoverInvoice(Model_Invoice $invoice)
     {
         $clientModel = $this->di['db']->load('Client', $invoice->client_id);
         $clientBalanceService = $this->di['mod_service']('Client', 'Balance');
@@ -46,8 +44,10 @@ class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterf
 
         $invoiceService = $this->di['mod_service']('Invoice');
         $totalSumWithTaxes = $invoiceService->getTotalWithTax($invoice);
-        if ($totalSumWithTaxes > $sumInBalance)
+        if ($totalSumWithTaxes > $sumInBalance) {
             return false;
+        }
+
         return true;
     }
 
@@ -55,17 +55,17 @@ class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterf
     {
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
 
-        if (!$this->enoughInBalanceToCoverInvoice($invoiceModel)){
+        if (!$this->enoughInBalanceToCoverInvoice($invoiceModel)) {
             return __trans('Not enough in balance');
         }
 
         $invoiceService = $this->di['mod_service']('Invoice');
-        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
+        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)) {
             return __trans('It is forbidden to pay a deposit invoice with this gateway');
         }
 
         $ipnUrl = $this->getServiceUrl($invoice_id);
-        $invoiceUrl = $this->di['tools']->url('invoice/'.$invoiceModel->hash);
+        $invoiceUrl = $this->di['tools']->url('invoice/' . $invoiceModel->hash);
 
         $out = "<script type='text/javascript'>
                 $(document).ready(function(){
@@ -74,12 +74,13 @@ class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterf
                     });
                 });
                 </script>";
-       return $out;
+
+        return $out;
     }
 
     public function processTransaction($api_admin, $id, $data, $gateway_id)
     {
-        if(!$this->isIpnValid($data)) {
+        if (!$this->isIpnValid($data)) {
             throw new Payment_Exception('IPN is invalid');
         }
 
@@ -89,26 +90,27 @@ class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterf
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
 
         $invoiceService = $this->di['mod_service']('Invoice');
-        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
-            throw new Payment_Exception('It is forbidden to pay a deposit invoice with this gateway', array(), 303);
+        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)) {
+            throw new Payment_Exception('It is forbidden to pay a deposit invoice with this gateway', [], 303);
         }
 
-        if($invoice_id) {
+        if ($invoice_id) {
             $invoiceService->payInvoiceWithCredits($invoiceModel);
         }
-        $invoiceService->doBatchPayWithCredits(array('client_id' => $invoiceModel->client_id));
+        $invoiceService->doBatchPayWithCredits(['client_id' => $invoiceModel->client_id]);
 
         $tx->error = '';
         $tx->error_code = '';
         $tx->status = 'processed';
         $tx->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($tx);
+
         return true;
     }
 
     public function isIpnValid($data)
     {
-        /**
+        /*
          * @TODO do we need validation here? -_-
          */
         return true;
@@ -116,18 +118,19 @@ class Payment_Adapter_ClientBalance implements \FOSSBilling\InjectionAwareInterf
 
     public function getServiceUrl($invoice_id = 0)
     {
-        $gatewayModel = $this->di['db']->findOne('PayGateway', 'gateway = ? and enabled = 1', array('ClientBalance'));
-        if (!$gatewayModel instanceof \Model_PayGateway){
+        $gatewayModel = $this->di['db']->findOne('PayGateway', 'gateway = ? and enabled = 1', ['ClientBalance']);
+        if (!$gatewayModel instanceof Model_PayGateway) {
             throw new Payment_Exception('ClientBalance gateway is not enabled', null, 301);
         }
 
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
         $invoiceService = $this->di['mod_service']('Invoice');
-        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)){
+        if ($invoiceService->isInvoiceTypeDeposit($invoiceModel)) {
             throw new Payment_Exception('It is forbidden to pay a deposit invoice with this gateway', null, 302);
         }
 
         $gatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
+
         return $gatewayService->getCallbackUrl($gatewayModel, $invoiceModel);
     }
 }

--- a/src/library/Payment/Adapter/Custom.php
+++ b/src/library/Payment/Adapter/Custom.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Adapter_Custom
 {
     protected ?\Pimple\Container $di = null;
@@ -16,69 +15,70 @@ class Payment_Adapter_Custom
     {
     }
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
     public static function getConfig()
     {
-        return array(
-            'can_load_in_iframe'   =>  true,
-            'supports_one_time_payments'   =>  true,
-            'supports_subscriptions'       =>  true,
-            'description'     =>  'Custom payment gateway allows you to give instructions how can your client pay invoice. All system, client, order and invoice details can be printed. HTML and JavaScript code is supported.',
-            'logo' => array(
+        return [
+            'can_load_in_iframe' => true,
+            'supports_one_time_payments' => true,
+            'supports_subscriptions' => true,
+            'description' => 'Custom payment gateway allows you to give instructions how can your client pay invoice. All system, client, order and invoice details can be printed. HTML and JavaScript code is supported.',
+            'logo' => [
                 'logo' => 'custom.png',
                 'height' => '50px',
                 'width' => '50px',
-            ),
-            'form'  => array(
-                'single' => array(
-                    'textarea', array(
+            ],
+            'form' => [
+                'single' => [
+                    'textarea', [
                         'label' => 'Enter your text for single payment information',
-                    ),
-                ),
-                'recurrent' => array(
-                    'textarea', array(
+                    ],
+                ],
+                'recurrent' => [
+                    'textarea', [
                         'label' => 'Enter your text for subscription information',
-                    ),
-                ),
-            ),
-        ); 
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
-     * Generate payment text
-     * 
+     * Generate payment text.
+     *
      * @return string - html form with auto submit javascript
      */
     public function getHtml(Api_Handler $api_admin, int $invoice_id, bool $subscription): string
     {
         $invoiceModel = $this->di['db']->load('Invoice', $invoice_id);
-        $invoiceService = $this->di['mod_service']("Invoice");
+        $invoiceService = $this->di['mod_service']('Invoice');
         $invoice = $invoiceService->toApiArray($invoiceModel, true);
 
-        $vars = array(
-            '_client_id'    => $invoice['client']['id'],
-            'invoice'   =>  $invoice,
-            '_tpl'      =>  $subscription ? ($this->config['recurrent'] ?? '"Custom" payment adapter is not fully configured.') : ($this->config['single'] ?? '"Custom" payment adapter is not fully configured.'),
-        );
+        $vars = [
+            '_client_id' => $invoice['client']['id'],
+            'invoice' => $invoice,
+            '_tpl' => $subscription ? ($this->config['recurrent'] ?? '"Custom" payment adapter is not fully configured.') : ($this->config['single'] ?? '"Custom" payment adapter is not fully configured.'),
+        ];
         $systemService = $this->di['mod_service']('System');
+
         return $systemService->renderString($vars['_tpl'], true, $vars);
     }
 
     /**
      * Processes a transaction using a custom payment adapter.
      *
-     * @param \Api_Handler $api_admin The API admin object.
-     * @param int $id The ID of the transaction to process.
-     * @param array $data The data associated with the transaction.
-     * @param int $gateway_id The ID of the payment gateway to use.
+     * @param Api_Handler $api_admin  the API admin object
+     * @param int         $id         the ID of the transaction to process
+     * @param array       $data       the data associated with the transaction
+     * @param int         $gateway_id the ID of the payment gateway to use
      *
-     * @return bool Returns true if the transaction was processed successfully, false otherwise.
+     * @return bool returns true if the transaction was processed successfully, false otherwise
      */
-    public function processTransaction(\Api_Handler $api_admin, int $id, array $data, int $gateway_id)
+    public function processTransaction(Api_Handler $api_admin, int $id, array $data, int $gateway_id)
     {
         try {
             // Get the transaction and invoice associated with the transaction
@@ -106,9 +106,9 @@ class Payment_Adapter_Custom
             $tx->currency = $invoice->currency;
             $tx->updated_at = date('Y-m-d H:i:s');
 
-            // Store the updated transaction and use it's return to indicate a sucsess or failure. 
+            // Store the updated transaction and use it's return to indicate a sucsess or failure.
             return $this->di['db']->store($tx);
-        } catch (\Exception) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -2,25 +2,24 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use FOSSBilling\Environment;
 
-class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FOSSBilling\InjectionAwareInterface
+class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements FOSSBilling\InjectionAwareInterface
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi(): ?\Pimple\Container
+    public function getDi(): ?Pimple\Container
     {
         return $this->di;
     }
@@ -34,31 +33,31 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
 
     public static function getConfig()
     {
-        return array(
-            'supports_one_time_payments'   =>  true,
-            'supports_subscriptions'     =>  true,
-            'description'     =>  'Enter your PayPal email to start accepting payments by PayPal.',
-            'logo' => array(
+        return [
+            'supports_one_time_payments' => true,
+            'supports_subscriptions' => true,
+            'description' => 'Enter your PayPal email to start accepting payments by PayPal.',
+            'logo' => [
                 'logo' => 'paypal.png',
                 'height' => '25px',
                 'width' => '85px',
-            ),
-            'form'  => array(
-                'email' => array(
-                    'text', array(
+            ],
+            'form' => [
+                'email' => [
+                    'text', [
                         'label' => 'PayPal email address for payments',
-                        'validators' => array('EmailAddress'),
-                    ),
-                ),
-            ),
-        );
+                        'validators' => ['EmailAddress'],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function getHtml($api_admin, $invoice_id, $subscription)
     {
-        $invoice = $api_admin->invoice_get(array('id' => $invoice_id));
+        $invoice = $api_admin->invoice_get(['id' => $invoice_id]);
 
-        $data = array();
+        $data = [];
         if ($subscription) {
             $data = $this->getSubscriptionFields($invoice);
         } else {
@@ -66,6 +65,7 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         }
 
         $url = $this->serviceUrl();
+
         return $this->_generateForm($url, $data);
     }
 
@@ -77,111 +77,112 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
 
         $ipn = $data['post'];
 
-        $tx = $api_admin->invoice_transaction_get(array('id' => $id));
+        $tx = $api_admin->invoice_transaction_get(['id' => $id]);
 
         if (!$tx['invoice_id']) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'invoice_id' => $data['get']['bb_invoice_id']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'invoice_id' => $data['get']['bb_invoice_id']]);
         }
 
         if (!$tx['type'] && isset($ipn['txn_type'])) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'type' => $ipn['txn_type']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'type' => $ipn['txn_type']]);
         }
 
         if (!$tx['txn_id'] && isset($ipn['txn_id'])) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'txn_id' => $ipn['txn_id']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'txn_id' => $ipn['txn_id']]);
         }
 
         if (!$tx['txn_status'] && isset($ipn['payment_status'])) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'txn_status' => $ipn['payment_status']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'txn_status' => $ipn['payment_status']]);
         }
 
         if (!$tx['amount'] && isset($ipn['mc_gross'])) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'amount' => $ipn['mc_gross']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'amount' => $ipn['mc_gross']]);
         }
 
         if (!$tx['currency'] && isset($ipn['mc_currency'])) {
-            $api_admin->invoice_transaction_update(array('id' => $id, 'currency' => $ipn['mc_currency']));
+            $api_admin->invoice_transaction_update(['id' => $id, 'currency' => $ipn['mc_currency']]);
         }
 
-        $invoice = $api_admin->invoice_get(array('id' => $data['get']['bb_invoice_id']));
+        $invoice = $api_admin->invoice_get(['id' => $data['get']['bb_invoice_id']]);
         $client_id = $invoice['client']['id'];
 
         switch ($ipn['txn_type']) {
-
             case 'web_accept':
             case 'subscr_payment':
-
                 if ($ipn['payment_status'] == 'Completed') {
-                    $bd = array(
-                        'id'            =>  $client_id,
-                        'amount'        =>  $ipn['mc_gross'],
-                        'description'   =>  'PayPal transaction ' . $ipn['txn_id'],
-                        'type'          =>  'PayPal',
-                        'rel_id'        =>  $ipn['txn_id'],
-                    );
+                    $bd = [
+                        'id' => $client_id,
+                        'amount' => $ipn['mc_gross'],
+                        'description' => 'PayPal transaction ' . $ipn['txn_id'],
+                        'type' => 'PayPal',
+                        'rel_id' => $ipn['txn_id'],
+                    ];
                     if ($this->isIpnDuplicate($ipn)) {
                         throw new Payment_Exception('Cannot process duplicate IPN');
                     }
                     $api_admin->client_balance_add_funds($bd);
                     if ($tx['invoice_id']) {
-                        $api_admin->invoice_pay_with_credits(array('id' => $tx['invoice_id']));
+                        $api_admin->invoice_pay_with_credits(['id' => $tx['invoice_id']]);
                     } else {
-                        $api_admin->invoice_batch_pay_with_credits(array('client_id' => $client_id));
+                        $api_admin->invoice_batch_pay_with_credits(['client_id' => $client_id]);
                     }
                 }
 
                 break;
 
             case 'subscr_signup':
-                $sd = array(
-                    'client_id'     =>  $client_id,
-                    'gateway_id'    =>  $gateway_id,
-                    'currency'      =>  $ipn['mc_currency'],
-                    'sid'           =>  $ipn['subscr_id'],
-                    'status'        =>  'active',
-                    'period'        =>  str_replace(' ', '', $ipn['period3']),
-                    'amount'        =>  $ipn['amount3'],
-                    'rel_type'      =>  'invoice',
-                    'rel_id'        =>  $invoice['id'],
-                );
+                $sd = [
+                    'client_id' => $client_id,
+                    'gateway_id' => $gateway_id,
+                    'currency' => $ipn['mc_currency'],
+                    'sid' => $ipn['subscr_id'],
+                    'status' => 'active',
+                    'period' => str_replace(' ', '', $ipn['period3']),
+                    'amount' => $ipn['amount3'],
+                    'rel_type' => 'invoice',
+                    'rel_id' => $invoice['id'],
+                ];
                 $api_admin->invoice_subscription_create($sd);
 
-                $t = array(
-                    'id'            => $id,
-                    's_id'          => $sd['sid'],
-                    's_period'      => $sd['period'],
-                );
+                $t = [
+                    'id' => $id,
+                    's_id' => $sd['sid'],
+                    's_period' => $sd['period'],
+                ];
                 $api_admin->invoice_transaction_update($t);
+
                 break;
 
             case 'recurring_payment_suspended_due_to_max_failed_payment':
             case 'subscr_failed':
             case 'subscr_eot':
             case 'subscr_cancel':
-                $s = $api_admin->invoice_subscription_get(array('sid' => $ipn['subscr_id']));
-                $api_admin->invoice_subscription_update(array('id' => $s['id'], 'status' => 'canceled'));
+                $s = $api_admin->invoice_subscription_get(['sid' => $ipn['subscr_id']]);
+                $api_admin->invoice_subscription_update(['id' => $s['id'], 'status' => 'canceled']);
+
                 break;
 
             default:
                 error_log('Unknown paypal transaction ' . $id);
+
                 break;
         }
 
         if (isset($ipn['payment_status']) && $ipn['payment_status'] == 'Refunded') {
-            $refd = array(
-                'id'    => $invoice['id'],
-                'note'  => 'PayPal refund ' . $ipn['parent_txn_id'],
-            );
+            $refd = [
+                'id' => $invoice['id'],
+                'note' => 'PayPal refund ' . $ipn['parent_txn_id'],
+            ];
             $api_admin->invoice_refund($refd);
         }
 
-        $d = array(
-            'id'         => $id,
-            'error'      => '',
+        $d = [
+            'id' => $id,
+            'error' => '',
             'error_code' => '',
-            'status'     => 'processed',
+            'status' => 'processed',
             'updated_at' => date('Y-m-d H:i:s'),
-        );
+        ];
         $api_admin->invoice_transaction_update($d);
     }
 
@@ -205,15 +206,17 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         }
         $url = $this->serviceUrl();
         $ret = $this->download($url, $req);
+
         return $ret == 'VERIFIED';
     }
 
     public function moneyFormat($amount, $currency = null)
     {
-        //HUF currency do not accept decimal values
+        // HUF currency do not accept decimal values
         if ($currency == 'HUF') {
             return number_format($amount, 0);
         }
+
         return number_format($amount, 2, '.', '');
     }
 
@@ -234,14 +237,15 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
         }
 
         $client = $this->getHttpClient()->withOptions([
-            'verify_peer'   => false,
-            'verify_host'   => false,
-            'timeout'       => 600
+            'verify_peer' => false,
+            'verify_host' => false,
+            'timeout' => 600,
         ]);
         $response = $client->request('POST', $url, [
-            'body'  => $post_contents,
+            'body' => $post_contents,
         ]);
         $data = $response->getContent();
+
         return $data;
     }
 
@@ -250,13 +254,13 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
      */
     private function _generateForm($url, $data, $method = 'post')
     {
-        $form  = '';
+        $form = '';
         $form .= '<form name="payment_form" action="' . $url . '" method="' . $method . '">' . PHP_EOL;
         foreach ($data as $key => $value) {
             $form .= sprintf('<input type="hidden" name="%s" value="%s" />', $key, $value) . PHP_EOL;
         }
-        $form .=  '<input class="btn btn-primary" type="submit" value="Pay with PayPal" id="payment_button"/>'. PHP_EOL;
-        $form .=  '</form>' . PHP_EOL . PHP_EOL;
+        $form .= '<input class="btn btn-primary" type="submit" value="Pay with PayPal" id="payment_button"/>' . PHP_EOL;
+        $form .= '</form>' . PHP_EOL . PHP_EOL;
 
         if (isset($this->config['auto_redirect']) && $this->config['auto_redirect']) {
             $form .= sprintf('<h2>%s</h2>', __trans('Redirecting to PayPal.com'));
@@ -276,100 +280,102 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements \FO
                   AND amount = :transaction_amount
                 LIMIT 2';
 
-        $bindings = array(
+        $bindings = [
             ':transaction_id' => $ipn['txn_id'],
             ':transaction_status' => $ipn['payment_status'],
             ':transaction_type' => $ipn['txn_type'],
             ':transaction_amount' => $ipn['mc_gross'],
-        );
+        ];
 
         $rows = $this->di['db']->getAll($sql, $bindings);
         if ((is_countable($rows) ? count($rows) : 0) > 1) {
             return true;
         }
 
-
         return false;
     }
 
     public function getInvoiceTitle(array $invoice)
     {
-        $p = array(
+        $p = [
             ':id' => sprintf('%05s', $invoice['nr']),
             ':serie' => $invoice['serie'],
-            ':title' => $invoice['lines'][0]['title']
-        );
+            ':title' => $invoice['lines'][0]['title'],
+        ];
+
         return __trans('Payment for invoice :serie:id [:title]', $p);
     }
 
     public function getSubscriptionFields(array $invoice)
     {
-        $data = array();
+        $data = [];
         $subs = $invoice['subscription'];
 
-        $data['item_name']          = $this->getInvoiceTitle($invoice);
-        $data['item_number']        = $invoice['nr'];
-        $data['no_shipping']        = '1';
-        $data['no_note']            = '1'; // Do not prompt payers to include a note with their payments. Allowable values for Subscribe buttons:
-        $data['currency_code']      = $invoice['currency'];
-        $data['return']             = $this->config['thankyou_url'];
-        $data['cancel_return']      = $this->config['cancel_url'];
-        $data['notify_url']         = $this->config['notify_url'];
-        $data['business']           = $this->config['email'];
+        $data['item_name'] = $this->getInvoiceTitle($invoice);
+        $data['item_number'] = $invoice['nr'];
+        $data['no_shipping'] = '1';
+        $data['no_note'] = '1'; // Do not prompt payers to include a note with their payments. Allowable values for Subscribe buttons:
+        $data['currency_code'] = $invoice['currency'];
+        $data['return'] = $this->config['thankyou_url'];
+        $data['cancel_return'] = $this->config['cancel_url'];
+        $data['notify_url'] = $this->config['notify_url'];
+        $data['business'] = $this->config['email'];
 
-        $data['cmd']                = '_xclick-subscriptions';
-        $data['rm']                 = '2';
+        $data['cmd'] = '_xclick-subscriptions';
+        $data['rm'] = '2';
 
-        $data['invoice']            = $invoice['id'];
+        $data['invoice'] = $invoice['id'];
 
         // Recurrence info
-        $data['a3']                 = $this->moneyFormat($invoice['total'], $invoice['currency']); // Regular subscription price.
-        $data['p3']                 = $subs['cycle']; //Subscription duration. Specify an integer value in the allowable range for the units of duration that you specify with t3.
+        $data['a3'] = $this->moneyFormat($invoice['total'], $invoice['currency']); // Regular subscription price.
+        $data['p3'] = $subs['cycle']; // Subscription duration. Specify an integer value in the allowable range for the units of duration that you specify with t3.
 
-        /**
+        /*
          * t3: Regular subscription units of duration. Allowable values:
          *  D – for days; allowable range for p3 is 1 to 90
          *  W – for weeks; allowable range for p3 is 1 to 52
          *  M – for months; allowable range for p3 is 1 to 24
          *  Y – for years; allowable range for p3 is 1 to 5
          */
-        $data['t3']                 = $subs['unit'];
+        $data['t3'] = $subs['unit'];
 
-        $data['src']                = 1; //Recurring payments. Subscription payments recur unless subscribers cancel their subscriptions before the end of the current billing cycle or you limit the number of times that payments recur with the value that you specify for srt.
-        $data['sra']                = 1; //Reattempt on failure. If a recurring payment fails, PayPal attempts to collect the payment two more times before canceling the subscription.
-        $data['charset']            = 'UTF-8'; //Sets the character encoding for the billing information/log-in page, for the information you send to PayPal in your HTML button code, and for the information that PayPal returns to you as a result of checkout processes initiated by the payment button. The default is based on the character encoding settings in your account profile.
+        $data['src'] = 1; // Recurring payments. Subscription payments recur unless subscribers cancel their subscriptions before the end of the current billing cycle or you limit the number of times that payments recur with the value that you specify for srt.
+        $data['sra'] = 1; // Reattempt on failure. If a recurring payment fails, PayPal attempts to collect the payment two more times before canceling the subscription.
+        $data['charset'] = 'UTF-8'; // Sets the character encoding for the billing information/log-in page, for the information you send to PayPal in your HTML button code, and for the information that PayPal returns to you as a result of checkout processes initiated by the payment button. The default is based on the character encoding settings in your account profile.
 
-        //client data
+        // client data
         $buyer = $invoice['buyer'];
-        $data['address1']           = $buyer['address'];
-        $data['city']               = $buyer['city'];
-        $data['email']              = $buyer['email'];
-        $data['first_name']         = $buyer['first_name'];
-        $data['last_name']          = $buyer['last_name'];
-        $data['zip']                = $buyer['zip'];
-        $data['state']              = $buyer['state'];
-        $data['bn']                 = "FOSSBilling_SP";
+        $data['address1'] = $buyer['address'];
+        $data['city'] = $buyer['city'];
+        $data['email'] = $buyer['email'];
+        $data['first_name'] = $buyer['first_name'];
+        $data['last_name'] = $buyer['last_name'];
+        $data['zip'] = $buyer['zip'];
+        $data['state'] = $buyer['state'];
+        $data['bn'] = 'FOSSBilling_SP';
+
         return $data;
     }
 
     public function getOneTimePaymentFields(array $invoice)
     {
-        $data = array();
-        $data['item_name']          = $this->getInvoiceTitle($invoice);
-        $data['item_number']        = $invoice['nr'];
-        $data['no_shipping']        = '1';
-        $data['no_note']            = '1';
-        $data['currency_code']      = $invoice['currency'];
-        $data['rm']                 = '2';
-        $data['return']             = $this->config['thankyou_url'];
-        $data['cancel_return']      = $this->config['cancel_url'];
-        $data['notify_url']         = $this->config['notify_url'];
-        $data['business']           = $this->config['email'];
-        $data['cmd']                = '_xclick';
-        $data['amount']             = $this->moneyFormat($invoice['subtotal'], $invoice['currency']);
-        $data['tax']                = $this->moneyFormat($invoice['tax'], $invoice['currency']);
-        $data['bn']                 = "FOSSBilling_SP";
-        $data['charset']            = "utf-8";
+        $data = [];
+        $data['item_name'] = $this->getInvoiceTitle($invoice);
+        $data['item_number'] = $invoice['nr'];
+        $data['no_shipping'] = '1';
+        $data['no_note'] = '1';
+        $data['currency_code'] = $invoice['currency'];
+        $data['rm'] = '2';
+        $data['return'] = $this->config['thankyou_url'];
+        $data['cancel_return'] = $this->config['cancel_url'];
+        $data['notify_url'] = $this->config['notify_url'];
+        $data['business'] = $this->config['email'];
+        $data['cmd'] = '_xclick';
+        $data['amount'] = $this->moneyFormat($invoice['subtotal'], $invoice['currency']);
+        $data['tax'] = $this->moneyFormat($invoice['tax'], $invoice['currency']);
+        $data['bn'] = 'FOSSBilling_SP';
+        $data['charset'] = 'utf-8';
+
         return $data;
     }
 }

--- a/src/library/Payment/AdapterAbstract.php
+++ b/src/library/Payment/AdapterAbstract.php
@@ -3,23 +3,22 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 abstract class Payment_AdapterAbstract
 {
-    final public const TYPE_HTML             = 'html';
-    final public const TYPE_FORM             = 'form';
-    final public const TYPE_API              = 'api';
+    final public const TYPE_HTML = 'html';
+    final public const TYPE_FORM = 'form';
+    final public const TYPE_API = 'api';
 
     /**
      * Response text for notify_url
-     * This value is set after IPN is received and validated
+     * This value is set after IPN is received and validated.
      */
-    protected ?string $output = NULL;
+    protected ?string $output = null;
 
     /**
      * Are we in test mode?
@@ -27,7 +26,7 @@ abstract class Payment_AdapterAbstract
     public bool $testMode = false;
 
     /**
-     * Log object
+     * Log object.
      */
     private ?Box_Log $_log = null;
 
@@ -37,7 +36,7 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Constructs a new Payment_Adapter object
+     * Constructs a new Payment_Adapter object.
      *
      * @param array $_config The configuration for the payment adapter as configured within the admin panel
      *
@@ -45,50 +44,50 @@ abstract class Payment_AdapterAbstract
      */
     public function __construct(protected $_config)
     {
-        /**
+        /*
          * Redirect client after successful payment, usually to invoice
          */
         if (!$this->getParam('return_url')) {
-            throw new Payment_Exception('Return URL for payment gateway was not set', array(), 6001);
+            throw new Payment_Exception('Return URL for payment gateway was not set', [], 6001);
         }
 
-        /**
+        /*
          * URL to redirect client if payment process was canceled
          */
         if (!$this->getParam('cancel_url')) {
-            throw new Payment_Exception('Cancel URL for payment gateway was not set', array(), 6002);
+            throw new Payment_Exception('Cancel URL for payment gateway was not set', [], 6002);
         }
 
-        /**
+        /*
          * IPN notification url. Payment gateway posts data to this URL
          * to inform FOSSBilling about payment
          */
         if (!$this->getParam('notify_url')) {
-            throw new Payment_Exception('IPN Notification URL for payment gateway was not set', array(), 6003);
+            throw new Payment_Exception('IPN Notification URL for payment gateway was not set', [], 6003);
         }
 
-        /**
+        /*
          * If payment gateway has only one callback url, this url should be
          * used. It is equal to return_url + notify_url combined.
          * Client gets redirected to redirect_url, POST, GET data are considered
          * as IPN data, and client gets redirected to invoice page.
          */
         if (!$this->getParam('redirect_url')) {
-            throw new Payment_Exception('IPN redirect URL for payment gateway was not set', array(), 6004);
+            throw new Payment_Exception('IPN redirect URL for payment gateway was not set', [], 6004);
         }
 
         $this->init();
     }
 
     /**
-     * Return gateway configuration options
-     * 
+     * Return gateway configuration options.
+     *
      * @return array
      */
     abstract public static function getConfig();
 
     /**
-     * Return payment gateway type (TYPE_HTML, TYPE_FORM, TYPE_API)
+     * Return payment gateway type (TYPE_HTML, TYPE_FORM, TYPE_API).
      *
      * @return string
      */
@@ -98,7 +97,7 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Payment gateway endpoint
+     * Payment gateway endpoint.
      *
      * @return string
      */
@@ -108,24 +107,24 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Returns invoice id from callback IPN
+     * Returns invoice id from callback IPN.
      *
      * This method is called before transaction processing to determine
      * invoice id from IPN.
      *
      * @param array $data - Contains $_GET, $_POST, $HTTP_RAW_POST_DATA
-     * (or file_get_contents("php://input")) in format like:
-     * $data = array(
-     *  'get'=>$_GET,
-     *  'post'=>$_POST,
-     *  'http_raw_post_data'=>$HTTP_RAW_POST_DATA
-     * );
+     *                    (or file_get_contents("php://input")) in format like:
+     *                    $data = array(
+     *                    'get'=>$_GET,
+     *                    'post'=>$_POST,
+     *                    'http_raw_post_data'=>$HTTP_RAW_POST_DATA
+     *                    );
      *
      * @return int - invoice id
      */
     public function getInvoiceId($data)
     {
-        return isset($data['get']['bb_invoice_id']) ? (int)$data['get']['bb_invoice_id'] : NULL;
+        return isset($data['get']['bb_invoice_id']) ? (int) $data['get']['bb_invoice_id'] : null;
     }
 
     public function setLog(Box_Log $log)
@@ -139,6 +138,7 @@ abstract class Payment_AdapterAbstract
         if (!$log instanceof Box_Log) {
             $log = new Box_Log();
         }
+
         return $log;
     }
 
@@ -147,11 +147,11 @@ abstract class Payment_AdapterAbstract
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return \Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create();
     }
 
     /**
-     * Get config parameter
+     * Get config parameter.
      *
      * @param string $param the parameter name to retrieve from the config
      *
@@ -159,14 +159,13 @@ abstract class Payment_AdapterAbstract
      */
     public function getParam($param)
     {
-        return $this->_config[$param] ?? NULL;
+        return $this->_config[$param] ?? null;
     }
 
     /**
-     * Convert money amount to Gateway money format
+     * Convert money amount to Gateway money format.
      *
-     * @param float $amount The amount
-     *
+     * @param float  $amount   The amount
      * @param string $currency The currency (unused currently)
      *
      * @return string The formatted money string
@@ -177,13 +176,14 @@ abstract class Payment_AdapterAbstract
     }
 
     /**
-     * Toggles test mode
+     * Toggles test mode.
      *
      * @return Payment_AdapterAbstract
      */
     public function setTestMode(bool $bool)
     {
-        $this->testMode = (bool)$bool;
+        $this->testMode = (bool) $bool;
+
         return $this;
     }
 
@@ -194,7 +194,7 @@ abstract class Payment_AdapterAbstract
 
     /**
      * Set custom response text to be printed when IPN is received
-     * Used only by payment gateways who care about notify_url response
+     * Used only by payment gateways who care about notify_url response.
      */
     public function setOutput(string $response): void
     {

--- a/src/library/Payment/Exception.php
+++ b/src/library/Payment/Exception.php
@@ -2,23 +2,22 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Exception extends FOSSBilling\Exception
 {
-	/**
-	 * Creates a new translated exception, using the FOSSBilling\Exception class.
-	 *
-	 * @param string $message error message
-	 * @param array|null $variables translation variables
-	 * @param int $code The exception code.
-	 */
-    public function __construct(string $message, array $variables = NULL, int $code = 0)
+    /**
+     * Creates a new translated exception, using the FOSSBilling\Exception class.
+     *
+     * @param string     $message   error message
+     * @param array|null $variables translation variables
+     * @param int        $code      the exception code
+     */
+    public function __construct(string $message, array $variables = null, int $code = 0)
     {
-        parent:: __construct($message, $variables, $code, true);
+        parent::__construct($message, $variables, $code, true);
     }
 }

--- a/src/library/Payment/Invoice.php
+++ b/src/library/Payment/Invoice.php
@@ -2,39 +2,39 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Invoice
 {
-    private $id             = NULL; // FOSSBilling Invoice Id
-    private $number         = NULL; // Invoice number for accounting
-    private string $currency       = 'USD';
-    private array $items          = array();
-    private ?\Payment_Invoice_Subscription $subscription   = NULL;
-    private ?\Payment_Invoice_Buyer $buyer          = NULL;
-    private string $title          = 'Payment for invoice';
+    private $id; // FOSSBilling Invoice Id
+    private $number; // Invoice number for accounting
+    private string $currency = 'USD';
+    private array $items = [];
+    private ?\Payment_Invoice_Subscription $subscription = null;
+    private ?\Payment_Invoice_Buyer $buyer = null;
+    private string $title = 'Payment for invoice';
 
     /**
      * Set the invoice ID.
      *
-     * @param mixed $param The invoice ID.
+     * @param mixed $param the invoice ID
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setId(mixed $param)
     {
         $this->id = $param;
+
         return $this;
     }
 
     /**
      * Get the invoice ID.
      *
-     * @return mixed The invoice ID.
+     * @return mixed the invoice ID
      */
     public function getId()
     {
@@ -44,20 +44,21 @@ class Payment_Invoice
     /**
      * Set the invoice number.
      *
-     * @param mixed $param The invoice number.
+     * @param mixed $param the invoice number
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setNumber(mixed $param)
     {
         $this->number = $param;
+
         return $this;
     }
 
     /**
      * Get the invoice number.
      *
-     * @return mixed The invoice number.
+     * @return mixed the invoice number
      */
     public function getNumber()
     {
@@ -67,20 +68,21 @@ class Payment_Invoice
     /**
      * Set the currency.
      *
-     * @param string $param The currency.
+     * @param string $param the currency
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setCurrency($param)
     {
         $this->currency = $param;
+
         return $this;
     }
 
     /**
      * Get the currency.
      *
-     * @return string The currency.
+     * @return string the currency
      */
     public function getCurrency()
     {
@@ -90,20 +92,21 @@ class Payment_Invoice
     /**
      * Set the buyer.
      *
-     * @param Payment_Invoice_Buyer $param The buyer object.
+     * @param Payment_Invoice_Buyer $param the buyer object
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setBuyer(Payment_Invoice_Buyer $param)
     {
         $this->buyer = $param;
+
         return $this;
     }
 
     /**
      * Get the buyer.
      *
-     * @return Payment_Invoice_Buyer The buyer object.
+     * @return Payment_Invoice_Buyer the buyer object
      */
     public function getBuyer()
     {
@@ -113,9 +116,9 @@ class Payment_Invoice
     /**
      * Set the items.
      *
-     * @param array $items An array of Payment_Invoice_Item objects.
+     * @param array $items an array of Payment_Invoice_Item objects
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setItems(array $items)
     {
@@ -124,13 +127,14 @@ class Payment_Invoice
                 $this->items[] = $item;
             }
         }
+
         return $this;
     }
 
     /**
      * Get the items.
      *
-     * @return array An array of Payment_Invoice_Item objects.
+     * @return array an array of Payment_Invoice_Item objects
      */
     public function getItems()
     {
@@ -140,20 +144,21 @@ class Payment_Invoice
     /**
      * Set the subscription.
      *
-     * @param Payment_Invoice_Subscription $param The subscription object.
+     * @param Payment_Invoice_Subscription $param the subscription object
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setSubscription(Payment_Invoice_Subscription $param)
     {
         $this->subscription = $param;
+
         return $this;
     }
 
     /**
      * Get the subscription.
      *
-     * @return Payment_Invoice_Subscription The subscription object.
+     * @return Payment_Invoice_Subscription the subscription object
      */
     public function getSubscription()
     {
@@ -163,20 +168,21 @@ class Payment_Invoice
     /**
      * Set the title.
      *
-     * @param null|string $title The title.
+     * @param string|null $title the title
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setTitle($title)
     {
         $this->title = $title;
+
         return $this;
     }
 
     /**
      * Get the title.
      *
-     * @return null|string The title.
+     * @return string|null the title
      */
     public function getTitle()
     {
@@ -186,7 +192,7 @@ class Payment_Invoice
     /**
      * Get the total amount of the invoice (without tax).
      *
-     * @return float The total amount.
+     * @return float the total amount
      */
     public function getTotal()
     {
@@ -194,13 +200,14 @@ class Payment_Invoice
         foreach ($this->items as $item) {
             $total += $item->getTotal();
         }
+
         return $total;
     }
 
     /**
      * Get the total amount of the invoice (with tax).
      *
-     * @return float The total amount with tax.
+     * @return float the total amount with tax
      */
     public function getTotalWithTax()
     {
@@ -210,7 +217,7 @@ class Payment_Invoice
     /**
      * Get the tax amount of the invoice.
      *
-     * @return float The tax amount.
+     * @return float the tax amount
      */
     public function getTax()
     {
@@ -218,6 +225,7 @@ class Payment_Invoice
         foreach ($this->items as $item) {
             $tax += $item->getTax() * $item->getQuantity();
         }
+
         return $tax;
     }
 }

--- a/src/library/Payment/Invoice/Buyer.php
+++ b/src/library/Payment/Invoice/Buyer.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Invoice_Buyer
 {
     private $first_name;
@@ -25,20 +24,21 @@ class Payment_Invoice_Buyer
     /**
      * Set the first name of the buyer.
      *
-     * @param string $param The first name of the buyer.
+     * @param string $param the first name of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setFirstName($param)
     {
         $this->first_name = $param;
+
         return $this;
     }
 
     /**
      * Get the first name of the buyer.
      *
-     * @return string The first name of the buyer.
+     * @return string the first name of the buyer
      */
     public function getFirstName()
     {
@@ -48,20 +48,21 @@ class Payment_Invoice_Buyer
     /**
      * Set the last name of the buyer.
      *
-     * @param string $param The last name of the buyer.
+     * @param string $param the last name of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setLastName($param)
     {
         $this->last_name = $param;
+
         return $this;
     }
 
     /**
      * Get the last name of the buyer.
      *
-     * @return string The last name of the buyer.
+     * @return string the last name of the buyer
      */
     public function getLastName()
     {
@@ -71,44 +72,45 @@ class Payment_Invoice_Buyer
     /**
      * Set the company name of the buyer.
      *
-     * @param string $param The company name of the buyer.
+     * @param string $param the company name of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setCompany($param)
     {
         $this->company = $param;
+
         return $this;
     }
 
     /**
      * Get the company name of the buyer.
      *
-     * @return string The company name of the buyer.
+     * @return string the company name of the buyer
      */
     public function getCompany()
     {
         return $this->company;
     }
 
-
     /**
      * Set the email address of the buyer.
      *
-     * @param string $param The email address of the buyer.
+     * @param string $param the email address of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setEmail($param)
     {
         $this->email = $param;
+
         return $this;
     }
 
     /**
      * Get the email address of the buyer.
      *
-     * @return string The email address of the buyer.
+     * @return string the email address of the buyer
      */
     public function getEmail()
     {
@@ -118,20 +120,21 @@ class Payment_Invoice_Buyer
     /**
      * Set the mailing address of the buyer.
      *
-     * @param string $param The mailing address of the buyer.
+     * @param string $param the mailing address of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setAddress($param)
     {
         $this->address = $param;
+
         return $this;
     }
 
     /**
      * Get the mailing address of the buyer.
      *
-     * @return string The mailing address of the buyer.
+     * @return string the mailing address of the buyer
      */
     public function getAddress()
     {
@@ -141,13 +144,14 @@ class Payment_Invoice_Buyer
     /**
      * Set the city of the buyer's mailing address.
      *
-     * @param string $param The city of the buyer's mailing address.
+     * @param string $param the city of the buyer's mailing address
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setCity($param)
     {
         $this->city = $param;
+
         return $this;
     }
 
@@ -164,116 +168,117 @@ class Payment_Invoice_Buyer
     /**
      * Set the state/province of the buyer's mailing address.
      *
-     * @param string $param The state/province of the buyer's mailing address.
+     * @param string $param the state/province of the buyer's mailing address
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setState($param)
     {
         $this->state = $param;
+
         return $this;
     }
 
     /**
      * Get the state/province of the buyer's mailing address.
      *
-     * @return string The state/province of the buyer's mailing address.
+     * @return string the state/province of the buyer's mailing address
      */
     public function getState()
     {
         return $this->state;
     }
 
-
     /**
      * Set the country of the buyer's mailing address.
      *
-     * @param string $param The country of the buyer's mailing address.
+     * @param string $param the country of the buyer's mailing address
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setCountry($param)
     {
         $this->country = $param;
+
         return $this;
     }
 
     /**
      * Get the country of the buyer's mailing address.
      *
-     * @return string The country of the buyer's mailing address.
+     * @return string the country of the buyer's mailing address
      */
     public function getCountry()
     {
         return $this->country;
     }
 
-
     /**
      * Set the ZIP/postal code of the buyer's mailing address.
      *
-     * @param string $param The ZIP/postal code of the buyer's mailing address.
+     * @param string $param the ZIP/postal code of the buyer's mailing address
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setZip($param)
     {
         $this->zip = $param;
+
         return $this;
     }
 
     /**
      * Get the ZIP/postal code of the buyer's mailing address.
      *
-     * @return string The ZIP/postal code of the buyer's mailing address.
+     * @return string the ZIP/postal code of the buyer's mailing address
      */
     public function getZip()
     {
         return $this->zip;
     }
 
-
     /**
      * Set the phone number of the buyer.
      *
-     * @param string $param The phone number of the buyer.
+     * @param string $param the phone number of the buyer
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setPhone($param)
     {
         $this->phone = $param;
+
         return $this;
     }
 
     /**
      * Get the phone number of the buyer.
      *
-     * @return string The phone number of the buyer.
+     * @return string the phone number of the buyer
      */
     public function getPhone()
     {
         return $this->phone;
     }
 
-
     /**
      * Set the country code of the buyer's phone number.
      *
-     * @param string $param The country code of the buyer's phone number.
+     * @param string $param the country code of the buyer's phone number
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setPhoneCountryCode($param)
     {
         $this->phone_cc = $param;
+
         return $this;
     }
 
     /**
      * Get the country code of the buyer's phone number.
      *
-     * @return string The country code of the buyer's phone number.
+     * @return string the country code of the buyer's phone number
      */
     public function getPhoneCountryCode()
     {

--- a/src/library/Payment/Invoice/Item.php
+++ b/src/library/Payment/Invoice/Item.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Invoice_Item
 {
     private $id;
@@ -20,20 +19,21 @@ class Payment_Invoice_Item
     /**
      * Set the id of the item.
      *
-     * @param int $id The id of the item.
+     * @param int $id the id of the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setId($id)
     {
         $this->id = $id;
+
         return $this;
     }
 
     /**
      * Get the id of the item.
      *
-     * @return int The id of the item.
+     * @return int the id of the item
      */
     public function getId()
     {
@@ -43,20 +43,21 @@ class Payment_Invoice_Item
     /**
      * Set the title of the item.
      *
-     * @param string $title The title of the item.
+     * @param string $title the title of the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setTitle($title)
     {
         $this->title = $title;
+
         return $this;
     }
 
     /**
      * Get the title of the item.
      *
-     * @return string The title of the item.
+     * @return string the title of the item
      */
     public function getTitle()
     {
@@ -66,20 +67,21 @@ class Payment_Invoice_Item
     /**
      * Set the description of the item.
      *
-     * @param string $description The description of the item.
+     * @param string $description the description of the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setDescription($description)
     {
         $this->description = $description;
+
         return $this;
     }
 
     /**
      * Get the description of the item.
      *
-     * @return string The description of the item.
+     * @return string the description of the item
      */
     public function getDescription()
     {
@@ -89,20 +91,21 @@ class Payment_Invoice_Item
     /**
      * Set the price of the item.
      *
-     * @param float $price The price of the item.
+     * @param float $price the price of the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setPrice($price)
     {
         $this->price = $price;
+
         return $this;
     }
 
     /**
      * Get the price of the item.
      *
-     * @return float The price of the item.
+     * @return float the price of the item
      */
     public function getPrice()
     {
@@ -112,20 +115,21 @@ class Payment_Invoice_Item
     /**
      * Set the tax amount for the item.
      *
-     * @param float $tax The tax amount for the item.
+     * @param float $tax the tax amount for the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setTax($tax)
     {
         $this->tax = $tax;
+
         return $this;
     }
 
     /**
      * Get the tax amount for the item.
      *
-     * @return float The tax amount for the item.
+     * @return float the tax amount for the item
      */
     public function getTax()
     {
@@ -135,20 +139,21 @@ class Payment_Invoice_Item
     /**
      * Set the quantity of the item.
      *
-     * @param int $qty The quantity of the item.
+     * @param int $qty the quantity of the item
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setQuantity($qty)
     {
         $this->qty = $qty;
+
         return $this;
     }
 
     /**
      * Get the quantity of the item.
      *
-     * @return int The quantity of the item.
+     * @return int the quantity of the item
      */
     public function getQuantity()
     {
@@ -158,7 +163,7 @@ class Payment_Invoice_Item
     /**
      * Return the total price for this item.
      *
-     * @return float The total price for this item.
+     * @return float the total price for this item
      */
     public function getTotal()
     {
@@ -168,7 +173,7 @@ class Payment_Invoice_Item
     /**
      * Return the total price for this item including tax.
      *
-     * @return float The total price for this item including tax.
+     * @return float the total price for this item including tax
      */
     public function getTotalWithTax()
     {

--- a/src/library/Payment/Invoice/Subscription.php
+++ b/src/library/Payment/Invoice/Subscription.php
@@ -2,33 +2,34 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Invoice_Subscription
 {
     private $id;
     private $amount;
     private $cycle;
     private $unit;
-    
+
     /**
-     * Set id
+     * Set id.
+     *
      * @param int $id
      */
     public function setId($id)
     {
         $this->id = $id;
+
         return $this;
     }
 
     /**
-     * Get id
+     * Get id.
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -36,11 +37,12 @@ class Payment_Invoice_Subscription
     }
 
     /**
-     * @param double $price
+     * @param float $price
      */
     public function setAmount($price)
     {
         $this->amount = $price;
+
         return $this;
     }
 
@@ -52,6 +54,7 @@ class Payment_Invoice_Subscription
     public function setCycle($cycle)
     {
         $this->cycle = $cycle;
+
         return $this;
     }
 
@@ -63,6 +66,7 @@ class Payment_Invoice_Subscription
     public function setUnit($param)
     {
         $this->unit = $param;
+
         return $this;
     }
 

--- a/src/library/Payment/Transaction.php
+++ b/src/library/Payment/Transaction.php
@@ -2,48 +2,48 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Payment_Transaction
 {
-    final public const STATUS_UNKNOWN        = 'unknown';
-    final public const STATUS_PENDING        = 'pending';
-    final public const STATUS_COMPLETE       = 'complete';
+    final public const STATUS_UNKNOWN = 'unknown';
+    final public const STATUS_PENDING = 'pending';
+    final public const STATUS_COMPLETE = 'complete';
 
-    final public const TXTYPE_PAYMENT        = 'payment';
-    final public const TXTYPE_REFUND         = 'refund';
-    final public const TXTYPE_SUBSCR_CREATE  = 'subscription_create';
-    final public const TXTYPE_SUBSCR_CANCEL  = 'subscription_cancel';
-    final public const TXTYPE_UNKNOWN        = 'unknown';
+    final public const TXTYPE_PAYMENT = 'payment';
+    final public const TXTYPE_REFUND = 'refund';
+    final public const TXTYPE_SUBSCR_CREATE = 'subscription_create';
+    final public const TXTYPE_SUBSCR_CANCEL = 'subscription_cancel';
+    final public const TXTYPE_UNKNOWN = 'unknown';
 
-    private $id                 = NULL;
-    private string $type               = self::TXTYPE_UNKNOWN;
-    private string $status             = self::STATUS_UNKNOWN;
-    private $currency           = NULL;
-    private $amount             = NULL;
-    private $subscription_id    = NULL;
+    private $id;
+    private string $type = self::TXTYPE_UNKNOWN;
+    private string $status = self::STATUS_UNKNOWN;
+    private $currency;
+    private $amount;
+    private $subscription_id;
 
     /**
      * Set the transaction ID.
      *
-     * @param mixed $param The transaction ID.
+     * @param mixed $param the transaction ID
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setId(mixed $param)
     {
         $this->id = $param;
+
         return $this;
     }
 
     /**
      * Get the transaction ID.
      *
-     * @return mixed The transaction ID.
+     * @return mixed the transaction ID
      */
     public function getId()
     {
@@ -53,20 +53,21 @@ class Payment_Transaction
     /**
      * Set the transaction status.
      *
-     * @param string $param The transaction status.
+     * @param string $param the transaction status
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setStatus($param)
     {
         $this->status = $param;
+
         return $this;
     }
 
     /**
      * Get the transaction status.
      *
-     * @return string The transaction status.
+     * @return string the transaction status
      */
     public function getStatus()
     {
@@ -76,20 +77,21 @@ class Payment_Transaction
     /**
      * Set the transaction type.
      *
-     * @param string $param The transaction type.
+     * @param string $param the transaction type
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setType($param)
     {
         $this->type = $param;
+
         return $this;
     }
 
     /**
      * Get the transaction type.
      *
-     * @return string The transaction type.
+     * @return string the transaction type
      */
     public function getType()
     {
@@ -99,20 +101,21 @@ class Payment_Transaction
     /**
      * Set the transaction currency.
      *
-     * @param string $param The transaction currency.
+     * @param string $param the transaction currency
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setCurrency($param)
     {
         $this->currency = $param;
+
         return $this;
     }
 
     /**
      * Get the transaction currency.
      *
-     * @return string The transaction currency.
+     * @return string the transaction currency
      */
     public function getCurrency()
     {
@@ -122,20 +125,21 @@ class Payment_Transaction
     /**
      * Set the transaction amount.
      *
-     * @param float $param The transaction amount.
+     * @param float $param the transaction amount
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setAmount($param)
     {
         $this->amount = $param;
+
         return $this;
     }
 
     /**
      * Get the transaction amount.
      *
-     * @return float The transaction amount.
+     * @return float the transaction amount
      */
     public function getAmount()
     {
@@ -145,20 +149,21 @@ class Payment_Transaction
     /**
      * Set the ID of the subscription associated with the transaction.
      *
-     * @param string $param The subscription ID.
+     * @param string $param the subscription ID
      *
-     * @return $this The current object, for method chaining.
+     * @return $this the current object, for method chaining
      */
     public function setSubscriptionId($param)
     {
         $this->subscription_id = $param;
+
         return $this;
     }
 
     /**
      * Get the ID of the subscription associated with the transaction.
      *
-     * @return string The subscription ID.
+     * @return string the subscription ID
      */
     public function getSubscriptionId()
     {

--- a/src/library/Registrar/Adapter/Custom.php
+++ b/src/library/Registrar/Adapter/Custom.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -12,39 +12,40 @@ use Iodev\Whois\Factory;
 
 class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
 {
-    public $config = array(
-        'use_whois'   => FALSE,
-    );
+    public $config = [
+        'use_whois' => false,
+    ];
 
     public function __construct($options)
     {
-        if(isset($options['use_whois'])) {
-            $this->config['use_whois'] = (bool)$options['use_whois'];
+        if (isset($options['use_whois'])) {
+            $this->config['use_whois'] = (bool) $options['use_whois'];
         }
     }
 
     public function getTlds()
     {
-        return array();
+        return [];
     }
 
     public static function getConfig()
     {
-        return array(
+        return [
             'label' => 'Custom Registrar always responds with positive results. Usefull if no other registrar is suitable.',
-            'form'  => array(
-                'use_whois' => array('radio', array(
-                            'multiOptions' => array('1'=>'Yes', '0'=>'No'),
+            'form' => [
+                'use_whois' => ['radio', [
+                            'multiOptions' => ['1' => 'Yes', '0' => 'No'],
                             'label' => 'Use WHOIS to check for domain availability',
-                    ),
-                 ),
-            ),
-        );
+                    ],
+                 ],
+            ],
+        ];
     }
 
     public function isDomaincanBeTransferred(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Checking if domain can be transferred: ' . $domain->getName());
+
         return true;
     }
 
@@ -52,10 +53,12 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Checking domain availability: ' . $domain->getName());
 
-        if($this->config['use_whois']) {
+        if ($this->config['use_whois']) {
             $whois = Factory::get()->createWhois();
+
             return $whois->isDomainAvailable($domain->getName());
         }
+
         return true;
     }
 
@@ -66,6 +69,7 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
         $this->getLog()->debug('Ns2: ' . $domain->getNs2());
         $this->getLog()->debug('Ns3: ' . $domain->getNs3());
         $this->getLog()->debug('Ns4: ' . $domain->getNs4());
+
         return true;
     }
 
@@ -73,6 +77,7 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Transfering domain: ' . $domain->getName());
         $this->getLog()->debug('Epp code: ' . $domain->getEpp());
+
         return true;
     }
 
@@ -80,67 +85,77 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Getting whois: ' . $domain->getName());
 
-        if(!$domain->getRegistrationTime()) {
+        if (!$domain->getRegistrationTime()) {
             $domain->setRegistrationTime(time());
         }
-        if(!$domain->getExpirationTime()) {
+        if (!$domain->getExpirationTime()) {
             $years = $domain->getRegistrationPeriod();
             $domain->setExpirationTime(strtotime("+$years year"));
         }
+
         return $domain;
     }
 
     public function deleteDomain(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Removing domain: ' . $domain->getName());
+
         return true;
     }
 
     public function registerDomain(Registrar_Domain $domain)
     {
-        $this->getLog()->debug('Registering domain: ' . $domain->getName(). ' for '.$domain->getRegistrationPeriod(). ' years');
+        $this->getLog()->debug('Registering domain: ' . $domain->getName() . ' for ' . $domain->getRegistrationPeriod() . ' years');
+
         return true;
     }
 
     public function renewDomain(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Renewing domain: ' . $domain->getName());
+
         return true;
     }
 
     public function modifyContact(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Updating contact info: ' . $domain->getName());
+
         return true;
     }
 
     public function enablePrivacyProtection(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Enabling Privacy protection: ' . $domain->getName());
+
         return true;
     }
 
     public function disablePrivacyProtection(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Disabling Privacy protection: ' . $domain->getName());
+
         return true;
     }
 
     public function getEpp(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Retrieving domain transfer code: ' . $domain->getName());
+
         return '';
     }
 
     public function lock(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Locking domain: ' . $domain->getName());
+
         return true;
     }
 
     public function unlock(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Unlocking: ' . $domain->getName());
+
         return true;
     }
 }

--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -16,15 +16,15 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function __construct($options)
     {
-        if(isset($options['email']) && !empty($options['email'])) {
+        if (isset($options['email']) && !empty($options['email'])) {
             $this->config['email'] = $options['email'];
             unset($options['email']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Email', ':missing' => 'email'], 3001);
         }
 
-        if(isset($options['use_whois'])) {
-            $this->config['use_whois'] = (bool)$options['use_whois'];
+        if (isset($options['use_whois'])) {
+            $this->config['use_whois'] = (bool) $options['use_whois'];
         } else {
             $this->config['use_whois'] = false;
         }
@@ -34,36 +34,38 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public static function getConfig()
     {
-        return array(
-            'label'     =>  'This registrar type sends notifications to the given email about domain management events. For example, when client registers a new domain an email with domain details will be sent to you. It is then your responsibility to register domain on real registrar.',
-            'form'  => array(
-                'email' => array('text', array(
+        return [
+            'label' => 'This registrar type sends notifications to the given email about domain management events. For example, when client registers a new domain an email with domain details will be sent to you. It is then your responsibility to register domain on real registrar.',
+            'form' => [
+                'email' => ['text', [
                             'label' => 'Email address',
-                            'description'=>'Email to send domain change notifications'
-                    ),
-                 ),
-                'use_whois' => array('radio', array(
-                            'multiOptions' => array('1'=>'Yes', '0'=>'No'),
+                            'description' => 'Email to send domain change notifications',
+                    ],
+                 ],
+                'use_whois' => ['radio', [
+                            'multiOptions' => ['1' => 'Yes', '0' => 'No'],
                             'label' => 'Use WHOIS to check for domain availability',
-                    ),
-                 ),
-            ),
-        );
+                    ],
+                 ],
+            ],
+        ];
     }
 
     public function getTlds()
     {
-        return array();
+        return [];
     }
 
     public function isDomainAvailable(Registrar_Domain $domain)
     {
         $this->getLog()->debug('Checking domain availability: ' . $domain->getName());
 
-        if($this->config['use_whois']) {
+        if ($this->config['use_whois']) {
             $whois = Factory::get()->createWhois();
+
             return $whois->isDomainAvailable($domain->getName());
         }
+
         throw new Registrar_Exception('Email registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain availability']);
     }
 
@@ -74,7 +76,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function modifyNs(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Modify Name Servers';
         $params['content'] = 'A request to change domain nameservers has been received.';
 
@@ -83,7 +85,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function transferDomain(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Transfer domain';
         $params['content'] = 'A request to transfer domain has been received.';
 
@@ -97,7 +99,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function deleteDomain(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Delete domain';
         $params['content'] = 'A request to delete domain has been received.';
 
@@ -106,7 +108,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function registerDomain(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Register domain';
         $params['content'] = 'A request to register domain has been received.';
 
@@ -115,7 +117,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function renewDomain(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Renew domain';
         $params['content'] = 'A request to renew domain has been received.';
 
@@ -124,7 +126,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function modifyContact(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Modify Domain Contact';
         $params['content'] = 'A request to update domain contacts details has been received.';
 
@@ -133,7 +135,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function enablePrivacyProtection(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Turn On Domain privacy protection';
         $params['content'] = 'A request to change domain privacy protection has been received.';
 
@@ -142,7 +144,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function disablePrivacyProtection(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Turn Off Domain privacy protection';
         $params['content'] = 'A request to change domain privacy protection has been received.';
 
@@ -151,7 +153,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function getEpp(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Request for Epp code was received';
         $params['content'] = 'A request for Domain Transfer code was received.';
 
@@ -160,7 +162,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function lock(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Request to lock domain received';
         $params['content'] = 'A request to lock domain was received.';
 
@@ -169,7 +171,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 
     public function unlock(Registrar_Domain $domain)
     {
-        $params =array();
+        $params = [];
         $params['subject'] = 'Request to unlock domain received';
         $params['content'] = 'A request to unlock domain was received.';
 
@@ -187,13 +189,15 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
         $c .= $domain->__toString();
 
         $log = $this->getLog();
-        if($this->_testMode) {
-            $log->alert($params['subject'].PHP_EOL.PHP_EOL.$c);
+        if ($this->_testMode) {
+            $log->alert($params['subject'] . PHP_EOL . PHP_EOL . $c);
+
             return true;
         }
 
         mail($this->config['email'], $params['subject'], $c);
-        $log->info("Email sent: ".$params['subject']);
+        $log->info('Email sent: ' . $params['subject']);
+
         return true;
     }
 }

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -4,21 +4,21 @@ use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 {
-    public $config = array(
-        'apikey'   => null,
-        'password' => null
-    );
+    public $config = [
+        'apikey' => null,
+        'password' => null,
+    ];
 
     public function __construct($options)
     {
-        if(isset($options['apikey']) && !empty($options['apikey'])) {
+        if (isset($options['apikey']) && !empty($options['apikey'])) {
             $this->config['apikey'] = $options['apikey'];
             unset($options['apikey']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Internetbs', ':missing' => 'Internetbs API key'], 3001);
         }
 
-        if(isset($options['password']) && !empty($options['password'])) {
+        if (isset($options['password']) && !empty($options['password'])) {
             $this->config['password'] = $options['password'];
             unset($options['password']);
         } else {
@@ -28,27 +28,27 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 
     public static function getConfig()
     {
-        return array(
+        return [
             'label' => 'Manages domains on Internetbs via API',
-            'form'  => array(
-                'apikey' => array('text', array(
+            'form' => [
+                'apikey' => ['text', [
                             'label' => 'Internetbs API key',
-                            'description'=>'Internetbs API key',
-                    ),
-                 ),
-                'password' => array('password', array(
+                            'description' => 'Internetbs API key',
+                    ],
+                 ],
+                'password' => ['password', [
                             'label' => 'Internetbs API password',
-                            'description'=>'Internetbs API password',
+                            'description' => 'Internetbs API password',
                             'renderPassword' => true,
-                    ),
-                 ),
-            ),
-        );
+                    ],
+                 ],
+            ],
+        ];
     }
 
     public function getTlds()
     {
-        return array(
+        return [
             '.co', '.com', '.net', '.eu',
             '.org', '.it', '.fr', '.info',
             '.tel', '.us', '.biz', '.co.uk',
@@ -57,18 +57,18 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
             '.com.re', '.org.uk', '.me.uk', '.com.co',
             '.net.co', '.nom.co', '.co.in', '.net.in',
             '.org.in', '.firm.in', '.gen.in', '.ind.in',
-        );
+        ];
     }
 
     public function isDomainAvailable(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process('/Domain/Check', $params);
 
-        return ($result['status'] == 'AVAILABLE');
+        return $result['status'] == 'AVAILABLE';
     }
 
     public function isDomaincanBeTransferred(Registrar_Domain $domain): never
@@ -78,95 +78,94 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 
     public function modifyNs(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
-        $nsList = array();
+        $nsList = [];
         $nsList[] = $domain->getNs1();
         $nsList[] = $domain->getNs2();
         $nsList[] = $domain->getNs3();
         $nsList[] = $domain->getNs4();
-        
+
         $params['ns_list'] = implode(',', $nsList);
 
         $result = $this->_process('/Domain/Update', $params);
 
-        return ($result['status'] == 'SUCCESS');
+        return $result['status'] == 'SUCCESS';
     }
 
     public function modifyContact(Registrar_Domain $domain)
     {
         $c = $domain->getContactRegistrar();
 
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
-		// Set contact data
-		foreach (array('Registrant', 'Admin', 'Technical', 'Billing') as $contactType)
-        {
-            $params[$contactType. '_Organization'] = $c->getCompany();
-			$params[$contactType. '_FirstName']    = $c->getFirstName();
-			$params[$contactType. '_LastName']     = $c->getLastName();
-			$params[$contactType. '_Email']        = $c->getEmail();
-			$params[$contactType. '_PhoneNumber']  = '+' . $c->getTelCc() . '.' . $c->getTel();
-			$params[$contactType. '_Street']       = $c->getAddress1();
-            $params[$contactType. '_Street2']       = $c->getAddress2();
-            $params[$contactType. '_Street3']       = $c->getAddress3();
-			$params[$contactType. '_City']         = $c->getCity();
-			$params[$contactType. '_CountryCode']  = $c->getCountry();
-			$params[$contactType. '_PostalCode']   = $c->getZip();
-			$params[$contactType. '_Language']     = 'en';
+        // Set contact data
+        foreach (['Registrant', 'Admin', 'Technical', 'Billing'] as $contactType) {
+            $params[$contactType . '_Organization'] = $c->getCompany();
+            $params[$contactType . '_FirstName'] = $c->getFirstName();
+            $params[$contactType . '_LastName'] = $c->getLastName();
+            $params[$contactType . '_Email'] = $c->getEmail();
+            $params[$contactType . '_PhoneNumber'] = '+' . $c->getTelCc() . '.' . $c->getTel();
+            $params[$contactType . '_Street'] = $c->getAddress1();
+            $params[$contactType . '_Street2'] = $c->getAddress2();
+            $params[$contactType . '_Street3'] = $c->getAddress3();
+            $params[$contactType . '_City'] = $c->getCity();
+            $params[$contactType . '_CountryCode'] = $c->getCountry();
+            $params[$contactType . '_PostalCode'] = $c->getZip();
+            $params[$contactType . '_Language'] = 'en';
         }
 
         $result = $this->_process('/Domain/Update', $params);
 
-        return ($result['status'] == 'SUCCESS');
+        return $result['status'] == 'SUCCESS';
     }
 
     public function transferDomain(Registrar_Domain $domain)
     {
         $c = $domain->getContactRegistrar();
 
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
-		// Set contact data
-		foreach (array('Registrant', 'Admin', 'Technical', 'Billing') as $contactType)
-        {
-            $params[$contactType. '_Organization'] = $c->getCompany();
-			$params[$contactType. '_FirstName']    = $c->getFirstName();
-			$params[$contactType. '_LastName']     = $c->getLastName();
-			$params[$contactType. '_Email']        = $c->getEmail();
-			$params[$contactType. '_PhoneNumber']  = '+' . $c->getTelCc() . '.' . $c->getTel();
-			$params[$contactType. '_Street']       = $c->getAddress1();
-            $params[$contactType. '_Street2']       = $c->getAddress2();
-            $params[$contactType. '_Street3']       = $c->getAddress3();
-			$params[$contactType. '_City']         = $c->getCity();
-			$params[$contactType. '_CountryCode']  = $c->getCountry();
-			$params[$contactType. '_PostalCode']   = $c->getZip();
-			$params[$contactType. '_Language']     = 'en';
+        // Set contact data
+        foreach (['Registrant', 'Admin', 'Technical', 'Billing'] as $contactType) {
+            $params[$contactType . '_Organization'] = $c->getCompany();
+            $params[$contactType . '_FirstName'] = $c->getFirstName();
+            $params[$contactType . '_LastName'] = $c->getLastName();
+            $params[$contactType . '_Email'] = $c->getEmail();
+            $params[$contactType . '_PhoneNumber'] = '+' . $c->getTelCc() . '.' . $c->getTel();
+            $params[$contactType . '_Street'] = $c->getAddress1();
+            $params[$contactType . '_Street2'] = $c->getAddress2();
+            $params[$contactType . '_Street3'] = $c->getAddress3();
+            $params[$contactType . '_City'] = $c->getCity();
+            $params[$contactType . '_CountryCode'] = $c->getCountry();
+            $params[$contactType . '_PostalCode'] = $c->getZip();
+            $params[$contactType . '_Language'] = 'en';
         }
 
         $result = $this->_process('/Domain/Transfer/Initiate', $params);
-        
-        return ($result['status'] == 'SUCCESS');
+
+        return $result['status'] == 'SUCCESS';
     }
 
     public function getDomainDetails(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process('/Domain/Info', $params);
 
-        if ($result['status'] == 'SUCCESS'){
+        if ($result['status'] == 'SUCCESS') {
             return $this->_createDomainObj($result, $domain);
         } else {
             $placeholders = [':action:' => __trans('get domain details'), ':type:' => 'Internetbs'];
+
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
     }
@@ -180,49 +179,46 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
     {
         $c = $domain->getContactRegistrar();
 
-        $params = array(
+        $params = [
             'domain' => $domain->getName(),
-            'period' => $domain->getRegistrationPeriod() . 'Y'
-        );
+            'period' => $domain->getRegistrationPeriod() . 'Y',
+        ];
 
         // Add nameservers
-        $nsList = array();
+        $nsList = [];
         $nsList[] = $domain->getNs1();
         $nsList[] = $domain->getNs2();
-        if($domain->getNs3())  {
+        if ($domain->getNs3()) {
             $nsList[] = $domain->getNs3();
         }
-        if($domain->getNs4())  {
+        if ($domain->getNs4()) {
             $nsList[] = $domain->getNs4();
         }
         $params['ns_list'] = implode(',', $nsList);
-        
+
         // Set contact data
-        foreach (array('Registrant', 'Admin', 'Technical', 'Billing') as $contactType)
-        {
+        foreach (['Registrant', 'Admin', 'Technical', 'Billing'] as $contactType) {
             $params[$contactType . '_Organization'] = $c->getCompany();
-			$params[$contactType . '_FirstName']    = $c->getFirstName();
-			$params[$contactType . '_LastName']     = $c->getLastName();
-			$params[$contactType . '_Email']        = $c->getEmail();
-			$params[$contactType . '_PhoneNumber']  = '+' . $c->getTelCc() . '.' . $c->getTel();
-			$params[$contactType . '_Street']       = $c->getAddress1();
-            $params[$contactType . '_Street2']       = $c->getAddress2();
-            $params[$contactType . '_Street3']       = $c->getAddress3();
-			$params[$contactType . '_City']         = $c->getCity();
-			$params[$contactType . '_CountryCode']  = $c->getCountry();
-			$params[$contactType . '_PostalCode']   = $c->getZip();
-			$params[$contactType . '_Language']     = 'en';
+            $params[$contactType . '_FirstName'] = $c->getFirstName();
+            $params[$contactType . '_LastName'] = $c->getLastName();
+            $params[$contactType . '_Email'] = $c->getEmail();
+            $params[$contactType . '_PhoneNumber'] = '+' . $c->getTelCc() . '.' . $c->getTel();
+            $params[$contactType . '_Street'] = $c->getAddress1();
+            $params[$contactType . '_Street2'] = $c->getAddress2();
+            $params[$contactType . '_Street3'] = $c->getAddress3();
+            $params[$contactType . '_City'] = $c->getCity();
+            $params[$contactType . '_CountryCode'] = $c->getCountry();
+            $params[$contactType . '_PostalCode'] = $c->getZip();
+            $params[$contactType . '_Language'] = 'en';
         }
-        
-        if ($domain->getTld() == '.asia')
-        {
+
+        if ($domain->getTld() == '.asia') {
             $params['Registrant_DotAsiaCedLocality'] = $c->getCountry();
             $params['Registrant_DotAsiaCedEntity'] = 'naturalPerson';
             $params['Registrant_DotAsiaCedIdForm'] = 'passport';
         }
 
-        if ($domain->getTld() == '.fr' || $domain->getTld() == '.re')
-        {
+        if ($domain->getTld() == '.fr' || $domain->getTld() == '.re') {
             $tm = random_int(100_000_000, 999_999_999);
             $params['registrant_dotFRContactEntityType'] = 'OTHER';
             $params['admin_dotFRContactEntityType'] = 'OTHER';
@@ -233,152 +229,160 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
             $params['registrant_dotFRContactEntityTrademark'] = $tm;
             $params['admin_dotFRContactEntityTrademark'] = $tm;
         }
-        
-        if ($domain->getTld() == '.it')
-        {
+
+        if ($domain->getTld() == '.it') {
             $params['Registrant_dotitEntityType'] = 1;
             $params['Registrant_dotitNationality'] = $c->getCountry();
             $params['Registrant_dotitRegCode'] = $c->getDocumentNr();
             $params['Registrant_dotitHideWhois'] = ($domain->getPrivacyEnabled() ? 'YES' : 'NO');
             $params['Registrant_dotitProvince'] = $c->getState();
-            for ($i = 1; $i < 5; $i++)
+            for ($i = 1; $i < 5; ++$i) {
                 $params['Registrant_dotItTerm' . $i] = 'YES';
+            }
             $params['Registrant_clientIp'] = '1.1.1.1';
             $params['Admin_dotitProvince'] = $c->getState();
             $params['Technical_dotitProvince'] = $c->getState();
         }
-            
-        if ($domain->getTld() == '.us')
-        {
+
+        if ($domain->getTld() == '.us') {
             $params['Registrant_usPurpose'] = 'P3';
             $params['Registrant_usNexusCategory'] = 'C11';
         }
 
         $result = $this->_process('/Domain/Create', $params);
 
-        return (($result['product_0_status'] == 'PENDING')
-               || ($result['product_0_status'] == 'SUCCESS'));
+        return ($result['product_0_status'] == 'PENDING')
+               || ($result['product_0_status'] == 'SUCCESS');
     }
 
     public function renewDomain(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process('/Domain/Renew', $params);
 
-        return ($result['product_0_status'] == 'SUCCESS');
+        return $result['product_0_status'] == 'SUCCESS';
     }
 
     public function enablePrivacyProtection(Registrar_Domain $domain)
     {
         $cmd = '/Domain/PrivateWhois/Enable';
 
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process($cmd, $params);
 
-        return ($result['status'] == 'SUCCESS');
+        return $result['status'] == 'SUCCESS';
     }
 
     public function disablePrivacyProtection(Registrar_Domain $domain)
     {
         $cmd = '/Domain/PrivateWhois/Disable';
 
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process($cmd, $params);
 
-        return ($result['status'] == 'SUCCESS');
+        return $result['status'] == 'SUCCESS';
     }
-    
+
     public function getEpp(Registrar_Domain $domain)
     {
         $d = $this->getDomainDetails($domain);
+
         return $d->getEpp();
     }
 
     public function lock(Registrar_Domain $domain)
     {
         $cmd = '/Domain/RegistrarLock/Enable';
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
         $result = $this->_process($cmd, $params);
-        return ($result['status'] == 'SUCCESS');
+
+        return $result['status'] == 'SUCCESS';
     }
 
     public function unlock(Registrar_Domain $domain)
     {
         $cmd = '/Domain/RegistrarLock/Disable';
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
         $result = $this->_process($cmd, $params);
-        return ($result['status'] == 'SUCCESS');
+
+        return $result['status'] == 'SUCCESS';
     }
 
-	/**
-   	 * Runs an api command and returns parsed data.
- 	 * @param string $command
- 	 * @return array
- 	 */
-	private function _process($command, $params)
+    /**
+     * Runs an api command and returns parsed data.
+     *
+     * @param string $command
+     *
+     * @return array
+     */
+    private function _process($command, $params)
     {
         // Set authentication params
         $params['apikey'] = $this->config['apikey'];
         $params['password'] = $this->config['password'];
 
         $client = $this->getHttpClient()->withOptions([
-            'verify_peer'   => false,
-            'verify_host'   => false,
+            'verify_peer' => false,
+            'verify_host' => false,
         ]);
 
         try {
-            $response = $client->request('POST', $this->_getApiUrl().$command, [
-                'body'  => $params,
+            $response = $client->request('POST', $this->_getApiUrl() . $command, [
+                'body' => $params,
             ]);
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception(sprintf('HttpClientException: %s', $error->getMessage()));
             $this->getLog()->err($e);
+
             throw $e;
         }
-        
+
         $data = $response->getContent();
+
         return $this->_parseResult($data);
-	}
+    }
 
     /**
      * Parses data returned by request.
+     *
      * @param string $data
+     *
      * @return array
      */
-	private function _parseResult($data)
+    private function _parseResult($data)
     {
-		$lines = explode("\n", $data);
-		$result = array();
+        $lines = explode("\n", $data);
+        $result = [];
 
-		foreach ($lines as $line)
-        {
-			[$varName, $value] = explode("=", $line);
-			$result[strtolower(trim($varName))] = trim($value);
-		}
-        
-        if ((array_key_exists('status', $result))
-            && ($result['status'] == 'FAILURE'))
-        {
+        foreach ($lines as $line) {
+            [$varName, $value] = explode('=', $line);
+            $result[strtolower(trim($varName))] = trim($value);
+        }
+
+        if (array_key_exists('status', $result)
+            && ($result['status'] == 'FAILURE')) {
             throw new Registrar_Exception($result['message']);
         }
-        
-        if ($this->isTestEnv()) error_log(print_r($result, 1));
-        
-		return $result;
-	}
+
+        if ($this->isTestEnv()) {
+            error_log(print_r($result, 1));
+        }
+
+        return $result;
+    }
 
     public function isTestEnv()
     {
@@ -387,17 +391,21 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
 
     /**
      * Api URL.
+     *
      * @return string
      */
     private function _getApiUrl()
     {
-        if ($this->isTestEnv())
+        if ($this->isTestEnv()) {
             return 'https://testapi.internet.bs';
+        }
+
         return 'https://api.internet.bs';
     }
 
     /**
      * Creates domain object from received data array.
+     *
      * @return Registrar_Domain
      */
     private function _createDomainObj($result, Registrar_Domain $domain)
@@ -407,18 +415,23 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
         $name = '';
 
         // domain specific
-        if (array_key_exists($type . 'firstname', $result))
+        if (array_key_exists($type . 'firstname', $result)) {
             $name = $result[$type . 'firstname'];
-        if (array_key_exists($type . 'lastname', $result))
+        }
+        if (array_key_exists($type . 'lastname', $result)) {
             $name .= ' ' . $result[$type . 'lastname'];
-        
-        if (!array_key_exists($type . 'organization', $result))
+        }
+
+        if (!array_key_exists($type . 'organization', $result)) {
             $result[$type . 'organization'] = '';
-        if ($domain->getTld() == 'fr')
+        }
+        if ($domain->getTld() == 'fr') {
             $name = $result[$type . 'dotfrcontactentityname'];
-        if ($domain->getTld() == 'it')
+        }
+        if ($domain->getTld() == 'it') {
             $result['transferauthinfo'] = '';
-        
+        }
+
         $c = new Registrar_Domain_Contact();
         $c->setName($name)
           ->setEmail($result[$type . 'email'])
@@ -432,26 +445,25 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
           ->setCountry($result[$type . 'country'])
           ->setZip($result[$type . 'postalcode']);
 
-        if(isset($result['nameserver_0'])) {
+        if (isset($result['nameserver_0'])) {
             $domain->setNs1($result['nameserver_0']);
         }
-        
-        if(isset($result['nameserver_1'])) {
+
+        if (isset($result['nameserver_1'])) {
             $domain->setNs2($result['nameserver_1']);
         }
-        
-        if(isset($result['nameserver_2'])) {
+
+        if (isset($result['nameserver_2'])) {
             $domain->setNs3($result['nameserver_2']);
         }
-        
-        if(isset($result['nameserver_3'])) {
+
+        if (isset($result['nameserver_3'])) {
             $domain->setNs4($result['nameserver_3']);
         }
 
         $privacy = 0;
-        if (array_key_exists('privatewhois', $result))
-        {
-            $privacy =  ($result['privatewhois'] == 'FULL')
+        if (array_key_exists('privatewhois', $result)) {
+            $privacy = ($result['privatewhois'] == 'FULL')
                         || ($result['privatewhois'] == 'PARTIAL');
         }
 
@@ -459,24 +471,25 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
         $domain->setPrivacyEnabled($privacy);
         $domain->setEpp($result['transferauthinfo']);
         $domain->setContactRegistrar($c);
- 
+
         return $domain;
     }
 
     /**
      * Checks whether privacy is enabled.
+     *
      * @return bool
      */
     private function _isPrivacyEnabled(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain' => $domain->getName()
-        );
+        $params = [
+            'domain' => $domain->getName(),
+        ];
 
         $result = $this->_process('/Domain/PrivateWhois/Status', $params);
 
-        return (($result['status'] == 'SUCCESS')
+        return ($result['status'] == 'SUCCESS')
                 && (($result['privatewhoisstatus'] == 'FULL')
-                || ($result['privatewhoisstatus'] == 'PARTIAL')));
+                || ($result['privatewhoisstatus'] == 'PARTIAL'));
     }
 }

--- a/src/library/Registrar/Adapter/Netearthone.php
+++ b/src/library/Registrar/Adapter/Netearthone.php
@@ -4,14 +4,14 @@ class Registrar_Adapter_Netearthone extends Registrar_Adapter_Resellerclub
 {
     public function __construct($options)
     {
-        if(isset($options['userid']) && !empty($options['userid'])) {
+        if (isset($options['userid']) && !empty($options['userid'])) {
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'NetEarthOne', ':missing' => 'NetEarthOne Reseller ID'], 3001);
         }
 
-        if(isset($options['api-key']) && !empty($options['api-key'])) {
+        if (isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
@@ -21,21 +21,21 @@ class Registrar_Adapter_Netearthone extends Registrar_Adapter_Resellerclub
 
     public static function getConfig()
     {
-        return array(
-            'label'     =>  'Manages domains on NetEarthOne via API. NetEarthOne requires your server IP in order to work. Login to the NetEarthOne control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
-            'form'  => array(
-                'userid' => array('text', array(
+        return [
+            'label' => 'Manages domains on NetEarthOne via API. NetEarthOne requires your server IP in order to work. Login to the NetEarthOne control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
+            'form' => [
+                'userid' => ['text', [
                     'label' => 'Reseller ID. You can get this at NetEarthOne control panel Settings > Personal information > Primary profile > Reseller ID',
-                    'description'=> 'NetEarthOne Reseller ID'
-                ),
-                ),
-                'api-key' => array('password', array(
+                    'description' => 'NetEarthOne Reseller ID',
+                ],
+                ],
+                'api-key' => ['password', [
                     'label' => 'NetEarthOne API Key',
-                    'description'=> 'You can get this at NetEarthOne control panel, go to Settings -> API',
+                    'description' => 'You can get this at NetEarthOne control panel, go to Settings -> API',
                     'required' => false,
-                ),
-                ),
-            ),
-        );
+                ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/library/Registrar/Adapter/Resellbiz.php
+++ b/src/library/Registrar/Adapter/Resellbiz.php
@@ -4,14 +4,14 @@ class Registrar_Adapter_Resellbiz extends Registrar_Adapter_Resellerclub
 {
     public function __construct($options)
     {
-        if(isset($options['userid']) && !empty($options['userid'])) {
+        if (isset($options['userid']) && !empty($options['userid'])) {
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Resell.biz', ':missing' => 'Resell.biz Reseller ID'], 3001);
         }
 
-        if(isset($options['api-key']) && !empty($options['api-key'])) {
+        if (isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
@@ -21,21 +21,21 @@ class Registrar_Adapter_Resellbiz extends Registrar_Adapter_Resellerclub
 
     public static function getConfig()
     {
-        return array(
-            'label'     =>  'Manages domains on Resell.biz via API. Resell.biz requires your server IP in order to work. Login to the Resell.biz control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
-            'form'  => array(
-                'userid' => array('text', array(
+        return [
+            'label' => 'Manages domains on Resell.biz via API. Resell.biz requires your server IP in order to work. Login to the Resell.biz control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
+            'form' => [
+                'userid' => ['text', [
                     'label' => 'Reseller ID. You can get this at Resell.biz control panel Settings > Personal information > Primary profile > Reseller ID',
-                    'description'=> 'Resell.biz Reseller ID'
-                ),
-                ),
-                'api-key' => array('password', array(
+                    'description' => 'Resell.biz Reseller ID',
+                ],
+                ],
+                'api-key' => ['password', [
                     'label' => 'Resell.biz API Key',
-                    'description'=> 'You can get this at Resell.biz control panel, go to Settings -> API',
+                    'description' => 'You can get this at Resell.biz control panel, go to Settings -> API',
                     'required' => false,
-                ),
-                ),
-            ),
-        );
+                ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -2,13 +2,13 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-/**
+/*
  * HTTP API documentation http://cp.onlyfordemo.net/kb/answer/744
  */
 
@@ -16,65 +16,67 @@ use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 {
-    public $config = array(
-        'userid'   => null,
+    public $config = [
+        'userid' => null,
         'password' => null,
         'api-key' => null,
-    );
+    ];
 
     public function isKeyValueNotEmpty($array, $key)
     {
         $value = $array[$key] ?? '';
-        if (strlen(trim($value)) == 0){
+        if (strlen(trim($value)) == 0) {
             return false;
         }
+
         return true;
     }
 
     public function __construct($options)
     {
-        if(isset($options['userid']) && !empty($options['userid'])) {
+        if (isset($options['userid']) && !empty($options['userid'])) {
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'ResellerClub', ':missing' => 'ResellerClub Reseller ID'], 3001);
         }
 
-        if(isset($options['api-key']) && !empty($options['api-key'])) {
+        if (isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'ResellerClub', ':missing' => 'ResellerClub API Key'], 3001);
         }
     }
-    
+
     public static function getConfig()
     {
-        return array(
-            'label'     =>  'Manages domains on ResellerClub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
-            'form'  => array(
-                'userid' => array('text', array(
+        return [
+            'label' => 'Manages domains on ResellerClub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
+            'form' => [
+                'userid' => ['text', [
                             'label' => 'Reseller ID. You can get this at ResellerClub control panel Settings > Personal information > Primary profile > Reseller ID',
-                            'description'=> 'ResellerClub Reseller ID'
-                        ),
-                     ),
-                'api-key' => array('password', array(
+                            'description' => 'ResellerClub Reseller ID',
+                        ],
+                     ],
+                'api-key' => ['password', [
                             'label' => 'ResellerClub API Key',
-                            'description'=> 'You can get this at ResellerClub control panel, go to Settings -> API',
+                            'description' => 'You can get this at ResellerClub control panel, go to Settings -> API',
                             'required' => false,
-                        ),
-                     ),
-            ),
-        );
+                        ],
+                     ],
+            ],
+        ];
     }
-    
+
     /**
-     * Tells what TLDs can be registered via this adapter
+     * Tells what TLDs can be registered via this adapter.
+     *
      * @return string[]
      */
     public function getTlds()
     {
-        return array(
+        return [
             '.com', '.net', '.biz', '.org', '.info', '.name', '.co',
             '.asia', '.ru', '.com.ru', '.net.ru', '.org.ru',
             '.de', '.es', '.us', '.xxx', '.ca', '.au', '.com.au',
@@ -90,57 +92,60 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             '.sa.com', '.se.com', '.se.net', '.uk.com',
             '.uk.net', '.ru.com', '.com.cn', '.net.cn',
             '.org.cn', '.nl', '.co', '.com.co', '.pw',
-        );
+        ];
     }
 
     public function isDomainAvailable(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain-name'           =>  $domain->getSld(),
-            'tlds'                  =>  array($domain->getTld(false)),
-            'suggest-alternative'   =>  false,
-        );
+        $params = [
+            'domain-name' => $domain->getSld(),
+            'tlds' => [$domain->getTld(false)],
+            'suggest-alternative' => false,
+        ];
 
         $result = $this->_makeRequest('domains/available', $params);
-        if(!isset($result[$domain->getName()])) {
+        if (!isset($result[$domain->getName()])) {
             return true;
         }
 
         $check = $result[$domain->getName()];
-        if($check && $check['status'] == 'available') {
+        if ($check && $check['status'] == 'available') {
             return true;
         }
+
         return false;
     }
 
     public function isDomaincanBeTransferred(Registrar_Domain $domain)
     {
-        $params = array(
-            'domain-name'       =>  $domain->getName(),
-        );
+        $params = [
+            'domain-name' => $domain->getName(),
+        ];
         $result = $this->_makeRequest('domains/validate-transfer', $params, 'GET');
-        return (strtolower($result) == 'true');
+
+        return strtolower($result) == 'true';
     }
 
     public function modifyNs(Registrar_Domain $domain)
     {
-        $ns = array();
+        $ns = [];
         $ns[] = $domain->getNs1();
         $ns[] = $domain->getNs2();
-        if($domain->getNs3())  {
+        if ($domain->getNs3()) {
             $ns[] = $domain->getNs3();
         }
-        if($domain->getNs4())  {
+        if ($domain->getNs4()) {
             $ns[] = $domain->getNs4();
         }
 
-        $params = array(
-            'order-id'  =>  $this->_getDomainOrderId($domain),
-            'ns'        =>  $ns,
-        );
+        $params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+            'ns' => $ns,
+        ];
 
         $result = $this->_makeRequest('domains/modify-ns', $params, 'POST');
-        return ($result['status'] == 'Success');
+
+        return $result['status'] == 'Success';
     }
 
     public function modifyContact(Registrar_Domain $domain)
@@ -150,29 +155,30 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         $contact_id = $cdetails['Contact']['registrant'];
 
         $c = $domain->getContactRegistrar();
-        
-        $required_params = array(
-            'contact-id'        =>  $contact_id,
-            'name'              =>  $c->getName(),
-            'company'           =>  $c->getCompany(),
-            'email'             =>  $c->getEmail(),
-            'address-line-1'    =>  $c->getAddress1(),
-            'city'              =>  $c->getCity(),
-            'zipcode'           =>  $c->getZip(),
-            'phone-cc'          =>  $c->getTelCc(),
-            'phone'             =>  $c->getTel(),
-            'country'           =>  $c->getCountry(),
-        );
 
-        $optional_params = array(
-            'address-line-2'    =>  $c->getAddress2(),
-            'address-line-3'    =>  $c->getAddress3(),
-            'state'             =>  $c->getState(),
-        );
+        $required_params = [
+            'contact-id' => $contact_id,
+            'name' => $c->getName(),
+            'company' => $c->getCompany(),
+            'email' => $c->getEmail(),
+            'address-line-1' => $c->getAddress1(),
+            'city' => $c->getCity(),
+            'zipcode' => $c->getZip(),
+            'phone-cc' => $c->getTelCc(),
+            'phone' => $c->getTel(),
+            'country' => $c->getCountry(),
+        ];
+
+        $optional_params = [
+            'address-line-2' => $c->getAddress2(),
+            'address-line-3' => $c->getAddress3(),
+            'state' => $c->getState(),
+        ];
 
         $params = [...$optional_params, ...$required_params];
         $result = $this->_makeRequest('contacts/modify', $params, 'POST');
-        return ($result['status'] == 'Success');
+
+        return $result['status'] == 'Success';
     }
 
     public function transferDomain(Registrar_Domain $domain)
@@ -181,32 +187,32 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         $contacts = $this->_getDefaultContactDetails($domain, $customer['customerid']);
         $contact_id = $contacts['Contact']['registrant'];
 
-        $ns = array();
+        $ns = [];
         $ns[] = $domain->getNs1();
         $ns[] = $domain->getNs2();
-        if($domain->getNs3())  {
+        if ($domain->getNs3()) {
             $ns[] = $domain->getNs3();
         }
-        if($domain->getNs4())  {
+        if ($domain->getNs4()) {
             $ns[] = $domain->getNs4();
         }
 
-        $required_params = array(
-            'domain-name'       =>  $domain->getName(),
-            'auth-code'         =>  $domain->getEpp(),
-            'ns'                =>  $ns,
-            'customer-id'       =>  $customer['customerid'],
-            'reg-contact-id'    =>  $contact_id,
-            'admin-contact-id'  =>  $contact_id,
-            'tech-contact-id'   =>  $contact_id,
-            'billing-contact-id'=>  $contact_id,
-            'invoice-option'    =>  'NoInvoice',
-            'protect-privacy'   =>  false,
-        );
+        $required_params = [
+            'domain-name' => $domain->getName(),
+            'auth-code' => $domain->getEpp(),
+            'ns' => $ns,
+            'customer-id' => $customer['customerid'],
+            'reg-contact-id' => $contact_id,
+            'admin-contact-id' => $contact_id,
+            'tech-contact-id' => $contact_id,
+            'billing-contact-id' => $contact_id,
+            'invoice-option' => 'NoInvoice',
+            'protect-privacy' => false,
+        ];
 
-        if($domain->getTld() == '.asia') {
+        if ($domain->getTld() == '.asia') {
             $required_params['attr-name1'] = 'cedcontactid';
-            $required_params['attr-value1'] = "default";
+            $required_params['attr-value1'] = 'default';
         }
 
         return $this->_makeRequest('domains/transfer', $required_params, 'POST');
@@ -214,26 +220,27 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     private function _getDomainOrderId(Registrar_Domain $d)
     {
-        $required_params = array(
-            'domain-name'   =>  $d->getName(),
-        );
+        $required_params = [
+            'domain-name' => $d->getName(),
+        ];
+
         return $this->_makeRequest('domains/orderid', $required_params);
     }
 
     public function getDomainDetails(Registrar_Domain $d)
     {
         $orderid = $this->_getDomainOrderId($d);
-        $params = array(
-            'order-id'      =>  $orderid,
-            'options'       =>  'All',
-        );
+        $params = [
+            'order-id' => $orderid,
+            'options' => 'All',
+        ];
         $data = $this->_makeRequest('domains/details', $params);
-        
+
         $d->setRegistrationTime($data['creationtime']);
         $d->setExpirationTime($data['endtime']);
         $d->setEpp($data['domsecret']);
-        $d->setPrivacyEnabled(($data['isprivacyprotected'] == 'true'));
-        
+        $d->setPrivacyEnabled($data['isprivacyprotected'] == 'true');
+
         /* Contact details */
         $wc = $data['admincontact'];
         $c = new Registrar_Domain_Contact();
@@ -248,90 +255,91 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             ->setCountry($wc['country'])
             ->setState($wc['state'])
             ->setZip($wc['zip']);
-        
-        if(isset($wc['address2'])) {
+
+        if (isset($wc['address2'])) {
             $c->setAddress2($wc['address2']);
         }
 
-        if(isset($wc['address3'])) {
+        if (isset($wc['address3'])) {
             $c->setAddress3($wc['address3']);
         }
 
         $d->setContactRegistrar($c);
 
-        if(isset($data['ns1'])) {
+        if (isset($data['ns1'])) {
             $d->setNs1($data['ns1']);
         }
-        if(isset($data['ns2'])) {
+        if (isset($data['ns2'])) {
             $d->setNs2($data['ns2']);
         }
-        if(isset($data['ns3'])) {
+        if (isset($data['ns3'])) {
             $d->setNs3($data['ns3']);
         }
-        if(isset($data['ns4'])) {
+        if (isset($data['ns4'])) {
             $d->setNs4($data['ns4']);
         }
-        
+
         return $d;
     }
 
     public function deleteDomain(Registrar_Domain $domain)
     {
-        $required_params = array(
-            'order-id'  =>  $this->_getDomainOrderId($domain),
-        );
+        $required_params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+        ];
         $result = $this->_makeRequest('domains/delete', $required_params, 'POST');
-        return (strtolower($result['status']) == 'success');
+
+        return strtolower($result['status']) == 'success';
     }
 
     public function registerDomain(Registrar_Domain $domain)
     {
-        if($this->_hasCompletedOrder($domain)) {
+        if ($this->_hasCompletedOrder($domain)) {
             return true;
         }
-        
+
         $tld = $domain->getTld();
         $customer = $this->_getCustomerDetails($domain);
         $customer_id = $customer['customerid'];
-        
-        $ns = array();
+
+        $ns = [];
         $ns[] = $domain->getNs1();
         $ns[] = $domain->getNs2();
-        if($domain->getNs3())  {
+        if ($domain->getNs3()) {
             $ns[] = $domain->getNs3();
         }
-        if($domain->getNs4())  {
+        if ($domain->getNs4()) {
             $ns[] = $domain->getNs4();
         }
 
         [$reg_contact_id, $admin_contact_id, $tech_contact_id, $billing_contact_id] = $this->_getAllContacts($tld, $customer_id, $domain->getContactRegistrar());
 
-        $params = array(
-            'domain-name'       =>  $domain->getName(),
-            'years'             =>  $domain->getRegistrationPeriod(),
-            'ns'                =>  $ns,
-            'customer-id'       =>  $customer_id,
-            'reg-contact-id'    =>  $reg_contact_id,
-            'admin-contact-id'  =>  $admin_contact_id,
-            'tech-contact-id'   =>  $tech_contact_id,
-            'billing-contact-id'=>  $billing_contact_id,
-            'invoice-option'    =>  'NoInvoice',
-            'protect-privacy'   =>  false,
-        );
+        $params = [
+            'domain-name' => $domain->getName(),
+            'years' => $domain->getRegistrationPeriod(),
+            'ns' => $ns,
+            'customer-id' => $customer_id,
+            'reg-contact-id' => $reg_contact_id,
+            'admin-contact-id' => $admin_contact_id,
+            'tech-contact-id' => $tech_contact_id,
+            'billing-contact-id' => $billing_contact_id,
+            'invoice-option' => 'NoInvoice',
+            'protect-privacy' => false,
+        ];
 
-        if($tld == '.asia') {
+        if ($tld == '.asia') {
             $params['attr-name1'] = 'cedcontactid';
-            $params['attr-value1'] = "default";
+            $params['attr-value1'] = 'default';
         }
 
-        if($tld == '.de') {
-            $params['ns'] = array('dns1.directi.com', 'dns2.directi.com', 'dns3.directi.com', 'dns4.directi.com');
+        if ($tld == '.de') {
+            $params['ns'] = ['dns1.directi.com', 'dns2.directi.com', 'dns3.directi.com', 'dns4.directi.com'];
         }
 
-        if ($tld == '.au' || $tld == '.net.au' || $tld == '.com.au'){
+        if ($tld == '.au' || $tld == '.net.au' || $tld == '.com.au') {
             $contact = $domain->getContactRegistrar();
 
-            if(strlen(trim($contact->getCompanyNumber())) == 0 ) {
+            if (strlen(trim($contact->getCompanyNumber())) == 0) {
                 throw new Registrar_Exception('A valid contact company number is mandatory for registering an .AU domain name');
             }
             $params['attr-name1'] = 'id-type';
@@ -343,199 +351,209 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $params['attr-name4'] = 'isAUWarranty';
             $params['attr-value4'] = '1';
         }
-        
+
         $result = $this->_makeRequest('domains/register', $params, 'POST');
-        return ($result['status'] == 'Success');
+
+        return $result['status'] == 'Success';
     }
 
     public function renewDomain(Registrar_Domain $domain)
     {
-        $params = array(
-            'order-id'          =>  $this->_getDomainOrderId($domain),
-            'years'             =>  $domain->getRegistrationPeriod(),
-            'exp-date'          =>  $domain->getExpirationTime(),
-            'invoice-option'    =>  'NoInvoice',
-        );
+        $params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+            'years' => $domain->getRegistrationPeriod(),
+            'exp-date' => $domain->getExpirationTime(),
+            'invoice-option' => 'NoInvoice',
+        ];
 
         $result = $this->_makeRequest('domains/renew', $params, 'POST');
-        return ($result['actionstatus'] == 'Success');
+
+        return $result['actionstatus'] == 'Success';
     }
 
     public function enablePrivacyProtection(Registrar_Domain $domain)
     {
         $order_id = $this->_getDomainOrderId($domain);
-        $params = array(
-            'order-id'        =>  $order_id,
-            'protect-privacy' =>  true,
-            'reason'          =>  'Owners decision',
-        );
+        $params = [
+            'order-id' => $order_id,
+            'protect-privacy' => true,
+            'reason' => 'Owners decision',
+        ];
 
         $result = $this->_makeRequest('domains/modify-privacy-protection', $params, 'POST');
-        return (strtolower($result['actionstatus']) == 'success');
+
+        return strtolower($result['actionstatus']) == 'success';
     }
 
     public function disablePrivacyProtection(Registrar_Domain $domain)
     {
         $order_id = $this->_getDomainOrderId($domain);
-        $params = array(
-            'order-id'        =>  $order_id,
-            'protect-privacy' =>  false,
-            'reason'          =>  'Owners decision',
-        );
+        $params = [
+            'order-id' => $order_id,
+            'protect-privacy' => false,
+            'reason' => 'Owners decision',
+        ];
 
         $result = $this->_makeRequest('domains/modify-privacy-protection', $params, 'POST');
-        return (strtolower($result['actionstatus']) == 'success');
+
+        return strtolower($result['actionstatus']) == 'success';
     }
 
     public function getEpp(Registrar_Domain $domain)
     {
-        $params = array(
-            'order-id'      =>  $this->_getDomainOrderId($domain),
-            'options'       =>  'OrderDetails',
-        );
+        $params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+            'options' => 'OrderDetails',
+        ];
         $data = $this->_makeRequest('domains/details', $params);
-        if(!isset($data['domsecret'])) {
+        if (!isset($data['domsecret'])) {
             $placeholders = [':action:' => __trans('get the transfer code'), ':type:' => 'ResellerClub'];
+
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
+
         return $data['domsecret'];
     }
 
     public function lock(Registrar_Domain $domain)
     {
-        $params = array(
-            'order-id'        =>  $this->_getDomainOrderId($domain),
-        );
+        $params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+        ];
         $result = $this->_makeRequest('domains/enable-theft-protection', $params, 'POST');
-        return (strtolower($result['status']) == 'success');
+
+        return strtolower($result['status']) == 'success';
     }
 
     public function unlock(Registrar_Domain $domain)
     {
-        $params = array(
-            'order-id'        =>  $this->_getDomainOrderId($domain),
-        );
+        $params = [
+            'order-id' => $this->_getDomainOrderId($domain),
+        ];
         $result = $this->_makeRequest('domains/disable-theft-protection', $params, 'POST');
-        return (strtolower($result['status']) == 'success');
+
+        return strtolower($result['status']) == 'success';
     }
-    
+
     private function _getCustomerDetails(Registrar_Domain $domain)
     {
         $c = $domain->getContactRegistrar();
-        $params = array(
-            'username'       =>  $c->getEmail(),
-        );
+        $params = [
+            'username' => $c->getEmail(),
+        ];
 
         try {
             $result = $this->_makeRequest('customers/details', $params);
-        } catch(Registrar_Exception) {
+        } catch (Registrar_Exception) {
             $this->_createCustomer($domain);
             $result = $this->_makeRequest('customers/details', $params);
         }
 
-        return (array)$result;
+        return (array) $result;
     }
 
     private function _createCustomer(Registrar_Domain $domain)
     {
         $c = $domain->getContactRegistrar();
         $company = $c->getCompany();
-        if (!isset($company) || strlen(trim($company)) == 0 ){
+        if (!isset($company) || strlen(trim($company)) == 0) {
             $company = 'N/A';
         }
         $phoneNum = $c->getTel();
-        $phoneNum = preg_replace( "/[^0-9]/", "", $phoneNum);
+        $phoneNum = preg_replace('/[^0-9]/', '', $phoneNum);
         $phoneNum = substr($phoneNum, 0, 12);
-        $params = array(
-            'username'                       =>  $c->getEmail(),
-            'passwd'                         =>  $c->getPassword(),
-            'name'                           =>  $c->getName(),
-            'company'                        =>  $company,
-            'address-line-1'                 =>  $c->getAddress1(),
-            'address-line-2'                 =>  $c->getAddress2(),
-            'city'                           =>  $c->getCity(),
-            'state'                          =>  $c->getState(),
-            'country'                        =>  $c->getCountry(),
-            'zipcode'                        =>  $c->getZip(),
-            'phone-cc'                       =>  $c->getTelCc(),
-            'phone'                          =>  $phoneNum,
-            'lang-pref'                      =>  'en',
-            'sales-contact-id'               =>  '',
-            'accounting-currency-symbol'     =>  'USD',
-            'selling-currency-symbol'        =>  'USD',
-            'request-headers'                =>  '',
-        );
+        $params = [
+            'username' => $c->getEmail(),
+            'passwd' => $c->getPassword(),
+            'name' => $c->getName(),
+            'company' => $company,
+            'address-line-1' => $c->getAddress1(),
+            'address-line-2' => $c->getAddress2(),
+            'city' => $c->getCity(),
+            'state' => $c->getState(),
+            'country' => $c->getCountry(),
+            'zipcode' => $c->getZip(),
+            'phone-cc' => $c->getTelCc(),
+            'phone' => $phoneNum,
+            'lang-pref' => 'en',
+            'sales-contact-id' => '',
+            'accounting-currency-symbol' => 'USD',
+            'selling-currency-symbol' => 'USD',
+            'request-headers' => '',
+        ];
 
-        $optional_params = array(
-            'address-line-3'                 =>  '',
-            'alt-phone-cc'                   =>  '',
-            'alt-phone'                      =>  '',
-            'fax-cc'                         =>  '',
-            'fax'                            =>  '',
-            'mobile-cc'                      =>  '',
-            'mobile'                         =>  '',
-        );
+        $optional_params = [
+            'address-line-3' => '',
+            'alt-phone-cc' => '',
+            'alt-phone' => '',
+            'fax-cc' => '',
+            'fax' => '',
+            'mobile-cc' => '',
+            'mobile' => '',
+        ];
 
         $params = [...$optional_params, ...$params];
         $customer_id = $this->_makeRequest('customers/signup', $params, 'POST');
+
         return $customer_id;
     }
-    
+
     public function getContactIdForDomain(Registrar_Domain $domain)
     {
         $c = $domain->getContactRegistrar();
         $customer = $this->_getCustomerDetails($domain);
         $customer_id = $customer['customerid'];
-        
-        $tld = $domain->getTld();
-        $contact = array(
-            'customer-id'                    =>  $customer_id,
-            'type'                           =>  'Contact',
-            'email'                          =>  $c->getEmail(),
-            'name'                           =>  $c->getName(),
-            'company'                        =>  $c->getCompany(),
-            'address-line-1'                 =>  $c->getAddress1(),
-            'address-line-2'                 =>  $c->getAddress2(),
-            'city'                           =>  $c->getCity(),
-            'state'                          =>  $c->getState(),
-            'country'                        =>  $c->getCountry(),
-            'zipcode'                        =>  $c->getZip(),
-            'phone-cc'                       =>  $c->getTelCc(),
-            'phone'                          =>  $c->getTel(),
-        );        
 
-        if($tld == '.uk') {
-            $contact['type'] =   'UkContact';
+        $tld = $domain->getTld();
+        $contact = [
+            'customer-id' => $customer_id,
+            'type' => 'Contact',
+            'email' => $c->getEmail(),
+            'name' => $c->getName(),
+            'company' => $c->getCompany(),
+            'address-line-1' => $c->getAddress1(),
+            'address-line-2' => $c->getAddress2(),
+            'city' => $c->getCity(),
+            'state' => $c->getState(),
+            'country' => $c->getCountry(),
+            'zipcode' => $c->getZip(),
+            'phone-cc' => $c->getTelCc(),
+            'phone' => $c->getTel(),
+        ];
+
+        if ($tld == '.uk') {
+            $contact['type'] = 'UkContact';
         }
-        
-        if($tld == '.eu') {
-            $contact['type'] =   'EuContact';
+
+        if ($tld == '.eu') {
+            $contact['type'] = 'EuContact';
         }
-        
-        if($tld == '.cn') {
-            $contact['type'] =   'CnContact';
+
+        if ($tld == '.cn') {
+            $contact['type'] = 'CnContact';
         }
-        
-        if($tld == '.ca') {
-            $contact['type'] =   'CaContact';
+
+        if ($tld == '.ca') {
+            $contact['type'] = 'CaContact';
         }
-        
-        if($tld == '.de') {
-            $contact['type'] =   'DeContact';
+
+        if ($tld == '.de') {
+            $contact['type'] = 'DeContact';
         }
-        
-        if($tld == '.es') {
-            $contact['type'] =   'EsContact';
+
+        if ($tld == '.es') {
+            $contact['type'] = 'EsContact';
         }
-        
-        if($tld == '.ru') {
-            $contact['type'] =   'RuContact';
+
+        if ($tld == '.ru') {
+            $contact['type'] = 'RuContact';
         }
 
         $id = $this->_makeRequest('contacts/add', $contact, 'POST');
+
         return $id;
     }
-    
+
     private function getResellerDetails()
     {
         return $this->_makeRequest('resellers/details');
@@ -548,47 +566,49 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     /**
      * @see http://manage.resellerclub.com/kb/answer/808
+     *
      * @param array $params
+     *
      * @return stdClass
      */
     private function addSubReseller($params)
     {
         // default values
-        $required_params = array(
-            'username'                       =>  '',
-            'passwd'                         =>  '',
-            'name'                           =>  '',
-            'company'                        =>  '',
-            'address-line-1'                 =>  '',
-            'city'                           =>  '',
-            'state'                          =>  '',
-            'country'                        =>  '',
-            'zipcode'                        =>  '',
-            'phone-cc'                       =>  '',
-            'phone'                          =>  '',
-            'lang-pref'                      =>  'en',
-            'sales-contact-id'               =>  '',
-            'accounting-currency-symbol'     =>  'USD',
-            'selling-currency-symbol'        =>  'USD',
-            'request-headers'                =>  '',
-        );
+        $required_params = [
+            'username' => '',
+            'passwd' => '',
+            'name' => '',
+            'company' => '',
+            'address-line-1' => '',
+            'city' => '',
+            'state' => '',
+            'country' => '',
+            'zipcode' => '',
+            'phone-cc' => '',
+            'phone' => '',
+            'lang-pref' => 'en',
+            'sales-contact-id' => '',
+            'accounting-currency-symbol' => 'USD',
+            'selling-currency-symbol' => 'USD',
+            'request-headers' => '',
+        ];
 
-        $optional_params = array(
-            'address-line-2'                 =>  '',
-            'address-line-3'                 =>  '',
-            'alt-phone-cc'                   =>  '',
-            'alt-phone'                      =>  '',
-            'fax-cc'                         =>  '',
-            'fax'                            =>  '',
-            'mobile-cc'                      =>  '',
-            'mobile'                         =>  '',
-        );
+        $optional_params = [
+            'address-line-2' => '',
+            'address-line-3' => '',
+            'alt-phone-cc' => '',
+            'alt-phone' => '',
+            'fax-cc' => '',
+            'fax' => '',
+            'mobile-cc' => '',
+            'mobile' => '',
+        ];
 
         $params = $this->_checkRequiredParams($required_params, $params);
         $params = array_merge($optional_params, $params);
         $result = $this->_makeRequest('resellers/signup', $params, 'POST');
 
-        if(isset($result['status']) && $result['status'] == 'AlreadyReseller') {
+        if (isset($result['status']) && $result['status'] == 'AlreadyReseller') {
             throw new Registrar_Exception('You are already registered as reseller');
         }
 
@@ -597,54 +617,57 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     private function _getDefaultContactDetails(Registrar_Domain $domain, $customerid)
     {
-        $params = array(
-            'customer-id'   =>  $customerid,
-            'type'          =>  'Contact',
-        );
+        $params = [
+            'customer-id' => $customerid,
+            'type' => 'Contact',
+        ];
 
         return $this->_makeRequest('contacts/default', $params, 'POST');
     }
 
     private function removeCustomer($params)
     {
-        $required_params = array(
-            'customer-id'   =>  '',
-        );
+        $required_params = [
+            'customer-id' => '',
+        ];
         $params = $this->_checkRequiredParams($required_params, $params);
         $result = $this->_makeRequest('customers/delete', $params, 'POST');
-        return ($result == 'true');
+
+        return $result == 'true';
     }
-    
+
     private function _hasCompletedOrder(Registrar_Domain $domain)
     {
         try {
             $orderid = $this->_getDomainOrderId($domain);
-            $params = array(
-                'order-id'      =>  $orderid,
-                'options'       =>  'All',
-            );
+            $params = [
+                'order-id' => $orderid,
+                'options' => 'All',
+            ];
             $data = $this->_makeRequest('domains/details', $params);
-        } catch(Exception) {
+        } catch (Exception) {
             return false;
         }
-        
-        return ($data['currentstatus'] == 'Active');
+
+        return $data['currentstatus'] == 'Active';
     }
-    
+
     public function isTestEnv()
     {
         return $this->_testMode;
     }
 
     /**
-     * Api URL
+     * Api URL.
+     *
      * @return string
      */
     private function _getApiUrl()
     {
-        if($this->isTestEnv()) {
+        if ($this->isTestEnv()) {
             return 'http://test.httpapi.com/api/';
         }
+
         return 'https://httpapi.com/api/';
     }
 
@@ -657,63 +680,70 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
     }
 
     /**
-     * Perform call to Api
+     * Perform call to Api.
+     *
      * @param string $url
-     * @param array $params
+     * @param array  $params
      * @param string $method
+     *
      * @return string
+     *
      * @throws Registrar_Exception
      */
-    protected function _makeRequest($url ,$params = array(), $method = 'GET', $type = 'json')
+    protected function _makeRequest($url, $params = [], $method = 'GET', $type = 'json')
     {
         $params = $this->includeAuthorizationParams($params);
 
         $client = $this->getHttpClient()->withOptions([
-            'timeout'   => 60,
-            'verify_peer'   => false,
-            'verify_host'   => false
+            'timeout' => 60,
+            'verify_peer' => false,
+            'verify_host' => false,
         ]);
 
-        $callUrl = $this->_getApiUrl().$url.'.'.$type;
+        $callUrl = $this->_getApiUrl() . $url . '.' . $type;
 
         try {
-            if($method == 'POST') {
+            if ($method == 'POST') {
                 $result = $client->request('POST', $callUrl, [
-                    'body'  => $this->_formatParams($params),
+                    'body' => $this->_formatParams($params),
                 ]);
             } else {
-                $result = $client->request('GET', $callUrl.'?'.$this->_formatParams($params));
-                $this->getLog()->debug('API REQUEST: '.$callUrl.'?'.$this->_formatParams($params));
+                $result = $client->request('GET', $callUrl . '?' . $this->_formatParams($params));
+                $this->getLog()->debug('API REQUEST: ' . $callUrl . '?' . $this->_formatParams($params));
             }
 
             $this->getLog()->info('API RESULT: ' . $result->getContent());
-        
+
             // response checker
             $json = $result->toArray();
-            if(!is_array($json)) {
+            if (!is_array($json)) {
                 return $result->getContent();
             }
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception(sprintf('HttpClientException: %s', $error->getMessage()));
             $this->getLog()->err($e);
+
             throw $e;
         }
 
-        if(isset($json['status']) && $json['status'] == 'ERROR') {
-            error_log("ResellerClub error: " . $json['message']);
+        if (isset($json['status']) && $json['status'] == 'ERROR') {
+            error_log('ResellerClub error: ' . $json['message']);
             $placeholders = [':action:' => $url, ':type:' => 'ResellerClub'];
+
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
 
-        if(isset($json['status']) && $json['status'] == 'error') {
-            error_log("ResellerClub error: " . $json['error']);
+        if (isset($json['status']) && $json['status'] == 'error') {
+            error_log('ResellerClub error: ' . $json['error']);
             $placeholders = [':action"' => $url, ':type:' => 'ResellerClub'];
+
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
-        
-        if(isset($json['status']) && $json['status'] == 'Failed') {
-            error_log("ResellerClub error: " . $json['actionstatusdesc']);
+
+        if (isset($json['status']) && $json['status'] == 'Failed') {
+            error_log('ResellerClub error: ' . $json['actionstatusdesc']);
             $placeholders = [':action:' => $url, ':type:' => 'ResellerClub'];
+
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
 
@@ -721,35 +751,42 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
     }
 
     /**
-     * Convert params to resellerClub format
+     * Convert params to resellerClub format.
+     *
      * @see http://manage.resellerclub.com/kb/answer/755
+     *
      * @param array $params
+     *
      * @return string
      */
     private function _formatParams($params)
     {
-        foreach($params as $key => &$param) {
-            if(is_bool($param)) {
+        foreach ($params as $key => &$param) {
+            if (is_bool($param)) {
                 $param = ($param) ? 'true' : 'false';
             }
         }
 
         $params = http_build_query($params);
         $params = preg_replace('~%5B(\d+)%5D~', '', $params);
+
         return $params;
     }
 
     /**
-     * Check if all required params are present, if not add default values
+     * Check if all required params are present, if not add default values.
+     *
      * @param array $required_params - list of required params with default values
-     * @param array $params - given params
+     * @param array $params          - given params
+     *
      * @return array
+     *
      * @throws Registrar_Exception
      */
     private function _checkRequiredParams($required_params, $params)
     {
-        foreach($required_params as $param => $value) {
-            if(!isset($params[$param])) {
+        foreach ($required_params as $param => $value) {
+            if (!isset($params[$param])) {
                 $params[$param] = $value;
             }
         }
@@ -757,64 +794,64 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         return $params;
     }
 
-    private function _getAllContacts($tld, $customer_id, \Registrar_Domain_Contact $client)
+    private function _getAllContacts($tld, $customer_id, Registrar_Domain_Contact $client)
     {
-        if ($tld[0] != "."){
-            $tld = "." . $tld; //$tld must start with a dot(.)
+        if ($tld[0] != '.') {
+            $tld = '.' . $tld; // $tld must start with a dot(.)
         }
 
         $company = $client->getCompany();
-        if (!isset($company) || strlen(trim($company)) == 0 ){
+        if (!isset($company) || strlen(trim($company)) == 0) {
             $company = $client->getFirstName() . ' ' . $client->getLastName();
         }
 
-        $contact = array(
-            'customer-id'                    =>  $customer_id,
-            'type'                           =>  'Contact',
-            'email'                          =>  $client->getEmail(),
-            'name'                           =>  $client->getFirstName() . ' ' . $client->getLastName(),
-            'company'                        =>  $company,
-            'address-line-1'                 =>  $client->getAddress1(),
-            'city'                           =>  $client->getCity(),
-            'state'                          =>  $client->getState(),
-            'country'                        =>  $client->getCountry(),
-            'zipcode'                        =>  $client->getZip(),
-            'phone-cc'                       =>  $client->getTelCc(),
-            'phone'                          =>  substr($client->getTel(), 0, 12),//phone must be 4-12 digits
-        );
+        $contact = [
+            'customer-id' => $customer_id,
+            'type' => 'Contact',
+            'email' => $client->getEmail(),
+            'name' => $client->getFirstName() . ' ' . $client->getLastName(),
+            'company' => $company,
+            'address-line-1' => $client->getAddress1(),
+            'city' => $client->getCity(),
+            'state' => $client->getState(),
+            'country' => $client->getCountry(),
+            'zipcode' => $client->getZip(),
+            'phone-cc' => $client->getTelCc(),
+            'phone' => substr($client->getTel(), 0, 12), // phone must be 4-12 digits
+        ];
 
-        //@see http://manage.resellerclub.com/kb/answer/790 for us contact details
-        if($tld == '.us') {
-            $contact['attr-name1'] =   'purpose';
-            $contact['attr-value1'] =  'P3';
+        // @see http://manage.resellerclub.com/kb/answer/790 for us contact details
+        if ($tld == '.us') {
+            $contact['attr-name1'] = 'purpose';
+            $contact['attr-value1'] = 'P3';
 
-            $contact['attr-name2'] =   'category';
-            $contact['attr-value2'] =  'C12';
+            $contact['attr-name2'] = 'category';
+            $contact['attr-value2'] = 'C12';
         }
 
         // create general contact id
         $reg_contact_id = $this->_getContact($contact, $customer_id, $contact['type']);
 
-        if($tld == '.nl') {
-            $contact['type'] =   'NlContact';
+        if ($tld == '.nl') {
+            $contact['type'] = 'NlContact';
             $contact['attr-name1'] = 'legalForm';
             $contact['attr-value1'] = 'PERSOON';
         }
 
-        if($tld == '.uk' || $tld == '.co.uk' || $tld == '.org.uk') {
-            $contact['type'] =   'UkContact';
+        if ($tld == '.uk' || $tld == '.co.uk' || $tld == '.org.uk') {
+            $contact['type'] = 'UkContact';
         }
 
-        if($tld == '.eu') {
-            $contact['type'] =   'EuContact';
+        if ($tld == '.eu') {
+            $contact['type'] = 'EuContact';
         }
 
-        if($tld == '.cn') {
-            $contact['type'] =   'CnContact';
+        if ($tld == '.cn') {
+            $contact['type'] = 'CnContact';
         }
 
-        if($tld == '.ca') {
-            $contact['type'] =   'CaContact';
+        if ($tld == '.ca') {
+            $contact['type'] = 'CaContact';
 
             $contact['attr-name1'] = 'CPR';
             $contact['attr-value1'] = 'LGR';
@@ -826,106 +863,105 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $contact['attr-value3'] = 'y';
         }
 
-        if($tld == '.de') {
-            $contact['type'] =   'DeContact';
+        if ($tld == '.de') {
+            $contact['type'] = 'DeContact';
         }
 
-        if($tld == '.es') {
-            if(strlen(trim($client->getDocumentNr())) == 0 ) {
+        if ($tld == '.es') {
+            if (strlen(trim($client->getDocumentNr())) == 0) {
                 throw new Registrar_Exception('Valid contact passport information is required while registering ES domain name');
             }
 
-            //@see http://manage.directi.com/kb/answer/790
-            $contact['type'] =   'EsContact';
-            $contact['attr-name1']  = 'es_form_juridica';
+            // @see http://manage.directi.com/kb/answer/790
+            $contact['type'] = 'EsContact';
+            $contact['attr-name1'] = 'es_form_juridica';
             $contact['attr-value1'] = '1';
-            $contact['attr-name2']  = 'es_tipo_identificacion';
+            $contact['attr-name2'] = 'es_tipo_identificacion';
             $contact['attr-value2'] = '0';
-            $contact['attr-name3']  = 'es_identificacion';
+            $contact['attr-name3'] = 'es_identificacion';
             $contact['attr-value3'] = $client->getDocumentNr();
-
         }
 
-        if ($tld == '.co' || str_ends_with($tld, '.co')){
+        if ($tld == '.co' || str_ends_with($tld, '.co')) {
             $contact['type'] = 'CoContact';
         }
 
-        if($tld == '.asia') {
-            if(strlen(trim($client->getDocumentNr())) == 0 ) {
+        if ($tld == '.asia') {
+            if (strlen(trim($client->getDocumentNr())) == 0) {
                 throw new Registrar_Exception('Valid contact passport information is required while registering ASIA domain name');
             }
 
-            $contact['attr-name1'] =   'locality';
-            $contact['attr-value1'] =  'TH'; // {Two-lettered Country code}
+            $contact['attr-name1'] = 'locality';
+            $contact['attr-value1'] = 'TH'; // {Two-lettered Country code}
 
-            $contact['attr-name2'] =   'legalentitytype';
-            $contact['attr-value2'] =  'naturalPerson'; // {naturalPerson | corporation | cooperative | partnership | government | politicalParty | society | institution | other}
+            $contact['attr-name2'] = 'legalentitytype';
+            $contact['attr-value2'] = 'naturalPerson'; // {naturalPerson | corporation | cooperative | partnership | government | politicalParty | society | institution | other}
 
-            $contact['attr-name3'] =   'otherlegalentitytype';
-            $contact['attr-value3'] =  'naturalPerson'; // {Mention legal entity type. Mandatory if legalentitytype chosen as 'other'}
+            $contact['attr-name3'] = 'otherlegalentitytype';
+            $contact['attr-value3'] = 'naturalPerson'; // {Mention legal entity type. Mandatory if legalentitytype chosen as 'other'}
 
-            $contact['attr-name4'] =   'identform';
-            $contact['attr-value4'] =  'passport'; // {passport | certificate | legislation | societyRegistry | politicalPartyRegistry | other}
+            $contact['attr-name4'] = 'identform';
+            $contact['attr-value4'] = 'passport'; // {passport | certificate | legislation | societyRegistry | politicalPartyRegistry | other}
 
-            $contact['attr-name5'] =   'otheridentform';
-            $contact['attr-value5'] =  'passport'; // {Mention Identity form. Mandatory if identform chosen as 'other'}
+            $contact['attr-name5'] = 'otheridentform';
+            $contact['attr-value5'] = 'passport'; // {Mention Identity form. Mandatory if identform chosen as 'other'}
 
-            $contact['attr-name6'] =   'identnumber';
-            $contact['attr-value6'] =  $client->getDocumentNr(); // {Mention Identification Number}]
+            $contact['attr-name6'] = 'identnumber';
+            $contact['attr-value6'] = $client->getDocumentNr(); // {Mention Identification Number}]
         }
 
-        if($tld == '.ru' || $tld == '.com.ru' || $tld == '.org.ru' || $tld == '.net.ru') {
-            if(strlen(trim($client->getBirthday())) === 0 || strtotime($client->getBirthday()) === false) {
+        if ($tld == '.ru' || $tld == '.com.ru' || $tld == '.org.ru' || $tld == '.net.ru') {
+            if (strlen(trim($client->getBirthday())) === 0 || strtotime($client->getBirthday()) === false) {
                 throw new Registrar_Exception('Valid contact birthdate is required while registering RU domain name');
             }
 
-            if(strlen(trim($client->getDocumentNr())) === 0 ) {
+            if (strlen(trim($client->getDocumentNr())) === 0) {
                 throw new Registrar_Exception('Valid contact passport information is required while registering RU domain name');
             }
 
-            if(str_word_count($contact['company']) < 2) {
+            if (str_word_count($contact['company']) < 2) {
                 $contact['company'] .= ' Inc';
             }
 
-            $contact['type'] =   'RuContact';
-            $contact['attr-name1']  = 'contract-type';
+            $contact['type'] = 'RuContact';
+            $contact['attr-name1'] = 'contract-type';
             $contact['attr-value1'] = 'PRS';
-            $contact['attr-name2']  = 'birth-date';
+            $contact['attr-name2'] = 'birth-date';
             $contact['attr-value2'] = date('d.m.Y', strtotime($client->getBirthday()));
-            $contact['attr-name3']  = 'person-r';
-            $contact['attr-value3'] = $client->getFirstName(). ' ' . $client->getLastName();
-            $contact['attr-name4']  = 'address-r';
+            $contact['attr-name3'] = 'person-r';
+            $contact['attr-value3'] = $client->getFirstName() . ' ' . $client->getLastName();
+            $contact['attr-name4'] = 'address-r';
             $contact['attr-value4'] = $client->getAddress1();
-            $contact['attr-name5']  = 'passport';
+            $contact['attr-name5'] = 'passport';
             $contact['attr-value5'] = $client->getDocumentNr();
         }
 
-        if($tld == '.ca') {
+        if ($tld == '.ca') {
             $client->setIdnLanguageCode('fr');
         }
-        if($tld == '.de') {
+        if ($tld == '.de') {
             $client->setIdnLanguageCode('de');
         }
-        if($tld == '.es') {
+        if ($tld == '.es') {
             $client->setIdnLanguageCode('es');
         }
-        if($tld == '.eu') {
+        if ($tld == '.eu') {
             $client->setIdnLanguageCode('latin');
         }
 
-        $param_exists = TRUE;
+        $param_exists = true;
         $attr_number = 1;
-        while ($param_exists){
-            if (!array_key_exists("attr-name".$attr_number, $contact)){
-                $contact['attr-name'.$attr_number] = 'idnLanguageCode';
-                $contact['attr-value'.$attr_number] = strtolower($client->getIdnLanguageCode());
-                $param_exists = FALSE;
+        while ($param_exists) {
+            if (!array_key_exists('attr-name' . $attr_number, $contact)) {
+                $contact['attr-name' . $attr_number] = 'idnLanguageCode';
+                $contact['attr-value' . $attr_number] = strtolower($client->getIdnLanguageCode());
+                $param_exists = false;
             }
-            $attr_number++;
+            ++$attr_number;
         }
 
         $special_contact_id = null;
-        if($contact['type'] != 'Contact') {
+        if ($contact['type'] != 'Contact') {
             $special_contact_id = $this->_getContact($contact, $customer_id, $contact['type']);
         }
 
@@ -935,43 +971,43 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         $billing_contact_id = $special_contact_id ?? $reg_contact_id;
 
         // override some parameters
-        if(in_array($tld, array('.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu'))) {
+        if (in_array($tld, ['.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu'])) {
             $admin_contact_id = -1;
         }
 
-        if(in_array($tld, array('.uk', '.co.uk','.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu'))) {
+        if (in_array($tld, ['.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu'])) {
             $tech_contact_id = -1;
         }
 
-        if(in_array($tld, array('.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu', '.ca', '.nl'))) {
+        if (in_array($tld, ['.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu', '.ca', '.nl'])) {
             $billing_contact_id = -1;
         }
 
-        //general contact is special contact for these TLD'S
-        if(in_array($tld, array('.de', '.nl', '.ru', '.es', '.uk', '.co.uk', '.org.uk', '.eu', '.com.ru', '.net.ru', '.org.ru', '.co'))) {
+        // general contact is special contact for these TLD'S
+        if (in_array($tld, ['.de', '.nl', '.ru', '.es', '.uk', '.co.uk', '.org.uk', '.eu', '.com.ru', '.net.ru', '.org.ru', '.co'])) {
             $reg_contact_id = $special_contact_id;
         }
 
-        return array($reg_contact_id, $admin_contact_id, $tech_contact_id, $billing_contact_id);
+        return [$reg_contact_id, $admin_contact_id, $tech_contact_id, $billing_contact_id];
     }
 
     private function _getContact($contact, $customer_id, $type = 'Contact')
     {
         try {
-            $params = array(
-                'customer-id'   => $customer_id,
+            $params = [
+                'customer-id' => $customer_id,
                 'no-of-records' => 20,
-                'page-no'       => 1,
-                'status'        => 'Active',
-                'type'          => $type,
-            );
+                'page-no' => 1,
+                'status' => 'Active',
+                'type' => $type,
+            ];
             $result = $this->_makeRequest('contacts/search', $params, 'GET', 'json');
-            if($result['recsonpage'] < 1) {
+            if ($result['recsonpage'] < 1) {
                 throw new Registrar_Exception('Contact not found');
             }
             $existing_contact_id = $result['result'][0]['entity.entityid'];
-            $this->_makeRequest('contacts/delete', array('contact-id'=>$existing_contact_id), 'POST');
-        } catch(Registrar_Exception $e) {
+            $this->_makeRequest('contacts/delete', ['contact-id' => $existing_contact_id], 'POST');
+        } catch (Registrar_Exception $e) {
             $this->getLog()->info($e->getMessage());
         }
 
@@ -980,7 +1016,8 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     private function getCARegistrantAgreementVersion()
     {
-        $agreement = $this->_makeRequest('contacts/dotca/registrantagreement', array(), 'GET', 'json');
+        $agreement = $this->_makeRequest('contacts/dotca/registrantagreement', [], 'GET', 'json');
+
         return $agreement['version'];
     }
 }

--- a/src/library/Registrar/Adapter/Resellerid.php
+++ b/src/library/Registrar/Adapter/Resellerid.php
@@ -4,14 +4,14 @@ class Registrar_Adapter_Resellerid extends Registrar_Adapter_Resellerclub
 {
     public function __construct($options)
     {
-        if(isset($options['userid']) && !empty($options['userid'])) {
+        if (isset($options['userid']) && !empty($options['userid'])) {
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'ResellerID', ':missing' => 'ResellerID Reseller ID'], 3001);
         }
 
-        if(isset($options['api-key']) && !empty($options['api-key'])) {
+        if (isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
         } else {
@@ -21,21 +21,21 @@ class Registrar_Adapter_Resellerid extends Registrar_Adapter_Resellerclub
 
     public static function getConfig()
     {
-        return array(
-            'label'     =>  'Manages domains on ResellerID via API. ResellerID requires your server IP in order to work. Login to the ResellerID control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
-            'form'  => array(
-                'userid' => array('text', array(
+        return [
+            'label' => 'Manages domains on ResellerID via API. ResellerID requires your server IP in order to work. Login to the ResellerID control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
+            'form' => [
+                'userid' => ['text', [
                     'label' => 'Reseller ID. You can get this at ResellerID control panel Settings > Personal information > Primary profile > Reseller ID',
-                    'description'=> 'ResellerID Reseller ID'
-                ),
-                ),
-                'api-key' => array('password', array(
+                    'description' => 'ResellerID Reseller ID',
+                ],
+                ],
+                'api-key' => ['password', [
                     'label' => 'ResellerID API Key',
-                    'description'=> 'You can get this at ResellerID control panel, go to Settings -> API',
+                    'description' => 'You can get this at ResellerID control panel, go to Settings -> API',
                     'required' => false,
-                ),
-                ),
-            ),
-        );
+                ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -2,33 +2,32 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 abstract class Registrar_AdapterAbstract
 {
-    protected $_log = null;
+    protected $_log;
 
     /**
      * Are we in test mode ?
      *
-     * @var boolean
+     * @var bool
      */
     protected $_testMode = false;
 
     /**
-     * Related order
+     * Related order.
      */
     protected ?\Model_ClientOrder $_order = null;
 
     /**
-     * Return array with configuration
-     * 
+     * Return array with configuration.
+     *
      * Must be overriden in adapter class
-     * 
+     *
      * @return array
      */
     abstract public static function getConfig();
@@ -38,181 +37,182 @@ abstract class Registrar_AdapterAbstract
      *
      * If the function returns an empty array, the registrar can register any TLD.
      *
-     * @return array Array of TLDs that the registrar is capable of registering.
+     * @return array array of TLDs that the registrar is capable of registering
      */
     abstract public function getTlds();
 
     /**
      * Checks if a domain is available for registration.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to check.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to check
+     *
      * @return bool True if the domain is available, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while checking the domain availability.
+     *
+     * @throws Registrar_Exception if there was an error while checking the domain availability
      */
     abstract public function isDomainAvailable(Registrar_Domain $domain);
 
     /**
      * Checks if a domain can be transferred to the registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to check.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to check
+     *
      * @return bool True if the domain can be transferred, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while checking the domain transferability.
+     *
+     * @throws Registrar_Exception if there was an error while checking the domain transferability
      */
     abstract public function isDomaincanBeTransferred(Registrar_Domain $domain);
 
     /**
      * Modifies the name servers for a domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to update, including the new name servers.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to update, including the new name servers
+     *
      * @return bool True if the name servers were modified successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while modifying the name servers.
+     *
+     * @throws Registrar_Exception if there was an error while modifying the name servers
      */
     abstract public function modifyNs(Registrar_Domain $domain);
 
     /**
      * Modifies the contact information for a domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to update, including the new contact information.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to update, including the new contact information
+     *
      * @return bool True if the contact information was modified successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while modifying the contact information.
+     *
+     * @throws Registrar_Exception if there was an error while modifying the contact information
      */
     abstract public function modifyContact(Registrar_Domain $domain);
 
     /**
      * Transfers a domain to the registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to transfer, including the domain transfer code.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to transfer, including the domain transfer code
+     *
      * @return bool True if the domain was transferred successfully, otherwise the adapter should throw an exceptions
-     * 
-     * @throws Registrar_Exception If there was an error while transferring the domain.
+     *
+     * @throws Registrar_Exception if there was an error while transferring the domain
      */
     abstract public function transferDomain(Registrar_Domain $domain);
 
     /**
      * Returns the details of a registered domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to query.
-     * 
-     * @return Registrar_Domain Domain object containing the updated details of the registered domain.
-     * 
-     * @throws Registrar_Exception If the domain is not registered or there was an error while retrieving the domain details.
+     * @param Registrar_Domain $domain domain object containing the details of the domain to query
+     *
+     * @return Registrar_Domain domain object containing the updated details of the registered domain
+     *
+     * @throws Registrar_Exception if the domain is not registered or there was an error while retrieving the domain details
      */
     abstract public function getDomainDetails(Registrar_Domain $domain);
 
     /**
      * Returns the domain transfer code (also known as the EPP code or auth code) for a domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain.
-     * 
-     * @return string The domain transfer code.
-     * 
-     * @throws Registrar_Exception If there was an error while retrieving the domain transfer code.
+     * @param Registrar_Domain $domain domain object containing the details of the domain
+     *
+     * @return string the domain transfer code
+     *
+     * @throws Registrar_Exception if there was an error while retrieving the domain transfer code
      */
     abstract public function getEpp(Registrar_Domain $domain);
 
     /**
      * Registers a domain with the registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to register.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to register
+     *
      * @return bool True if the domain was registered successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while registering the domain.
+     *
+     * @throws Registrar_Exception if there was an error while registering the domain
      */
     abstract public function registerDomain(Registrar_Domain $domain);
 
     /**
      * Renews a domain registration with the registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to renew.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to renew
+     *
      * @return bool True if the domain was renewed successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while renewing the domain.
+     *
+     * @throws Registrar_Exception if there was an error while renewing the domain
      */
     abstract public function renewDomain(Registrar_Domain $domain);
 
     /**
      * Deletes a domain from the registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to delete.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to delete
+     *
      * @return bool True if the domain was deleted successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while deleting the domain.
+     *
+     * @throws Registrar_Exception if there was an error while deleting the domain
      */
     abstract public function deleteDomain(Registrar_Domain $domain);
 
     /**
      * Enables privacy protection for a domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain for which to enable privacy protection.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain for which to enable privacy protection
+     *
      * @return bool True if privacy protection was enabled successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while enabling privacy protection.
+     *
+     * @throws Registrar_Exception if there was an error while enabling privacy protection
      */
     abstract public function enablePrivacyProtection(Registrar_Domain $domain);
 
     /**
      * Disables privacy protection for a domain.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain for which to disable privacy protection.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain for which to disable privacy protection
+     *
      * @return bool True if privacy protection was disabled successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while disabling privacy protection.
+     *
+     * @throws Registrar_Exception if there was an error while disabling privacy protection
      */
     abstract public function disablePrivacyProtection(Registrar_Domain $domain);
 
     /**
      * Locks a domain to prevent transfer to another registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to lock.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to lock
+     *
      * @return bool True if the domain was locked successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while locking the domain.
+     *
+     * @throws Registrar_Exception if there was an error while locking the domain
      */
     abstract public function lock(Registrar_Domain $domain);
 
     /**
      * Unlocks a domain to allow transfer to another registrar.
      *
-     * @param Registrar_Domain $domain Domain object containing the details of the domain to unlock.
-     * 
+     * @param Registrar_Domain $domain domain object containing the details of the domain to unlock
+     *
      * @return bool True if the domain was unlocked successfully, otherwise the adapter should throw an exception
-     * 
-     * @throws Registrar_Exception If there was an error while unlocking the domain.
+     *
+     * @throws Registrar_Exception if there was an error while unlocking the domain
      */
     abstract public function unlock(Registrar_Domain $domain);
 
     /**
      * Sets the logger object to use for logging messages.
      *
-     * @param Box_Log $log The logger object to use.
-     * 
-     * @return Registrar_AdapterAbstract The current adapter object, for method chaining.
+     * @param Box_Log $log the logger object to use
+     *
+     * @return Registrar_AdapterAbstract the current adapter object, for method chaining
      */
     public function setLog(Box_Log $log)
     {
         $this->_log = $log;
+
         return $this;
     }
 
     /**
      * Gets the logger object currently in use for logging messages.
      *
-     * @return Box_Log The logger object.
+     * @return Box_Log the logger object
      */
     public function getLog()
     {
@@ -221,6 +221,7 @@ abstract class Registrar_AdapterAbstract
             $log = new Box_Log();
             $log->addWriter(new Box_LogDb('Model_ActivitySystem'));
         }
+
         return $log;
     }
 
@@ -229,24 +230,25 @@ abstract class Registrar_AdapterAbstract
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return \Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create();
     }
 
     /**
      * Enables test mode for the adapter.
      *
-     * @return Registrar_AdapterAbstract The current adapter object, for method chaining.
+     * @return Registrar_AdapterAbstract the current adapter object, for method chaining
      */
     public function enableTestMode()
     {
         $this->_testMode = true;
+
         return $this;
     }
 
     /**
      * Sets the order related to the domain.
      */
-    public function setOrder(\Model_ClientOrder $order): static
+    public function setOrder(Model_ClientOrder $order): static
     {
         $this->_order = $order;
 

--- a/src/library/Registrar/Domain.php
+++ b/src/library/Registrar/Domain.php
@@ -2,26 +2,25 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Registrar_Domain implements \Stringable
+class Registrar_Domain implements Stringable
 {
-    private $_tld = null;
-    private $_sld = null;
-    private $_registered_at = null;
-    private $_expires_at = null;
+    private $_tld;
+    private $_sld;
+    private $_registered_at;
+    private $_expires_at;
     private ?int $_period = null;
-    private $_epp = null;
+    private $_epp;
     private ?bool $_privacy = null;
-    private $_locked = null;
-    private $_ns1 = null;
-    private $_ns2 = null;
-    private $_ns3 = null;
-    private $_ns4 = null;
+    private $_locked;
+    private $_ns1;
+    private $_ns2;
+    private $_ns3;
+    private $_ns4;
 
     private ?\Registrar_Domain_Contact $_contact_registrar = null;
 
@@ -33,7 +32,8 @@ class Registrar_Domain implements \Stringable
 
     public function setRegistrationPeriod($years)
     {
-        $this->_period = (int)$years;
+        $this->_period = (int) $years;
+
         return $this;
     }
 
@@ -50,6 +50,7 @@ class Registrar_Domain implements \Stringable
     public function setExpirationTime($param)
     {
         $this->_expires_at = $param;
+
         return $this;
     }
 
@@ -61,6 +62,7 @@ class Registrar_Domain implements \Stringable
     public function setRegistrationTime($param)
     {
         $this->_registered_at = $param;
+
         return $this;
     }
 
@@ -72,6 +74,7 @@ class Registrar_Domain implements \Stringable
     public function setContactRegistrar(Registrar_Domain_Contact $c)
     {
         $this->_contact_registrar = $c;
+
         return $this;
     }
 
@@ -83,6 +86,7 @@ class Registrar_Domain implements \Stringable
     public function setContactAdmin(Registrar_Domain_Contact $c)
     {
         $this->_contact_admin = $c;
+
         return $this;
     }
 
@@ -94,6 +98,7 @@ class Registrar_Domain implements \Stringable
     public function setContactTech(Registrar_Domain_Contact $c)
     {
         $this->_contact_tech = $c;
+
         return $this;
     }
 
@@ -105,6 +110,7 @@ class Registrar_Domain implements \Stringable
     public function setContactBilling(Registrar_Domain_Contact $c)
     {
         $this->_contact_billing = $c;
+
         return $this;
     }
 
@@ -116,6 +122,7 @@ class Registrar_Domain implements \Stringable
     public function setEpp($param)
     {
         $this->_epp = $param;
+
         return $this;
     }
 
@@ -126,7 +133,8 @@ class Registrar_Domain implements \Stringable
 
     public function setPrivacyEnabled($param)
     {
-        $this->_privacy = (bool)$param;
+        $this->_privacy = (bool) $param;
+
         return $this;
     }
 
@@ -138,20 +146,23 @@ class Registrar_Domain implements \Stringable
     public function setTld($param)
     {
         $this->_tld = $param;
+
         return $this;
     }
 
     public function getTld($with_dot = true)
     {
-        if($with_dot === false && $this->_tld[0] == '.') {
+        if ($with_dot === false && $this->_tld[0] == '.') {
             return ltrim($this->_tld, '.');
         }
+
         return $this->_tld;
     }
 
     public function setSld($param)
     {
         $this->_sld = $param;
+
         return $this;
     }
 
@@ -163,6 +174,7 @@ class Registrar_Domain implements \Stringable
     public function setNs1($param)
     {
         $this->_ns1 = $param;
+
         return $this;
     }
 
@@ -174,6 +186,7 @@ class Registrar_Domain implements \Stringable
     public function setNs2($param)
     {
         $this->_ns2 = $param;
+
         return $this;
     }
 
@@ -185,6 +198,7 @@ class Registrar_Domain implements \Stringable
     public function setNs3($param)
     {
         $this->_ns3 = $param;
+
         return $this;
     }
 
@@ -196,6 +210,7 @@ class Registrar_Domain implements \Stringable
     public function setNs4($param)
     {
         $this->_ns4 = $param;
+
         return $this;
     }
 
@@ -207,6 +222,7 @@ class Registrar_Domain implements \Stringable
     public function setLocked($param)
     {
         $this->_locked = $param;
+
         return $this;
     }
 
@@ -215,35 +231,36 @@ class Registrar_Domain implements \Stringable
         return $this->_locked;
     }
 
-    public function __toString(): string {
+    public function __toString(): string
+    {
         $c = '';
-        $c .= sprintf("Name: %s", $this->getName()).PHP_EOL;
-        $c .= sprintf("TLD: %s", $this->getTld()).PHP_EOL;
-        $c .= sprintf("SLD: %s", $this->getSld()).PHP_EOL;
+        $c .= sprintf('Name: %s', $this->getName()) . PHP_EOL;
+        $c .= sprintf('TLD: %s', $this->getTld()) . PHP_EOL;
+        $c .= sprintf('SLD: %s', $this->getSld()) . PHP_EOL;
 
-        $c .= sprintf("EPP: %s", $this->getEpp()).PHP_EOL;
-        $c .= sprintf("Registration period: %s year(s)", $this->getRegistrationPeriod()).PHP_EOL;
+        $c .= sprintf('EPP: %s', $this->getEpp()) . PHP_EOL;
+        $c .= sprintf('Registration period: %s year(s)', $this->getRegistrationPeriod()) . PHP_EOL;
 
         $registered_at = ($this->getRegistrationTime()) ? date('Y-m-d', $this->getRegistrationTime()) : '-';
-        $c .= sprintf("Registered at: %s", $registered_at).PHP_EOL;
+        $c .= sprintf('Registered at: %s', $registered_at) . PHP_EOL;
 
         $expires_at = ($this->getExpirationTime()) ? date('Y-m-d', $this->getExpirationTime()) : '-';
-        $c .= sprintf("Expires at: %s", $expires_at).PHP_EOL;
+        $c .= sprintf('Expires at: %s', $expires_at) . PHP_EOL;
 
         $privacy = ($this->getPrivacyEnabled()) ? 'Yes' : 'No';
-        $c .= sprintf("WHOIS Privacy Protection enabled: %s", $privacy);
-        $c .=PHP_EOL;
-        $c .=PHP_EOL;
-        
-        $c .= sprintf("Nameserver #1: %s", $this->getNs1()).PHP_EOL;
-        $c .= sprintf("Nameserver #2: %s", $this->getNs2()).PHP_EOL;
-        $c .= sprintf("Nameserver #3: %s", $this->getNs3()).PHP_EOL;
-        $c .= sprintf("Nameserver #4: %s", $this->getNs4()).PHP_EOL;
+        $c .= sprintf('WHOIS Privacy Protection enabled: %s', $privacy);
+        $c .= PHP_EOL;
+        $c .= PHP_EOL;
 
-        if($this->getContactRegistrar() instanceof Registrar_Domain_Contact) {
-            $c .=PHP_EOL;
-            $c .=PHP_EOL;
-            $c .= sprintf("Contact Registrar").PHP_EOL;
+        $c .= sprintf('Nameserver #1: %s', $this->getNs1()) . PHP_EOL;
+        $c .= sprintf('Nameserver #2: %s', $this->getNs2()) . PHP_EOL;
+        $c .= sprintf('Nameserver #3: %s', $this->getNs3()) . PHP_EOL;
+        $c .= sprintf('Nameserver #4: %s', $this->getNs4()) . PHP_EOL;
+
+        if ($this->getContactRegistrar() instanceof Registrar_Domain_Contact) {
+            $c .= PHP_EOL;
+            $c .= PHP_EOL;
+            $c .= 'Contact Registrar' . PHP_EOL;
             $c .= $this->getContactRegistrar()->__toString();
         }
 

--- a/src/library/Registrar/Domain/Contact.php
+++ b/src/library/Registrar/Domain/Contact.php
@@ -2,13 +2,12 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Registrar_Domain_Contact implements \Stringable
+class Registrar_Domain_Contact implements Stringable
 {
     private $id;
     private $name;
@@ -50,9 +49,9 @@ class Registrar_Domain_Contact implements \Stringable
     public function setCompanyNumber($company_number)
     {
         $this->company_number = $company_number;
+
         return $this;
     }
-
 
     /**
      * @return string
@@ -68,6 +67,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setIdnLanguageCode($idn_language_code)
     {
         $this->idn_language_code = $idn_language_code;
+
         return $this;
     }
 
@@ -85,12 +85,14 @@ class Registrar_Domain_Contact implements \Stringable
     public function setBirthday($birthday)
     {
         $this->birthday = $birthday;
+
         return $this;
     }
 
     public function setId($param)
     {
         $this->id = $param;
+
         return $this;
     }
 
@@ -102,49 +104,59 @@ class Registrar_Domain_Contact implements \Stringable
     public function setName($param)
     {
         $this->name = $param;
+
         return $this;
     }
 
     public function getName()
     {
-    	if ($this->name) return $this->name;
+        if ($this->name) {
+            return $this->name;
+        }
 
-    	return $this->firstname . ' ' . $this->lastname;
+        return $this->firstname . ' ' . $this->lastname;
     }
 
     public function setFirstName($param)
     {
         $this->firstname = $param;
+
         return $this;
     }
 
     public function getFirstName()
     {
-    	if ($this->firstname) return $this->firstname;
-    	
-    	$bits = explode(' ', $this->name);
-    	
-    	return $bits[0] ?? '';
+        if ($this->firstname) {
+            return $this->firstname;
+        }
+
+        $bits = explode(' ', $this->name);
+
+        return $bits[0] ?? '';
     }
 
     public function setLastName($param)
     {
         $this->lastname = $param;
+
         return $this;
     }
 
     public function getLastName()
     {
-    	if ($this->lastname) return $this->lastname;
-    	
-    	$bits = explode(' ', $this->name);
-    	
-    	return isset($bits[1]) ? str_replace($bits[0] . ' ', '', $this->name) : '';
+        if ($this->lastname) {
+            return $this->lastname;
+        }
+
+        $bits = explode(' ', $this->name);
+
+        return isset($bits[1]) ? str_replace($bits[0] . ' ', '', $this->name) : '';
     }
 
     public function setEmail($param)
     {
         $this->email = $param;
+
         return $this;
     }
 
@@ -156,6 +168,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setCity($param)
     {
         $this->city = $param;
+
         return $this;
     }
 
@@ -167,6 +180,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setCountry($param)
     {
         $this->country = $param;
+
         return $this;
     }
 
@@ -178,6 +192,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setState($param)
     {
         $this->state = $param;
+
         return $this;
     }
 
@@ -189,6 +204,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setZip($param)
     {
         $this->zip = $param;
+
         return $this;
     }
 
@@ -200,6 +216,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setTel($param)
     {
         $this->tel = $param;
+
         return $this;
     }
 
@@ -211,6 +228,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setTelCc($param)
     {
         $this->tel_cc = $param;
+
         return $this;
     }
 
@@ -222,6 +240,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setFax($param)
     {
         $this->fax = $param;
+
         return $this;
     }
 
@@ -233,6 +252,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setFaxCc($param)
     {
         $this->fax_cc = $param;
+
         return $this;
     }
 
@@ -244,6 +264,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setCompany($param)
     {
         $this->company = $param;
+
         return $this;
     }
 
@@ -255,6 +276,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setAddress1($param)
     {
         $this->address_1 = $param;
+
         return $this;
     }
 
@@ -266,6 +288,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setAddress2($param)
     {
         $this->address_2 = $param;
+
         return $this;
     }
 
@@ -277,6 +300,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setAddress3($param)
     {
         $this->address_3 = $param;
+
         return $this;
     }
 
@@ -288,6 +312,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setUsername($param)
     {
         $this->username = $param;
+
         return $this;
     }
 
@@ -299,6 +324,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setPassword($param)
     {
         $this->password = $param;
+
         return $this;
     }
 
@@ -310,6 +336,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setDocumentType($param)
     {
         $this->document_type = $param;
+
         return $this;
     }
 
@@ -321,6 +348,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setDocumentNr($param)
     {
         $this->document_nr = $param;
+
         return $this;
     }
 
@@ -332,6 +360,7 @@ class Registrar_Domain_Contact implements \Stringable
     public function setJobTitle($param)
     {
         $this->job_title = $param;
+
         return $this;
     }
 
@@ -342,41 +371,43 @@ class Registrar_Domain_Contact implements \Stringable
 
     public function getAddress()
     {
-        $data = array(
+        $data = [
             $this->getAddress1(),
             $this->getAddress2(),
             $this->getAddress3(),
-        );
+        ];
+
         return implode(' ', $data);
     }
 
     public function __toString(): string
     {
         $c = '';
-        $c .= sprintf("Id: %s", $this->getId()).PHP_EOL;
-        $c .= sprintf("Name: %s", $this->getName()).PHP_EOL;
+        $c .= sprintf('Id: %s', $this->getId()) . PHP_EOL;
+        $c .= sprintf('Name: %s', $this->getName()) . PHP_EOL;
         $c .= PHP_EOL;
-        $c .= sprintf("Email: %s", $this->getEmail()).PHP_EOL;
-        $c .= sprintf("Username: %s", $this->getUsername()).PHP_EOL;
-        $c .= sprintf("Password: %s", $this->getPassword()).PHP_EOL;
+        $c .= sprintf('Email: %s', $this->getEmail()) . PHP_EOL;
+        $c .= sprintf('Username: %s', $this->getUsername()) . PHP_EOL;
+        $c .= sprintf('Password: %s', $this->getPassword()) . PHP_EOL;
         $c .= PHP_EOL;
-        $c .= sprintf("Company: %s", $this->getCompany()).PHP_EOL;
-        $c .= sprintf("Address: %s", $this->getAddress()).PHP_EOL;
-        $c .= sprintf("City: %s", $this->getCity()).PHP_EOL;
-        $c .= sprintf("State: %s", $this->getState()).PHP_EOL;
-        $c .= sprintf("Zip: %s", $this->getZip()).PHP_EOL;
-        $c .= sprintf("Country: %s", $this->getCountry()).PHP_EOL;
+        $c .= sprintf('Company: %s', $this->getCompany()) . PHP_EOL;
+        $c .= sprintf('Address: %s', $this->getAddress()) . PHP_EOL;
+        $c .= sprintf('City: %s', $this->getCity()) . PHP_EOL;
+        $c .= sprintf('State: %s', $this->getState()) . PHP_EOL;
+        $c .= sprintf('Zip: %s', $this->getZip()) . PHP_EOL;
+        $c .= sprintf('Country: %s', $this->getCountry()) . PHP_EOL;
         $c .= PHP_EOL;
-        $c .= sprintf("Tel: %s", $this->getTelCc() . ' '. $this->getTel()).PHP_EOL;
-        $c .= sprintf("Fax: %s", $this->getFaxCc() . ' '. $this->getFax()).PHP_EOL;
+        $c .= sprintf('Tel: %s', $this->getTelCc() . ' ' . $this->getTel()) . PHP_EOL;
+        $c .= sprintf('Fax: %s', $this->getFaxCc() . ' ' . $this->getFax()) . PHP_EOL;
         $c .= PHP_EOL;
-        $c .= sprintf("Document type: %s", $this->getDocumentType()).PHP_EOL;
-        $c .= sprintf("Document nr: %s", $this->getDocumentNr()).PHP_EOL;
+        $c .= sprintf('Document type: %s', $this->getDocumentType()) . PHP_EOL;
+        $c .= sprintf('Document nr: %s', $this->getDocumentNr()) . PHP_EOL;
+
         return $c;
     }
-    
+
     public function toArray()
     {
-    	return get_object_vars($this);
+        return get_object_vars($this);
     }
 }

--- a/src/library/Registrar/Domain/Nameserver.php
+++ b/src/library/Registrar/Domain/Nameserver.php
@@ -2,20 +2,20 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-class Registrar_Domain_Nameserver implements \Stringable
+class Registrar_Domain_Nameserver implements Stringable
 {
-    private $host = null;
-    private $ip = null;
+    private $host;
+    private $ip;
 
     public function setHost($param)
     {
         $this->host = $param;
+
         return $this;
     }
 
@@ -27,6 +27,7 @@ class Registrar_Domain_Nameserver implements \Stringable
     public function setIp($param)
     {
         $this->ip = $param;
+
         return $this;
     }
 
@@ -35,10 +36,12 @@ class Registrar_Domain_Nameserver implements \Stringable
         return $this->ip;
     }
 
-    public function __toString(): string {
+    public function __toString(): string
+    {
         $c = '';
-        $c .= sprintf("Host: %s", $this->getHost()).PHP_EOL;
-        $c .= sprintf("Ip: %s", $this->getIp()).PHP_EOL;
+        $c .= sprintf('Host: %s', $this->getHost()) . PHP_EOL;
+        $c .= sprintf('Ip: %s', $this->getIp()) . PHP_EOL;
+
         return $c;
     }
 }

--- a/src/library/Registrar/Exception.php
+++ b/src/library/Registrar/Exception.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Registrar_Exception extends FOSSBilling\Exception
 {
     /**
      * Creates a new translated exception, using the FOSSBilling\Exception class.
      *
-	 * @param string $message error message
-	 * @param array|null $variables translation variables
-	 * @param int $code The exception code.
+     * @param string     $message   error message
+     * @param array|null $variables translation variables
+     * @param int        $code      the exception code
      */
-    public function __construct(string $message, array $variables = NULL, int $code = 0)
+    public function __construct(string $message, array $variables = null, int $code = 0)
     {
         parent::__construct($message, $variables, $code, true);
     }

--- a/src/library/Server/Account.php
+++ b/src/library/Server/Account.php
@@ -2,33 +2,33 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Account
 {
-    private $username   = NULL;
-    private $password   = NULL;
-    private $domain     = NULL;
-    private $ip         = NULL;
+    private $username;
+    private $password;
+    private $domain;
+    private $ip;
 
-    private ?\Server_Package $package    = NULL;
+    private ?\Server_Package $package = null;
 
-    private ?\Server_Client $client     = NULL;
-    private ?bool $reseller   = NULL;
-    private ?bool $suspended  = NULL;
-    private $ns_1       = NULL;
-    private $ns_2       = NULL;
-    private $ns_3       = NULL;
-    private $ns_4       = NULL;
-    private $note       = NULL;
-    
+    private ?\Server_Client $client = null;
+    private ?bool $reseller = null;
+    private ?bool $suspended = null;
+    private $ns_1;
+    private $ns_2;
+    private $ns_3;
+    private $ns_4;
+    private $note;
+
     public function setUsername($param)
     {
         $this->username = $param;
+
         return $this;
     }
 
@@ -40,6 +40,7 @@ class Server_Account
     public function setPassword($param)
     {
         $this->password = $param;
+
         return $this;
     }
 
@@ -51,6 +52,7 @@ class Server_Account
     public function setDomain($param)
     {
         $this->domain = $param;
+
         return $this;
     }
 
@@ -62,6 +64,7 @@ class Server_Account
     public function setIp($param)
     {
         $this->ip = $param;
+
         return $this;
     }
 
@@ -76,6 +79,7 @@ class Server_Account
     public function setClient(Server_Client $param)
     {
         $this->client = $param;
+
         return $this;
     }
 
@@ -93,6 +97,7 @@ class Server_Account
     public function setPackage(Server_Package $param)
     {
         $this->package = $param;
+
         return $this;
     }
 
@@ -104,6 +109,7 @@ class Server_Account
     public function setNote($param)
     {
         $this->note = $param;
+
         return $this;
     }
 
@@ -114,7 +120,8 @@ class Server_Account
 
     public function setReseller($param)
     {
-        $this->reseller = (bool)$param;
+        $this->reseller = (bool) $param;
+
         return $this;
     }
 
@@ -125,7 +132,8 @@ class Server_Account
 
     public function setSuspended($param)
     {
-        $this->suspended = (bool)$param;
+        $this->suspended = (bool) $param;
+
         return $this;
     }
 
@@ -133,10 +141,11 @@ class Server_Account
     {
         return $this->suspended;
     }
-    
+
     public function setNs1($param)
     {
         $this->ns_1 = $param;
+
         return $this;
     }
 
@@ -144,10 +153,11 @@ class Server_Account
     {
         return $this->ns_1;
     }
-    
+
     public function setNs2($param)
     {
         $this->ns_2 = $param;
+
         return $this;
     }
 
@@ -159,6 +169,7 @@ class Server_Account
     public function setNs3($param)
     {
         $this->ns_3 = $param;
+
         return $this;
     }
 
@@ -170,6 +181,7 @@ class Server_Account
     public function setNs4($param)
     {
         $this->ns_4 = $param;
+
         return $this;
     }
 

--- a/src/library/Server/Client.php
+++ b/src/library/Server/Client.php
@@ -2,45 +2,45 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Client
 {
-    private $id         = NULL;
-    private $email      = NULL;
-    private ?string $full_name  = 'FOSSBilling Client';
-    private ?string $company    = 'FOSSBilling';
-    private ?string $www        = 'www.fossbilling.org';
-    private $address_1  = NULL;
-    private $address_2  = NULL;
-    private $street     = NULL;
-    private ?string $state      = 'n/a';
-    private ?string $country    = 'US';
-    private $city       = NULL;
-    private $zip        = NULL;
-    private $telephone  = NULL;
-    private $fax  = NULL;
+    private $id;
+    private $email;
+    private ?string $full_name = 'FOSSBilling Client';
+    private ?string $company = 'FOSSBilling';
+    private ?string $www = 'www.fossbilling.org';
+    private $address_1;
+    private $address_2;
+    private $street;
+    private ?string $state = 'n/a';
+    private ?string $country = 'US';
+    private $city;
+    private $zip;
+    private $telephone;
+    private $fax;
 
     public function __call($name, $arguments)
     {
         if (version_compare(PHP_VERSION, '5.4.0') < 0) {
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        }
-        else {
+        } else {
             // Get only the stack frames we need (PHP 5.4 only).
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         }
-        error_log(sprintf("Calling %s inaccessible method %s from %s::%d", static::class, $name, $backtrace[1]['file'], $backtrace[1]['line']));
+        error_log(sprintf('Calling %s inaccessible method %s from %s::%d', static::class, $name, $backtrace[1]['file'], $backtrace[1]['line']));
+
         return '';
     }
 
     public function setId($id)
     {
         $this->id = $id;
+
         return $this;
     }
 
@@ -52,6 +52,7 @@ class Server_Client
     public function setFullName($param)
     {
         $this->full_name = $param;
+
         return $this;
     }
 
@@ -63,6 +64,7 @@ class Server_Client
     public function setCompany($company)
     {
         $this->company = $company;
+
         return $this;
     }
 
@@ -74,6 +76,7 @@ class Server_Client
     public function setEmail($param)
     {
         $this->email = $param;
+
         return $this;
     }
 
@@ -85,6 +88,7 @@ class Server_Client
     public function setAddress1($param)
     {
         $this->address_1 = $param;
+
         return $this;
     }
 
@@ -92,10 +96,11 @@ class Server_Client
     {
         return $this->address_1;
     }
-    
+
     public function setAddress2($param)
     {
         $this->address_2 = $param;
+
         return $this;
     }
 
@@ -103,10 +108,11 @@ class Server_Client
     {
         return $this->address_2;
     }
-    
+
     public function setStreet($param)
     {
         $this->street = $param;
+
         return $this;
     }
 
@@ -114,10 +120,11 @@ class Server_Client
     {
         return $this->street;
     }
-    
+
     public function setCity($param)
     {
         $this->city = $param;
+
         return $this;
     }
 
@@ -129,6 +136,7 @@ class Server_Client
     public function setState($param)
     {
         $this->state = $param;
+
         return $this;
     }
 
@@ -140,6 +148,7 @@ class Server_Client
     public function setCountry($param)
     {
         $this->country = $param;
+
         return $this;
     }
 
@@ -151,6 +160,7 @@ class Server_Client
     public function setZip($param)
     {
         $this->zip = $param;
+
         return $this;
     }
 
@@ -162,6 +172,7 @@ class Server_Client
     public function setTelephone($param)
     {
         $this->telephone = $param;
+
         return $this;
     }
 
@@ -169,10 +180,11 @@ class Server_Client
     {
         return $this->telephone;
     }
-    
+
     public function setFax($param)
     {
         $this->fax = $param;
+
         return $this;
     }
 
@@ -180,10 +192,11 @@ class Server_Client
     {
         return $this->fax;
     }
-    
+
     public function setWww($param)
     {
         $this->www = $param;
+
         return $this;
     }
 

--- a/src/library/Server/Exception.php
+++ b/src/library/Server/Exception.php
@@ -2,22 +2,21 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Exception extends FOSSBilling\Exception
 {
     /**
      * Creates a new translated exception, using the FOSSBilling\Exception class.
      *
-	 * @param string $message error message
-	 * @param array|null $variables translation variables
-	 * @param int $code The exception code.
+     * @param string     $message   error message
+     * @param array|null $variables translation variables
+     * @param int        $code      the exception code
      */
-    public function __construct(string $message, array $variables = NULL, int $code = 0)
+    public function __construct(string $message, array $variables = null, int $code = 0)
     {
         parent::__construct($message, $variables, $code, true);
     }

--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -2,26 +2,25 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 abstract class Server_Manager
 {
     private ?\Box_Log $_log = null;
 
-    protected $_config = array(
-        'ip'         =>  NULL,
-        'host'       =>  NULL,
-        'secure'     =>  FALSE,
-        'username'   =>  NULL,
-        'password'   =>  NULL,
-        'accesshash' =>  NULL,
-        'config'     =>  NULL,
-        'port'       =>  NULL,
-    );
+    protected $_config = [
+        'ip' => null,
+        'host' => null,
+        'secure' => false,
+        'username' => null,
+        'password' => null,
+        'accesshash' => null,
+        'config' => null,
+        'port' => null,
+    ];
 
     /**
      * Constructor for the class.
@@ -48,7 +47,7 @@ abstract class Server_Manager
         }
 
         if (isset($options['secure'])) {
-            $this->_config['secure'] = (bool)$options['secure'];
+            $this->_config['secure'] = (bool) $options['secure'];
         }
 
         if (isset($options['username'])) {
@@ -67,14 +66,14 @@ abstract class Server_Manager
             $this->_config['ssl'] = $options['ssl'];
         }
 
-        /**
+        /*
          * Custom configuration.
          */
         if (isset($options['config'])) {
             $this->_config['config'] = $options['config'];
         }
 
-        /**
+        /*
          * Custom connection port to API.
          * If not provided, using default server manager port
          */
@@ -89,8 +88,9 @@ abstract class Server_Manager
      * Generates a username for an account based on the provided domain name.
      * Server managers may define this function to provide their own method for username generation depending on the specifics of the server they are integrated with.
      *
-     * @param mixed $domain_name The domain name used to generate the username.
-     * @return string The generated username.
+     * @param mixed $domain_name the domain name used to generate the username
+     *
+     * @return string the generated username
      */
     public function generateUsername(mixed $domain_name)
     {
@@ -98,33 +98,38 @@ abstract class Server_Manager
         $username = substr($username, 0, 7);
         $randnum = random_int(0, 9);
         $prefix = $this->_config['config']['userprefix'] ?? '';
-        return  $prefix . $username . $randnum;
+
+        return $prefix . $username . $randnum;
     }
 
     /**
      * Sets the logger object.
      *
-     * @param Box_Log $value The logger object.
+     * @param Box_Log $value the logger object
+     *
      * @return $this
      */
     public function setLog(Box_Log $value)
     {
         $this->_log = $value;
+
         return $this;
     }
 
     /**
      * Returns the logger object.
      *
-     * @return Box_Log The logger object.
+     * @return Box_Log the logger object
      */
     public function getLog()
     {
         if (!$this->_log instanceof Box_Log) {
             $log = new Box_Log();
             $log->addWriter(new Box_LogDb('Model_ActivitySystem'));
+
             return $log;
         }
+
         return $this->_log;
     }
 
@@ -133,43 +138,43 @@ abstract class Server_Manager
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return \Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create();
     }
 
     /**
      * Initializes the object after construction.
-     * 
+     *
      * This function can be used to perform any necessary setup tasks that are required after the object has been constructed.
-     *  
-     * @return void 
+     *
+     * @return void
      */
     protected function init()
     {
     }
 
     /**
-     * Returns the login URL for the server. (ex: panel.example.com)
-     * 
-     * @param null|Server_Account $account Either the related `Server_Account` which can be used to generate an SSO link or `null`.
-     * 
+     * Returns the login URL for the server. (ex: panel.example.com).
+     *
+     * @param Server_Account|null $account either the related `Server_Account` which can be used to generate an SSO link or `null`
+     *
      * @return string
      */
     abstract public function getLoginUrl(?Server_Account $account);
 
     /**
      * Returns the login URL for the server for reseller accounts.
-     * 
-     * @param null|Server_Account $account Either the related `Server_Account` which can be used to generate an SSO link or `null`.
-     * 
+     *
+     * @param Server_Account|null $account either the related `Server_Account` which can be used to generate an SSO link or `null`
+     *
      * @return string
      */
     abstract public function getResellerLoginUrl(?Server_Account $account);
 
     /**
      * Used to test the connection to the server and verify the server configuration is correct.
-     * 
+     *
      * @return bool
-     * 
+     *
      * @throws Server_Exception
      */
     abstract public function testConnection();
@@ -177,129 +182,115 @@ abstract class Server_Manager
     /**
      * Creates a new account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to create.
-     * 
+     * @param Server_Account $a account object containing the details of the account to create
+     *
      * @return bool True if the account was created successfully, if not the server manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while creating the account.
+     *
+     * @throws Server_Exception if there was an error while creating the account
      */
     abstract public function createAccount(Server_Account $a);
-
 
     /**
      * Synchronizes the account status from the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to synchronize.
-     * 
-     * @return Server_Account A new account object with the updated status.
-     * 
-     * @throws Server_Exception If there was an error while synchronizing the account.
+     * @param Server_Account $a account object containing the details of the account to synchronize
+     *
+     * @return Server_Account a new account object with the updated status
+     *
+     * @throws Server_Exception if there was an error while synchronizing the account
      */
     abstract public function synchronizeAccount(Server_Account $a);
-
 
     /**
      * Suspends an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to suspend.
-     * 
+     * @param Server_Account $a account object containing the details of the account to suspend
+     *
      * @return bool True if the account was suspended successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while suspending the account.
+     *
+     * @throws Server_Exception if there was an error while suspending the account
      */
     abstract public function suspendAccount(Server_Account $a);
-
 
     /**
      * Unsuspends an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to unsuspend.
-     * 
+     * @param Server_Account $a account object containing the details of the account to unsuspend
+     *
      * @return bool True if the account was unsuspended successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while unsuspending the account.
+     *
+     * @throws Server_Exception if there was an error while unsuspending the account
      */
     abstract public function unsuspendAccount(Server_Account $a);
-
 
     /**
      * Cancels an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to cancel.
-     * 
+     * @param Server_Account $a account object containing the details of the account to cancel
+     *
      * @return bool True if the account was canceled successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while canceling the account.
+     *
+     * @throws Server_Exception if there was an error while canceling the account
      */
     abstract public function cancelAccount(Server_Account $a);
-
 
     /**
      * Changes the password for an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to update.
-     * 
-     * @param string $new_password The new password for the account.
-     * 
+     * @param Server_Account $a            account object containing the details of the account to update
+     * @param string         $new_password the new password for the account
+     *
      * @return bool True if the password was changed successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while changing the password.
+     *
+     * @throws Server_Exception if there was an error while changing the password
      */
     abstract public function changeAccountPassword(Server_Account $a, $new_password);
-
 
     /**
      * Changes the username for an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to update.
-     * 
-     * @param string $new_username The new username for the account.
-     * 
+     * @param Server_Account $a            account object containing the details of the account to update
+     * @param string         $new_username the new username for the account
+     *
      * @return bool True if the username was changed successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while changing the username.
+     *
+     * @throws Server_Exception if there was an error while changing the username
      */
     abstract public function changeAccountUsername(Server_Account $a, $new_username);
-
 
     /**
      * Changes the domain for an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to update.
-     * 
-     * @param string $new_domain The new domain for the account.
-     * 
+     * @param Server_Account $a          account object containing the details of the account to update
+     * @param string         $new_domain the new domain for the account
+     *
      * @return bool True if the domain was changed successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while changing the domain.
+     *
+     * @throws Server_Exception if there was an error while changing the domain
      */
     abstract public function changeAccountDomain(Server_Account $a, $new_domain);
-
 
     /**
      * Changes the IP address for an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to update.
-     * 
-     * @param string $new_ip The new IP address for the account.
-     * 
+     * @param Server_Account $a      account object containing the details of the account to update
+     * @param string         $new_ip the new IP address for the account
+     *
      * @return bool True if the IP address was changed successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while changing the IP address.
+     *
+     * @throws Server_Exception if there was an error while changing the IP address
      */
     abstract public function changeAccountIp(Server_Account $a, $new_ip);
-
 
     /**
      * Changes the package for an account on the server.
      *
-     * @param Server_Account $a Account object containing the details of the account to update.
-     * 
-     * @param Server_Package $p New package for the account.
-     * 
+     * @param Server_Account $a account object containing the details of the account to update
+     * @param Server_Package $p new package for the account
+     *
      * @return bool True if the package was changed successfully, if not the sever manager should throw an exception
-     * 
-     * @throws Server_Exception If there was an error while changing the package.
+     *
+     * @throws Server_Exception if there was an error while changing the package
      */
     abstract public function changeAccountPackage(Server_Account $a, Server_Package $p);
 }

--- a/src/library/Server/Manager/CWP.php
+++ b/src/library/Server/Manager/CWP.php
@@ -2,291 +2,302 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
 /**
- * CWP API
+ * CWP API.
+ *
  * @see https://docs.control-webpanel.com/docs/developer-tools/api-manager
  */
 class Server_Manager_CWP extends Server_Manager
 {
-	public function init()
-	{
-		if (empty($this->_config['ip'])) {
-			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'IP address'], 2001);
-		}
+    public function init()
+    {
+        if (empty($this->_config['ip'])) {
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'IP address'], 2001);
+        }
 
-		if (empty($this->_config['host'])) {
-			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'Hostname'], 2001);
-		}
+        if (empty($this->_config['host'])) {
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'Hostname'], 2001);
+        }
 
-		if (empty($this->_config['accesshash'])) {
-			throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'API Key / Access Hash'], 2001);
-		} else {
-			$this->_config['accesshash'] = trim($this->_config['accesshash']);
-		}
+        if (empty($this->_config['accesshash'])) {
+            throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'CWP', ':missing' => 'API Key / Access Hash'], 2001);
+        } else {
+            $this->_config['accesshash'] = trim($this->_config['accesshash']);
+        }
 
-		if (empty($this->_config['port'])) {
-			$this->_config['port'] = '2304';
-		}
-	}
+        if (empty($this->_config['port'])) {
+            $this->_config['port'] = '2304';
+        }
+    }
 
-	public static function getForm()
-	{
-		return [
-			'label' => 'CWP',
-			'form' => [
-				'credentials' => [
-					'fields' => [
-						[
-							'name' => 'accesshash',
-							'type' => 'text',
-							'label' => 'API key',
-							'placeholder' => 'API key you generated from within CWP.',
-							'required' => true,
-						],
-					],
-				],
-			]
-		];
-	}
+    public static function getForm()
+    {
+        return [
+            'label' => 'CWP',
+            'form' => [
+                'credentials' => [
+                    'fields' => [
+                        [
+                            'name' => 'accesshash',
+                            'type' => 'text',
+                            'label' => 'API key',
+                            'placeholder' => 'API key you generated from within CWP.',
+                            'required' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-	/**
-	 * We can actually generate a direct log-in link from CWP, but I'm not sure if that's a secure thing to do here.
-	 */
-	public function getLoginUrl(?Server_Account $account = null)
-	{
-		$host = $this->_config['host'];
-		return 'https://' . $host . ':2083';
-	}
+    /**
+     * We can actually generate a direct log-in link from CWP, but I'm not sure if that's a secure thing to do here.
+     */
+    public function getLoginUrl(Server_Account $account = null)
+    {
+        $host = $this->_config['host'];
 
-	public function getResellerLoginUrl(?Server_Account $account = null)
-	{
-		$host = $this->_config['host'];
-		return 'https://' . $host . ':2031';
-	}
+        return 'https://' . $host . ':2083';
+    }
 
-	/**
-	 * CWP doesn't have a connection test function, so we ask what kind of server it is (EX: KVM / OpenVZ)
-	 * No error means the connection worked and we can continue
-	 */
-	public function testConnection()
-	{
-		$data = [
-			'action'  => 'list',
-		];
+    public function getResellerLoginUrl(Server_Account $account = null)
+    {
+        $host = $this->_config['host'];
 
-		if ($this->makeAPIRequest('account', $data)) {
-			return true;
-		} else {
-			throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'CWP']);
-		}
-	}
+        return 'https://' . $host . ':2031';
+    }
 
-	public function synchronizeAccount(Server_Account $a)
-	{
-		$this->getLog()->info('Synchronizing account with server ' . $a->getUsername());
+    /**
+     * CWP doesn't have a connection test function, so we ask what kind of server it is (EX: KVM / OpenVZ)
+     * No error means the connection worked and we can continue.
+     */
+    public function testConnection()
+    {
+        $data = [
+            'action' => 'list',
+        ];
 
-		$data = [
-			'action'  => 'list',
-			'user'    => $a->getUsername()
-		];
+        if ($this->makeAPIRequest('account', $data)) {
+            return true;
+        } else {
+            throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'CWP']);
+        }
+    }
 
-		$new = clone $a;
-		$acc = $this->makeAPIRequest('accountdetail', $data);
+    public function synchronizeAccount(Server_Account $a)
+    {
+        $this->getLog()->info('Synchronizing account with server ' . $a->getUsername());
 
-		if ($acc['account_info']['state'] == 'suspended') {
-			$new->setSuspended(true);
-		} else {
-			$new->setSuspended(false);
-		}
+        $data = [
+            'action' => 'list',
+            'user' => $a->getUsername(),
+        ];
 
-		$new->setPackage($acc['account_info']['package_name']);
-		$new->setReseller($acc['account_info']['reseller']);
-		return $new;
-	}
+        $new = clone $a;
+        $acc = $this->makeAPIRequest('accountdetail', $data);
 
-	/**
-	 * Package name must match on both CWP and FOSSBilling!
-	 */
-	public function createAccount(Server_Account $a)
-	{
-		$this->getLog()->info('Creating account ' . $a->getUsername());
+        if ($acc['account_info']['state'] == 'suspended') {
+            $new->setSuspended(true);
+        } else {
+            $new->setSuspended(false);
+        }
 
-		$client = $a->getClient();
-		$package = $a->getPackage()->getName();
+        $new->setPackage($acc['account_info']['package_name']);
+        $new->setReseller($acc['account_info']['reseller']);
 
-		$ip = $this->_config['ip'];
+        return $new;
+    }
 
-		$data = [
-			'action'       => 'add',
-			'domain'       => $a->getDomain(),
-			'user'         => $a->getUsername(),
-			'pass'         => base64_encode($a->getPassword()),
-			'email'        => $client->getEmail(),
-			'package'      => $package,
-			'server_ips'   => $ip,
-			'encodepass'   => true
-		];
+    /**
+     * Package name must match on both CWP and FOSSBilling!
+     */
+    public function createAccount(Server_Account $a)
+    {
+        $this->getLog()->info('Creating account ' . $a->getUsername());
 
-		if ($a->getReseller()) {
-			$data['reseller'] = 1;
-		}
+        $client = $a->getClient();
+        $package = $a->getPackage()->getName();
 
-		if ($this->makeAPIRequest('account', $data)) {
-			return true;
-		} else {
-			$placeholders = [':action:' => __trans('create account'), ':type:' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+        $ip = $this->_config['ip'];
 
-	public function suspendAccount(Server_Account $a)
-	{
-		$this->getLog()->info('Suspending account ' . $a->getUsername());
+        $data = [
+            'action' => 'add',
+            'domain' => $a->getDomain(),
+            'user' => $a->getUsername(),
+            'pass' => base64_encode($a->getPassword()),
+            'email' => $client->getEmail(),
+            'package' => $package,
+            'server_ips' => $ip,
+            'encodepass' => true,
+        ];
 
-		$data = [
-			'action'   => 'susp',
-			'user'     => $a->getUsername()
-		];
+        if ($a->getReseller()) {
+            $data['reseller'] = 1;
+        }
 
-		if ($this->makeAPIRequest('account', $data)) {
-			return true;
-		} else {
-			$placeholders = ['action' => __trans('suspend account'), 'type' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+        if ($this->makeAPIRequest('account', $data)) {
+            return true;
+        } else {
+            $placeholders = [':action:' => __trans('create account'), ':type:' => 'CWP'];
 
-	public function unsuspendAccount(Server_Account $a)
-	{
-		$this->getLog()->info('Un-suspending account ' . $a->getUsername());
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
 
-		$data = [
-			'action'   => 'unsp',
-			'user'     => $a->getUsername()
-		];
+    public function suspendAccount(Server_Account $a)
+    {
+        $this->getLog()->info('Suspending account ' . $a->getUsername());
 
-		if ($this->makeAPIRequest('account', $data)) {
-			return true;
-		} else {
-			$placeholders = [':action:' => __trans('unsuspend account'), ':type:' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+        $data = [
+            'action' => 'susp',
+            'user' => $a->getUsername(),
+        ];
 
-	public function cancelAccount(Server_Account $a)
-	{
-		$this->getLog()->info('Canceling account ' . $a->getUsername());
+        if ($this->makeAPIRequest('account', $data)) {
+            return true;
+        } else {
+            $placeholders = ['action' => __trans('suspend account'), 'type' => 'CWP'];
 
-		$client = $a->getClient();
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
 
-		$data = [
-			'action'  => 'del',
-			'user'    => $a->getUsername(),
-			'email'   => $client->getEmail()
-		];
+    public function unsuspendAccount(Server_Account $a)
+    {
+        $this->getLog()->info('Un-suspending account ' . $a->getUsername());
 
-		if ($this->makeAPIRequest('account', $data)) {
-			return true;
-		} else {
-			$placeholders = [':action:' => __trans('cancel account'), ':type:' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+        $data = [
+            'action' => 'unsp',
+            'user' => $a->getUsername(),
+        ];
 
-	public function changeAccountPackage(Server_Account $a, Server_Package $p)
-	{
-		$this->getLog()->info('Changing package on account ' . $a->getUsername());
+        if ($this->makeAPIRequest('account', $data)) {
+            return true;
+        } else {
+            $placeholders = [':action:' => __trans('unsuspend account'), ':type:' => 'CWP'];
 
-		$package = $a->getPackage()->getName();
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
 
-		$data = [
-			'action'   => 'upd',
-			'user'     => $a->getUsername(),
-			'package'  => $package
-		];
+    public function cancelAccount(Server_Account $a)
+    {
+        $this->getLog()->info('Canceling account ' . $a->getUsername());
 
-		if ($this->makeAPIRequest('changepack', $data)) {
-			return true;
-		} else {
-			$placeholders = [':action:' => __trans('change account package'), ':type:' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+        $client = $a->getClient();
 
-	public function changeAccountPassword(Server_Account $a, $new)
-	{
-		$this->getLog()->info('Changing password on account ' . $a->getUsername());
+        $data = [
+            'action' => 'del',
+            'user' => $a->getUsername(),
+            'email' => $client->getEmail(),
+        ];
 
-		$data = [
-			'action'  => 'udp',
-			'user'    => $a->getUsername(),
-			'pass'    => $new
-		];
+        if ($this->makeAPIRequest('account', $data)) {
+            return true;
+        } else {
+            $placeholders = [':action:' => __trans('cancel account'), ':type:' => 'CWP'];
 
-		if ($this->makeAPIRequest('changepass', $data)) {
-			return true;
-		} else {
-			$placeholders = [':action:' => __trans('change account password'), ':type:' => 'CWP'];
-			throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-		}
-	}
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
 
-	/**
-	 * Function graveyard for things CWP doesn't support
-	 */
-	public function changeAccountUsername(Server_Account $a, $new): never
-	{
-		throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('username changes')]);
-	}
+    public function changeAccountPackage(Server_Account $a, Server_Package $p)
+    {
+        $this->getLog()->info('Changing package on account ' . $a->getUsername());
 
-	public function changeAccountDomain(Server_Account $a, $new): never
-	{
-		throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('changing the account domain')]);
-	}
+        $package = $a->getPackage()->getName();
 
-	public function changeAccountIp(Server_Account $a, $new): never
-	{
-		throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('changing the account IP')]);
-	}
+        $data = [
+            'action' => 'upd',
+            'user' => $a->getUsername(),
+            'package' => $package,
+        ];
 
-	/**
-	 * Makes the HTTP request to the server
-	 */
-	private function makeAPIRequest($func, $data)
-	{
-		$data['key'] = $this->_config['accesshash'];
-		$host = $this->_config['host'];
-		$port = $this->_config['port'];
-		$url = 'https://' . $host . ":" . $port . '/v1/' . $func;
+        if ($this->makeAPIRequest('changepack', $data)) {
+            return true;
+        } else {
+            $placeholders = [':action:' => __trans('change account package'), ':type:' => 'CWP'];
 
-		$client = $this->getHttpClient()->withOptions([
-			'verify_peer'	=> false,
-			'verify_host'	=> false,
-		]);
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
 
-		$request = $client->request('POST', $url, [
-			'body'	=> $data,
-		]);
+    public function changeAccountPassword(Server_Account $a, $new)
+    {
+        $this->getLog()->info('Changing password on account ' . $a->getUsername());
 
-		$response = $request->toArray();
+        $data = [
+            'action' => 'udp',
+            'user' => $a->getUsername(),
+            'pass' => $new,
+        ];
 
-		$status = $response['status'] ?? 'Error';
-		$result = $response['result'] ?? null;
-		$msg = $response['msg'] ?? 'CWP did not return a message in it\'s response.';
+        if ($this->makeAPIRequest('changepass', $data)) {
+            return true;
+        } else {
+            $placeholders = [':action:' => __trans('change account password'), ':type:' => 'CWP'];
 
-		if ($status == 'OK' && $func != 'accountdetail') {
-			return true;
-		} elseif ($status !== 'OK') {
-			error_log('CWP Server manager error. Status: ' . $status . '. Message: ' . $msg);
-			return false;
-		} else {
-			return $result;
-		}
-	}
+            throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
+        }
+    }
+
+    /**
+     * Function graveyard for things CWP doesn't support.
+     */
+    public function changeAccountUsername(Server_Account $a, $new): never
+    {
+        throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('username changes')]);
+    }
+
+    public function changeAccountDomain(Server_Account $a, $new): never
+    {
+        throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('changing the account domain')]);
+    }
+
+    public function changeAccountIp(Server_Account $a, $new): never
+    {
+        throw new Server_Exception(':type: does not support :action:', [':type:' => 'CWP', ':action:' => __trans('changing the account IP')]);
+    }
+
+    /**
+     * Makes the HTTP request to the server.
+     */
+    private function makeAPIRequest($func, $data)
+    {
+        $data['key'] = $this->_config['accesshash'];
+        $host = $this->_config['host'];
+        $port = $this->_config['port'];
+        $url = 'https://' . $host . ':' . $port . '/v1/' . $func;
+
+        $client = $this->getHttpClient()->withOptions([
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+
+        $request = $client->request('POST', $url, [
+            'body' => $data,
+        ]);
+
+        $response = $request->toArray();
+
+        $status = $response['status'] ?? 'Error';
+        $result = $response['result'] ?? null;
+        $msg = $response['msg'] ?? 'CWP did not return a message in it\'s response.';
+
+        if ($status == 'OK' && $func != 'accountdetail') {
+            return true;
+        } elseif ($status !== 'OK') {
+            error_log('CWP Server manager error. Status: ' . $status . '. Message: ' . $msg);
+
+            return false;
+        } else {
+            return $result;
+        }
+    }
 }

--- a/src/library/Server/Manager/Custom.php
+++ b/src/library/Server/Manager/Custom.php
@@ -2,145 +2,139 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Manager_Custom extends Server_Manager
 {
     /**
      * Method is called just after obejct contruct is complete.
-     * Add required parameters checks here. 
+     * Add required parameters checks here.
      */
-	public function init()
+    public function init()
     {
-        
-	}
-
-    /**
-     * Return server manager parameters.
-     * @return type 
-     */
-    public static function getForm()
-    {
-        return array(
-            'label'     =>  'Custom Server Manager',
-        );
     }
 
     /**
-     * Returns link to account management page
-     * 
-     * @return string 
+     * Return server manager parameters.
+     *
+     * @return type
      */
-    public function getLoginUrl(?Server_Account $account = null)
+    public static function getForm()
+    {
+        return [
+            'label' => 'Custom Server Manager',
+        ];
+    }
+
+    /**
+     * Returns link to account management page.
+     *
+     * @return string
+     */
+    public function getLoginUrl(Server_Account $account = null)
     {
         return 'http://www.google.com?q=cpanel';
     }
 
     /**
-     * Returns link to reseller account management
-     * @return string 
+     * Returns link to reseller account management.
+     *
+     * @return string
      */
-    public function getResellerLoginUrl(?Server_Account $account = null)
+    public function getResellerLoginUrl(Server_Account $account = null)
     {
         return 'http://www.google.com?q=whm';
     }
 
     /**
      * This method is called to check if configuration is correct
-     * and class can connect to server
-     * 
-     * @return boolean 
+     * and class can connect to server.
+     *
+     * @return bool
      */
     public function testConnection()
     {
-        return TRUE;
+        return true;
     }
 
     /**
      * MEthods retrieves information from server, assignes new values to
      * cloned Server_Account object and returns it.
-     * @param Server_Account $a
-     * @return Server_Account 
+     *
+     * @return Server_Account
      */
     public function synchronizeAccount(Server_Account $a)
     {
-        $this->getLog()->info('Synchronizing account with server '.$a->getUsername());
+        $this->getLog()->info('Synchronizing account with server ' . $a->getUsername());
         $new = clone $a;
-        //@example - retrieve username from server and set it to cloned object
-        //$new->setUsername('newusername');
+
+        // @example - retrieve username from server and set it to cloned object
+        // $new->setUsername('newusername');
         return $new;
     }
 
     /**
-     * Create new account on server
-     * 
-     * @param Server_Account $a 
+     * Create new account on server.
      */
-	public function createAccount(Server_Account $a)
+    public function createAccount(Server_Account $a)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Creating reseller hosting account');
         } else {
             $this->getLog()->info('Creating shared hosting account');
         }
-	}
+    }
 
     /**
-     * Suspend account on server
-     * @param Server_Account $a 
+     * Suspend account on server.
      */
-	public function suspendAccount(Server_Account $a)
+    public function suspendAccount(Server_Account $a)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Suspending reseller hosting account');
         } else {
             $this->getLog()->info('Suspending shared hosting account');
         }
-	}
+    }
 
     /**
-     * Unsuspend account on server
-     * @param Server_Account $a 
+     * Unsuspend account on server.
      */
-	public function unsuspendAccount(Server_Account $a)
+    public function unsuspendAccount(Server_Account $a)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Unsuspending reseller hosting account');
         } else {
             $this->getLog()->info('Unsuspending shared hosting account');
         }
-	}
+    }
 
     /**
-     * Cancel account on server
-     * @param Server_Account $a 
+     * Cancel account on server.
      */
-	public function cancelAccount(Server_Account $a)
+    public function cancelAccount(Server_Account $a)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Canceling reseller hosting account');
         } else {
             $this->getLog()->info('Canceling shared hosting account');
         }
-	}
+    }
 
     /**
-     * Change account package on server
-     * @param Server_Account $a
-     * @param Server_Package $p 
+     * Change account package on server.
      */
-	public function changeAccountPackage(Server_Account $a, Server_Package $p)
+    public function changeAccountPackage(Server_Account $a, Server_Package $p)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Updating reseller hosting account');
         } else {
             $this->getLog()->info('Updating shared hosting account');
         }
-        
+
         $p->getName();
         $p->getQuota();
         $p->getBandwidth();
@@ -150,18 +144,18 @@ class Server_Manager_Custom extends Server_Manager
         $p->getMaxFtp();
         $p->getMaxSql();
         $p->getMaxPop();
-        
+
         $p->getCustomValue('param_name');
-	}
+    }
 
     /**
-     * Change account username on server
-     * @param Server_Account $a
+     * Change account username on server.
+     *
      * @param type $new - new account username
      */
     public function changeAccountUsername(Server_Account $a, $new)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Changing reseller hosting account username');
         } else {
             $this->getLog()->info('Changing shared hosting account username');
@@ -169,13 +163,13 @@ class Server_Manager_Custom extends Server_Manager
     }
 
     /**
-     * Change account domain on server
-     * @param Server_Account $a
+     * Change account domain on server.
+     *
      * @param type $new - new domain name
      */
     public function changeAccountDomain(Server_Account $a, $new)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Changing reseller hosting account domain');
         } else {
             $this->getLog()->info('Changing shared hosting account domain');
@@ -183,13 +177,13 @@ class Server_Manager_Custom extends Server_Manager
     }
 
     /**
-     * Change account password on server
-     * @param Server_Account $a
+     * Change account password on server.
+     *
      * @param type $new - new password
      */
     public function changeAccountPassword(Server_Account $a, $new)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Changing reseller hosting account password');
         } else {
             $this->getLog()->info('Changing shared hosting account password');
@@ -197,13 +191,13 @@ class Server_Manager_Custom extends Server_Manager
     }
 
     /**
-     * Change account IP on server
-     * @param Server_Account $a
+     * Change account IP on server.
+     *
      * @param type $new - account IP
      */
     public function changeAccountIp(Server_Account $a, $new)
     {
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $this->getLog()->info('Changing reseller hosting account ip');
         } else {
             $this->getLog()->info('Changing shared hosting account ip');

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -2,32 +2,31 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Manager_Directadmin extends Server_Manager
 {
     public function init()
     {
-        if(empty($this->_config['host'])) {
+        if (empty($this->_config['host'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'hostname'], 2001);
         }
 
-        if(empty($this->_config['username'])) {
+        if (empty($this->_config['username'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'username'], 2001);
         }
 
-        if(empty($this->_config['password'])) {
+        if (empty($this->_config['password'])) {
             throw new Server_Exception('The ":server_manager" server manager is not fully configured. Please configure the :missing', [':server_manager' => 'DirectAdmin', ':missing' => 'password'], 2001);
         }
     }
 
     public static function getForm()
     {
-        return array(
+        return [
             'label' => 'DirectAdmin',
             'form' => [
                 'credentials' => [
@@ -45,11 +44,11 @@ class Server_Manager_Directadmin extends Server_Manager
                             'label' => 'Password / Login Key',
                             'placeholder' => 'Password or login key used to connect to the server',
                             'required' => true,
-                        ]
-                    ]
-                ]
-            ]
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function _getPort()
@@ -57,13 +56,14 @@ class Server_Manager_Directadmin extends Server_Manager
         return is_numeric($this->_config['port']) ? $this->_config['port'] : '2222';
     }
 
-    public function getLoginUrl(?Server_Account $account = null): string
+    public function getLoginUrl(Server_Account $account = null): string
     {
         $protocol = $this->_config['secure'] ? 'https://' : 'http://';
-        return $protocol . $this->_config['host'] . ':'. $this -> _getPort();
+
+        return $protocol . $this->_config['host'] . ':' . $this->_getPort();
     }
 
-    public function getResellerLoginUrl(?Server_Account $account = null)
+    public function getResellerLoginUrl(Server_Account $account = null)
     {
         return $this->getLoginUrl();
     }
@@ -74,17 +74,19 @@ class Server_Manager_Directadmin extends Server_Manager
         $username = preg_replace('/[^A-Za-z0-9]/', '', $domain_name);
 
         // Username must start with a-z.
-        $username = is_numeric(substr($username, 0, 1)) ? substr_replace($username, chr(random_int(97,122)), 0, 1) : $username;
+        $username = is_numeric(substr($username, 0, 1)) ? substr_replace($username, chr(random_int(97, 122)), 0, 1) : $username;
 
         // Username must be at most 10 characters long, and sufficiently random to avoid collisons.
         $username = substr($username, 0, 7);
         $randnum = random_int(0, 99);
+
         return $username . $randnum;
     }
 
     public function testConnection()
     {
         $results = $this->_request('CMD_API_SHOW_RESELLER_IPS');
+
         return is_array($results);
     }
 
@@ -96,112 +98,111 @@ class Server_Manager_Directadmin extends Server_Manager
     public function createAccount(Server_Account $a)
     {
         $ips = $this->getIps();
-        if(empty($ips)) {
+        if (empty($ips)) {
             throw new Server_Exception('There are no available IPs on this server.');
         }
         $ip = $ips[array_rand($ips)];
 
         $package = $a->getPackage();
-        $client  = $a->getClient();
+        $client = $a->getClient();
 
-        $fields             = array();
-        $fields['action']   = 'create';
-        $fields['add']      = 'Submit';
+        $fields = [];
+        $fields['action'] = 'create';
+        $fields['add'] = 'Submit';
         $fields['username'] = $a->getUsername();
-        $fields['email']    = $client->getEmail();
-        $fields['passwd']   = $a->getPassword();
-        $fields['passwd2']  = $a->getPassword();
-        $fields['domain']   = $a->getDomain();
+        $fields['email'] = $client->getEmail();
+        $fields['passwd'] = $a->getPassword();
+        $fields['passwd2'] = $a->getPassword();
+        $fields['domain'] = $a->getDomain();
 
         // do not create new package
         //        $packages = $this->getPackages();
         //        $fields['package'] = $package->getName();
 
-        $fields['ip']     = $ip;
+        $fields['ip'] = $ip;
         $fields['notify'] = 'no';
 
-        $fields['bandwidth'] = $package->getBandwidth(); //Amount of bandwidth User will be allowed to use. Number, in Megabytes
-        if($package->getBandwidth() == 'unlimited') {
-            $fields['ubandwidth'] = 'ON'; //ON or OFF. If ON, bandwidth is ignored and no limit is set
+        $fields['bandwidth'] = $package->getBandwidth(); // Amount of bandwidth User will be allowed to use. Number, in Megabytes
+        if ($package->getBandwidth() == 'unlimited') {
+            $fields['ubandwidth'] = 'ON'; // ON or OFF. If ON, bandwidth is ignored and no limit is set
         }
-        $fields['quota'] = $package->getQuota(); //Amount of disk space User will be allowed to use. Number, in Megabytes
-        if($package->getQuota() == 'unlimited') {
-            $fields['uquota'] = 'ON'; //ON or OFF. If ON, quota is ignored and no limit is set
+        $fields['quota'] = $package->getQuota(); // Amount of disk space User will be allowed to use. Number, in Megabytes
+        if ($package->getQuota() == 'unlimited') {
+            $fields['uquota'] = 'ON'; // ON or OFF. If ON, quota is ignored and no limit is set
         }
-        $fields['vdomains'] = $package->getMaxDomains(); //Number of domains the User will be allowed to create
-        if($package->getMaxDomains() == 'unlimited') {
-            $fields['uvdomains'] = 'ON'; //ON or OFF. If ON, vdomains is ignored and no limit is set
+        $fields['vdomains'] = $package->getMaxDomains(); // Number of domains the User will be allowed to create
+        if ($package->getMaxDomains() == 'unlimited') {
+            $fields['uvdomains'] = 'ON'; // ON or OFF. If ON, vdomains is ignored and no limit is set
         }
-        $fields['nsubdomains'] = $package->getMaxSubdomains(); //Number of subdomains the User will be allowed to create
-        if($package->getMaxSubdomains() == 'unlimited') {
-            $fields['unsubdomains'] = 'ON'; //ON or OFF. If ON, nsubdomains is ignored and no limit is set
+        $fields['nsubdomains'] = $package->getMaxSubdomains(); // Number of subdomains the User will be allowed to create
+        if ($package->getMaxSubdomains() == 'unlimited') {
+            $fields['unsubdomains'] = 'ON'; // ON or OFF. If ON, nsubdomains is ignored and no limit is set
         }
-        $fields['domainptr'] = $package->getMaxParkedDomains(); //Number of domain pointers the User will be allowed to create
-        if($package->getMaxParkedDomains() == 'unlimited') {
-            $fields['udomainptr'] = 'ON'; //ON or OFF Unlimited option for domainptr
+        $fields['domainptr'] = $package->getMaxParkedDomains(); // Number of domain pointers the User will be allowed to create
+        if ($package->getMaxParkedDomains() == 'unlimited') {
+            $fields['udomainptr'] = 'ON'; // ON or OFF Unlimited option for domainptr
         }
-        $fields['nemails'] = $package->getMaxPop(); //Number of pop accounts the User will be allowed to create
-        if($package->getMaxPop() == 'unlimited') {
-            $fields['unemails'] = 'ON'; //ON or OFF Unlimited option for nemails
+        $fields['nemails'] = $package->getMaxPop(); // Number of pop accounts the User will be allowed to create
+        if ($package->getMaxPop() == 'unlimited') {
+            $fields['unemails'] = 'ON'; // ON or OFF Unlimited option for nemails
         }
-        $fields['mysql'] = $package->getMaxSql(); //Number of MySQL databases the User will be allowed to create
-        if($package->getMaxSql() == 'unlimited') {
-            $fields['umysql'] = 'ON'; //ON or OFF Unlimited option for mysql
+        $fields['mysql'] = $package->getMaxSql(); // Number of MySQL databases the User will be allowed to create
+        if ($package->getMaxSql() == 'unlimited') {
+            $fields['umysql'] = 'ON'; // ON or OFF Unlimited option for mysql
         }
-        $fields['ftp'] = $package->getMaxFtp(); //Number of ftp accounts the User will be allowed to create
-        if($package->getMaxFtp() == 'unlimited') {
-            $fields['uftp'] = 'ON'; //ON or OFF Unlimited option for ftp
+        $fields['ftp'] = $package->getMaxFtp(); // Number of ftp accounts the User will be allowed to create
+        if ($package->getMaxFtp() == 'unlimited') {
+            $fields['uftp'] = 'ON'; // ON or OFF Unlimited option for ftp
         }
-        $fields['nemailf'] = $package->getCustomValue('nemailf'); //Number of forwarders the User will be allowed to create
-        if($fields['nemailf'] == 'unlimited') {
-            $fields['unemailf'] = 'ON'; //ON or OFF Unlimited option for nemailf
+        $fields['nemailf'] = $package->getCustomValue('nemailf'); // Number of forwarders the User will be allowed to create
+        if ($fields['nemailf'] == 'unlimited') {
+            $fields['unemailf'] = 'ON'; // ON or OFF Unlimited option for nemailf
         }
-        $fields['nemailml'] = $package->getCustomValue('nemailml'); //Number of mailing lists the User will be allowed to create
-        if($fields['nemailml'] == 'unlimited') {
-            $fields['unemailml'] = 'ON'; //ON or OFF Unlimited option for nemailml
+        $fields['nemailml'] = $package->getCustomValue('nemailml'); // Number of mailing lists the User will be allowed to create
+        if ($fields['nemailml'] == 'unlimited') {
+            $fields['unemailml'] = 'ON'; // ON or OFF Unlimited option for nemailml
         }
-        $fields['nemailr'] = $package->getCustomValue('nemailr'); //Number of autoresponders the User will be allowed to create
-        if($fields['nemailr'] == 'unlimited') {
-            $fields['unemailr'] = 'ON'; //ON or OFF Unlimited option for nemailr
+        $fields['nemailr'] = $package->getCustomValue('nemailr'); // Number of autoresponders the User will be allowed to create
+        if ($fields['nemailr'] == 'unlimited') {
+            $fields['unemailr'] = 'ON'; // ON or OFF Unlimited option for nemailr
         }
 
-        $fields['aftp']       = $package->getCustomValue('aftp') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to have anonymous ftp accounts.
-        $fields['cgi']        = $package->getCustomValue('cgi') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-        $fields['php']        = $package->getCustomValue('php') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run php scripts.
-        $fields['spam']       = $package->getCustomValue('spam') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
-        $fields['cron']       = $package->getCustomValue('cron') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to creat cronjobs.
-        $fields['catchall']   = $package->getCustomValue('catchall') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
-        $fields['ssl']        = $package->getCustomValue('ssl') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to access their websites through secure https://.
-        $fields['ssh']        = $package->getCustomValue('ssh') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have an ssh account.
-        $fields['sysinfo']    = $package->getCustomValue('sysinfo') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to a page that shows the system information.
-        $fields['login_keys'] = $package->getCustomValue('login_keys') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have access to the Login Key system for extra account passwords.
-        $fields['dnscontrol'] = $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to modify his/her dns records.
-        $fields['suspend_at_limit'] = $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be suspended if their User bandwidth limit is exceeded.
-        $command              = 'CMD_API_ACCOUNT_USER';
+        $fields['aftp'] = $package->getCustomValue('aftp') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will be able to have anonymous ftp accounts.
+        $fields['cgi'] = $package->getCustomValue('cgi') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
+        $fields['php'] = $package->getCustomValue('php') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run php scripts.
+        $fields['spam'] = $package->getCustomValue('spam') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
+        $fields['cron'] = $package->getCustomValue('cron') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to creat cronjobs.
+        $fields['catchall'] = $package->getCustomValue('catchall') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
+        $fields['ssl'] = $package->getCustomValue('ssl') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to access their websites through secure https://.
+        $fields['ssh'] = $package->getCustomValue('ssh') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have an ssh account.
+        $fields['sysinfo'] = $package->getCustomValue('sysinfo') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have access to a page that shows the system information.
+        $fields['login_keys'] = $package->getCustomValue('login_keys') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have access to the Login Key system for extra account passwords.
+        $fields['dnscontrol'] = $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will be able to modify his/her dns records.
+        $fields['suspend_at_limit'] = $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF'; // ON or OFF If ON, the User will be suspended if their User bandwidth limit is exceeded.
+        $command = 'CMD_API_ACCOUNT_USER';
 
-        if($a->getReseller()) {
+        if ($a->getReseller()) {
             $command = 'CMD_ACCOUNT_RESELLER';
 
-            $fields['ips'] = 1; //Number of ips that will be allocated to the Reseller upon account during account
-            $fields['ip']  = 'assign';
+            $fields['ips'] = 1; // Number of ips that will be allocated to the Reseller upon account during account
+            $fields['ip'] = 'assign';
         }
 
         try {
             $results = $this->_request($command, $fields);
-        }
-        catch(Exception $e) {
-            if(strtolower($e->getMessage()) == strtolower(sprintf('Server Manager DirectAdmin Error: "%s" ', 'That domain already exists'))) {
+        } catch (Exception $e) {
+            if (strtolower($e->getMessage()) == strtolower(sprintf('Server Manager DirectAdmin Error: "%s" ', 'That domain already exists'))) {
                 return true;
             } else {
                 throw new Server_Exception($e->getMessage());
             }
         }
 
-        if(str_contains(implode('', $results), 'Unable to assign the Reseller ANY ips')) {
+        if (str_contains(implode('', $results), 'Unable to assign the Reseller ANY ips')) {
             throw new Server_Exception('Unable to assign the Reseller ANY ips. Make sure to have free, un-assigned ips.');
         }
 
-        if(str_contains(implode('', $results), 'Error Creating User')) {
+        if (str_contains(implode('', $results), 'Error Creating User')) {
             throw new Server_Exception('Error creating user');
         }
 
@@ -211,15 +212,15 @@ class Server_Manager_Directadmin extends Server_Manager
     public function suspendAccount(Server_Account $a)
     {
         $info = $this->getAccountInfo($a);
-        if($info['suspended'] == 'yes') {
+        if ($info['suspended'] == 'yes') {
             return true;
         }
 
-        $fields             = array();
+        $fields = [];
         $fields['location'] = 'CMD_USER_SHOW';
-        $fields['suspend']  = 'Suspend';
-        $fields['select0']  = $a->getUsername();
-        $result             = $this->_request('CMD_API_SELECT_USERS', $fields);
+        $fields['suspend'] = 'Suspend';
+        $fields['select0'] = $a->getUsername();
+        $result = $this->_request('CMD_API_SELECT_USERS', $fields);
 
         return true;
     }
@@ -227,25 +228,27 @@ class Server_Manager_Directadmin extends Server_Manager
     public function unsuspendAccount(Server_Account $a)
     {
         $info = $this->getAccountInfo($a);
-        if($info['suspended'] == 'no') {
+        if ($info['suspended'] == 'no') {
             throw new Server_Exception('Server Manager DirectAdmin Error: "Account is not suspended"');
         }
 
-        $fields             = array();
+        $fields = [];
         $fields['location'] = 'CMD_USER_SHOW';
-        $fields['suspend']  = 'Unsuspend';
-        $fields['select0']  = $a->getUsername();
+        $fields['suspend'] = 'Unsuspend';
+        $fields['select0'] = $a->getUsername();
         $this->_request('CMD_API_SELECT_USERS', $fields);
+
         return true;
     }
 
     public function cancelAccount(Server_Account $a)
     {
-        $fields              = array();
+        $fields = [];
         $fields['confirmed'] = 'Confirm';
-        $fields['delete']    = 'yes';
-        $fields['select0']   = $a->getUsername();
+        $fields['delete'] = 'yes';
+        $fields['select0'] = $a->getUsername();
         $this->_request('CMD_API_SELECT_USERS', $fields);
+
         return true;
     }
 
@@ -253,79 +256,81 @@ class Server_Manager_Directadmin extends Server_Manager
     {
         $package = $a->getPackage();
 
-        $fields           = array();
+        $fields = [];
         $fields['action'] = 'customize';
-        $fields['user']   = $a->getUsername();
+        $fields['user'] = $a->getUsername();
 
-        $fields['bandwidth'] = $package->getBandwidth(); //Amount of bandwidth User will be allowed to use. Number, in Megabytes
-        if($package->getBandwidth() == 'unlimited') {
-            $fields['ubandwidth'] = 'ON'; //ON or OFF. If ON, bandwidth is ignored and no limit is set
+        $fields['bandwidth'] = $package->getBandwidth(); // Amount of bandwidth User will be allowed to use. Number, in Megabytes
+        if ($package->getBandwidth() == 'unlimited') {
+            $fields['ubandwidth'] = 'ON'; // ON or OFF. If ON, bandwidth is ignored and no limit is set
         }
-        $fields['quota'] = $package->getQuota(); //Amount of disk space User will be allowed to use. Number, in Megabytes
-        if($package->getQuota() == 'unlimited') {
-            $fields['uquota'] = 'ON'; //ON or OFF. If ON, quota is ignored and no limit is set
+        $fields['quota'] = $package->getQuota(); // Amount of disk space User will be allowed to use. Number, in Megabytes
+        if ($package->getQuota() == 'unlimited') {
+            $fields['uquota'] = 'ON'; // ON or OFF. If ON, quota is ignored and no limit is set
         }
-        $fields['vdomains'] = $package->getMaxDomains(); //Number of domains the User will be allowed to create
-        if($package->getMaxDomains() == 'unlimited') {
-            $fields['uvdomains'] = 'ON'; //ON or OFF. If ON, vdomains is ignored and no limit is set
+        $fields['vdomains'] = $package->getMaxDomains(); // Number of domains the User will be allowed to create
+        if ($package->getMaxDomains() == 'unlimited') {
+            $fields['uvdomains'] = 'ON'; // ON or OFF. If ON, vdomains is ignored and no limit is set
         }
-        $fields['nsubdomains'] = $package->getMaxSubdomains(); //Number of subdomains the User will be allowed to create
-        if($package->getMaxSubdomains() == 'unlimited') {
-            $fields['unsubdomains'] = 'ON'; //ON or OFF. If ON, nsubdomains is ignored and no limit is set
+        $fields['nsubdomains'] = $package->getMaxSubdomains(); // Number of subdomains the User will be allowed to create
+        if ($package->getMaxSubdomains() == 'unlimited') {
+            $fields['unsubdomains'] = 'ON'; // ON or OFF. If ON, nsubdomains is ignored and no limit is set
         }
-        $fields['nemails'] = $package->getMaxPop(); //Number of pop accounts the User will be allowed to create
-        if($package->getMaxPop() == 'unlimited') {
-            $fields['unemails'] = 'ON'; //ON or OFF Unlimited option for nemails
+        $fields['nemails'] = $package->getMaxPop(); // Number of pop accounts the User will be allowed to create
+        if ($package->getMaxPop() == 'unlimited') {
+            $fields['unemails'] = 'ON'; // ON or OFF Unlimited option for nemails
         }
-        $fields['nemailf'] = $package->getMaxEmailForwarders(); //Number of forwarders the User will be allowed to create
-        if($package->getMaxEmailForwarders() == 'unlimited') {
-            $fields['unemailf'] = 'ON'; //ON or OFF Unlimited option for nemailf
+        $fields['nemailf'] = $package->getMaxEmailForwarders(); // Number of forwarders the User will be allowed to create
+        if ($package->getMaxEmailForwarders() == 'unlimited') {
+            $fields['unemailf'] = 'ON'; // ON or OFF Unlimited option for nemailf
         }
-        $fields['nemailml'] = $package->getMaxEmailLists(); //Number of mailing lists the User will be allowed to create
-        if($package->getMaxEmailLists() == 'unlimited') {
-            $fields['unemailml'] = 'ON'; //ON or OFF Unlimited option for nemailml
+        $fields['nemailml'] = $package->getMaxEmailLists(); // Number of mailing lists the User will be allowed to create
+        if ($package->getMaxEmailLists() == 'unlimited') {
+            $fields['unemailml'] = 'ON'; // ON or OFF Unlimited option for nemailml
         }
-        $fields['nemailr'] = $package->getMaxEmailAutoresponders(); //Number of autoresponders the User will be allowed to create
-        if($package->getMaxEmailAutoresponders() == 'unlimited') {
-            $fields['unemailr'] = 'ON'; //ON or OFF Unlimited option for nemailr
+        $fields['nemailr'] = $package->getMaxEmailAutoresponders(); // Number of autoresponders the User will be allowed to create
+        if ($package->getMaxEmailAutoresponders() == 'unlimited') {
+            $fields['unemailr'] = 'ON'; // ON or OFF Unlimited option for nemailr
         }
-        $fields['mysql'] = $package->getMaxSql(); //Number of MySQL databases the User will be allowed to create
-        if($package->getMaxSql() == 'unlimited') {
-            $fields['umysql'] = 'ON'; //ON or OFF Unlimited option for mysql
+        $fields['mysql'] = $package->getMaxSql(); // Number of MySQL databases the User will be allowed to create
+        if ($package->getMaxSql() == 'unlimited') {
+            $fields['umysql'] = 'ON'; // ON or OFF Unlimited option for mysql
         }
-        $fields['domainptr'] = $package->getMaxParkedDomains(); //Number of domain pointers the User will be allowed to create
-        if($package->getMaxParkedDomains() == 'unlimited') {
-            $fields['udomainptr'] = 'ON'; //ON or OFF Unlimited option for domainptr
+        $fields['domainptr'] = $package->getMaxParkedDomains(); // Number of domain pointers the User will be allowed to create
+        if ($package->getMaxParkedDomains() == 'unlimited') {
+            $fields['udomainptr'] = 'ON'; // ON or OFF Unlimited option for domainptr
         }
-        $fields['ftp'] = $package->getMaxFtp(); //Number of ftp accounts the User will be allowed to create
-        if($package->getMaxFtp() == 'unlimited') {
-            $fields['uftp'] = 'ON'; //ON or OFF Unlimited option for ftp
+        $fields['ftp'] = $package->getMaxFtp(); // Number of ftp accounts the User will be allowed to create
+        if ($package->getMaxFtp() == 'unlimited') {
+            $fields['uftp'] = 'ON'; // ON or OFF Unlimited option for ftp
         }
-        $fields['aftp']       = $package->getHasAnonymousFtp() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will be able to have anonymous ftp accounts.
-        $fields['cgi']        = $package->getHasCgi() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-        $fields['php']        = $package->getHasPhp() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run php scripts.
-        $fields['spam']       = $package->getHasSpamFilter() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
-        $fields['cron']       = $package->getHasCron() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to creat cronjobs.
-        $fields['catchall']   = $package->getHasCatchAll() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
-        $fields['ssl']        = $package->getHasSll() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have the ability to access their websites through secure https://.
-        $fields['ssh']        = $package->getHasShell() ? 'ON' : 'OFF'; //ON or OFF If ON, the User will have an ssh account.
-        $fields['sysinfo']    = 'ON'; //ON or OFF If ON, the User will have access to a page that shows the system information.
-        $fields['dnscontrol'] = 'ON'; //ON or OFF If ON, the User will be able to modify his/her dns records.
+        $fields['aftp'] = $package->getHasAnonymousFtp() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will be able to have anonymous ftp accounts.
+        $fields['cgi'] = $package->getHasCgi() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run cgi scripts in their cgi-bin.
+        $fields['php'] = $package->getHasPhp() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run php scripts.
+        $fields['spam'] = $package->getHasSpamFilter() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to run scan email with SpamAssassin.
+        $fields['cron'] = $package->getHasCron() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to creat cronjobs.
+        $fields['catchall'] = $package->getHasCatchAll() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
+        $fields['ssl'] = $package->getHasSll() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have the ability to access their websites through secure https://.
+        $fields['ssh'] = $package->getHasShell() ? 'ON' : 'OFF'; // ON or OFF If ON, the User will have an ssh account.
+        $fields['sysinfo'] = 'ON'; // ON or OFF If ON, the User will have access to a page that shows the system information.
+        $fields['dnscontrol'] = 'ON'; // ON or OFF If ON, the User will be able to modify his/her dns records.
 
         $fields['ns1'] = $a->getNs1();
         $fields['ns2'] = $a->getNs2();
 
         $this->_request('CMD_API_MODIFY_USER', $fields);
+
         return true;
     }
 
     public function changeAccountPassword(Server_Account $a, $newPassword)
     {
-        $fields             = array();
+        $fields = [];
         $fields['username'] = $a->getUsername();
-        $fields['passwd']   = $newPassword;
-        $fields['passwd2']  = $newPassword;
+        $fields['passwd'] = $newPassword;
+        $fields['passwd2'] = $newPassword;
         $this->_request('CMD_API_USER_PASSWD', $fields);
+
         return true;
     }
 
@@ -346,37 +351,40 @@ class Server_Manager_Directadmin extends Server_Manager
 
     public function changeAccountPackage(Server_Account $a, Server_Package $p)
     {
-        $fields            = array();
-        $fields['action']  = 'package';
-        $fields['user']    = $a->getUsername();
+        $fields = [];
+        $fields['action'] = 'package';
+        $fields['user'] = $a->getUsername();
         $fields['package'] = $a->getPackage()->getName();
         $this->_request('CMD_API_MODIFY_USER', $fields);
+
         return true;
     }
 
     private function getAccountInfo(Server_Account $a)
     {
-        $fields           = array();
+        $fields = [];
         $fields['action'] = 'create';
-        $fields['add']    = 'Submit';
-        $fields['user']   = $a->getUsername();
+        $fields['add'] = 'Submit';
+        $fields['user'] = $a->getUsername();
+
         return $this->_request('CMD_API_SHOW_USER_CONFIG', $fields);
     }
 
     private function getUserInfo(Server_Account $a)
     {
-        $fields         = array();
+        $fields = [];
         $fields['user'] = $a->getUsername();
-        $result         = $this->_request('CMD_API_SHOW_USER_CONFIG', $fields);
+        $result = $this->_request('CMD_API_SHOW_USER_CONFIG', $fields);
+
         return;
     }
 
     private function checkAuth()
     {
-        $r = $this->_request('CMD_API_VERIFY_PASSWORD', array(
+        $r = $this->_request('CMD_API_VERIFY_PASSWORD', [
             'user' => $this->_config['username'],
-            'passwd' => $this->_config['password']
-        ));
+            'passwd' => $this->_config['password'],
+        ]);
 
         return true;
     }
@@ -389,13 +397,14 @@ class Server_Manager_Directadmin extends Server_Manager
     private function getIps()
     {
         $results = $this->_request('CMD_API_SHOW_RESELLER_IPS');
-        return $results['list'] ?? array();
+
+        return $results['list'] ?? [];
     }
 
     /**
      * @param string $command
      */
-    private function _request($command, $fields = array(), $post = true)
+    private function _request($command, $fields = [], $post = true)
     {
         $host = $this->_config['host'];
         $protocol = $this->_config['secure'] ? 'https://' : 'http://';
@@ -403,48 +412,51 @@ class Server_Manager_Directadmin extends Server_Manager
         $fieldstring = http_build_query($fields);
 
         $httpClient = $this->getHttpClient()->withOptions([
-            'verify_peer'   => false,
-            'verify_host'   => false,
-            'timeout'       => 60,
-            'auth_basic'    => [ $this->_config['username'], $this->_config['password'] ],
+            'verify_peer' => false,
+            'verify_host' => false,
+            'timeout' => 60,
+            'auth_basic' => [$this->_config['username'], $this->_config['password']],
         ]);
 
-        $url = $protocol . $host . ':'. $this -> _getPort().'/' . $command . '?' . $fieldstring;
+        $url = $protocol . $host . ':' . $this->_getPort() . '/' . $command . '?' . $fieldstring;
         $this->getLog()->debug($url);
 
         try {
-            if($post) {
+            if ($post) {
                 $request = $httpClient->request('POST', $url, [
-                    'body'  => $fields,
+                    'body' => $fields,
                 ]);
             } else {
                 $request = $httpClient->request('GET', $url);
             }
 
             $data = $request->getContent();
-        } catch (\Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface |
-                 \Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface $error) {
-            $e = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
-            $this->getLog()->err($e);
-            throw $e;
-        }
+        } catch (Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface|
+                 Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface $error) {
+                     $e = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
+                     $this->getLog()->err($e);
 
-        if(strlen(strstr($data, 'DirectAdmin Login')) > 0) {
+                     throw $e;
+                 }
+
+        if (strlen(strstr($data, 'DirectAdmin Login')) > 0) {
             throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'DirectAdmin']);
         }
 
-        if(strlen(strstr($data, "The request you've made cannot be executed because it does not exist in your authority level")) > 0) {
+        if (strlen(strstr($data, "The request you've made cannot be executed because it does not exist in your authority level")) > 0) {
             throw new Server_Exception('Server Manager DirectAdmin Error: "The request you have made cannot be executed because it does not exist in your authority level"');
         }
 
         $r = $this->_parseResponse($data);
 
-        if(isset($r['error']) && $r['error'] == 1) {
+        if (isset($r['error']) && $r['error'] == 1) {
             $placeholders = [':action:' => $command, ':type:' => 'DirectAdmin'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
-        $response = empty($r) ? array() : $r;
+        $response = empty($r) ? [] : $r;
+
         return $response;
     }
 
@@ -461,6 +473,7 @@ class Server_Manager_Directadmin extends Server_Manager
         parse_str($data, $r);
 
         $this->getLog()->debug('Parsed Response: ' . print_r($r, 1));
+
         return $r;
     }
 }

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -2,12 +2,11 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Manager_Hestia extends Server_Manager
 {
     /**
@@ -49,7 +48,7 @@ class Server_Manager_Hestia extends Server_Manager
                         ],
                     ],
                 ],
-            ]
+            ],
         ];
     }
 
@@ -58,7 +57,7 @@ class Server_Manager_Hestia extends Server_Manager
      *
      * @return string
      */
-    public function getLoginUrl(?Server_Account $account = null)
+    public function getLoginUrl(Server_Account $account = null)
     {
         return 'https://' . $this->_config['host'] . ':' . $this->_getPort() . '/';
     }
@@ -68,7 +67,7 @@ class Server_Manager_Hestia extends Server_Manager
      *
      * @return string
      */
-    public function getResellerLoginUrl(?Server_Account $account = null)
+    public function getResellerLoginUrl(Server_Account $account = null)
     {
         return $this->getLoginUrl();
     }
@@ -78,9 +77,9 @@ class Server_Manager_Hestia extends Server_Manager
         $host = 'https://' . $this->_config['host'] . ':' . $this->_getPort() . '/api/';
 
         // Server credentials
-        if ('' != $this->_config['accesshash'] && '' != $this->_config['username']) {
-            $params['hash'] = $this->_config['username'] . ":" . $this->_config['accesshash'];
-        } elseif ('' != $this->_config['accesshash']) {
+        if ($this->_config['accesshash'] != '' && $this->_config['username'] != '') {
+            $params['hash'] = $this->_config['username'] . ':' . $this->_config['accesshash'];
+        } elseif ($this->_config['accesshash'] != '') {
             $params['hash'] = $this->_config['accesshash'];
         } else {
             $params['user'] = $this->_config['username'];
@@ -89,19 +88,19 @@ class Server_Manager_Hestia extends Server_Manager
 
         // Send POST query
         $client = $this->getHttpClient()->withOptions([
-            'verify_peer'   => false,
-            'verify_host'   => false,
-            'timeout'       => 30,
+            'verify_peer' => false,
+            'verify_host' => false,
+            'timeout' => 30,
         ]);
         $response = $client->request('POST', $host, [
-            'body'  => $params,
+            'body' => $params,
         ]);
         $result = $response->getContent();
 
         if (str_contains($result, 'Error')) {
             throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'HestiaCP']);
-        } elseif (0 !== intval($result)) {
-            error_log("HestiaCP returned error code $result for the " . $params['cmd'] . "command");
+        } elseif (intval($result) !== 0) {
+            error_log("HestiaCP returned error code $result for the " . $params['cmd'] . 'command');
         }
 
         return $result;
@@ -135,7 +134,7 @@ class Server_Manager_Hestia extends Server_Manager
 
         // Make request and check sys info
         $result = $this->_makeRequest($postvars);
-        if (0 == intval($result)) {
+        if (intval($result) == 0) {
             return true;
         } else {
             throw new Server_Exception('Failed to connect to the :type: server. Please verify your credentials and configuration', [':type:' => 'HestiaCP']);
@@ -154,17 +153,15 @@ class Server_Manager_Hestia extends Server_Manager
     {
         $this->getLog()->info('Synchronizing account with server ' . $a->getUsername());
         $new = clone $a;
-        //@example - retrieve username from server and set it to cloned object
-        //$new->setUsername('newusername');
+
+        // @example - retrieve username from server and set it to cloned object
+        // $new->setUsername('newusername');
         return $new;
     }
 
     /**
      * Create new account on server.
-     *
-     * @param Server_Account $a
      */
-
     public function createAccount(Server_Account $a)
     {
         $p = $a->getPackage();
@@ -185,7 +182,7 @@ class Server_Manager_Hestia extends Server_Manager
         ];
         // Make request and create user
         $result1 = $this->_makeRequest($postvars);
-        if (0 == intval($result1)) {
+        if (intval($result1) == 0) {
             // Create Domain Prepare POST query
             $postvars2 = [
                 'returncode' => 'yes',
@@ -196,20 +193,23 @@ class Server_Manager_Hestia extends Server_Manager
             $result2 = $this->_makeRequest($postvars2);
         } else {
             $placeholders = [':action:' => __trans('create user'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
-        if (0 !== intval($result2)) {
+        if (intval($result2) !== 0) {
             $postvars3 = [
                 'returncode' => 'yes',
                 'cmd' => 'v-delete-user',
                 'arg1' => $a->getUsername(),
             ];
             $result3 = $this->_makeRequest($postvars3);
-            if (0 !== intval($result3)) {
+            if (intval($result3) !== 0) {
                 $placeholders = [':action1:' => __trans('delete domain'), ':action2:' => __trans('create domain'), ':type:' => 'HestiaCP'];
+
                 throw new Server_Exception('Failed to :action1: on the :type: server after failed to :action2:, check the error logs for further details', $placeholders);
             }
             $placeholders = [':action:' => __trans('create domain'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
@@ -232,11 +232,12 @@ class Server_Manager_Hestia extends Server_Manager
         // Make request and suspend user
         $result = $this->_makeRequest($postvars);
         // Check if error 6 the account is suspended on server
-        if (6 == intval($result)) {
+        if (intval($result) == 6) {
             return true;
         }
-        if (0 !== intval($result)) {
+        if (intval($result) !== 0) {
             $placeholders = [':action:' => __trans('suspend account'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
@@ -260,8 +261,9 @@ class Server_Manager_Hestia extends Server_Manager
         ];
 
         $result = $this->_makeRequest($postvars);
-        if (0 !== intval($result)) {
+        if (intval($result) !== 0) {
             $placeholders = [':action:' => __trans('unsuspend account'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
@@ -287,10 +289,11 @@ class Server_Manager_Hestia extends Server_Manager
         ];
         // Make request and delete user
         $result = $this->_makeRequest($postvars);
-        if ('3' == intval($result)) {
+        if (intval($result) == '3') {
             return true;
-        } elseif (0 !== intval($result)) {
+        } elseif (intval($result) !== 0) {
             $placeholders = [':action:' => __trans('cancel account'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
@@ -319,8 +322,9 @@ class Server_Manager_Hestia extends Server_Manager
         ];
         // Make request and change package
         $result = $this->_makeRequest($postvars);
-        if (0 !== intval($result)) {
+        if (intval($result) !== 0) {
             $placeholders = [':action:' => __trans('change account package'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
@@ -362,8 +366,9 @@ class Server_Manager_Hestia extends Server_Manager
         ];
         // Make request and change password
         $result = $this->_makeRequest($postvars);
-        if (0 !== intval($result)) {
+        if (intval($result) !== 0) {
             $placeholders = [':action:' => __trans('change account password'), ':type:' => 'HestiaCP'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -2,22 +2,22 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Manager_Plesk extends Server_Manager
 {
     private ?\PleskX\Api\Client $_client = null;
 
-    public function init() {
+    public function init()
+    {
         $this->_config['port'] = empty($this->_config['port']) ? 8443 : $this->_config['port'];
 
-        $this->_client = new \PleskX\Api\Client($this->_config['host'], $this->_config['port']);
+        $this->_client = new PleskX\Api\Client($this->_config['host'], $this->_config['port']);
         $this->_client->setCredentials($this->_config['username'], $this->_config['password']);
-	}
+    }
 
     public static function getForm()
     {
@@ -26,18 +26,19 @@ class Server_Manager_Plesk extends Server_Manager
         ];
     }
 
-    public function getLoginUrl(?Server_Account $account = null): string
+    public function getLoginUrl(Server_Account $account = null): string
     {
         $protocol = $this->_config['secure'] ? 'https' : 'http';
-        $url = $protocol . "://" . $this->_config['host'] . ':' . $this->_config['port'];
+        $url = $protocol . '://' . $this->_config['host'] . ':' . $this->_config['port'];
         if ($account) {
             $sessionId = $this->_client->session()->create($account->getUsername(), $_SERVER['REMOTE_ADDR']);
             $url .= '/enterprise/rsession_init.php?PHPSESSID=' . $sessionId;
         }
+
         return $url;
     }
 
-    public function getResellerLoginUrl(?Server_Account $account = null)
+    public function getResellerLoginUrl(Server_Account $account = null)
     {
         return $this->getLoginUrl();
     }
@@ -52,7 +53,7 @@ class Server_Manager_Plesk extends Server_Manager
 
         return true;
     }
-    
+
     public function synchronizeAccount(Server_Account $a): never
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'Plesk', ':action:' => __trans('account synchronization')]);
@@ -60,15 +61,15 @@ class Server_Manager_Plesk extends Server_Manager
 
     public function createAccount(Server_Account $a)
     {
-    	$this->getLog()->info('Creating account ' . $a->getUsername());
+        $this->getLog()->info('Creating account ' . $a->getUsername());
 
-    	if ($a->getReseller()) {
-    		$ips = $this->_getIps();
-    		foreach($ips['exclusive'] as $key => $ip) {
-	    		if (!$ip['empty']) {
-    				unset ($ips['exclusive'][$key]);
-    			}
-    		}
+        if ($a->getReseller()) {
+            $ips = $this->_getIps();
+            foreach ($ips['exclusive'] as $key => $ip) {
+                if (!$ip['empty']) {
+                    unset($ips['exclusive'][$key]);
+                }
+            }
 
             /*
     		if (count($ips['exclusive']) == 0) {
@@ -78,19 +79,20 @@ class Server_Manager_Plesk extends Server_Manager
             */
             if ((is_countable($ips['exclusive']) ? count($ips['exclusive']) : 0) > 0) {
                 $ips['exclusive'] = array_values($ips['exclusive']);
-    		    $rand = array_rand($ips['exclusive']);
-    		    $a->setIp($ips['exclusive'][$rand]['ip']);
+                $rand = array_rand($ips['exclusive']);
+                $a->setIp($ips['exclusive'][$rand]['ip']);
             }
-    	}
+        }
 
-    	$id = $this->_createClient($a);
+        $id = $this->_createClient($a);
         $client = $a->getClient();
-    	if (!$id) {
-    		$placeholders = [':action:' => __trans('create account'), ':type"' => 'Plesk'];
+        if (!$id) {
+            $placeholders = [':action:' => __trans('create account'), ':type"' => 'Plesk'];
+
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
-    	} else {
-            $client->setId((string)$id);
-    	}
+        } else {
+            $client->setId((string) $id);
+        }
         $this->setSubscription($a);
 
         // We need to improve the way we handle the IP address before we should enable this.
@@ -102,55 +104,53 @@ class Server_Manager_Plesk extends Server_Manager
     	}
         */
 
-    	return true;
+        return true;
     }
 
     public function setSubscription(Server_Account $a)
     {
-        $this->getLog()->info('Setting subscription for account ' .  $a->getUsername());
+        $this->getLog()->info('Setting subscription for account ' . $a->getUsername());
 
-        $this->_client->webspace()->request($this->_createSubscriptionProps($a, "add"));
-
+        $this->_client->webspace()->request($this->_createSubscriptionProps($a, 'add'));
     }
 
     // ??
     public function createServicePlan(Server_Account $a)
     {
-        
     }
 
     public function updateSubscription(Server_Account $a)
     {
         $this->getLog()->info('Updating subscription for account ' . $a->getUsername());
 
-        $this->_client->webspace()->request($this->_createSubscriptionProps($a, "set"));
+        $this->_client->webspace()->request($this->_createSubscriptionProps($a, 'set'));
     }
 
     public function deleteSubscription(Server_Account $a)
     {
         $result = $this->_client->webspace()->delete('name', $a->getDomain());
-        
+
         return $result;
     }
 
     public function suspendAccount(Server_Account $a, $suspend = true)
     {
-    	if ($a->getReseller()) {
+        if ($a->getReseller()) {
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 16]);
-    	} else {
+        } else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 16]);
-    	}
+        }
 
         return $result;
     }
 
     public function unsuspendAccount(Server_Account $a)
     {
-    	if ($a->getReseller()) {
+        if ($a->getReseller()) {
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['status' => 0]);
-    	} else {
+        } else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['status' => 0]);
-    	}
+        }
 
         return $result;
     }
@@ -158,53 +158,53 @@ class Server_Manager_Plesk extends Server_Manager
     public function cancelAccount(Server_Account $a)
     {
         if ($a->getReseller()) {
-    		$result = $this->_client->reseller()->delete('login', $a->getUsername());
-    	} else {
-    		$result = $this->_client->customer()->delete('login', $a->getUsername());
-    	}
+            $result = $this->_client->reseller()->delete('login', $a->getUsername());
+        } else {
+            $result = $this->_client->customer()->delete('login', $a->getUsername());
+        }
 
         return $result;
     }
 
     public function changeAccountPackage(Server_Account $a, Server_Package $p)
     {
-    	$domainId = null;
-     $id = $this->_modifyClient($a);
+        $domainId = null;
+        $id = $this->_modifyClient($a);
         $client = $a->getClient();
-    	if (!$id) {
-    		throw new Server_Exception('Can\'t modify client');
-    	} else {
+        if (!$id) {
+            throw new Server_Exception('Can\'t modify client');
+        } else {
             $client->setId($id);
-    	}
+        }
 
         $a->setPackage($p);
         $this->updateSubscription($a);
 
-    	if ($a->getReseller()) {
-    		$this->_addNs($a, $domainId);
-    	}
+        if ($a->getReseller()) {
+            $this->_addNs($a, $domainId);
+        }
 
-    	return true;
+        return true;
     }
 
     public function changeAccountPassword(Server_Account $a, $new)
     {
-    	$this->getLog()->info('Changing password for account ' . $a->getUsername());
+        $this->getLog()->info('Changing password for account ' . $a->getUsername());
 
-    	if ($a->getReseller()) {
+        if ($a->getReseller()) {
             $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), ['passwd' => $new]);
-    	} else {
+        } else {
             $result = $this->_client->customer()->setProperties('login', $a->getUsername(), ['passwd' => $new]);
-    	}
+        }
 
-    	return $result;
+        return $result;
     }
 
     public function changeAccountUsername(Server_Account $a, $new): never
     {
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'Plesk', ':action:' => __trans('username changes')]);
     }
-    
+
     public function changeAccountDomain(Server_Account $a, $new)
     {
         $this->getLog()->info('Updating domain for account ' . $a->getUsername());
@@ -214,14 +214,14 @@ class Server_Manager_Plesk extends Server_Manager
         $params = [
             'set' => [
                 'filter' => [
-                    'owner-login' => $a->getUsername()
+                    'owner-login' => $a->getUsername(),
                 ],
                 'values' => [
                     'gen_setup' => [
-                        'name' => $new
-                    ]
-                ]
-            ]
+                        'name' => $new,
+                    ],
+                ],
+            ],
         ];
 
         $this->_client->webspace()->request($params);
@@ -232,293 +232,303 @@ class Server_Manager_Plesk extends Server_Manager
         throw new Server_Exception(':type: does not support :action:', [':type:' => 'Plesk', ':action:' => __trans('changing the account IP')]);
     }
 
-    private function _getIps() {
-    	$response = $this->_client->ip()->get();
+    private function _getIps()
+    {
+        $response = $this->_client->ip()->get();
 
-		$ips = array('shared' => array(), 'exclusive' => array());
-		
-        foreach($response as $ip) {
-            $ips[(string)$ip->type][] = array(
-				'ip'		=>	(string)$ip->ipAddress,
-				'empty'		=>	empty($ip->default) ? true : false,
-			);
-		}
+        $ips = ['shared' => [], 'exclusive' => []];
 
-		return $ips;
+        foreach ($response as $ip) {
+            $ips[(string) $ip->type][] = [
+                'ip' => (string) $ip->ipAddress,
+                'empty' => empty($ip->default) ? true : false,
+            ];
+        }
+
+        return $ips;
     }
 
     private function _setIp(Server_Account $a, $new)
     {
-    	$params = array(
-    		'reseller'	=>	array(
-    			'ippool-add-ip'	=>	array(
-    				'reseller-id'   =>	$a->getUsername(),
-    				'ip'    =>	array(
-                        'ip-address' => $new
-                    ),
-    			),
-    		),
-    	);
+        $params = [
+            'reseller' => [
+                'ippool-add-ip' => [
+                    'reseller-id' => $a->getUsername(),
+                    'ip' => [
+                        'ip-address' => $new,
+                    ],
+                ],
+            ],
+        ];
 
         $response = $this->_client->request($params);
     }
 
-    private function _addNs(Server_Account $a, $domainId) {
-    	// Will be done in the future
+    private function _addNs(Server_Account $a, $domainId)
+    {
+        // Will be done in the future
 
-		return true;
+        return true;
     }
 
     private function _getNs(Server_Account $a, $domainId)
     {
         $response = $this->_client->dns()->get('domain_id', $domainId);
 
-   		$ns = array();
+        $ns = [];
 
-   		foreach ($response->dns->get_rec->result as $dns) {
-   			if ($dns->data->type == 'NS') {
-   				$ns[] = (string)$dns->id;
-   			}
-   		}
+        foreach ($response->dns->get_rec->result as $dns) {
+            if ($dns->data->type == 'NS') {
+                $ns[] = (string) $dns->id;
+            }
+        }
 
-   		return $ns;
+        return $ns;
     }
 
-    private function _removeDns($ns) {
-		foreach($ns as $key => $id)	{
-			$params['dns']['del_rec']['filter']['id' . $key] = $id;
-		}
-		if (empty($params)) {
-			return true;
-		}
+    private function _removeDns($ns)
+    {
+        foreach ($ns as $key => $id) {
+            $params['dns']['del_rec']['filter']['id' . $key] = $id;
+        }
+        if (empty($params)) {
+            return true;
+        }
 
         $response = $this->_client->request($params);
 
-   		return true;
+        return true;
     }
 
-    private function _modifyClient(Server_Account $a) {
+    private function _modifyClient(Server_Account $a)
+    {
         $client = $a->getClient();
 
         if ($a->getReseller()) {
-    		$result = $this->_client->reseller()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
-    	} else {
-    		$result = $this->_client->customer()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
-    	}
+            $result = $this->_client->reseller()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
+        } else {
+            $result = $this->_client->customer()->setProperties('login', $a->getUsername(), $this->_createClientProps($a));
+        }
 
         return $result;
     }
 
-    private function _changeIpType(Server_Account $a) {
+    private function _changeIpType(Server_Account $a)
+    {
         $client = $a->getClient();
-    	$params = array(
-    		'reseller'	=>	array(
-    			'ippool-set-ip'	=>	array(
-    				'reseller-id'	=>	$client->getId(),
-    				'filter'	=>	array(
-    					'ip-address'	=>	$a->getIp(),
-    				),
-    				'values'	=>	array(
-    					'ip-type'	=>	'shared',
-    				),
-    			),
-    		),
-    	);
+        $params = [
+            'reseller' => [
+                'ippool-set-ip' => [
+                    'reseller-id' => $client->getId(),
+                    'filter' => [
+                        'ip-address' => $a->getIp(),
+                    ],
+                    'values' => [
+                        'ip-type' => 'shared',
+                    ],
+                ],
+            ],
+        ];
 
         $response = $this->_client->reseller()->request($params);
 
-   		if (isset($response->reseller->{'ippool-set-ip'}->result->status) &&
-   			$response->reseller->{'ippool-set-ip'}->result->status == 'ok') {
-   			return true;
-   		} else {
-   			return false;
-   		}
+        if (isset($response->reseller->{'ippool-set-ip'}->result->status)
+            && $response->reseller->{'ippool-set-ip'}->result->status == 'ok') {
+            return true;
+        } else {
+            return false;
+        }
     }
 
-    private function _createSubscriptionProps(Server_Account $a, $action) {
+    private function _createSubscriptionProps(Server_Account $a, $action)
+    {
         $p = $a->getPackage();
-        $props = array (
-                $action	=>  array(
-                    'gen_setup'	=>	array(
-                        'name'          => $a->getDomain(),
-                        'owner-login'	=>	$a->getUsername(),
-                        'htype'			=>	'vrt_hst',
-                        'ip_address'    => $a->getIp()
-                    ),
-                    'hosting' => array(
-                        'vrt_hst'	=>	array(
-                            'property'	=>	array(
-                                array(
-                                    'name'	=>	'ftp_login',
-                                    'value'	=>	$a->getUsername(),
-                                ),
-                                array(
-                                    'name'	=>	'ftp_password',
-                                    'value'	=>	$a->getPassword(),
-                                ),
-                                array(
-                                    'name'	=>	'php',
-                                    'value'	=>	'true',
-                                ),
-                                array(
-                                    'name'	=>	'ssl',
-                                    'value'	=>	'true',
-                                ),
-                                array(
-                                    'name'	=>	'cgi',
-                                    'value'	=>	'true',
-                                ),
-                            ),
+        $props = [
+                $action => [
+                    'gen_setup' => [
+                        'name' => $a->getDomain(),
+                        'owner-login' => $a->getUsername(),
+                        'htype' => 'vrt_hst',
+                        'ip_address' => $a->getIp(),
+                    ],
+                    'hosting' => [
+                        'vrt_hst' => [
+                            'property' => [
+                                [
+                                    'name' => 'ftp_login',
+                                    'value' => $a->getUsername(),
+                                ],
+                                [
+                                    'name' => 'ftp_password',
+                                    'value' => $a->getPassword(),
+                                ],
+                                [
+                                    'name' => 'php',
+                                    'value' => 'true',
+                                ],
+                                [
+                                    'name' => 'ssl',
+                                    'value' => 'true',
+                                ],
+                                [
+                                    'name' => 'cgi',
+                                    'value' => 'true',
+                                ],
+                            ],
                             'ip_address' => $a->getIp(),
-                        ),
-                    ),
-                    'limits'	=>	array(
-                        'limit'	=> array(
-                            array(
-                                'name'	=>	'max_db',
-                                'value'	=>	$p->getMaxSql() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_maillists',
-                                'value'	=>	$p->getMaxEmailLists() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_maillists',
-                                'value'	=>	$p->getMaxEmailLists() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_box',
-                                'value'	=>	$p->getMaxPop() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_traffic',
-                                'value'	=>	$p->getBandwidth() ? $p->getBandwidth() * 1024 * 1024: 0,
-                            ),
-                            array(
-                                'name'	=>	'disk_space',
-                                'value'	=>	$p->getQuota() ? $p->getQuota() * 1024 * 1024 : 0,
-                            ),
-                            array(
-                                'name'	=>	'max_subdom',
-                                'value'	=>	$p->getMaxSubdomains() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_subftp_users',
-                                'value'	=>	$p->getMaxFtp() ?: 0,
-                            ),
-                            array(
-                                'name'	=>	'max_site',
-                                'value'	=>	$p->getMaxDomains() ?: 0,
-                            ),
-                        ), 
-                    ),
-                    'permissions'	=>	array(
-                        'permission'	=>	array(
-                            array(
-                                'name'	=>	'manage_subdomains',
-                                'value'	=>	$p->getMaxSubdomains() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_dns',
-                                'value'	=>	'true'
-                            ),
-                            array(
-                                'name'	=>	'manage_crontab',
-                                'value'	=>	$p->getHasCron() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_anonftp',
-                                'value'	=>	$p->getHasAnonymousFtp() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_sh_access',
-                                'value'	=>	$p->getHasShell() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_maillists',
-                                'value'	=>	$p->getMaxEmailLists() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'create_domains',
-                                'value'	=>	'true',
-                            ),
-                            array(
-                                'name'	=>	'manage_phosting',
-                                'value'	=>	'true',
-                            ),
-                            array(
-                                'name'	=>	'manage_quota',
-                                'value'	=>	$a->getReseller() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_not_chroot_shell',
-                                'value'	=>	$p->getHasShell() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_domain_aliases',
-                                'value'	=>	'true',
-                            ),
-                            array(
-                                'name'	=>	'manage_subftp',
-                                'value'	=>	$p->getMaxFtp() ? 'true' : 'false',
-                            ),
-                            array(
-                                'name'	=>	'manage_spamfilter',
-                                'value'	=>	$p->getHasSpamFilter() ? 'true' : 'false',
-                            ),
-                        ),
-                    ),
-                ),
-            );
+                        ],
+                    ],
+                    'limits' => [
+                        'limit' => [
+                            [
+                                'name' => 'max_db',
+                                'value' => $p->getMaxSql() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_maillists',
+                                'value' => $p->getMaxEmailLists() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_maillists',
+                                'value' => $p->getMaxEmailLists() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_box',
+                                'value' => $p->getMaxPop() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_traffic',
+                                'value' => $p->getBandwidth() ? $p->getBandwidth() * 1024 * 1024 : 0,
+                            ],
+                            [
+                                'name' => 'disk_space',
+                                'value' => $p->getQuota() ? $p->getQuota() * 1024 * 1024 : 0,
+                            ],
+                            [
+                                'name' => 'max_subdom',
+                                'value' => $p->getMaxSubdomains() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_subftp_users',
+                                'value' => $p->getMaxFtp() ?: 0,
+                            ],
+                            [
+                                'name' => 'max_site',
+                                'value' => $p->getMaxDomains() ?: 0,
+                            ],
+                        ],
+                    ],
+                    'permissions' => [
+                        'permission' => [
+                            [
+                                'name' => 'manage_subdomains',
+                                'value' => $p->getMaxSubdomains() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_dns',
+                                'value' => 'true',
+                            ],
+                            [
+                                'name' => 'manage_crontab',
+                                'value' => $p->getHasCron() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_anonftp',
+                                'value' => $p->getHasAnonymousFtp() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_sh_access',
+                                'value' => $p->getHasShell() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_maillists',
+                                'value' => $p->getMaxEmailLists() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'create_domains',
+                                'value' => 'true',
+                            ],
+                            [
+                                'name' => 'manage_phosting',
+                                'value' => 'true',
+                            ],
+                            [
+                                'name' => 'manage_quota',
+                                'value' => $a->getReseller() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_not_chroot_shell',
+                                'value' => $p->getHasShell() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_domain_aliases',
+                                'value' => 'true',
+                            ],
+                            [
+                                'name' => 'manage_subftp',
+                                'value' => $p->getMaxFtp() ? 'true' : 'false',
+                            ],
+                            [
+                                'name' => 'manage_spamfilter',
+                                'value' => $p->getHasSpamFilter() ? 'true' : 'false',
+                            ],
+                        ],
+                    ],
+                ],
+            ];
 
         return $props;
     }
 
     /**
-     * Creates a new client account
+     * Creates a new client account.
+     *
+     * @return int client's Plesk id
+     *
      * @throws Server_Exception
-     * @return integer client's Plesk id
      */
-    private function _createClient(Server_Account $a) {
+    private function _createClient(Server_Account $a)
+    {
         $client = $a->getClient();
 
         $props = [
-            'cname'				=>	$client->getCompany(),
-    		'pname'				=>	$client->getFullname(),
-    		'login'				=>	$a->getUsername(),
-    		'passwd'			=>	$a->getPassword(),
-    		'phone'				=>	$client->getTelephone(),
-    		'fax'				=>	$client->getFax(),
-    		'email'				=>	$client->getEmail(),
-    		'address'			=>	$client->getAddress1(),
-    		'city'				=>	$client->getCity(),
-    		'state'				=>	$client->getState(),
-            'description'       =>  "Created using FOSSBilling.",
+            'cname' => $client->getCompany(),
+            'pname' => $client->getFullname(),
+            'login' => $a->getUsername(),
+            'passwd' => $a->getPassword(),
+            'phone' => $client->getTelephone(),
+            'fax' => $client->getFax(),
+            'email' => $client->getEmail(),
+            'address' => $client->getAddress1(),
+            'city' => $client->getCity(),
+            'state' => $client->getState(),
+            'description' => 'Created using FOSSBilling.',
         ];
 
-    	if ($a->getReseller()) {
-    		$result = $this->_client->reseller()->create($props);
-    	} else {
+        if ($a->getReseller()) {
+            $result = $this->_client->reseller()->create($props);
+        } else {
             $result = $this->_client->customer()->create($props);
-    	}
+        }
 
         return true;
     }
 
-    private function _createClientProps(Server_Account $a) {
+    private function _createClientProps(Server_Account $a)
+    {
         $client = $a->getClient();
 
         $props = [
-            'cname'				=>	$client->getCompany(),
-            'pname'				=>	$client->getFullname(),
-    		'login'				=>	$a->getUsername(),
-    		'passwd'			=>	$a->getPassword(),
-    		'phone'				=>	$client->getTelephone(),
-    		'fax'				=>	$client->getFax(),
-    		'email'				=>	$client->getEmail(),
-    		'address'			=>	$client->getAddress1(),
-    		'city'				=>	$client->getCity(),
-    		'state'				=>	$client->getState(),
+            'cname' => $client->getCompany(),
+            'pname' => $client->getFullname(),
+            'login' => $a->getUsername(),
+            'passwd' => $a->getPassword(),
+            'phone' => $client->getTelephone(),
+            'fax' => $client->getFax(),
+            'email' => $client->getEmail(),
+            'address' => $client->getAddress1(),
+            'city' => $client->getCity(),
+            'state' => $client->getState(),
         ];
 
         return $props;

--- a/src/library/Server/Package.php
+++ b/src/library/Server/Package.php
@@ -2,49 +2,50 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
 class Server_Package
 {
-    private ?string $name           = 'FOSSBilling';
-    private $quota                  = NULL;
-    private $bandwidth              = NULL;
-    
-    private $maxdomains             = NULL;
-    private $maxsubdomains          = NULL;
-    private $maxparkeddomains       = NULL;
-    private $maxftp                 = NULL;
-    private $maxsql                 = NULL;
-    private $maxpop                 = NULL;
-    
-    private array $custom                 = array();
+    private ?string $name = 'FOSSBilling';
+    private $quota;
+    private $bandwidth;
+
+    private $maxdomains;
+    private $maxsubdomains;
+    private $maxparkeddomains;
+    private $maxftp;
+    private $maxsql;
+    private $maxpop;
+
+    private array $custom = [];
 
     public function __call($name, $arguments)
     {
         if (version_compare(PHP_VERSION, '5.4.0') < 0) {
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        }
-        else {
+        } else {
             // Get only the stack frames we need (PHP 5.4 only).
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         }
-        error_log(sprintf("Calling %s inaccessible method %s from %s::%d", static::class, $name, $backtrace[1]['file'], $backtrace[1]['line']));
+        error_log(sprintf('Calling %s inaccessible method %s from %s::%d', static::class, $name, $backtrace[1]['file'], $backtrace[1]['line']));
+
         return '';
     }
-    
+
     public function setCustomValues(array $param)
     {
         $this->custom = $param;
+
         return $this;
     }
-    
+
     public function setCustomValue($param, $value)
     {
         $this->custom[$param] = $value;
+
         return $this;
     }
 
@@ -53,12 +54,13 @@ class Server_Package
      */
     public function getCustomValue($param)
     {
-        return $this->custom[$param] ?? NULL;
+        return $this->custom[$param] ?? null;
     }
-    
+
     public function setName($param)
     {
         $this->name = $param;
+
         return $this;
     }
 
@@ -70,6 +72,7 @@ class Server_Package
     public function setQuota($param)
     {
         $this->quota = $param;
+
         return $this;
     }
 
@@ -81,6 +84,7 @@ class Server_Package
     public function setBandwidth($param)
     {
         $this->bandwidth = $param;
+
         return $this;
     }
 
@@ -92,6 +96,7 @@ class Server_Package
     public function setMaxDomains($param)
     {
         $this->maxdomains = $param;
+
         return $this;
     }
 
@@ -99,10 +104,11 @@ class Server_Package
     {
         return $this->maxdomains;
     }
-    
+
     public function setMaxSubdomains($param)
     {
         $this->maxsubdomains = $param;
+
         return $this;
     }
 
@@ -114,6 +120,7 @@ class Server_Package
     public function setMaxParkedDomains($param)
     {
         $this->maxparkeddomains = $param;
+
         return $this;
     }
 
@@ -125,6 +132,7 @@ class Server_Package
     public function setMaxFtp($param)
     {
         $this->maxftp = $param;
+
         return $this;
     }
 
@@ -136,6 +144,7 @@ class Server_Package
     public function setMaxSql($param)
     {
         $this->maxsql = $param;
+
         return $this;
     }
 
@@ -147,6 +156,7 @@ class Server_Package
     public function setMaxPop($param)
     {
         $this->maxpop = $param;
+
         return $this;
     }
 

--- a/src/modules/Spamchecker/Api/Guest.php
+++ b/src/modules/Spamchecker/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -17,7 +17,7 @@ namespace Box\Mod\Spamchecker\Api;
 class Guest extends \Api_Abstract
 {
     /**
-     * Returns recaptcha configuration info
+     * Returns recaptcha configuration info.
      *
      * @return array
      */

--- a/src/modules/Spamchecker/Service.php
+++ b/src/modules/Spamchecker/Service.php
@@ -3,7 +3,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -14,8 +14,8 @@ namespace Box\Mod\Spamchecker;
 use EmailChecker\Adapter;
 use EmailChecker\Utilities;
 use FOSSBilling\InjectionAwareInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class Service implements InjectionAwareInterface
 {
@@ -79,18 +79,18 @@ class Service implements InjectionAwareInterface
         $config = $di['mod_config']('Spamchecker');
 
         if (isset($config['captcha_enabled']) && $config['captcha_enabled']) {
-            if (isset($config['captcha_version']) && 2 == $config['captcha_version']) {
-                if (!isset($config['captcha_recaptcha_privatekey']) || '' == $config['captcha_recaptcha_privatekey']) {
+            if (isset($config['captcha_version']) && $config['captcha_version'] == 2) {
+                if (!isset($config['captcha_recaptcha_privatekey']) || $config['captcha_recaptcha_privatekey'] == '') {
                     throw new \FOSSBilling\InformationException("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>here</a>");
                 }
 
-                if (!isset($params['g-recaptcha-response']) || '' == $params['g-recaptcha-response']) {
+                if (!isset($params['g-recaptcha-response']) || $params['g-recaptcha-response'] == '') {
                     throw new \FOSSBilling\InformationException('You have to complete the CAPTCHA to continue');
                 }
 
                 $client = HttpClient::create();
                 $response = $client->request('POST', 'https://google.com/recaptcha/api/siteverify', [
-                    'body'  => [
+                    'body' => [
                         'secret' => $config['captcha_recaptcha_privatekey'],
                         'response' => $params['g-recaptcha-response'],
                         'remoteip' => $di['request']->getClientAddress(),
@@ -162,22 +162,23 @@ class Service implements InjectionAwareInterface
 
     /**
      * Checks if a provided email address is using a disposable email service.
-     * 
-     * @param string $email The email address to check.
-     * @param bool $throw (optional) Configures if you want the function to throw an exception. Defaults to true.
-     * 
-     * @return bool true if the email address is disposable, false if it isn't.
+     *
+     * @param string $email the email address to check
+     * @param bool   $throw (optional) Configures if you want the function to throw an exception. Defaults to true.
+     *
+     * @return bool true if the email address is disposable, false if it isn't
      */
     public function isATempEmail(string $email, bool $throw = true): bool
     {
-        /* 
+        /*
          * The EmailChecker package utilizes PHP's email verification which does not correctly validate international email addresses.
          * We are already using a proper validation package that does validate these as it should, so below is actually a workaround for the limitation.
          * @see https://github.com/MattKetmo/EmailChecker/issues/92
-         * 
+         *
          * Without this workaround, FOSSBilling would be unable to accept international email addresses when disposable email checking is enabled.
          */
         $adapter = new Adapter\ArrayAdapter($this->getTempMailDomainDB());
+
         try {
             [$local, $domain] = Utilities::parseEmailAddress($email);
         } catch (\Exception) {
@@ -197,8 +198,6 @@ class Service implements InjectionAwareInterface
      * Fetches the most recent list of disposable email addresses, parses them to remove blanks or invalid domains, and then returns it as an array.
      * The database is from here: https://github.com/7c/fakefilter
      * Results are cached for 1 week unless there's an error at which point the list will be retried in a half hour.
-     * 
-     * @return array 
      */
     private function getTempMailDomainDB(): array
     {
@@ -213,6 +212,7 @@ class Service implements InjectionAwareInterface
                 @file_put_contents($dbPath, $response->getContent());
             } else {
                 $item->expiresAfter(3600);
+
                 return [];
             }
 
@@ -220,6 +220,7 @@ class Service implements InjectionAwareInterface
             @unlink($dbPath);
             if (!$database) {
                 $item->expiresAfter(3600);
+
                 return [];
             }
 

--- a/src/modules/Wysiwyg/Api/Admin.php
+++ b/src/modules/Wysiwyg/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
@@ -16,13 +16,14 @@ class Admin extends \Api_Abstract
     {
         $mod = $this->di['mod']('wysiwyg');
         $config = $mod->getConfig();
+
         return $config['editor'] ?? 'ckeditor';
     }
 
     public function editors()
     {
-        return array(
-            'ckeditor'  =>  'CKEditor',
-        );
+        return [
+            'ckeditor' => 'CKEditor',
+        ];
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
-putenv("APP_ENV=test");
+
+putenv('APP_ENV=test');
 define('PATH_TESTS', __DIR__);
 
 require_once __DIR__ . '/../src/load.php';
@@ -13,12 +14,12 @@ define('BB_DB_HOST', $config['db']['host']);
 define('BB_DB_TYPE', $config['db']['type']);
 
 // Add test libraries
-set_include_path(implode(PATH_SEPARATOR, array(
+set_include_path(implode(PATH_SEPARATOR, [
     get_include_path(),
     PATH_TESTS . '/library',
     PATH_TESTS . '/includes',
     PATH_TESTS . '/includes/Vps',
-)));
+]));
 
 require_once 'BBTestCase.php';
 require_once 'BBDatabaseTestCase.php';
@@ -31,9 +32,9 @@ require_once 'DummyBean.php';
 $di = include PATH_ROOT . '/di.php';
 $di['translate']();
 
-//Setup the autoloader
+// Setup the autoloader
 $testsLoader = new AntCMS\AntLoader([
-    'mode' => 'filesystem'
+    'mode' => 'filesystem',
 ]);
 $testsLoader->addNamespace('', DIRECTORY_SEPARATOR . 'library', 'psr0');
 $testsLoader->register();

--- a/tests/includes/ApiTestCase.php
+++ b/tests/includes/ApiTestCase.php
@@ -1,11 +1,12 @@
 <?php
+
 class ApiTestCase extends PHPUnit\Framework\TestCase
 {
     protected ?\Pimple\Container $di;
-    protected $session = NULL;
-    protected $api_guest = NULL;
-    protected $api_client = NULL;
-    protected $api_admin = NULL;
+    protected $session;
+    protected $api_guest;
+    protected $api_client;
+    protected $api_admin;
 
     public function setUp(): void
     {

--- a/tests/includes/BBDatabaseTestCase.php
+++ b/tests/includes/BBDatabaseTestCase.php
@@ -1,19 +1,20 @@
 <?php
+
 use PHPUnit\Framework\TestCase;
 
 abstract class BBDatabaseTestCase extends Testcase
 {
-    static private ?\PDO $pdo = null;
-    private $conn = NULL;
+    private static ?\PDO $pdo = null;
+    private $conn;
 
-    protected $_seedFilesPath = NULL;
+    protected $_seedFilesPath;
     protected $_initialSeedFile = 'initial.xml';
 
     final public function getConnection()
     {
         if ($this->conn === null) {
             if (self::$pdo == null) {
-                self::$pdo = new PDO( 'mysql:dbname='.BB_DB_NAME.';host=127.0.0.1;port='.BB_DB_PORT, BB_DB_USER, BB_DB_PASSWORD );
+                self::$pdo = new PDO('mysql:dbname=' . BB_DB_NAME . ';host=127.0.0.1;port=' . BB_DB_PORT, BB_DB_USER, BB_DB_PASSWORD);
             }
             $this->conn = $this->createDefaultDBConnection(self::$pdo, BB_DB_NAME);
         }
@@ -22,21 +23,21 @@ abstract class BBDatabaseTestCase extends Testcase
     }
 
     /**
-     * Returns the seed files folder path
+     * Returns the seed files folder path.
      *
      * @return string
      */
     public function getSeedFilesPath()
     {
-        if ($this->_seedFilesPath == NULL) {
-            $this->_seedFilesPath = PATH_TESTS.'/fixtures';
+        if ($this->_seedFilesPath == null) {
+            $this->_seedFilesPath = PATH_TESTS . '/fixtures';
         }
 
         return rtrim($this->_seedFilesPath, '/') . '/';
     }
 
     /**
-     * Retrieve from flat XML files data used to populate the database
+     * Retrieve from flat XML files data used to populate the database.
      *
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */

--- a/tests/includes/BBDbApiTestCase.php
+++ b/tests/includes/BBDbApiTestCase.php
@@ -1,25 +1,26 @@
 <?php
+
 abstract class BBDbApiTestCase extends BBDatabaseTestCase
 {
     protected ?\Pimple\Container $di;
-    protected $session = NULL;
-    protected $api_guest = NULL;
-    protected $api_client = NULL;
-    protected $api_admin = NULL;
-    protected $api_system = NULL;
+    protected $session;
+    protected $api_guest;
+    protected $api_client;
+    protected $api_admin;
+    protected $api_system;
 
     public function setBoxUpdateMock()
     {
         $updatedMock = $this->getMockBuilder('Box_Update')->getMock();
         $updatedMock->expects($this->any())
             ->method('isUpdateAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $updatedMock->expects($this->any())
             ->method('getLatestVersion')
-            ->will($this->returnValue('10.20.30'));
+            ->willReturn('10.20.30');
         $updatedMock->expects($this->any())
             ->method('performUpdate')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $this->di['updater'] = $updatedMock;
     }
 
@@ -37,13 +38,13 @@ abstract class BBDbApiTestCase extends BBDatabaseTestCase
         $this->api_client = $this->di['api_client'];
         $this->api_admin = $this->di['api_admin'];
         $this->api_system = $this->di['api_system'];
-        //$this->api_admin->hook_batch_connect();
+        // $this->api_admin->hook_batch_connect();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        
+
         $refl = new ReflectionObject($this);
         foreach ($refl->getProperties() as $prop) {
             if (!$prop->isStatic() && !str_starts_with($prop->getDeclaringClass()->getName(), 'PHPUnit_')) {

--- a/tests/includes/BBModTestCase.php
+++ b/tests/includes/BBModTestCase.php
@@ -1,22 +1,22 @@
 <?php
+
 class BBModTestCase extends BBDbApiTestCase
 {
-    protected $_mod = null;
-    
+    protected $_mod;
+
     public function setUp(): void
     {
         global $di;
         $mod = $di['mod']($this->_mod);
-        if(!$mod->isCore()) {
+        if (!$mod->isCore()) {
             $mod->install();
         }
 
         parent::setUp();
 
         try {
-            $this->api_admin->extension_activate(array('id'=>$this->_mod,'type'=>'mod'));
-        } catch(Exception) {
-            
+            $this->api_admin->extension_activate(['id' => $this->_mod, 'type' => 'mod']);
+        } catch (Exception) {
         }
     }
 }

--- a/tests/includes/BBTestCase.php
+++ b/tests/includes/BBTestCase.php
@@ -2,7 +2,7 @@
 
 class BBTestCase extends PHPUnit\Framework\TestCase
 {
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $refl = new ReflectionObject($this);

--- a/tests/includes/DummyBean.php
+++ b/tests/includes/DummyBean.php
@@ -1,11 +1,13 @@
 <?php
+
 // Define a dummy class for RedBeanPHP, so test can easily be adjusted for future versions of RedBeanPHP.
-class DummyBean extends \RedBeanPHP\OODBBean
+class DummyBean extends RedBeanPHP\OODBBean
 {
-    function __construct()
+    public function __construct()
     {
-        $bean = new \RedBeanPHP\OODBBean();
-        $this->__info['changelist'] = array();
+        $bean = new RedBeanPHP\OODBBean();
+        $this->__info['changelist'] = [];
+
         return $bean;
     }
 }

--- a/tests/includes/FakeTemplateWrapper.php
+++ b/tests/includes/FakeTemplateWrapper.php
@@ -7,11 +7,10 @@
  * class is declared "final" and cannot be mocked.
  *
  * https://github.rpi.edu/DotCIOweb/test-pantheon-starterkit/blob/107b23d9f231c392e2cd9b4f677f4c1a30e508fa/core/modules/help_topics/tests/src/Unit/HelpTopicTwigTest.php
- *
  */
 
 /**
- * @deprecated Since Twig 3: Will be remove or maybe could be find best way.
+ * @deprecated since Twig 3: Will be remove or maybe could be find best way
  */
 class FakeTemplateWrapper
 {
@@ -19,22 +18,18 @@ class FakeTemplateWrapper
      * Constructor.
      *
      * @param string $body
-     * Body text to return from the render() method.
+     *                     Body text to return from the render() method
      */
     public function __construct(
         /**
          * Body text to return from the render() method.
          */
         protected $body
-    )
-    {
+    ) {
     }
-    
+
     /**
      * Mocks the \Twig_TemplateWrapper render() method.
-     *
-     * @param array $context
-     * (optional) Render context.
      */
     public function render(array $context = [])
     {

--- a/tests/includes/Payment/Adapter/Dummy.php
+++ b/tests/includes/Payment/Adapter/Dummy.php
@@ -1,16 +1,17 @@
 <?php
+
 class Payment_Adapter_Dummy
 {
     protected ?\Pimple\Container $di = null;
 
-    public function setDi(\Pimple\Container $di): void
+    public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
     }
 
     public function getConfig()
     {
-        return array();
+        return [];
     }
 
     public function getType()
@@ -20,17 +21,17 @@ class Payment_Adapter_Dummy
 
     public function getServiceUrl()
     {
-		return 'https://www.google.com/?q=dummy';
+        return 'https://www.google.com/?q=dummy';
     }
 
     public function singlePayment(Payment_Invoice $invoice)
     {
-        return array();
+        return [];
     }
 
     public function recurrentPayment(Payment_Invoice $invoice)
     {
-        return array();
+        return [];
     }
 
     public function ipn($data, Payment_Invoice $invoice)
@@ -42,6 +43,7 @@ class Payment_Adapter_Dummy
         $tx->setIsValid(true);
         $tx->setStatus(Payment_Transaction::STATUS_COMPLETE);
         $tx->setType(Payment_Transaction::TXTYPE_PAYMENT);
+
         return $tx;
     }
 }

--- a/tests/includes/PhpConsole.php
+++ b/tests/includes/PhpConsole.php
@@ -1,9 +1,10 @@
 <?php
 
 /**
- *
  * @see http://code.google.com/p/php-console
+ *
  * @author Barbushin Sergey http://linkedin.com/in/barbushin
+ *
  * @version 1.1
  *
  * @desc Sending messages to Google Chrome console
@@ -13,313 +14,334 @@
  *
  * All class properties and methods are static because it's required to let
  * them work on script shutdown when FATAL error occurs.
- *
  */
-class PhpConsole {
+class PhpConsole
+{
+    public static $ignoreRepeatedEvents = false;
+    public static $callOldErrorHandler = true;
+    public static $callOldExceptionsHandler = true;
 
-	public static $ignoreRepeatedEvents = false;
-	public static $callOldErrorHandler = true;
-	public static $callOldExceptionsHandler = true;
+    /**
+     * @var PhpConsole
+     */
+    protected static $instance;
 
-	/**
-	 * @var PhpConsole
-	 */
-	protected static $instance;
+    protected $handledMessagesHashes = [];
+    protected $sourceBasePath;
 
-	protected $handledMessagesHashes = array();
-	protected $sourceBasePath;
+    protected function __construct($handleErrors, $handleExceptions, $sourceBasePath)
+    {
+        if ($handleErrors) {
+            $this->initErrorsHandler();
+        }
+        if ($handleExceptions) {
+            $this->initExceptionsHandler();
+        }
+        if ($sourceBasePath) {
+            $this->sourceBasePath = realpath($sourceBasePath);
+        }
+        $this->initClient();
+    }
 
-	protected function __construct($handleErrors, $handleExceptions, $sourceBasePath) {
-		if($handleErrors) {
-			$this->initErrorsHandler();
-		}
-		if($handleExceptions) {
-			$this->initExceptionsHandler();
-		}
-		if($sourceBasePath) {
-			$this->sourceBasePath = realpath($sourceBasePath);
-		}
-		$this->initClient();
-	}
+    public static function start($handleErrors = true, $handleExceptions = true, $sourceBasePath = null)
+    {
+        if (self::$instance) {
+            exit('PhpConsole already started');
+        }
+        self::$instance = new PhpConsole($handleErrors, $handleExceptions, $sourceBasePath);
+    }
 
-	public static function start($handleErrors = true, $handleExceptions = true, $sourceBasePath = null) {
-		if(self::$instance) {
-			die('PhpConsole already started');
-		}
-		self::$instance = new PhpConsole($handleErrors, $handleExceptions, $sourceBasePath);
-	}
+    public static function getInstance()
+    {
+        if (!self::$instance) {
+            exit('PhpConsole not started');
+        }
 
-	public static function getInstance() {
-		if(!self::$instance) {
-			die('PhpConsole not started');
-		}
-		return self::$instance;
-	}
+        return self::$instance;
+    }
 
-	protected function handle(PhpConsoleEvent $event) {
-		if(self::$ignoreRepeatedEvents) {
-			$eventHash = md5($event->message . $event->file . $event->line);
-			if(in_array($eventHash, $this->handledMessagesHashes)) {
-				return;
-			}
-			else {
-				$this->handledMessagesHashes[] = $eventHash;
-			}
-		}
-		$this->sendEventToClient($event);
-	}
+    protected function handle(PhpConsoleEvent $event)
+    {
+        if (self::$ignoreRepeatedEvents) {
+            $eventHash = md5($event->message . $event->file . $event->line);
+            if (in_array($eventHash, $this->handledMessagesHashes)) {
+                return;
+            } else {
+                $this->handledMessagesHashes[] = $eventHash;
+            }
+        }
+        $this->sendEventToClient($event);
+    }
 
-	public function __destruct() {
-		self::flushMessagesBuffer();
-	}
+    public function __destruct()
+    {
+        self::flushMessagesBuffer();
+    }
 
-	/***************************************************************
-	CLIENT
-	 **************************************************************/
+    /***************************************************************
+    CLIENT
+     **************************************************************/
 
-	final public const clientProtocolCookie = 'phpcslc';
-	final public const serverProtocolCookie = 'phpcsls';
-	final public const serverProtocol = 4;
-	final public const messagesCookiePrefix = 'phpcsl_';
-	final public const cookiesLimit = 50;
-	final public const cookieSizeLimit = 4000;
-	final public const messageLengthLimit = 2500;
+    final public const clientProtocolCookie = 'phpcslc';
+    final public const serverProtocolCookie = 'phpcsls';
+    final public const serverProtocol = 4;
+    final public const messagesCookiePrefix = 'phpcsl_';
+    final public const cookiesLimit = 50;
+    final public const cookieSizeLimit = 4000;
+    final public const messageLengthLimit = 2500;
 
-	protected static $isEnabledOnClient;
-	protected static $isDisabled;
-	protected static $messagesBuffer = array();
-	protected static $bufferLength = 0;
-	protected static $messagesSent = 0;
-	protected static $cookiesSent = 0;
-	protected static $index = 0;
+    protected static $isEnabledOnClient;
+    protected static $isDisabled;
+    protected static $messagesBuffer = [];
+    protected static $bufferLength = 0;
+    protected static $messagesSent = 0;
+    protected static $cookiesSent = 0;
+    protected static $index = 0;
 
-	protected function initClient() {
-		if(self::$isEnabledOnClient === null) {
-			self::setEnabledOnServer();
-			self::$isEnabledOnClient = self::isEnabledOnClient();
-			if(self::$isEnabledOnClient) {
-				ob_start();
-			}
-		}
-	}
+    protected function initClient()
+    {
+        if (self::$isEnabledOnClient === null) {
+            self::setEnabledOnServer();
+            self::$isEnabledOnClient = self::isEnabledOnClient();
+            if (self::$isEnabledOnClient) {
+                ob_start();
+            }
+        }
+    }
 
-	protected static function isEnabledOnClient() {
-		return isset($_COOKIE[self::clientProtocolCookie]) && $_COOKIE[self::clientProtocolCookie] == self::serverProtocol;
-	}
+    protected static function isEnabledOnClient()
+    {
+        return isset($_COOKIE[self::clientProtocolCookie]) && $_COOKIE[self::clientProtocolCookie] == self::serverProtocol;
+    }
 
-	protected static function setEnabledOnServer() {
-		if(!isset($_COOKIE[self::serverProtocolCookie]) || $_COOKIE[self::serverProtocolCookie] != self::serverProtocol) {
-			self::setCookie(self::serverProtocolCookie, self::serverProtocol);
-		}
-	}
+    protected static function setEnabledOnServer()
+    {
+        if (!isset($_COOKIE[self::serverProtocolCookie]) || $_COOKIE[self::serverProtocolCookie] != self::serverProtocol) {
+            self::setCookie(self::serverProtocolCookie, self::serverProtocol);
+        }
+    }
 
-	protected function sendEventToClient(PhpConsoleEvent $event) {
-		if(!self::$isEnabledOnClient || self::$isDisabled) {
-			return;
-		}
-		$message = array();
-		$message['type'] = str_starts_with($event->tags, 'error,') ? 'error' : 'debug';
-		$message['subject'] = $event->type;
-		$message['text'] = substr($event->message, 0, self::messageLengthLimit);
+    protected function sendEventToClient(PhpConsoleEvent $event)
+    {
+        if (!self::$isEnabledOnClient || self::$isDisabled) {
+            return;
+        }
+        $message = [];
+        $message['type'] = str_starts_with($event->tags, 'error,') ? 'error' : 'debug';
+        $message['subject'] = $event->type;
+        $message['text'] = substr($event->message, 0, self::messageLengthLimit);
 
-		if($event->file) {
-			$message['source'] = ($this->sourceBasePath ? preg_replace('!^' . preg_quote($this->sourceBasePath, '!') . '!', '', $event->file) : $event->file) . ($event->line ? ':' . $event->line : '');
-		}
-		if($event->trace) {
-			$traceArray = $this->convertTraceToArray($event->trace, $event->file, $event->line);
-			if($traceArray) {
-				$message['trace'] = $traceArray;
-			}
-		}
+        if ($event->file) {
+            $message['source'] = ($this->sourceBasePath ? preg_replace('!^' . preg_quote($this->sourceBasePath, '!') . '!', '', $event->file) : $event->file) . ($event->line ? ':' . $event->line : '');
+        }
+        if ($event->trace) {
+            $traceArray = $this->convertTraceToArray($event->trace, $event->file, $event->line);
+            if ($traceArray) {
+                $message['trace'] = $traceArray;
+            }
+        }
 
-		self::pushMessageToBuffer($message);
+        self::pushMessageToBuffer($message);
 
-		if(strpos($event->tags, ',fatal')) {
-			self::flushMessagesBuffer();
-		}
-	}
+        if (strpos($event->tags, ',fatal')) {
+            self::flushMessagesBuffer();
+        }
+    }
 
-	protected function convertTraceToArray($traceData, $eventFile = null, $eventLine = null) {
-		$trace = array();
-		foreach($traceData as $call) {
-			if((isset($call['class']) && $call['class'] == self::class) || (!$trace && isset($call['file']) && $call['file'] == $eventFile && $call['line'] == $eventLine)) {
-				$trace = array();
-				continue;
-			}
-			$args = array();
-			if(isset($call['args'])) {
-				foreach($call['args'] as $arg) {
-					if(is_object($arg)) {
-						$args[] = $arg::class;
-					}
-					elseif(is_array($arg)) {
-						$args[] = 'Array';
-					}
-					else {
-						$arg = var_export($arg, 1);
-						$args[] = strlen($arg) > 12 ? substr($arg, 0, 8) . '...\'' : $arg;
-					}
-				}
-			}
-			if(isset($call['file']) && $this->sourceBasePath) {
-				$call['file'] = preg_replace('!^' . preg_quote($this->sourceBasePath, '!') . '!', '', $call['file']);
-			}
-			$trace[] = (isset($call['file']) ? ($call['file'] . ':' . $call['line']) : '[internal call]') . ' - ' . (isset($call['class']) ? $call['class'] . $call['type'] : '') . $call['function'] . '(' . implode(', ', $args) . ')';
-		}
-		$trace = array_reverse($trace);
-		foreach($trace as $i => &$call) {
-			$call = '#' . ($i + 1) . ' ' . $call;
-		}
-		return $trace;
-	}
+    protected function convertTraceToArray($traceData, $eventFile = null, $eventLine = null)
+    {
+        $trace = [];
+        foreach ($traceData as $call) {
+            if ((isset($call['class']) && $call['class'] == self::class) || (!$trace && isset($call['file']) && $call['file'] == $eventFile && $call['line'] == $eventLine)) {
+                $trace = [];
 
-	protected static function pushMessageToBuffer($message) {
-		$encodedMessageLength = strlen(rawurlencode(json_encode($message)));
-		if(self::$bufferLength + $encodedMessageLength > self::cookieSizeLimit) {
-			self::flushMessagesBuffer();
-		}
-		self::$messagesBuffer[] = $message;
-		self::$bufferLength += $encodedMessageLength;
-	}
+                continue;
+            }
+            $args = [];
+            if (isset($call['args'])) {
+                foreach ($call['args'] as $arg) {
+                    if (is_object($arg)) {
+                        $args[] = $arg::class;
+                    } elseif (is_array($arg)) {
+                        $args[] = 'Array';
+                    } else {
+                        $arg = var_export($arg, 1);
+                        $args[] = strlen($arg) > 12 ? substr($arg, 0, 8) . '...\'' : $arg;
+                    }
+                }
+            }
+            if (isset($call['file']) && $this->sourceBasePath) {
+                $call['file'] = preg_replace('!^' . preg_quote($this->sourceBasePath, '!') . '!', '', $call['file']);
+            }
+            $trace[] = (isset($call['file']) ? ($call['file'] . ':' . $call['line']) : '[internal call]') . ' - ' . (isset($call['class']) ? $call['class'] . $call['type'] : '') . $call['function'] . '(' . implode(', ', $args) . ')';
+        }
+        $trace = array_reverse($trace);
+        foreach ($trace as $i => &$call) {
+            $call = '#' . ($i + 1) . ' ' . $call;
+        }
 
-	protected static function getNextIndex() {
-		return substr(number_format(microtime(1), 3, '', ''), -6) + self::$index++;
-	}
+        return $trace;
+    }
 
-	public static function flushMessagesBuffer() {
-		if(self::$messagesBuffer) {
-			self::sendMessages(self::$messagesBuffer);
-			self::$bufferLength = 0;
-			self::$messagesSent += count(self::$messagesBuffer);
-			self::$messagesBuffer = array();
-			self::$cookiesSent++;
-			if(self::$cookiesSent == self::cookiesLimit) {
-				self::$isDisabled = true;
-				$message = array('type' => 'error', 'subject' => 'PHP CONSOLE', 'text' => 'MESSAGES LIMIT EXCEEDED BECAUSE OF COOKIES STORAGE LIMIT. TOTAL MESSAGES SENT: ' . self::$messagesSent, 'source' => __FILE__, 'notify' => 3);
-				self::sendMessages(array($message));
-			}
-		}
-	}
+    protected static function pushMessageToBuffer($message)
+    {
+        $encodedMessageLength = strlen(rawurlencode(json_encode($message)));
+        if (self::$bufferLength + $encodedMessageLength > self::cookieSizeLimit) {
+            self::flushMessagesBuffer();
+        }
+        self::$messagesBuffer[] = $message;
+        self::$bufferLength += $encodedMessageLength;
+    }
 
-	protected static function setCookie($name, $value) {
-		if(headers_sent($file, $line)) {
-			die('PhpConsole ERROR: setcookie() failed because haders are sent (' . $file . ':' . $line . '). Try to use ob_start()');
-		}
-		setcookie($name, $value, ['expires' => null, 'path' => '/']);
-	}
+    protected static function getNextIndex()
+    {
+        return substr(number_format(microtime(1), 3, '', ''), -6) + self::$index++;
+    }
 
-	protected static function sendMessages($messages) {
-		self::setCookie(self::messagesCookiePrefix . self::getNextIndex(), json_encode($messages));
-	}
+    public static function flushMessagesBuffer()
+    {
+        if (self::$messagesBuffer) {
+            self::sendMessages(self::$messagesBuffer);
+            self::$bufferLength = 0;
+            self::$messagesSent += count(self::$messagesBuffer);
+            self::$messagesBuffer = [];
+            ++self::$cookiesSent;
+            if (self::$cookiesSent == self::cookiesLimit) {
+                self::$isDisabled = true;
+                $message = ['type' => 'error', 'subject' => 'PHP CONSOLE', 'text' => 'MESSAGES LIMIT EXCEEDED BECAUSE OF COOKIES STORAGE LIMIT. TOTAL MESSAGES SENT: ' . self::$messagesSent, 'source' => __FILE__, 'notify' => 3];
+                self::sendMessages([$message]);
+            }
+        }
+    }
 
-	/***************************************************************
-	ERRORS
-	 **************************************************************/
+    protected static function setCookie($name, $value)
+    {
+        if (headers_sent($file, $line)) {
+            exit('PhpConsole ERROR: setcookie() failed because haders are sent (' . $file . ':' . $line . '). Try to use ob_start()');
+        }
+        setcookie($name, $value, ['expires' => null, 'path' => '/']);
+    }
 
-	protected $codesTags = array(E_ERROR => 'fatal', E_WARNING => 'warning', E_PARSE => 'fatal', E_NOTICE => 'notice', E_CORE_ERROR => 'fatal', E_CORE_WARNING => 'warning', E_COMPILE_ERROR => 'fatal', E_COMPILE_WARNING => 'warning', E_USER_ERROR => 'fatal', E_USER_WARNING => 'warning', E_USER_NOTICE => 'notice', E_STRICT => 'warning');
-	protected $codesNames = array(E_ERROR => 'E_ERROR', E_WARNING => 'E_WARNING', E_PARSE => 'E_PARSE', E_NOTICE => 'E_NOTICE', E_CORE_ERROR => 'E_CORE_ERROR', E_CORE_WARNING => 'E_CORE_WARNING', E_COMPILE_ERROR => 'E_COMPILE_ERROR', E_COMPILE_WARNING => 'E_COMPILE_WARNING', E_USER_ERROR => 'E_USER_ERROR', E_USER_WARNING => 'E_USER_WARNING', E_USER_NOTICE => 'E_USER_NOTICE', E_STRICT => 'E_STRICT');
-	protected $notCompitableCodes = array('E_RECOVERABLE_ERROR' => 'warning', 'E_DEPRECATED' => 'warning');
-	protected $oldErrorHandler;
+    protected static function sendMessages($messages)
+    {
+        self::setCookie(self::messagesCookiePrefix . self::getNextIndex(), json_encode($messages));
+    }
 
-	protected function initErrorsHandler() {
-		ini_set('display_errors', false);
-		ini_set('html_errors', false);
-		ini_set('ignore_repeated_errors', self::$ignoreRepeatedEvents);
-		ini_set('ignore_repeated_source', self::$ignoreRepeatedEvents);
+    /***************************************************************
+    ERRORS
+     **************************************************************/
 
-		foreach($this->notCompitableCodes as $code => $tag) {
-			if(defined($code)) {
-				$this->codesTags[constant($code)] = $tag;
-				$this->codesNames[constant($code)] = $code;
-			}
-		}
+    protected $codesTags = [E_ERROR => 'fatal', E_WARNING => 'warning', E_PARSE => 'fatal', E_NOTICE => 'notice', E_CORE_ERROR => 'fatal', E_CORE_WARNING => 'warning', E_COMPILE_ERROR => 'fatal', E_COMPILE_WARNING => 'warning', E_USER_ERROR => 'fatal', E_USER_WARNING => 'warning', E_USER_NOTICE => 'notice', E_STRICT => 'warning'];
+    protected $codesNames = [E_ERROR => 'E_ERROR', E_WARNING => 'E_WARNING', E_PARSE => 'E_PARSE', E_NOTICE => 'E_NOTICE', E_CORE_ERROR => 'E_CORE_ERROR', E_CORE_WARNING => 'E_CORE_WARNING', E_COMPILE_ERROR => 'E_COMPILE_ERROR', E_COMPILE_WARNING => 'E_COMPILE_WARNING', E_USER_ERROR => 'E_USER_ERROR', E_USER_WARNING => 'E_USER_WARNING', E_USER_NOTICE => 'E_USER_NOTICE', E_STRICT => 'E_STRICT'];
+    protected $notCompitableCodes = ['E_RECOVERABLE_ERROR' => 'warning', 'E_DEPRECATED' => 'warning'];
+    protected $oldErrorHandler;
 
-		$this->oldErrorHandler = set_error_handler($this->handleError(...));
-		register_shutdown_function(array($this, 'checkFatalError'));
-	}
+    protected function initErrorsHandler()
+    {
+        ini_set('display_errors', false);
+        ini_set('html_errors', false);
+        ini_set('ignore_repeated_errors', self::$ignoreRepeatedEvents);
+        ini_set('ignore_repeated_source', self::$ignoreRepeatedEvents);
 
-	public function checkFatalError() {
-		$error = error_get_last();
-		if($error) {
-			$this->handleError($error['type'], $error['message'], $error['file'], $error['line']);
-		}
-	}
+        foreach ($this->notCompitableCodes as $code => $tag) {
+            if (defined($code)) {
+                $this->codesTags[constant($code)] = $tag;
+                $this->codesNames[constant($code)] = $code;
+            }
+        }
 
-	public function handleError($code = null, $message = null, $file = null, $line = null) {
-		if(error_reporting() == 0) { // if error has been supressed with an @
-			return;
-		}
-		if(!$code) {
-			$code = E_USER_ERROR;
-		}
+        $this->oldErrorHandler = set_error_handler($this->handleError(...));
+        register_shutdown_function([$this, 'checkFatalError']);
+    }
 
-		$event = new PhpConsoleEvent();
-		$event->tags = 'error,' . ($this->codesTags[$code] ?? 'warning');
-		$event->message = $message;
-		$event->type = $this->codesNames[$code] ?? $code;
-		$event->file = $file;
-		$event->line = $line;
-		$event->trace = debug_backtrace();
+    public function checkFatalError()
+    {
+        $error = error_get_last();
+        if ($error) {
+            $this->handleError($error['type'], $error['message'], $error['file'], $error['line']);
+        }
+    }
 
-		$this->handle($event);
+    public function handleError($code = null, $message = null, $file = null, $line = null)
+    {
+        if (error_reporting() == 0) { // if error has been supressed with an @
+            return;
+        }
+        if (!$code) {
+            $code = E_USER_ERROR;
+        }
 
-		if(self::$callOldErrorHandler && $this->oldErrorHandler) {
-			call_user_func_array($this->oldErrorHandler, array($code, $message, $file, $line));
-		}
-	}
+        $event = new PhpConsoleEvent();
+        $event->tags = 'error,' . ($this->codesTags[$code] ?? 'warning');
+        $event->message = $message;
+        $event->type = $this->codesNames[$code] ?? $code;
+        $event->file = $file;
+        $event->line = $line;
+        $event->trace = debug_backtrace();
 
-	/***************************************************************
-	EXCEPTIONS
-	 **************************************************************/
+        $this->handle($event);
 
-	protected $oldExceptionsHandler;
+        if (self::$callOldErrorHandler && $this->oldErrorHandler) {
+            call_user_func_array($this->oldErrorHandler, [$code, $message, $file, $line]);
+        }
+    }
 
-	protected function initExceptionsHandler() {
-		$this->oldExceptionsHandler = set_exception_handler($this->handleException(...));
-	}
+    /***************************************************************
+    EXCEPTIONS
+     **************************************************************/
 
-	public function handleException(\Throwable $exception) {
-		$event = new PhpConsoleEvent();
-		$event->message = $exception->getMessage();
-		$event->tags = 'error,fatal,exception,' . $exception::class;
-		$event->type = $exception::class;
-		$event->file = $exception->getFile();
-		$event->line = $exception->getLine();
-		$event->trace = $exception->getTrace();
+    protected $oldExceptionsHandler;
 
-		$this->handle($event);
+    protected function initExceptionsHandler()
+    {
+        $this->oldExceptionsHandler = set_exception_handler($this->handleException(...));
+    }
 
-		// TODO: check if need to throw
-		if(self::$callOldExceptionsHandler && $this->oldExceptionsHandler) {
-			call_user_func($this->oldExceptionsHandler, $exception);
-		}
-	}
+    public function handleException(Throwable $exception)
+    {
+        $event = new PhpConsoleEvent();
+        $event->message = $exception->getMessage();
+        $event->tags = 'error,fatal,exception,' . $exception::class;
+        $event->type = $exception::class;
+        $event->file = $exception->getFile();
+        $event->line = $exception->getLine();
+        $event->trace = $exception->getTrace();
 
-	/***************************************************************
-	DEBUG
-	 **************************************************************/
+        $this->handle($event);
 
-	public static function debug($message, $tags = 'debug') {
-		if(self::$instance) {
-			$event = new PhpConsoleEvent();
-			$event->message = $message;
-			$event->tags = $tags;
-			$event->type = $tags;
-			self::$instance->handle($event);
-		}
-	}
+        // TODO: check if need to throw
+        if (self::$callOldExceptionsHandler && $this->oldExceptionsHandler) {
+            call_user_func($this->oldExceptionsHandler, $exception);
+        }
+    }
+
+    /***************************************************************
+    DEBUG
+     **************************************************************/
+
+    public static function debug($message, $tags = 'debug')
+    {
+        if (self::$instance) {
+            $event = new PhpConsoleEvent();
+            $event->message = $message;
+            $event->tags = $tags;
+            $event->type = $tags;
+            self::$instance->handle($event);
+        }
+    }
 }
 
-class PhpConsoleEvent {
-
-	public $message;
-	public $type;
-	public $tags;
-	public $trace;
-	public $file;
-	public $line;
+class PhpConsoleEvent
+{
+    public $message;
+    public $type;
+    public $tags;
+    public $trace;
+    public $file;
+    public $line;
 }
 
-function debug($message, $tags = 'debug') {
-	PhpConsole::debug($message, $tags);
+function debug($message, $tags = 'debug')
+{
+    PhpConsole::debug($message, $tags);
 }

--- a/tests/includes/Plugin/BblicenseMock.php
+++ b/tests/includes/Plugin/BblicenseMock.php
@@ -1,26 +1,27 @@
 <?php
+
 class Plugin_BblicenseMock
 {
     public function partner_order_reset()
     {
         return true;
     }
-    
+
     public function partner_order_create()
     {
         return true;
     }
-    
+
     public function partner_order_suspend()
     {
         return true;
     }
-    
+
     public function partner_order_unsuspend()
     {
         return true;
     }
-    
+
     public function partner_order_delete()
     {
         return true;

--- a/tests/includes/Plugin/Example/Example.php
+++ b/tests/includes/Plugin/Example/Example.php
@@ -1,59 +1,56 @@
 <?php
+
 class Example
 {
     public function __construct(private readonly ?array $config = null)
     {
     }
-    
-    public function activate($service, $order, $params = array())
+
+    public function activate($service, $order, $params = [])
     {
-        
     }
-    
-    public function renew($service, $order, $params = array())
+
+    public function renew($service, $order, $params = [])
     {
-        
     }
-    
-    public function suspend($service, $order, $params = array())
+
+    public function suspend($service, $order, $params = [])
     {
-        
     }
-    
-    public function unsuspend($service, $order, $params = array())
+
+    public function unsuspend($service, $order, $params = [])
     {
-        
     }
-    
-    public function cancel($service, $order, $params = array())
+
+    public function cancel($service, $order, $params = [])
     {
         return $this->suspend($service, $order, $params);
     }
-    
-    public function uncancel($service, $order, $params = array())
+
+    public function uncancel($service, $order, $params = [])
     {
         return $this->unsuspend($service, $order, $params);
     }
-    
-    public function delete($service, $order, $params = array())
+
+    public function delete($service, $order, $params = [])
     {
-        
     }
-    
+
     public function get_config()
     {
         return $this->config;
     }
-    
+
     /**
-     * Custom function to return passed params
-     * 
+     * Custom function to return passed params.
+     *
      * @param type $service
      * @param type $order
      * @param type $params
-     * @return type 
+     *
+     * @return type
      */
-    public function return_params($service, $order, $params = array())
+    public function return_params($service, $order, $params = [])
     {
         return $params;
     }

--- a/tests/includes/QueryDebuggerListener.php
+++ b/tests/includes/QueryDebuggerListener.php
@@ -7,7 +7,7 @@ class QueryDebuggerListener extends Doctrine_EventListener
         $query = $event->getQuery();
         $params = $event->getParams();
 
-        //the below makes some naive assumptions about the queries being logged
+        // the below makes some naive assumptions about the queries being logged
         while (sizeof($params) > 0) {
             $param = array_shift($params);
 
@@ -16,7 +16,7 @@ class QueryDebuggerListener extends Doctrine_EventListener
             }
 
             $query = substr_replace($query, $param, strpos($query, '?'), 1);
-            
+
             debug($query);
         }
     }

--- a/tests/includes/TagOptional.php
+++ b/tests/includes/TagOptional.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Zend Framework
+ * Zend Framework.
  *
  * LICENSE
  *
@@ -13,9 +13,10 @@
  * to license@zend.com so we can send you a copy immediately.
  *
  * @category   Zend
- * @package    Zend_Reflection
+ *
  * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ *
  * @version    $Id: Param.php 20096 2010-01-06 02:05:09Z bkarwin $
  */
 
@@ -24,7 +25,7 @@ require_once 'Zend/Reflection/Docblock/Tag.php';
 
 /**
  * @category   Zend
- * @package    Zend_Reflection
+ *
  * @copyright  Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
@@ -33,29 +34,31 @@ class TagOptional extends Zend_Reflection_Docblock_Tag
     /**
      * @var string
      */
-    protected $_type = null;
+    protected $_type;
 
     /**
      * @var string
      */
-    protected $_variableName = null;
+    protected $_variableName;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param string $tagDocblockLine
      */
     public function __construct($tagDocblockLine)
     {
-        $matches = array();
+        $matches = [];
 
         if (!preg_match('#^@(\w+)\s+([\w|\\\]+)(?:\s+(\$\S+))?(?:\s+(.*))?#s', $tagDocblockLine, $matches)) {
             require_once 'Zend/Reflection/Exception.php';
+
             throw new Zend_Reflection_Exception('Provided docblock line is does not contain a valid tag');
         }
 
         if ($matches[1] != 'optional') {
             require_once 'Zend/Reflection/Exception.php';
+
             throw new Zend_Reflection_Exception('Provided docblock line is does not contain a valid @optional tag');
         }
 
@@ -72,7 +75,7 @@ class TagOptional extends Zend_Reflection_Docblock_Tag
     }
 
     /**
-     * Get parameter variable type
+     * Get parameter variable type.
      *
      * @return string
      */
@@ -82,7 +85,7 @@ class TagOptional extends Zend_Reflection_Docblock_Tag
     }
 
     /**
-     * Get parameter name
+     * Get parameter name.
      *
      * @return string
      */

--- a/tests/integration/bb-library/Api/HandlerTest.php
+++ b/tests/integration/bb-library/Api/HandlerTest.php
@@ -1,14 +1,14 @@
 <?php
+
 class HandlerTest extends BBDbApiTestCase
 {
-
     public static function api_roles()
     {
-        return array(
-            array('api_guest'),
-            array('api_admin'),
-            array('api_client'),
-        );
+        return [
+            ['api_guest'],
+            ['api_admin'],
+            ['api_client'],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('api_roles')]
@@ -30,7 +30,7 @@ class HandlerTest extends BBDbApiTestCase
     {
         $api = $this->di['api_guest'];
         $method = 'methodWithoutUnderscore';
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(710);
         $api->$method();
     }
@@ -39,7 +39,7 @@ class HandlerTest extends BBDbApiTestCase
     {
         $api = $this->di['api_guest'];
         $moduleName = '__';
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(714);
         $version = $api->$moduleName();
     }
@@ -48,7 +48,7 @@ class HandlerTest extends BBDbApiTestCase
     {
         $api = $this->di['api_guest'];
         $moduleName = 'notActiveModule_version';
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(715);
         $version = $api->$moduleName();
     }

--- a/tests/integration/bb-library/Box/DatabaseTest.php
+++ b/tests/integration/bb-library/Box/DatabaseTest.php
@@ -1,30 +1,30 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class DatabaseTest extends BBDbApiTestCase
 {
-
     public function testModel()
     {
         $model = $this->di['db']->dispense('Admin');
-        $this->assertInstanceOf(\RedBeanPHP\SimpleModel::class, $model);
+        $this->assertInstanceOf(RedBeanPHP\SimpleModel::class, $model);
         $id = $this->di['db']->store($model);
 
         $this->assertNotNull($id);
-        $model = $this->di['db']->findOne('Admin', 'id = ?', array($id));
-        $this->assertInstanceOf(\RedBeanPHP\SimpleModel::class, $model);
+        $model = $this->di['db']->findOne('Admin', 'id = ?', [$id]);
+        $this->assertInstanceOf(RedBeanPHP\SimpleModel::class, $model);
 
         $model = $this->di['db']->load('Admin', $id);
-        $this->assertInstanceOf(\RedBeanPHP\SimpleModel::class, $model);
+        $this->assertInstanceOf(RedBeanPHP\SimpleModel::class, $model);
 
         $model = $this->di['db']->getExistingModelById('Admin', $id);
-        $this->assertInstanceOf(\RedBeanPHP\SimpleModel::class, $model);
+        $this->assertInstanceOf(RedBeanPHP\SimpleModel::class, $model);
 
         $array = $this->di['db']->toArray($model);
         $this->assertIsArray($array);
 
         $models = $this->di['db']->find('Admin');
-        foreach($models as $m) {
-            $this->assertInstanceOf(\RedBeanPHP\SimpleModel::class, $m);
+        foreach ($models as $m) {
+            $this->assertInstanceOf(RedBeanPHP\SimpleModel::class, $m);
         }
 
         $this->assertNull($this->di['db']->trash($model));
@@ -33,25 +33,25 @@ class DatabaseTest extends BBDbApiTestCase
     public function testBean()
     {
         $bean = $this->di['db']->dispense('admin');
-        $this->assertInstanceOf(\RedBeanPHP\OODBBean::class, $bean);
+        $this->assertInstanceOf(RedBeanPHP\OODBBean::class, $bean);
         $id = $this->di['db']->store($bean);
         $this->assertNotNull($id);
 
-        $model = $this->di['db']->findOne('admin', 'id = ?', array($id));
-        $this->assertInstanceOf(\RedBeanPHP\OODBBean::class, $model);
+        $model = $this->di['db']->findOne('admin', 'id = ?', [$id]);
+        $this->assertInstanceOf(RedBeanPHP\OODBBean::class, $model);
 
         $model = $this->di['db']->load('admin', $id);
-        $this->assertInstanceOf(\RedBeanPHP\OODBBean::class, $model);
+        $this->assertInstanceOf(RedBeanPHP\OODBBean::class, $model);
 
         $model = $this->di['db']->getExistingModelById('admin', $id);
-        $this->assertInstanceOf(\RedBeanPHP\OODBBean::class, $model);
+        $this->assertInstanceOf(RedBeanPHP\OODBBean::class, $model);
 
         $array = $this->di['db']->toArray($model);
         $this->assertIsArray($array);
 
         $models = $this->di['db']->find('admin');
-        foreach($models as $m) {
-            $this->assertInstanceOf(\RedBeanPHP\OODBBean::class, $m);
+        foreach ($models as $m) {
+            $this->assertInstanceOf(RedBeanPHP\OODBBean::class, $m);
         }
 
         $this->assertNull($this->di['db']->trash($model));

--- a/tests/integration/bb-library/Box/DiTest.php
+++ b/tests/integration/bb-library/Box/DiTest.php
@@ -1,7 +1,7 @@
 <?php
+
 class DiTest extends PHPUnit\Framework\TestCase
 {
-
     public function setup(): void
     {
         global $di;
@@ -21,25 +21,25 @@ class DiTest extends PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Box_Url', $di['url']);
         $this->assertInstanceOf('Box_EventManager', $di['events_manager']);
 
-        $this->assertInstanceOf('\\' . \FOSSBilling\Session::class, $di['session']);
+        $this->assertInstanceOf('\\' . FOSSBilling\Session::class, $di['session']);
         $this->assertInstanceOf('Box_Authorization', $di['auth']);
-        $this->assertInstanceOf(\Twig\Environment::class, $di['twig']);
-        $this->assertInstanceOf('\\' . \FOSSBilling\Tools::class, $di['tools']);
-        $this->assertInstanceOf('\\' . \FOSSBilling\Validate::class, $di['validator']);
+        $this->assertInstanceOf(Twig\Environment::class, $di['twig']);
+        $this->assertInstanceOf('\\' . FOSSBilling\Tools::class, $di['tools']);
+        $this->assertInstanceOf('\\' . FOSSBilling\Validate::class, $di['validator']);
 
         $this->assertTrue(isset($di['mod']));
         $this->assertTrue(isset($di['mod_config']));
-        $this->assertInstanceOf(\Box\Mod\Cron\Service::class, $di['mod_service']('cron'));
-        $this->assertInstanceOf('\\' . \FOSSBilling\ExtensionManager::class, $di['extension_manager']);
+        $this->assertInstanceOf(Box\Mod\Cron\Service::class, $di['mod_service']('cron'));
+        $this->assertInstanceOf('\\' . FOSSBilling\ExtensionManager::class, $di['extension_manager']);
         $this->assertInstanceOf('\Box_Update', $di['updater']);
         $this->assertInstanceOf('\Server_Package', $di['server_package']);
         $this->assertInstanceOf('\Server_Client', $di['server_client']);
         $this->assertInstanceOf('\Server_Account', $di['server_account']);
         $this->assertTrue(isset($di['server_manager']));
-        $this->assertInstanceOf('\\' . \FOSSBilling\Requirements::class, $di['requirements']);
-        $this->assertInstanceOf('\\' . \Box\Mod\Theme\Model\Theme::class, $di['theme']);
+        $this->assertInstanceOf('\\' . FOSSBilling\Requirements::class, $di['requirements']);
+        $this->assertInstanceOf('\\' . Box\Mod\Theme\Model\Theme::class, $di['theme']);
         $this->assertInstanceOf('\Model_Cart', $di['cart']);
-        $this->assertInstanceOf('\\' . \GeoIp2\Database\Reader::class, $di['geoip']);
+        $this->assertInstanceOf('\\' . GeoIp2\Database\Reader::class, $di['geoip']);
         $this->assertInstanceOf('\Box_Password', $di['password']);
         $this->assertInstanceOf('\Box_Translate', $di['translate']());
     }

--- a/tests/integration/bb-library/Box/LogTest.php
+++ b/tests/integration/bb-library/Box/LogTest.php
@@ -5,10 +5,10 @@ class LogTest extends BBDbApiTestCase
 {
     public static function logWithoutParamsProvider()
     {
-        return array(
-            array('Test message'),
-            array('Test message with param %s, but param not passed'),
-        );
+        return [
+            ['Test message'],
+            ['Test message with param %s, but param not passed'],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('logWithoutParamsProvider')]
@@ -17,13 +17,12 @@ class LogTest extends BBDbApiTestCase
         $msg = 'Test message';
         $this->di['logger']->info($msg);
 
-        $array   = $this->api_admin->activity_log_get_list();
-        $log     = $array['list'][0]; //by default sorting by ID descending order so newest will always be first array item
+        $array = $this->api_admin->activity_log_get_list();
+        $log = $array['list'][0]; // by default sorting by ID descending order so newest will always be first array item
         $message = $log['message'];
 
         $this->assertEquals($msg, $message);
     }
-
 
     public function testLogProvider()
     {
@@ -31,12 +30,12 @@ class LogTest extends BBDbApiTestCase
         $msg1 = 'No params in message, param passed';
         $msg2 = 'Test message with param %s';
 
-        $this->assertTrue(($rand <= 100 && $rand > 0));
+        $this->assertTrue($rand <= 100 && $rand > 0);
 
-        return array(
-            array($msg1, $rand, $msg1),
-            array($msg2, $rand, 'Test message with param ' . $rand),
-        );
+        return [
+            [$msg1, $rand, $msg1],
+            [$msg2, $rand, 'Test message with param ' . $rand],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('testLogProvider')]
@@ -44,8 +43,8 @@ class LogTest extends BBDbApiTestCase
     {
         $this->di['logger']->info($msg, $param);
 
-        $array   = $this->api_admin->activity_log_get_list();
-        $log     = $array['list'][0]; //by default sorting by ID descending order so newest will always be first array item
+        $array = $this->api_admin->activity_log_get_list();
+        $log = $array['list'][0]; // by default sorting by ID descending order so newest will always be first array item
         $message = $log['message'];
 
         $this->assertEquals($expected, $message);
@@ -53,14 +52,13 @@ class LogTest extends BBDbApiTestCase
 
     public function testLogMultipleVariables()
     {
-        $msg  = '%sMultiple params in message, one param passed%s';
+        $msg = '%sMultiple params in message, one param passed%s';
         $rand = random_int(1, 100);
         $this->di['logger']->info($msg, $rand, $rand);
-        $array   = $this->api_admin->activity_log_get_list();
-        $log     = $array['list'][0]; //by default sorting by ID descending order so newest will always be first array item
+        $array = $this->api_admin->activity_log_get_list();
+        $log = $array['list'][0]; // by default sorting by ID descending order so newest will always be first array item
         $message = $log['message'];
 
         $this->assertEquals(sprintf($msg, $rand, $rand), $message);
     }
-    
 }

--- a/tests/integration/bb-library/Box/ModTest.php
+++ b/tests/integration/bb-library/Box/ModTest.php
@@ -5,12 +5,12 @@ class ModTest extends BBDbApiTestCase
 {
     public function testConfig()
     {
-        $conf = array(
-            'ext'      => 'mod_client',
-            'required' => array(
-                'last-name'
-            )
-        );
+        $conf = [
+            'ext' => 'mod_client',
+            'required' => [
+                'last-name',
+            ],
+        ];
 
         $this->api_admin->extension_config_save($conf);
 

--- a/tests/integration/bb-library/Payment/Adapter/CustomTest.php
+++ b/tests/integration/bb-library/Payment/Adapter/CustomTest.php
@@ -1,15 +1,16 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Payment_Adapter_CustomTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'gateway_Custom.xml';
-    
+
     public function testCustom()
     {
-        $config = array(
-            'single'        =>  'test',
-            'recurrent'     =>  'test',
-        );
+        $config = [
+            'single' => 'test',
+            'recurrent' => 'test',
+        ];
         $adapter = new Payment_Adapter_Custom($config);
         $adapter->setDi($this->di);
         $adapter->getConfig();
@@ -17,6 +18,5 @@ class Payment_Adapter_CustomTest extends BBDbApiTestCase
 
         $tx = $this->di['db']->load('Transaction', 1);
         $adapter->process($tx);
-
     }
 }

--- a/tests/integration/bb-library/Payment/Adapter/PayPalEmailTest.php
+++ b/tests/integration/bb-library/Payment/Adapter/PayPalEmailTest.php
@@ -1,37 +1,38 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Payment_Adapter_PayPalEmailTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'gateway_PayPal.xml';
-    
+
     public function testGateway()
     {
-        $config = array();
+        $config = [];
         $config['test_mode'] = true;
-        $config['email']      = 'example@gmail.com';
+        $config['email'] = 'example@gmail.com';
         $config['return_url'] = 'http://www.google.com?q=return';
         $config['cancel_url'] = 'http://www.google.com?q=cancel';
         $config['notify_url'] = 'http://www.google.com?q=notify';
-        
+
         $adapter = new Payment_Adapter_PayPalEmail($config);
         $adapter->setDi($this->di);
         $adapter->getConfig();
         $adapter->getHtml($this->api_admin, 1, false);
         $adapter->getHtml($this->api_admin, 2, true);
-        
+
         $subscr_payment = json_decode('{"get":{"bb_gateway_id":"1","bb_invoice_id":"1"},"post":{"transaction_subject":"Subscription for FOSSBilling Pro License","payment_date":"11:24:34 Mar 08, 2012 PST","txn_type":"subscr_payment","subscr_id":"S-9X268688JL8514304","last_name":"Doe","residence_country":"GB","item_name":"Subscription for FOSSBilling Pro License","payment_gross":"5.95","mc_currency":"USD","business":"clients@fossbilling.org","payment_type":"instant","protection_eligibility":"Ineligible","verify_sign":"A2QxLKJxNBOK3utJMiCwOkOiLG3tAo4.KtJCsCemU7s98tgtW37-hOOx","payer_status":"verified","payer_email":"john.doe@gmail.com","txn_id":"6SR32195AP993094V","receiver_email":"clients@fossbilling.org","first_name":"John","payer_id":"9W3LMGTFS5RTY","receiver_id":"79PMKLAHPL5YH","item_number":"BOX05697","payment_status":"Completed","payment_fee":"0.47","mc_fee":"0.47","mc_gross":"5.95","charset":"windows-1252","notify_version":"3.4","ipn_track_id":"54b4dbrfvg396"},"http_raw_post_data":"transaction_subject=Subscription+for+FOSSBilling+Pro+License&payment_date=11%3A24%3A34+Mar+08%2C+2012+PST&txn_type=subscr_payment&subscr_id=S-9X268688JL8514304&last_name=Doe&residence_country=GB&item_name=Subscription+for+FOSSBilling+Pro+License&payment_gross=5.95&mc_currency=USD&business=clients%40fossbilling.org&payment_type=instant&protection_eligibility=Ineligible&verify_sign=A2QxLKJxNBOK3utOLuCwOkOiLG3tAo4.KtJCsCemU7db97vtW37-hOOx&payer_status=verified&payer_email=mitcheyDoe%40gmail.com&txn_id=6SR99524AP993094V&receiver_email=clients%40fossbilling.org&first_name=John&payer_id=9W3MDRHPS5RTY&receiver_id=79PMKLAHYN3HN&item_number=BOX05697&payment_status=Completed&payment_fee=0.47&mc_fee=0.47&mc_gross=5.95&charset=windows-1252&notify_version=3.4&ipn_track_id=54b4dbfade396"}', 1);
         $adapter->processTransaction($this->api_admin, 1, $subscr_payment, 1);
-        
+
         $web_accept = json_decode('{"get":{"bb_gateway_id":"1","bb_invoice_id":"1"},"post":{"transaction_subject":"Payment for invoice BOX05623","payment_date":"08:26:14 Mar 01, 2012 PST","txn_type":"web_accept","last_name":"Doe","residence_country":"US","item_name":"Payment for invoice BOX05623","payment_gross":"5.95","mc_currency":"USD","business":"sales@fossbilling.org","payment_type":"instant","protection_eligibility":"Ineligible","verify_sign":"A.DRDmKsJOHhCaHehJk34EQqLY1rAuZ0ksJDt.45zrn5eO7JxP0.4QP.","payer_status":"verified","tax":"0.00","payer_email":"john.doe@gmail.com","txn_id":"8X786252873429051","quantity":"1","receiver_email":"clients@fossbilling.org","first_name":"John","payer_id":"29NE5SEU5VR2E","receiver_id":"79PMKLAHPL5YH","item_number":"BOX05623","handling_amount":"0.00","payment_status":"Completed","payment_fee":"0.44","mc_fee":"0.44","shipping":"0.00","mc_gross":"5.95","custom":"","charset":"windows-1252","notify_version":"3.4","ipn_track_id":"6fd845df6f247"},"http_raw_post_data":"transaction_subject=Payment+for+invoice+BOX05623&payment_date=08%3A26%3A14+Mar+01%2C+2012+PST&txn_type=web_accept&last_name=Doe&residence_country=LT&item_name=Payment+for+invoice+BOX05623&payment_gross=5.95&mc_currency=USD&business=sales%40fossbilling.org&payment_type=instant&protection_eligibility=Ineligible&verify_sign=A.DRDmKsJOHhCaHehJr9EQqLY1rAuZ0ksJDt.45zrn5eO7JxP0.4QP.&payer_status=verified&tax=0.00&payer_email=fordnox%40gmail.com&txn_id=8X786252873429051&quantity=1&receiver_email=clients%40fossbilling.org&first_name=John&payer_id=29NE5SEU5VR2E&receiver_id=79PMKLAHYN3HN&item_number=BOX05623&handling_amount=0.00&payment_status=Completed&payment_fee=0.44&mc_fee=0.44&shipping=0.00&mc_gross=5.95&custom=&charset=windows-1252&notify_version=3.4&ipn_track_id=6fd802df6f247"}', 1);
         $adapter->processTransaction($this->api_admin, 1, $web_accept, 1);
-        
+
         $refund_ipn = json_decode('{"get":{"bb_gateway_id":"1","bb_invoice_id":"1"},"post":{"transaction_subject":"Subscription for FOSSBilling Pro License","payment_date":"17:42:05 Mar 13, 2012 PDT", "txn_type":"subscr_payment","subscr_id":"S-9X268688JL8514304","last_name":"Doe","residence_country":"GB","item_name":"Subscription for FOSSBilling Pro License","payment_gross":"-5.95","mc_currency":"USD","business":"clients@fossbilling.org","payment_type":"instant","protection_eligibility":"Ineligible","verify_sign":"ArFZ5DF1pEd4euI2jpvbEwe5Q4BiAB46zG6F4TMlFNMtpDC7L5z6VPsB","payer_email":"mitcheyDoe@gmail.com","txn_id":"33R88456DU653693H","receiver_email":"clients@fossbilling.org","first_name":"John","parent_txn_id":"6SR99524AP993094V","payer_id":"9W3LMGTFS5RTY","receiver_id":"79PMKLAHPL5YH","reason_code":"refund","item_number":"BOX05697","payment_status":"Refunded","payment_fee":"-0.17","mc_fee":"-0.17","mc_gross":"-5.95","charset":"windows-1252","notify_version":"3.4","ipn_track_id":"71f325984a82e"},"http_raw_post_data":"transaction_subject=Subscription+for+FOSSBilling+Pro+License&payment_date=17%3A42%3A05+Mar+13%2C+2012+PDT&subscr_id=S-9X268688JL8514304&last_name=Doe&residence_country=GB&item_name=Subscription+for+FOSSBilling+Pro+License&payment_gross=-5.95&mc_currency=USD&business=clients%40fossbilling.org&payment_type=instant&protection_eligibility=Ineligible&verify_sign=ArFZ5DF1pEd6dfI2jpvbEwe5Q4BiAB46zG6F4TMlFNMtpDC7L5z6VPsB&payer_email=mitcheyDoe%40gmail.com&txn_id=33R88456DU653693H&receiver_email=clients%40fossbilling.org&first_name=John&parent_txn_id=6SR99524AP993094V&payer_id=9W3MDRHPS5RTY&receiver_id=79PMKLAHYN3HN&reason_code=refund&item_number=BOX05697&payment_status=Refunded&payment_fee=-0.17&mc_fee=-0.17&mc_gross=-5.95&charset=windows-1252&notify_version=3.4&ipn_track_id=71f784354a82e"}', 1);
         $adapter->processTransaction($this->api_admin, 1, $refund_ipn, 1);
     }
 
     public function testGatewayProductionUrl()
     {
-        $config = array();
+        $config = [];
         $config['email'] = 'example@gmail.com';
         $config['test_mode'] = false;
         $config['return_url'] = 'http://www.google.com?q=return';
@@ -46,13 +47,13 @@ class Payment_Adapter_PayPalEmailTest extends BBDbApiTestCase
 
     public function testGatewayTestmodeUrl()
     {
-        $config = array();
+        $config = [];
         $config['email'] = 'example@gmail.com';
         $config['test_mode'] = true;
         $config['return_url'] = 'http://www.google.com?q=return';
         $config['cancel_url'] = 'http://www.google.com?q=cancel';
         $config['notify_url'] = 'http://www.google.com?q=notify';
-        
+
         $adapter = new Payment_Adapter_PayPalEmail($config);
         $adapter->setDi($this->di);
         $form = $adapter->getHtml($this->api_admin, 1, false);

--- a/tests/integration/bb-modules/mod_activity/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_activity/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_AdminTest extends BBDbApiTestCase
 {
@@ -6,30 +7,30 @@ class Api_AdminTest extends BBDbApiTestCase
 
     public function testActivity()
     {
-        $bool = $this->api_admin->activity_log_delete(array('id'=>1));
-        $this->assertTrue($bool);
-        
-        $bool = $this->api_admin->activity_log();
-        $this->assertFalse($bool);
-        
-        $bool = $this->api_admin->activity_log(array('m'=>'this is test message to log'));
+        $bool = $this->api_admin->activity_log_delete(['id' => 1]);
         $this->assertTrue($bool);
 
-        $bool = $this->api_admin->activity_log_email(array('subject' => 'This is an email subject'));
+        $bool = $this->api_admin->activity_log();
+        $this->assertFalse($bool);
+
+        $bool = $this->api_admin->activity_log(['m' => 'this is test message to log']);
+        $this->assertTrue($bool);
+
+        $bool = $this->api_admin->activity_log_email(['subject' => 'This is an email subject']);
         $this->assertTrue($bool);
     }
 
     public function testLogDeleteIdNotSetException()
     {
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
 
-        $this->api_admin->activity_log_delete(array());
+        $this->api_admin->activity_log_delete([]);
     }
 
     public function testLogNotFoundException()
     {
-        $this->expectException(\FOSSBilling\Exception::class);
-        $this->api_admin->activity_log_delete(array('id' => 100));
+        $this->expectException(FOSSBilling\Exception::class);
+        $this->api_admin->activity_log_delete(['id' => 100]);
     }
 
     public function testActivityLogGetList()
@@ -59,13 +60,13 @@ class Api_AdminTest extends BBDbApiTestCase
 
     public function testBatchDelete()
     {
-        $array = $this->api_admin->activity_log_get_list(array());
+        $array = $this->api_admin->activity_log_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->activity_batch_delete(array('ids' => $ids));
-        $array  = $this->api_admin->activity_log_get_list(array());
+        $result = $this->api_admin->activity_batch_delete(['ids' => $ids]);
+        $array = $this->api_admin->activity_log_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);

--- a/tests/integration/bb-modules/mod_api/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_api/ServiceTest.php
@@ -25,5 +25,4 @@ class ServiceTest extends BBDbApiTestCase
         $result = $service->logRequest();
         $this->assertIsInt($result);
     }
-
 }

--- a/tests/integration/bb-modules/mod_branding/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_branding/ServiceTest.php
@@ -1,12 +1,13 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class ServiceTest extends ApiTestCase
 {
-    private $configLicense = null;
+    private $configLicense;
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
-        if ($this->configLicense){
+        if ($this->configLicense) {
             $this->di['config']['license'] = $this->configLicense;
         }
     }

--- a/tests/integration/bb-modules/mod_cart/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_cart/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Cart_Api_AdminTest extends BBDbApiTestCase
 {
@@ -11,7 +12,7 @@ class Box_Mod_Cart_Api_AdminTest extends BBDbApiTestCase
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
         $this->assertIsArray($list);
-        if (count($list)){
+        if (count($list)) {
             $item = $list[0];
             $this->assertArrayHasKey('promocode', $item);
             $this->assertArrayHasKey('discount', $item);
@@ -20,20 +21,20 @@ class Box_Mod_Cart_Api_AdminTest extends BBDbApiTestCase
             $this->assertArrayHasKey('currency', $item);
             $currency = $item['currency'];
             $this->assertIsArray($currency);
-            $this->assertArrayHasKey("code", $currency);
-            $this->assertArrayHasKey("title", $currency);
-            $this->assertArrayHasKey("conversion_rate", $currency);
-            $this->assertArrayHasKey("format", $currency);
-            $this->assertArrayHasKey("price_format", $currency);
-            $this->assertArrayHasKey("default", $currency);
+            $this->assertArrayHasKey('code', $currency);
+            $this->assertArrayHasKey('title', $currency);
+            $this->assertArrayHasKey('conversion_rate', $currency);
+            $this->assertArrayHasKey('format', $currency);
+            $this->assertArrayHasKey('price_format', $currency);
+            $this->assertArrayHasKey('default', $currency);
         }
     }
 
     public function testGet()
     {
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
         $cartArr = $this->api_admin->cart_get($data);
         $this->assertIsArray($cartArr);
     }

--- a/tests/integration/bb-modules/mod_cart/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_cart/Api_ClientTest.php
@@ -1,25 +1,26 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Cart_Api_ClientTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_cart.xml';
-    
+
     public function testCheckout()
     {
-        $this->api_guest->cart_set_currency(array('currency'=>'USD'));
-        
+        $this->api_guest->cart_set_currency(['currency' => 'USD']);
+
         // test custom products
-        $data = array(
-            'id'       =>  1,
-            'period'    =>  '1M',
-            'quantity'  =>  2,
-        );
+        $data = [
+            'id' => 1,
+            'period' => '1M',
+            'quantity' => 2,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
         $cart_before_promo = $this->api_guest->cart_get();
 
-        $bool = $this->api_guest->cart_apply_promo(array('promocode'=>'PHPUNIT'));
+        $bool = $this->api_guest->cart_apply_promo(['promocode' => 'PHPUNIT']);
         $this->assertTrue($bool);
 
         $cart_after_promo = $this->api_guest->cart_get();
@@ -27,108 +28,106 @@ class Box_Mod_Cart_Api_ClientTest extends BBDbApiTestCase
         $this->assertTrue($cart_before_promo['total'] != $cart_after_promo['total'], 'Could not apply promo to cart');
 
         $array = $this->api_client->cart_checkout();
-        $this->assertInternalType('array',$array);
+        $this->assertInternalType('array', $array);
         $this->assertTrue(isset($array['invoice_hash']));
         $this->assertTrue(isset($array['order_id']));
     }
 
-    public function testCheckout_EmptyCart()
+    public function testCheckoutEmptyCart()
     {
-        $this->api_guest->cart_set_currency(array('currency'=>'USD'));
+        $this->api_guest->cart_set_currency(['currency' => 'USD']);
 
         // test custom products
-        $data = array(
-            'id'       =>  1,
-            'period'    =>  '1M',
-            'quantity'  =>  2,
-        );
+        $data = [
+            'id' => 1,
+            'period' => '1M',
+            'quantity' => 2,
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Can not checkout empty cart.');
 
         $this->api_client->cart_checkout();
     }
-    
+
     /**
-     * If client order total amount is 0 then activate it after placement
+     * If client order total amount is 0 then activate it after placement.
      */
     public function testPromoOrderActivation()
     {
-        $this->api_guest->cart_set_currency(array('currency'=>'USD'));
-        
+        $this->api_guest->cart_set_currency(['currency' => 'USD']);
+
         // add custom product
-        $data = array(
-            'id'        =>  1,
-            'period'    =>  '1M',
-            'quantity'  =>  1,
-        );
+        $data = [
+            'id' => 1,
+            'period' => '1M',
+            'quantity' => 1,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
-        
-        $bool = $this->api_guest->cart_apply_promo(array('promocode'=>'TOTAL_DISCOUNT'));
+
+        $bool = $this->api_guest->cart_apply_promo(['promocode' => 'TOTAL_DISCOUNT']);
         $this->assertTrue($bool);
-        
+
         $d = $this->api_client->cart_checkout();
-        
-        $order = $this->api_client->order_get(array('id'=>$d['order_id']));
-        
+
+        $order = $this->api_client->order_get(['id' => $d['order_id']]);
+
         $this->assertEquals(0, $order['total'] - $order['discount']);
         $this->assertEquals('active', $order['status'], 'Order should be activated if total amount is 0 after discount and product setup is after_payment');
     }
-    
+
     /**
-     * Test if promo code can be applied only once per client
+     * Test if promo code can be applied only once per client.
      */
     public function testPromoOncePerClient()
     {
-        $this->api_guest->cart_set_currency(array('currency'=>'USD'));
-        
+        $this->api_guest->cart_set_currency(['currency' => 'USD']);
+
         // test custom products
-        $data = array(
-            'id'       =>  1,
-            'period'    =>  '1M',
-            'quantity'  =>  2,
-        );
+        $data = [
+            'id' => 1,
+            'period' => '1M',
+            'quantity' => 2,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
-        
-        $bool = $this->api_guest->cart_apply_promo(array('promocode'=>'ONCE_PER_CLIENT'));
+
+        $bool = $this->api_guest->cart_apply_promo(['promocode' => 'ONCE_PER_CLIENT']);
         $this->assertTrue($bool);
-        
+
         try {
             $this->api_client->cart_checkout();
             $this->fail('Promo code was aplied multiple times. Promo can only be applied once.');
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertEquals(9874, $e->getCode());
         }
     }
 
     /**
-     * checkout cart with product with addon and client has insufficient funds to cover
+     * checkout cart with product with addon and client has insufficient funds to cover.
      */
     public function testAddonActivatedWhileOrderInvoiceUnpaid()
     {
-
         $this->api_guest->cart_reset();
-        $data = array(
-            'id'       =>  11,
-            'period'    =>  '6M',
-            'domain' => array(
-                'action' => "register",
-                'owndomain_sld' =>"",
-                'owndomain_tld' =>".com",
-                'register_sld' =>"newdomainregister",
-                'register_tld' =>".com",
-                'register_years' => "1",
-            ),
+        $data = [
+            'id' => 11,
+            'period' => '6M',
+            'domain' => [
+                'action' => 'register',
+                'owndomain_sld' => '',
+                'owndomain_tld' => '.com',
+                'register_sld' => 'newdomainregister',
+                'register_tld' => '.com',
+                'register_years' => '1',
+            ],
             'multiple' => 1,
-
-        );
+        ];
         $this->api_guest->cart_add_item($data);
         $this->api_client->cart_checkout();
 
         $masterOrder = $this->di['db']->findOne('ClientOrder', 'group_master = 1 ORDER BY id desc');
-        $addonOrder = $this->di['db']->findOne('ClientOrder', 'group_id = ? and group_master = 0', array($masterOrder->group_id));
+        $addonOrder = $this->di['db']->findOne('ClientOrder', 'group_id = ? and group_master = 0', [$masterOrder->group_id]);
 
         $invoiceModel = $this->di['db']->load('Invoice', $masterOrder->unpaid_invoice_id);
 
@@ -142,36 +141,34 @@ class Box_Mod_Cart_Api_ClientTest extends BBDbApiTestCase
         $this->assertEquals(Model_Invoice::STATUS_UNPAID, $invoiceModel->status);
     }
 
-
     /**
-     * checkout cart with product with addon and client has sufficient funds to cover
+     * checkout cart with product with addon and client has sufficient funds to cover.
      */
     public function testOrderWithAddonCoverFromAccountBalance()
     {
         $this->api_guest->cart_reset();
-        $data = array(
-            'id'       =>  11,
-            'period'    =>  '6M',
-            'domain' => array(
-                'action' => "register",
-                'owndomain_sld' =>"",
-                'owndomain_tld' =>".com",
-                'register_sld' =>"newdomainregister2",
-                'register_tld' =>".com",
-                'register_years' => "1",
-            ),
+        $data = [
+            'id' => 11,
+            'period' => '6M',
+            'domain' => [
+                'action' => 'register',
+                'owndomain_sld' => '',
+                'owndomain_tld' => '.com',
+                'register_sld' => 'newdomainregister2',
+                'register_tld' => '.com',
+                'register_years' => '1',
+            ],
             'multiple' => 1,
+        ];
 
-        );
-
-        $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit'));
+        $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit']);
         $this->api_guest->cart_add_item($data);
         $this->api_client->cart_checkout();
 
         $masterOrder = $this->di['db']->findOne('ClientOrder', 'group_master = 1 ORDER BY id desc');
-        $addonOrder = $this->di['db']->findOne('ClientOrder', 'group_id = ? and group_master = 0', array($masterOrder->group_id));
+        $addonOrder = $this->di['db']->findOne('ClientOrder', 'group_id = ? and group_master = 0', [$masterOrder->group_id]);
 
-        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', "type = 'order' and rel_id = ?", array($masterOrder->id));
+        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', "type = 'order' and rel_id = ?", [$masterOrder->id]);
         $invoiceModel = $this->di['db']->load('Invoice', $invoiceItemModel->invoice_id);
 
         $this->assertInstanceOf('Model_ClientOrder', $masterOrder);
@@ -183,5 +180,4 @@ class Box_Mod_Cart_Api_ClientTest extends BBDbApiTestCase
         $this->assertEquals(Model_ClientOrder::STATUS_ACTIVE, $addonOrder->status);
         $this->assertEquals(Model_Invoice::STATUS_PAID, $invoiceModel->status);
     }
-
 }

--- a/tests/integration/bb-modules/mod_cart/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_cart/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
 {
@@ -12,7 +13,7 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
 
     public function testCurrency()
     {
-        $data = array('currency'=>'USD');
+        $data = ['currency' => 'USD'];
         $bool = $this->api_guest->cart_set_currency($data);
         $this->assertTrue($bool);
 
@@ -30,9 +31,9 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
 
         $this->assertTrue($bool);
@@ -42,82 +43,82 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
         $pid = 1;
-        $data = array(
-            'id'        => $pid,
-            'addons'    => array(
-                5  =>  array(
-                    'selected'  =>  1,
-                    'period'    =>  '1Y',
-                    'quantity'  =>  2,
-                ),
-            ),
-        );
+        $data = [
+            'id' => $pid,
+            'addons' => [
+                5 => [
+                    'selected' => 1,
+                    'period' => '1Y',
+                    'quantity' => 2,
+                ],
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
-        
+
         $cart = $this->api_guest->cart_get();
-        
-        //main product must be first in cart
+
+        // main product must be first in cart
         $this->assertEquals($pid, $cart['items'][0]['product_id']);
-        
+
         $this->assertEquals(2, count($cart['items']));
         $this->assertEquals(2, $cart['items'][1]['quantity']);
     }
 
-    public function testAddAddons_AddonPeriodNotEnabled()
+    public function testAddAddonsAddonPeriodNotEnabled()
     {
         $this->api_guest->cart_reset();
         $pid = 1;
-        $data = array(
-            'id'        => $pid,
-            'addons'    => array(
-                5  =>  array(
-                    'selected'  =>  1,
-                    'period'    =>  '1W',
-                    'quantity'  =>  2,
-                ),
-            ),
-        );
+        $data = [
+            'id' => $pid,
+            'addons' => [
+                5 => [
+                    'selected' => 1,
+                    'period' => '1W',
+                    'quantity' => 2,
+                ],
+            ],
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Selected billing period is invalid for the selected addon');
 
         $bool = $this->api_guest->cart_add_item($data);
     }
 
-    public function testAddAddons_MissingPeriodParameter()
+    public function testAddAddonsMissingPeriodParameter()
     {
         $this->api_guest->cart_reset();
         $pid = 1;
-        $data = array(
-            'id'        => $pid,
-            'addons'    => array(
-                5  =>  array(
-                    'selected'  =>  1,
-                    'quantity'  =>  2,
-                ),
-            ),
-        );
+        $data = [
+            'id' => $pid,
+            'addons' => [
+                5 => [
+                    'selected' => 1,
+                    'quantity' => 2,
+                ],
+            ],
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Addon period parameter not passed');
 
         $bool = $this->api_guest->cart_add_item($data);
     }
 
-    public function testAddAddons_AddonNotFoundById()
+    public function testAddAddonsAddonNotFoundById()
     {
         $this->api_guest->cart_reset();
         $pid = 1;
-        $data = array(
-            'id'        => $pid,
-            'addons'    => array(
-                31  =>  array(
-                    'selected'  =>  1,
-                    'quantity'  =>  2,
-                ),
-            ),
-        );
+        $data = [
+            'id' => $pid,
+            'addons' => [
+                31 => [
+                    'selected' => 1,
+                    'quantity' => 2,
+                ],
+            ],
+        ];
         $return = $this->api_guest->cart_add_item($data);
 
         $this->assertTrue($return);
@@ -130,10 +131,10 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  17,
-            'period'    =>  '1W',
-        );
+        $data = [
+            'id' => 17,
+            'period' => '1W',
+        ];
         $this->api_guest->cart_add_item($data);
     }
 
@@ -141,13 +142,13 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'                    =>  10,
-            'action'                =>  'register',
-            'register_tld'          =>  '.com',
-            'register_sld'          =>  'mytestdomain',
-            'register_years'        =>  5,
-        );
+        $data = [
+            'id' => 10,
+            'action' => 'register',
+            'register_tld' => '.com',
+            'register_sld' => 'mytestdomain',
+            'register_years' => 5,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
     }
@@ -156,13 +157,13 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'                    =>  10,
-            'action'                =>  'transfer',
-            'transfer_tld'          =>  '.com',
-            'transfer_sld'          =>  'domaintotransfer',
-            'transfer_code'         =>  5,
-        );
+        $data = [
+            'id' => 10,
+            'action' => 'transfer',
+            'transfer_tld' => '.com',
+            'transfer_sld' => 'domaintotransfer',
+            'transfer_code' => 5,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
@@ -176,25 +177,25 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  6,
-            'period'    =>  '3M',
-        );
+        $data = [
+            'id' => 6,
+            'period' => '3M',
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testAddDownloadableProduct()
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  7,
-        );
+        $data = [
+            'id' => 7,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
     }
-    
+
     /* @TODO: Handle tests for external modules better
     public function testAddSolusvmProduct()
     {
@@ -218,55 +219,55 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  9,
-            'period'        =>  '1Y',
-            'domain'    =>  array(
-                'action'=>  'register',
-                'register_years'=>  2,
-                'register_tld'=>  '.com',
-                'register_sld'=>  'resellerdomain',
-            ),
-        );
+        $data = [
+            'id' => 9,
+            'period' => '1Y',
+            'domain' => [
+                'action' => 'register',
+                'register_years' => 2,
+                'register_tld' => '.com',
+                'register_sld' => 'resellerdomain',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testAddHostingProductWithDomainRegistration()
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  8,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'register',
-                'register_years'=>  2,
-                'register_tld'=>  '.com',
-                'register_sld'=>  'example',
-            ),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'register',
+                'register_years' => 2,
+                'register_tld' => '.com',
+                'register_sld' => 'example',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
         $cart = $this->api_guest->cart_get();
         $this->assertTrue(count($cart['items']) == 2);
     }
-    
+
     public function testAddHostingProductWithFreeDomainRegistration()
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  11,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'register',
-                'register_years'=>  2,
-                'register_tld'=>  '.com',
-                'register_sld'=>  'example',
-            ),
-        );
+        $data = [
+            'id' => 11,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'register',
+                'register_years' => 2,
+                'register_tld' => '.com',
+                'register_sld' => 'example',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
@@ -274,21 +275,21 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
         $this->assertTrue($cart['items'][1]['free_domain']);
         $this->assertEquals(10, $cart['items'][1]['discount'], 'Could not set free domain for hosting product');
     }
-    
+
     public function testAddHostingProductWithFreeDomainTransfer()
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  11,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'transfer',
-                'transfer_code'=>  '123',
-                'transfer_tld'=>  '.com',
-                'transfer_sld'=>  'example',
-            ),
-        );
+        $data = [
+            'id' => 11,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'transfer',
+                'transfer_code' => '123',
+                'transfer_tld' => '.com',
+                'transfer_sld' => 'example',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
@@ -301,16 +302,16 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  8,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'transfer',
-                'transfer_code'=>  2,
-                'transfer_tld'=>  '.com',
-                'transfer_sld'=>  'example',
-            ),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'transfer',
+                'transfer_code' => 2,
+                'transfer_tld' => '.com',
+                'transfer_sld' => 'example',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
@@ -322,15 +323,15 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  8,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'owndomain',
-                'owndomain_tld'=>  '.com',
-                'owndomain_sld'=>  'exist',
-            ),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'owndomain',
+                'owndomain_tld' => '.com',
+                'owndomain_sld' => 'exist',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
     }
@@ -339,15 +340,15 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        =>  8,
-            'period'    =>  '3M',
-            'domain'    =>  array(
-                'action'=>  'owndomain',
-                'owndomain_tld'=>  '.com',
-                'owndomain_sld'=>  'example',
-            ),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '3M',
+            'domain' => [
+                'action' => 'owndomain',
+                'owndomain_tld' => '.com',
+                'owndomain_sld' => 'example',
+            ],
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
@@ -357,22 +358,22 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
 
     public function testFreeSetupPromo()
     {
-        $this->api_admin->currency_set_default(array('code'=>'USD'));
+        $this->api_admin->currency_set_default(['code' => 'USD']);
         $this->api_guest->cart_reset();
-        $this->api_guest->cart_set_currency(array('currency'=>'USD'));
+        $this->api_guest->cart_set_currency(['currency' => 'USD']);
 
         // test custom products
-        $data = array(
-            'id'       =>  13,
-            'quantity'  =>  1,
-        );
+        $data = [
+            'id' => 13,
+            'quantity' => 1,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
         $cart_before_promo = $this->api_guest->cart_get();
         $this->assertNull($cart_before_promo['promocode']);
 
-        $data = array('promocode'=>'FREE_SETUP');
+        $data = ['promocode' => 'FREE_SETUP'];
         $bool = $this->api_guest->cart_apply_promo($data);
         $this->assertTrue($bool);
 
@@ -383,32 +384,32 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
         $this->assertEquals(20, $cart_after_promo['items'][0]['discount']);
 
         $result = $this->api_client->cart_checkout();
-        $order = $this->api_client->order_get(array('id'=>$result['order_id']));
+        $order = $this->api_client->order_get(['id' => $result['order_id']]);
         $this->assertEquals(2, $order['promo_id']);
 
-        $invoice = $this->api_client->invoice_get(array('hash'=>$result['invoice_hash']));
+        $invoice = $this->api_client->invoice_get(['hash' => $result['invoice_hash']]);
 
         $this->assertEquals(50, $invoice['total']); // normal price
         $this->assertEquals(50, $invoice['lines'][0]['price']); // normal price
         $this->assertEquals(0, $invoice['lines'][1]['price']); // setup price
     }
-    
+
     public function testApplyPromo()
     {
         $this->api_guest->cart_reset();
 
         // test custom products
-        $data = array(
-            'id'       =>  1,
-            'type'      =>  'custom',
-            'period'    =>  '1M',
-            'quantity'  =>  1,
-        );
+        $data = [
+            'id' => 1,
+            'type' => 'custom',
+            'period' => '1M',
+            'quantity' => 1,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
         $cart_before_promo = $this->api_guest->cart_get();
-        $data = array('promocode'=>'PHPUNIT');
+        $data = ['promocode' => 'PHPUNIT'];
         $bool = $this->api_guest->cart_apply_promo($data);
         $this->assertTrue($bool);
 
@@ -422,8 +423,8 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     public function testRemoveItem()
     {
         $cart = $this->api_guest->cart_get();
-        foreach($cart['items'] as $item) {
-            $bool = $this->api_guest->cart_remove_item(array('id'=>$item['id']));
+        foreach ($cart['items'] as $item) {
+            $bool = $this->api_guest->cart_remove_item(['id' => $item['id']]);
             $this->assertTrue($bool);
         }
     }
@@ -432,32 +433,30 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
     {
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'id'        => 1,
-            'multiple' => true
-        );
+        $data = [
+            'id' => 1,
+            'multiple' => true,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $cart = $this->api_guest->cart_get();
 
         $this->assertEquals(1, count($cart['items']));
 
-
-        $data = array(
-            'id'        => 2,
+        $data = [
+            'id' => 2,
             'multiple' => true,
-            'addons'    => array(
-                3  =>  array(
-                    'selected'  =>  1,
-                    'period'    =>  '1Y',
-                    'quantity'  =>  2,
-                ),
-                4  =>  array(
-                    'selected'  =>  1,
-                    'period'    =>  '1Y',
-                ),
-            ),
-        );
-
+            'addons' => [
+                3 => [
+                    'selected' => 1,
+                    'period' => '1Y',
+                    'quantity' => 2,
+                ],
+                4 => [
+                    'selected' => 1,
+                    'period' => '1Y',
+                ],
+            ],
+        ];
 
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
@@ -466,96 +465,92 @@ class Box_Mod_Cart_Api_GuestTest extends BBDbApiTestCase
 
         $this->assertEquals(4, count($cart['items']));
 
-        $this->api_guest->cart_remove_item(array('id'=> $cart['items'][1]['id'])); //removing second item from cart. Should remove it's addons as well
+        $this->api_guest->cart_remove_item(['id' => $cart['items'][1]['id']]); // removing second item from cart. Should remove it's addons as well
         $cart = $this->api_guest->cart_get();
 
         $this->assertEquals(1, count($cart['items']));
-
     }
-    
+
     public function testMultiple()
     {
         $res = $this->api_admin->invoice_get_list();
         $this->assertEquals(0, $res['total'], 'Invoice exists in fixture?');
-        
+
         $this->api_guest->cart_reset();
-        
-        $data = array(
-            'id'       =>  1,
-            'type'      =>  'custom',
-            'period'    =>  '1M',
-            'quantity'  =>  2,
-            'multiple'  =>  true,
-        );
+
+        $data = [
+            'id' => 1,
+            'type' => 'custom',
+            'period' => '1M',
+            'quantity' => 2,
+            'multiple' => true,
+        ];
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
-        
+
         $cart = $this->api_guest->cart_get();
         $this->assertEquals(2, count($cart['items']));
-        
+
         $res = $this->api_client->cart_checkout();
-        
-        //one invoice for two products after checkout
+
+        // one invoice for two products after checkout
         $res = $this->api_admin->invoice_get_list();
         $this->assertEquals(1, $res['total'], 'Generated more than one invoice');
     }
 
-
     public static function testApplyPromoForClientProvider()
     {
-        $ids = array(1, 2);
+        $ids = [1, 2];
 
-        return array(
-            array(50, 5, $ids, true), //should throw exception because client group does not match ones set in Promo
-            array(50, 2, $ids, false),//Client group ID is same as set for Promo, su discount must be applied
-            array(50, 5, array(), false),//Promo does not have any client group set, so it is valid for any client and should apply discount
-            array(50, null, array(), false),//Client group ID is not set and there are no group IDs in Promo, should apply discount
-            array(50, null, $ids, true),//Client group ID is not set however there are group IDs in Promo, should throw an exception
-        );
+        return [
+            [50, 5, $ids, true], // should throw exception because client group does not match ones set in Promo
+            [50, 2, $ids, false], // Client group ID is same as set for Promo, su discount must be applied
+            [50, 5, [], false], // Promo does not have any client group set, so it is valid for any client and should apply discount
+            [50, null, [], false], // Client group ID is not set and there are no group IDs in Promo, should apply discount
+            [50, null, $ids, true], // Client group ID is not set however there are group IDs in Promo, should throw an exception
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('testApplyPromoForClientProvider')]
     public function testApplyPromoForClient($discount, $clientGroupId, $ids, $shouldThrowException)
     {
         if ($shouldThrowException) {
-            $this->expectException(\FOSSBilling\Exception::class);
+            $this->expectException(FOSSBilling\Exception::class);
         }
         $this->api_guest->cart_reset();
 
-        $data = array(
-            'code'          => '50OFF',
-            'type'          => 'percentage',
-            'value'         => $discount,
-            'active'        => 1,
-            'client_groups' => $ids
-        );
-        $id   = $this->api_admin->product_promo_create($data);
+        $data = [
+            'code' => '50OFF',
+            'type' => 'percentage',
+            'value' => $discount,
+            'active' => 1,
+            'client_groups' => $ids,
+        ];
+        $id = $this->api_admin->product_promo_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $client                  = $this->di['loggedin_client'];
+        $client = $this->di['loggedin_client'];
         $client->client_group_id = $clientGroupId;
 
-        $data = array(
-            'id'       => 1,
-            'type'     => 'custom',
-            'period'   => '1M',
+        $data = [
+            'id' => 1,
+            'type' => 'custom',
+            'period' => '1M',
             'quantity' => 1,
-        );
+        ];
 
         $bool = $this->api_guest->cart_add_item($data);
         $this->assertTrue($bool);
 
         $cart_before_promo = $this->api_guest->cart_get();
-        $data              = array('promocode' => '50OFF');
-        $bool              = $this->api_guest->cart_apply_promo($data);
+        $data = ['promocode' => '50OFF'];
+        $bool = $this->api_guest->cart_apply_promo($data);
         $this->assertTrue($bool);
 
         $cart_after_promo = $this->api_guest->cart_get();
-        $this->assertTrue($cart_before_promo['total'] - ($cart_before_promo['total'] * $discount / 100) == $cart_after_promo['total'], 'Could not apply promo to cart');
-
+        $this->assertTrue($cart_after_promo['total'] == $cart_before_promo['total'] - ($cart_before_promo['total'] * $discount / 100), 'Could not apply promo to cart');
     }
-
 }

--- a/tests/integration/bb-modules/mod_client/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_client/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ClientTest extends BBDbApiTestCase
 {
@@ -6,12 +7,12 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
 
     public function testClient()
     {
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->client_get($data);
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->client_login($data);
         $this->assertIsArray($array);
 
@@ -21,7 +22,7 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
         $data['status'] = 'active';
         $bool = $this->api_admin->client_update($data);
         $this->assertTrue($bool);
-        
+
         $data['password'] = 'new';
         $data['password_confirm'] = 'new';
         $bool = $this->api_admin->client_change_password($data);
@@ -30,92 +31,91 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
         $array = $this->api_admin->client_get_statuses($data);
         $this->assertIsArray($array);
 
-        $bool = $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit'));
+        $bool = $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit']);
         $this->assertTrue($bool);
 
         $array = $this->api_admin->client_balance_get_list($data);
         $this->assertIsArray($array);
         $this->assertEquals(count($array['list']), 1);
 
-        $bool = $this->api_admin->client_balance_delete(array('id' => 1));
+        $bool = $this->api_admin->client_balance_delete(['id' => 1]);
         $this->assertTrue($bool);
 
         $array = $this->api_admin->client_balance_get_list($data);
         $this->assertIsArray($array);
         $this->assertEquals(count($array['list']), 0);
-        
-        
-        $data = array(
-            'id'    => 1,
-        );
+
+        $data = [
+            'id' => 1,
+        ];
         $bool = $this->api_admin->client_login_history_delete($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->client_batch_expire_password_reminders();
         $this->assertTrue($bool);
     }
 
     public function testGetPairs()
     {
-        $data = array(
-            'search'    =>  'de',
-        );
+        $data = [
+            'search' => 'de',
+        ];
 
         $array = $this->api_admin->client_get_pairs($data);
         $this->assertIsArray($array);
     }
-    
+
     public function testGroups()
     {
-        $data = array(
-            'title'    =>  'testers',
-        );
+        $data = [
+            'title' => 'testers',
+        ];
 
         $id = $this->api_admin->client_group_create($data);
         $this->assertTrue(is_numeric($id));
-        
+
         $data['id'] = $id;
         $bool = $this->api_admin->client_group_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_admin->client_group_get($data);
         $this->assertIsArray($array);
 
         $array = $this->api_admin->client_group_get_pairs($data);
         $this->assertIsArray($array);
-        
+
         $bool = $this->api_admin->client_group_delete($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testGet()
     {
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->client_get($data);
         $this->assertIsArray($array);
         $this->assertNull($array['auth_type']);
     }
-    
+
     public function testCreate()
     {
-        $data = array(
-            'email'    =>  'tester@gmail.com',
-            'first_name'    =>  'Client',
-            'password'    =>  'password',
-        );
+        $data = [
+            'email' => 'tester@gmail.com',
+            'first_name' => 'Client',
+            'password' => 'password',
+        ];
 
         $id = $this->api_admin->client_create($data);
         $this->assertTrue($id > 1);
-        
-        $bool = $this->api_admin->client_delete(array('id'=>$id));
+
+        $bool = $this->api_admin->client_delete(['id' => $id]);
         $this->assertTrue($bool);
     }
 
     public function testLoginHistoryGetList()
     {
-        $array = $this->api_admin->client_login_history_get_list(array());
+        $array = $this->api_admin->client_login_history_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -140,7 +140,7 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
 
     public function testClientGetList()
     {
-        $array = $this->api_admin->client_get_list(array());
+        $array = $this->api_admin->client_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -185,10 +185,10 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
 
     public function testClientBalanceGetList()
     {
-        $bool = $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit'));
+        $bool = $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit']);
         $this->assertTrue($bool);
 
-        $array = $this->api_admin->client_balance_get_list(array());
+        $array = $this->api_admin->client_balance_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -207,29 +207,29 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
     public function testClientBatchDelete()
     {
         $id = $this->api_admin->client_create(
-            array(
-                'email'      => 'tester@gmail.com',
+            [
+                'email' => 'tester@gmail.com',
                 'first_name' => 'Client',
-                'password'   => 'password',
-            ));
+                'password' => 'password',
+            ]);
 
         $id2 = $this->api_admin->client_create(
-            array(
-                'email'      => 'tester2@gmail.com',
+            [
+                'email' => 'tester2@gmail.com',
                 'first_name' => 'Client',
-                'password'   => 'password',
-            ));
+                'password' => 'password',
+            ]);
         $id3 = $this->api_admin->client_create(
-            array(
-                'email'      => 'tester3@gmail.com',
+            [
+                'email' => 'tester3@gmail.com',
                 'first_name' => 'Client',
-                'password'   => 'password',
-            ));
+                'password' => 'password',
+            ]);
 
-        $array  = $this->api_admin->client_get_list(array());
-        $count  = count($array['list']);
-        $result = $this->api_admin->client_batch_delete(array('ids' => array($id, $id2, $id3)));
-        $array  = $this->api_admin->client_get_list(array());
+        $array = $this->api_admin->client_get_list([]);
+        $count = count($array['list']);
+        $result = $this->api_admin->client_batch_delete(['ids' => [$id, $id2, $id3]]);
+        $array = $this->api_admin->client_get_list([]);
 
         $this->assertEquals($count - 3, count($array['list']));
         $this->assertTrue($result);
@@ -237,11 +237,11 @@ class Api_Admin_ClientTest extends BBDbApiTestCase
 
     public function testClientBatchDeleteLog()
     {
-        $this->api_admin->client_login(array('id' => 1));
-        $array = $this->api_admin->client_login_history_get_list(array());
+        $this->api_admin->client_login(['id' => 1]);
+        $array = $this->api_admin->client_login_history_get_list([]);
 
-        $result = $this->api_admin->client_batch_delete_log(array('ids' => array($array['list'][0])));
-        $array = $this->api_admin->client_login_history_get_list(array());
+        $result = $this->api_admin->client_batch_delete_log(['ids' => [$array['list'][0]]]);
+        $array = $this->api_admin->client_login_history_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);

--- a/tests/integration/bb-modules/mod_client/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_client/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_ClientTest extends BBDbApiTestCase
 {
@@ -6,11 +7,10 @@ class Api_ClientTest extends BBDbApiTestCase
 
     public function testClient()
     {
-
         $array = $this->api_client->client_get();
         $this->assertIsArray($array);
 
-        $data = array(
+        $data = [
             'email' => 'newEmail@fossbilling.org',
             'first_name' => 'John',
             'last_name' => 'Doe',
@@ -22,33 +22,32 @@ class Api_ClientTest extends BBDbApiTestCase
             'country' => 'USA',
             'currency' => 'USD',
             'postcode' => 123456,
-            'api_token'=> 'phpunit_token'
-        );
+            'api_token' => 'phpunit_token',
+        ];
         $bool = $this->api_client->client_update($data);
         $this->assertTrue($bool);
 
-        $key = $this->api_client->client_api_key_get(array());
+        $key = $this->api_client->client_api_key_get([]);
         $this->assertIsString($key);
 
-        $newKey = $this->api_client->client_api_key_reset(array());
+        $newKey = $this->api_client->client_api_key_reset([]);
         $this->assertIsString($newKey);
         $this->assertNotEquals($key, $newKey);
 
-        $data = array(
+        $data = [
             'password' => 'newPa55word',
-            'password_confirm' => 'newPa55word'
-        );
+            'password_confirm' => 'newPa55word',
+        ];
         $bool = $this->api_client->client_change_password($data);
         $this->assertTrue($bool);
 
         $array = $this->api_client->client_balance_get_list($data);
         $this->assertIsArray($array);
-
     }
 
     public function testClientBalanceGetList()
     {
-        $array = $this->api_client->client_balance_get_list(array());
+        $array = $this->api_client->client_balance_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -61,9 +60,6 @@ class Api_ClientTest extends BBDbApiTestCase
             $this->assertArrayHasKey('amount', $item);
             $this->assertArrayHasKey('currency', $item);
             $this->assertArrayHasKey('created_at', $item);
-
         }
     }
-
-
 }

--- a/tests/integration/bb-modules/mod_client/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_client/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_ClientTest extends BBDbApiTestCase
 {
@@ -6,28 +7,28 @@ class Api_Guest_ClientTest extends BBDbApiTestCase
 
     public function testCreate()
     {
-        $this->api_admin->extension_config_save(array(
+        $this->api_admin->extension_config_save([
             'ext' => 'mod_client',
-            'required' => array(),
-        ));
+            'required' => [],
+        ]);
 
-        $e = random_int(5, 56666).'@gmail.com';
+        $e = random_int(5, 56666) . '@gmail.com';
         $pass = 'testA1sssss';
 
-        $data = array(
-            'aid'               =>  '2',
-            'email'             =>  $e,
-            'first_name'        =>  'John',
-            'last_name'         =>  'Doe',
-            'address_1'         =>  'Palo Alto',
-            'country'           =>  'USA',
-            'company_vat'       =>  'LS-2qwddwqdsd12',
-            'city'              =>  'California',
-            'tel_cc'            =>  '211',
-            'phone'             =>  '11212156485451',
-            'password'          =>  $pass,
-            'password_confirm'  =>  $pass,
-        );
+        $data = [
+            'aid' => '2',
+            'email' => $e,
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => 'Palo Alto',
+            'country' => 'USA',
+            'company_vat' => 'LS-2qwddwqdsd12',
+            'city' => 'California',
+            'tel_cc' => '211',
+            'phone' => '11212156485451',
+            'password' => $pass,
+            'password_confirm' => $pass,
+        ];
         $id = $this->api_guest->client_create($data);
         $this->assertIsInt($id);
         $client = $this->di['db']->load('Client', $id);
@@ -41,61 +42,61 @@ class Api_Guest_ClientTest extends BBDbApiTestCase
      */
     public function testRequiredFields()
     {
-        $this->api_admin->extension_config_save(array(
+        $this->api_admin->extension_config_save([
             'ext' => 'mod_client',
-            'required' => array(
-                'last_name'
-            ),
-        ));
+            'required' => [
+                'last_name',
+            ],
+        ]);
 
         $pass = 'testA222sssww';
-        $data = array(
-            'email'             =>  'test@example.com',
-            'first_name'        =>  'John',
-            'password'          =>  $pass,
-            'password_confirm'  =>  $pass,
-        );
+        $data = [
+            'email' => 'test@example.com',
+            'first_name' => 'John',
+            'password' => $pass,
+            'password_confirm' => $pass,
+        ];
         $id = $this->api_guest->client_create($data);
     }
 
     public function testPasswordReset()
     {
-        $data = array(
-            'email' =>  'client@fossbilling.org',
-        );
+        $data = [
+            'email' => 'client@fossbilling.org',
+        ];
         $bool = $this->api_guest->client_reset_password($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'hash' =>  'hash',
-        );
+        $data = [
+            'hash' => 'hash',
+        ];
         $bool = $this->api_guest->client_confirm_reset($data);
         $this->assertTrue($bool);
     }
 
     public function testVat()
     {
-        $data = array(
-            'country'   => 'GB',
-            'vat'       => 'GB999 9999 73',
-        );
+        $data = [
+            'country' => 'GB',
+            'vat' => 'GB999 9999 73',
+        ];
         $bool = $this->api_guest->client_is_vat($data);
-        //$this->assertTrue($bool);
+        // $this->assertTrue($bool);
     }
-    
+
     public function testClientLogin()
     {
-        $data = array(
-            'email'     =>  'client@fossbilling.org',
-            'password'  =>  'demo',
-        );
+        $data = [
+            'email' => 'client@fossbilling.org',
+            'password' => 'demo',
+        ];
         $array = $this->api_guest->client_login($data);
         $this->assertIsArray($array);
         $this->assertTrue(is_numeric($this->session->get('client_id')), 'Client id is not integer');
 
         $bool = $this->api_client->client_logout($data);
         $this->assertNull($this->session->get('client_id'));
-                
+
         $this->assertTrue($bool);
         $this->assertNull($this->session->get('admin'));
     }
@@ -108,41 +109,39 @@ class Api_Guest_ClientTest extends BBDbApiTestCase
 
     public function testCreateWithCustom()
     {
-        $this->api_admin->extension_config_save(array(
-            'ext'           => 'mod_client',
-            'required'      => array(
-                'last_name'
-            ),
-            'custom_fields' => array(
-                'custom_5' => array(
-                    'active'   => true,
+        $this->api_admin->extension_config_save([
+            'ext' => 'mod_client',
+            'required' => [
+                'last_name',
+            ],
+            'custom_fields' => [
+                'custom_5' => [
+                    'active' => true,
                     'required' => true,
-                    'title'    => 'Your username'
-                )
-            )
-        ));
+                    'title' => 'Your username',
+                ],
+            ],
+        ]);
 
-
-        $e    = random_int(5, 56666) . '@gmail.com';
+        $e = random_int(5, 56666) . '@gmail.com';
         $pass = 'testA1sssss';
 
-        $data = array(
-            'aid'              => '2',
-            'email'            => $e,
-            'first_name'       => 'John',
-            'last_name'        => 'Doe',
-            'address_1'        => 'Palo Alto',
-            'country'          => 'USA',
-            'company_vat'      => 'LS-2qwddwqdsd12',
-            'city'             => 'California',
-            'tel_cc'           => '211',
-            'phone'            => '11212156485451',
-            'password'         => $pass,
+        $data = [
+            'aid' => '2',
+            'email' => $e,
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => 'Palo Alto',
+            'country' => 'USA',
+            'company_vat' => 'LS-2qwddwqdsd12',
+            'city' => 'California',
+            'tel_cc' => '211',
+            'phone' => '11212156485451',
+            'password' => $pass,
             'password_confirm' => $pass,
-            'custom_5'         => 'JohnUsername'
-
-        );
-        $id   = $this->api_guest->client_create($data);
+            'custom_5' => 'JohnUsername',
+        ];
+        $id = $this->api_guest->client_create($data);
         $this->assertIsInt($id);
         $client = $this->di['db']->load('Client', $id);
 
@@ -154,38 +153,37 @@ class Api_Guest_ClientTest extends BBDbApiTestCase
      */
     public function testCreateWithCustomRequiredException()
     {
-        $this->api_admin->extension_config_save(array(
-            'ext'           => 'mod_client',
-            'required'      => array(
-                'last_name'
-            ),
-            'custom_fields' => array(
-                'custom_5' => array(
-                    'active'   => true,
+        $this->api_admin->extension_config_save([
+            'ext' => 'mod_client',
+            'required' => [
+                'last_name',
+            ],
+            'custom_fields' => [
+                'custom_5' => [
+                    'active' => true,
                     'required' => true,
-                    'title'    => 'Your username'
-                )
-            )
-        ));
+                    'title' => 'Your username',
+                ],
+            ],
+        ]);
 
-        $e    = random_int(5, 56666) . '@gmail.com';
+        $e = random_int(5, 56666) . '@gmail.com';
         $pass = 'testA1sssss';
 
-        $data = array(
-            'aid'              => '2',
-            'email'            => $e,
-            'first_name'       => 'John',
-            'last_name'        => 'Doe',
-            'address_1'        => 'Palo Alto',
-            'country'          => 'USA',
-            'company_vat'      => 'LS-2qwddwqdsd12',
-            'city'             => 'California',
-            'tel_cc'           => '211',
-            'phone'            => '11212156485451',
-            'password'         => $pass,
+        $data = [
+            'aid' => '2',
+            'email' => $e,
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => 'Palo Alto',
+            'country' => 'USA',
+            'company_vat' => 'LS-2qwddwqdsd12',
+            'city' => 'California',
+            'tel_cc' => '211',
+            'phone' => '11212156485451',
+            'password' => $pass,
             'password_confirm' => $pass,
-
-        );
-        $id   = $this->api_guest->client_create($data);
+        ];
+        $id = $this->api_guest->client_create($data);
     }
 }

--- a/tests/integration/bb-modules/mod_client/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_client/ServiceTest.php
@@ -1,24 +1,25 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Client_ServiceTest extends ApiTestCase
 {
     public function testEvents()
     {
-        $service = new \Box\Mod\Client\Service();
+        $service = new Box\Mod\Client\Service();
         $service->setDi($this->di);
-        $params = array(
+        $params = [
             'id' => 1,
             'password' => 'qwerty123',
-        );
+        ];
         $event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
         $bool = $service->onAfterClientSignUp($event);
         $this->assertTrue($bool);
     }
 
- public function testGenerateEmailConfirmationLink()
+    public function testGenerateEmailConfirmationLink()
     {
-        $service = new \Box\Mod\Client\Service();
+        $service = new Box\Mod\Client\Service();
         $service->setDi($this->di);
         $link = $service->generateEmailConfirmationLink(1);
         $this->assertIsString($link);
@@ -27,78 +28,78 @@ class Box_Mod_Client_ServiceTest extends ApiTestCase
 
     public function testRemove()
     {
-        //We have a client
-        $data = array(
-            'email'    =>  'tester@gmail.com',
-            'first_name'    =>  'Client',
-            'password'    =>  'password',
-        );
+        // We have a client
+        $data = [
+            'email' => 'tester@gmail.com',
+            'first_name' => 'Client',
+            'password' => 'password',
+        ];
 
         $id = $this->api_admin->client_create($data);
         $this->assertTrue($id > 1);
 
-        //Client has license orders
-        $data['client_id']      = $id;
-        $data['product_id']     = 6;
-        $data['period']         = '1M';
+        // Client has license orders
+        $data['client_id'] = $id;
+        $data['product_id'] = 6;
+        $data['period'] = '1M';
         $data['invoice_option'] = 'issue-invoice';
         $data['activate'] = 1;
-        $data['config'] = array();
+        $data['config'] = [];
 
         $orderId = $this->api_admin->order_create($data);
         $this->assertIsInt($orderId);
 
-        //Client has invoice with items for order
-        $invoiceModel = $this->di['db']->findOne('Invoice', 'client_id = ?', array($id));
+        // Client has invoice with items for order
+        $invoiceModel = $this->di['db']->findOne('Invoice', 'client_id = ?', [$id]);
         $this->assertInstanceOf('Model_Invoice', $invoiceModel);
 
-        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', array($invoiceModel->id));
-        $this->assertInstanceOf('Model_InvoiceItem', $invoiceItemModel );
+        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', [$invoiceModel->id]);
+        $this->assertInstanceOf('Model_InvoiceItem', $invoiceItemModel);
 
-        //Client has amount in balance
-        $bool = $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit'));
+        // Client has amount in balance
+        $bool = $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => 100, 'description' => 'Added from PHPUnit']);
         $this->assertTrue($bool);
 
-        //Client has activity history
+        // Client has activity history
         $log = $this->di['db']->dispense('ActivityClientHistory');
-        $log->client_id       = $id;
-        $log->ip              = '10.0.0.1';
-        $log->created_at      = date('Y-m-d H:i:s');
-        $log->updated_at      = date('Y-m-d H:i:s');
+        $log->client_id = $id;
+        $log->ip = '10.0.0.1';
+        $log->created_at = date('Y-m-d H:i:s');
+        $log->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($log);
 
-        //Client has email activity
+        // Client has email activity
         $entry = $this->di['db']->dispense('ActivityClientEmail');
-        $entry->client_id    = $id;
-        $entry->created_at   = date('Y-m-d H:i:s');
-        $entry->updated_at   = date('Y-m-d H:i:s');
+        $entry->client_id = $id;
+        $entry->created_at = date('Y-m-d H:i:s');
+        $entry->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($entry);
 
-        //Client has system activity
+        // Client has system activity
         $systemEntry = $this->di['db']->dispense('ActivitySystem');
-        $systemEntry->client_id       = $id;
-        $systemEntry->message         = 'PHP UNIT TEST';
-        $systemEntry->created_at      = date('Y-m-d H:i:s');
-        $systemEntry->updated_at      = date('Y-m-d H:i:s');
+        $systemEntry->client_id = $id;
+        $systemEntry->message = 'PHP UNIT TEST';
+        $systemEntry->created_at = date('Y-m-d H:i:s');
+        $systemEntry->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($systemEntry);
 
-        //Client has passwordReset record
+        // Client has passwordReset record
         $r = $this->di['db']->dispense('ClientPasswordReset');
-        $r->client_id   = $id;
-        $r->ip          = '10.0.0.1';
-        $r->hash        = sha1(random_int(50, random_int(10, 99)));
-        $r->created_at  = date('Y-m-d H:i:s');
-        $r->updated_at  = date('Y-m-d H:i:s');
+        $r->client_id = $id;
+        $r->ip = '10.0.0.1';
+        $r->hash = sha1(random_int(50, random_int(10, 99)));
+        $r->created_at = date('Y-m-d H:i:s');
+        $r->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($r);
 
         $clientModel = $this->di['db']->load('Client', $id);
         $this->assertInstanceOf('Model_Client', $clientModel);
 
-        $service = new \Box\Mod\Client\Service();
+        $service = new Box\Mod\Client\Service();
         $service->setDi($this->di);
         $service->remove($clientModel);
 
-        //Removed items from Db
+        // Removed items from Db
         $model = $this->di['db']->load('ClientOrder', $orderId);
         $this->assertNull($model);
         $model = $this->di['db']->load('Invoice', $invoiceModel->id);
@@ -113,12 +114,9 @@ class Box_Mod_Client_ServiceTest extends ApiTestCase
         $this->assertNull($model);
         $model = $this->di['db']->load('ClientPasswordReset', $r->id);
         $this->assertNull($model);
-        $model = $this->di['db']->find('ClientBalance', 'client_id = ?', array($clientModel->id));
+        $model = $this->di['db']->find('ClientBalance', 'client_id = ?', [$clientModel->id]);
         $this->assertEmpty($model);
         $model = $this->di['db']->findOne('Client', $clientModel->id);
         $this->assertNull($model);
-
     }
-
-
 }

--- a/tests/integration/bb-modules/mod_cron/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_cron/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_AdminTest extends BBDbApiTestCase
 {
@@ -8,7 +9,7 @@ class Api_AdminTest extends BBDbApiTestCase
     {
         $array = $this->api_system->cron_info();
         $this->assertIsArray($array);
-        
+
         $bool = $this->api_system->cron_run();
         $this->assertTrue($bool);
     }

--- a/tests/integration/bb-modules/mod_currency/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_currency/Api_AdminTest.php
@@ -1,26 +1,27 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_CurrencyTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'currencies.xml';
-    
+
     public function testCurrencies()
     {
         $array = $this->api_admin->currency_get_pairs();
         $this->assertIsArray($array);
 
-        $array = $this->api_admin->currency_get(array('code' => 'USD'));
+        $array = $this->api_admin->currency_get(['code' => 'USD']);
         $this->assertIsArray($array);
         $this->assertEquals('USD', $array['code']);
 
         $array = $this->api_admin->currency_get_default();
         $this->assertIsArray($array);
 
-        $data = array(
-            'code'  =>    'GBP',
-            'title'  =>    'British Pound',
-            'format'  =>    '{{price}}£',
-        );
+        $data = [
+            'code' => 'GBP',
+            'title' => 'British Pound',
+            'format' => '{{price}}£',
+        ];
         $code = $this->api_admin->currency_create($data);
         $this->assertIsString($code);
 
@@ -29,7 +30,7 @@ class Api_Admin_CurrencyTest extends BBDbApiTestCase
 
         $bool = $this->api_admin->currency_delete($data);
         $this->assertTrue($bool);
-        
+
         $data['code'] = 'EUR';
         $bool = $this->api_admin->currency_set_default($data);
         $this->assertTrue($bool);
@@ -46,7 +47,7 @@ class Api_Admin_CurrencyTest extends BBDbApiTestCase
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
         $this->assertIsArray($list);
-        if (count($list)){
+        if (count($list)) {
             $item = $list[0];
             $this->assertArrayHasKey('code', $item);
             $this->assertArrayHasKey('title', $item);

--- a/tests/integration/bb-modules/mod_currency/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_currency/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_GuestTest extends BBDbApiTestCase
 {
@@ -6,16 +7,16 @@ class Api_GuestTest extends BBDbApiTestCase
 
     public function testFormat()
     {
-        $string = $this->api_guest->currency_format(array('price'=>'2'));
+        $string = $this->api_guest->currency_format(['price' => '2']);
         $this->assertEquals('$2.00', $string);
-        
-        $string = $this->api_guest->currency_format(array('price'=>'2', 'convert'=>0));
+
+        $string = $this->api_guest->currency_format(['price' => '2', 'convert' => 0]);
         $this->assertEquals('$2.00', $string);
-        
-        $string = $this->api_guest->currency_format(array('price'=>'1', 'code' => 'EUR', 'convert'=>0));
+
+        $string = $this->api_guest->currency_format(['price' => '1', 'code' => 'EUR', 'convert' => 0]);
         $this->assertEquals('1.00 EUR', $string);
-        
-        $string = $this->api_guest->currency_format(array('price'=>'1', 'code' => 'EUR', 'convert'=>1));
+
+        $string = $this->api_guest->currency_format(['price' => '1', 'code' => 'EUR', 'convert' => 1]);
         $this->assertEquals('0.75 EUR', $string);
     }
 
@@ -24,11 +25,11 @@ class Api_GuestTest extends BBDbApiTestCase
         $array = $this->api_guest->currency_get_pairs();
         $this->assertIsArray($array);
 
-        $array = $this->api_guest->currency_get(array('code'=>'usd'));
+        $array = $this->api_guest->currency_get(['code' => 'usd']);
         $this->assertIsArray($array);
         $this->assertEquals('USD', $array['code']);
 
-        $array = $this->api_guest->currency_get(array('code'=>'eur'));
+        $array = $this->api_guest->currency_get(['code' => 'eur']);
         $this->assertIsArray($array);
         $this->assertEquals('EUR', $array['code']);
     }

--- a/tests/integration/bb-modules/mod_email/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_email/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_AdminTest extends BBDbApiTestCase
 {
@@ -9,40 +10,40 @@ class Api_AdminTest extends BBDbApiTestCase
         $bool = $this->api_admin->email_batch_template_generate();
         $this->assertTrue($bool);
     }
-    
+
     public function testReset()
     {
-        $data = array(
-            'code'    =>  'mod_email_test',
-        );
+        $data = [
+            'code' => 'mod_email_test',
+        ];
         $bool = $this->api_admin->email_template_reset($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testTemplates()
     {
         $array = $this->api_admin->email_template_get_list();
         $this->assertIsArray($array);
-        
-        $data = array(
-            'id'    =>  1,
-        );
+
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->email_template_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'action_code'    =>  'test',
-            'subject'    =>  'test',
-            'enabled'    =>  1,
-            'content'    =>  'test',
-        );
+        $data = [
+            'action_code' => 'test',
+            'subject' => 'test',
+            'enabled' => 1,
+            'content' => 'test',
+        ];
         $id = $this->api_admin->email_template_create($data);
         $this->assertTrue($id > 0);
 
         $data['id'] = $id;
         $bool = $this->api_admin->email_template_update($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->email_template_delete($data);
         $this->assertTrue($bool);
     }
@@ -54,42 +55,42 @@ class Api_AdminTest extends BBDbApiTestCase
         $data['subject'] = $subject;
         $bool = $this->api_admin->email_template_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_admin->email_template_get($data);
         $this->assertEquals($subject, $array['subject']);
     }
-    
+
     public function testEmails()
     {
         $array = $this->api_admin->email_email_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->email_email_get($data);
         $this->assertIsArray($array);
     }
 
     public function testSend()
     {
-        $data = array(
-            'to'    =>  'demo@boxbiling.com',
-            'to_name'    =>  'Client name',
-            'from'    =>  'admin@fossbilling.org',
-            'from_name'    =>  'Admin',
-            'subject'    =>  'This is subject',
-            'content'    =>  'This is message',
-        );
+        $data = [
+            'to' => 'demo@boxbiling.com',
+            'to_name' => 'Client name',
+            'from' => 'admin@fossbilling.org',
+            'from_name' => 'Admin',
+            'subject' => 'This is subject',
+            'content' => 'This is message',
+        ];
         $bool = $this->api_admin->email_send($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testResend()
     {
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $bool = $this->api_admin->email_email_resend($data);
         $this->assertTrue($bool);
 
@@ -99,10 +100,10 @@ class Api_AdminTest extends BBDbApiTestCase
 
     public function testDelete()
     {
-        $data = array(
-            'id'    =>  1,
-        );
-        
+        $data = [
+            'id' => 1,
+        ];
+
         $bool = $this->api_admin->email_email_delete($data);
         $this->assertTrue($bool);
 
@@ -118,44 +119,43 @@ class Api_AdminTest extends BBDbApiTestCase
         $bool = $this->api_admin->email_batch_template_enable();
         $this->assertTrue($bool);
     }
-    
+
     public function testCheck()
     {
         $bool = $this->api_admin->email_send_test();
         $this->assertTrue($bool);
     }
-    
+
     public function testRender()
     {
-        $data = array(
-            'id'    =>  1,
-            '_tpl'    =>  '{{ now|date("Y") }}',
-        );
+        $data = [
+            'id' => 1,
+            '_tpl' => '{{ now|date("Y") }}',
+        ];
         $string = $this->api_admin->email_template_render($data);
         $this->assertEquals(date('Y'), $string);
     }
-    
+
     public function testTemplateGeneralSend()
     {
-        $params = array();
+        $params = [];
         $params['to'] = 'client@fossbilling.org';
         $params['to_name'] = 'Client PHPUnit';
-        
+
         $params['code'] = 'mod_client_signup';
-        
+
         $params['default_template'] = 'Hello, message from {{ admin.client_get({"id":client_id}).first_name }}, {{subject}}';
         $params['default_subject'] = 'My subject for client';
-        
+
         $params['client_id'] = 1;
-        
+
         $bool = $this->api_admin->email_template_send($params);
         $this->assertTrue($bool);
-
     }
 
-    public function testTemplate_populateVariables()
+    public function testTemplatePopulateVariables()
     {
-        $params = array();
+        $params = [];
         $params['to'] = 'client@fossbilling.org';
         $params['to_name'] = 'Client PHPUnit';
 
@@ -175,24 +175,24 @@ class Api_AdminTest extends BBDbApiTestCase
 
         $this->assertTrue(str_contains($emailModel->subject, $clientModel->first_name), 'Template variables were not populated');
     }
-    
+
     public function testSendToClient()
     {
-        $params = array();
+        $params = [];
         $params['to_client'] = 1;
         $params['code'] = 'mod_client_signup';
-        
+
         $bool = $this->api_admin->email_template_send($params);
         $this->assertTrue($bool);
     }
-    
+
     public function testSendToStaff()
     {
-        $params = array();
-        $params['to_staff']     = true;
-        $params['code']         = 'mod_staff_client_signup';
-        $params['client']       = $this->api_admin->client_get(array('id'=>1));
-        
+        $params = [];
+        $params['to_staff'] = true;
+        $params['code'] = 'mod_staff_client_signup';
+        $params['client'] = $this->api_admin->client_get(['id' => 1]);
+
         $bool = $this->api_admin->email_template_send($params);
         $this->assertTrue($bool);
     }
@@ -246,13 +246,13 @@ class Api_AdminTest extends BBDbApiTestCase
 
     public function testBatchDelete()
     {
-        $array = $this->api_admin->email_email_get_list(array());
+        $array = $this->api_admin->email_email_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->email_batch_delete(array('ids' => $ids));
-        $array  = $this->api_admin->email_email_get_list(array());
+        $result = $this->api_admin->email_batch_delete(['ids' => $ids]);
+        $array = $this->api_admin->email_email_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);

--- a/tests/integration/bb-modules/mod_email/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_email/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_EmailTest extends BBDbApiTestCase
 {
@@ -8,19 +9,19 @@ class Api_Client_EmailTest extends BBDbApiTestCase
     {
         $array = $this->api_client->email_get_list();
         $this->assertIsArray($array);
-        
-        $data = array(
-            'id'    =>  1,
-        );
+
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_client->email_get($data);
         $this->assertIsArray($array);
     }
 
     public function testResend()
     {
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $bool = $this->api_client->email_resend($data);
         $this->assertTrue($bool);
 
@@ -30,10 +31,10 @@ class Api_Client_EmailTest extends BBDbApiTestCase
 
     public function testDelete()
     {
-        $data = array(
-            'id'    =>  1,
-        );
-        
+        $data = [
+            'id' => 1,
+        ];
+
         $bool = $this->api_client->email_delete($data);
         $this->assertTrue($bool);
 

--- a/tests/integration/bb-modules/mod_example/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_example/Api_ClientTest.php
@@ -1,14 +1,15 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_ClientTest extends BBDbApiTestCase
 {
     protected $_mod = 'example';
     protected $_initialSeedFile = 'mod_example.xml';
-    
+
     public function testExample()
     {
-        $this->api_admin->extension_activate(array('id'=>'example', 'type'=>'mod'));
-        
+        $this->api_admin->extension_activate(['id' => 'example', 'type' => 'mod']);
+
         $array = $this->api_client->example_get_info();
         $this->assertIsArray($array);
     }

--- a/tests/integration/bb-modules/mod_example/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_example/ServiceTest.php
@@ -1,30 +1,33 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class ServiceTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'example.xml';
 
-    public function testUninstall(){
+    public function testUninstall()
+    {
         $service = new Box\Mod\Example\Service();
         $result = $service->uninstall();
         $this->assertTrue($result);
-   }
+    }
 
-    public function testUpdate(){
+    public function testUpdate()
+    {
         $service = new Box\Mod\Example\Service();
-        $result = $service->update(array());
+        $result = $service->update([]);
         $this->assertTrue($result);
-   }
+    }
 
     public function testGetSearchQuery()
     {
         $service = new Box\Mod\Example\Service();
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
         $service->setDi($di);
 
-        $data = array(
-            'client_id' => 1
-        );
+        $data = [
+            'client_id' => 1,
+        ];
         [$sql, $params] = $service->getSearchQuery($data);
         $this->assertIsString($sql);
         $this->assertIsArray($params);
@@ -35,20 +38,19 @@ class ServiceTest extends BBDbApiTestCase
     public function testEvents()
     {
         $service = new Box\Mod\Example\Service();
-        $params = array(
+        $params = [
             'ip' => '123.123.123.123',
-        );
+        ];
         $event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
 
         $result = $service->onEventClientLoginFailed($event);
         $this->assertNull($result);
 
-
-        $params = array(
+        $params = [
             'client_id' => 1,
-            'id' => 1
-        );
+            'id' => 1,
+        ];
         $event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
 

--- a/tests/integration/bb-modules/mod_extension/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_extension/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ExtensionTest extends BBDbApiTestCase
 {
@@ -6,33 +7,33 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
 
     public function testSetup()
     {
-        $data = array(
+        $data = [
             'code' => 'extension',
-        );
+        ];
 
         try {
-            //do not allow install core extension
+            // do not allow install core extension
             $bool = $this->api_admin->extension_mod_install($data);
             $this->fail('Core extension can not be installed');
         } catch (Box_Exception) {
-            $this->assertTrue(TRUE);
+            $this->assertTrue(true);
         }
 
         try {
-            //do not allow uninstall core extension
+            // do not allow uninstall core extension
             $bool = $this->api_admin->extension_mod_uninstall($data);
             $this->fail('Core extension can not be uninstalled');
         } catch (Box_Exception) {
-            $this->assertTrue(TRUE);
+            $this->assertTrue(true);
         }
     }
 
     public function testUninstall()
     {
-        $data = array(
-            'type'  =>  'mod',
-            'id'    =>  'news',
-        );
+        $data = [
+            'type' => 'mod',
+            'id' => 'news',
+        ];
         $bool = $this->api_admin->extension_uninstall($data);
 
         $this->assertTrue($bool);
@@ -40,28 +41,28 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
 
     public function testUpdate()
     {
-        $versions = array(
+        $versions = [
             'version_old' => '1.1.1',
             'version_new' => '2.2.2',
-        );
-        $extension =  new Model_Extension();
-        $extension->loadBean(new \RedBeanPHP\OODBBean());
+        ];
+        $extension = new Model_Extension();
+        $extension->loadBean(new RedBeanPHP\OODBBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->onlyMethods(array('update', 'findExtension'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Extension\Service::class)->onlyMethods(['update', 'findExtension'])->getMock();
         $serviceMock->expects($this->any())
             ->method('update')
-            ->will($this->returnValue($versions));
+            ->willReturn($versions);
         $serviceMock->expects($this->any())
             ->method('findExtension')
-            ->will($this->returnValue($extension));
+            ->willReturn($extension);
 
         $serviceMock->setDi($this->di);
 
-        $data = array(
-            'type'  =>  'mod',
-            'id'    =>  'branding',
-        );
-        $api = new \Box\Mod\Extension\Api\Admin();
+        $data = [
+            'type' => 'mod',
+            'id' => 'branding',
+        ];
+        $api = new Box\Mod\Extension\Api\Admin();
         $api->setDi($this->di);
         $api->setService($serviceMock);
         $arr = $api->update($data);
@@ -70,15 +71,15 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
 
     public function testConfigs()
     {
-        $data = array(
-            'ext'           =>  'mod_email',
-            'mailer'        =>  'mail',
-            'smtp_host'     =>  'hostname',
-            'smtp_port'     =>  55,
-            'smtp_username' =>  'username',
-            'smtp_password' =>  'sasd132423%3@#//',
-            'smtp_security' =>  'yes',
-        );
+        $data = [
+            'ext' => 'mod_email',
+            'mailer' => 'mail',
+            'smtp_host' => 'hostname',
+            'smtp_port' => 55,
+            'smtp_username' => 'username',
+            'smtp_password' => 'sasd132423%3@#//',
+            'smtp_security' => 'yes',
+        ];
 
         $bool = $this->api_admin->extension_config_save($data);
         $this->assertTrue($bool);
@@ -91,10 +92,10 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
 
     public function testActivations()
     {
-        $data = array(
-            'id'    =>  'news',
-            'type'  =>  'mod',
-        );
+        $data = [
+            'id' => 'news',
+            'type' => 'mod',
+        ];
         $array = $this->api_admin->extension_activate($data);
         $this->assertIsArray($array);
         $bool = $this->api_guest->extension_is_on($data);
@@ -108,19 +109,19 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
 
     public function testLists()
     {
-        $data = array(
+        $data = [
             'type' => 'server-manager',
-        );
+        ];
         $array = $this->api_admin->extension_get_list($data);
         $this->assertIsArray($array);
 
-        $array = $this->api_admin->extension_get_list(array('active'=>true, 'type'=>'mod', 'search'=>'f'));
+        $array = $this->api_admin->extension_get_list(['active' => true, 'type' => 'mod', 'search' => 'f']);
         $this->assertIsArray($array);
 
-        $array = $this->api_admin->extension_get_list(array('installed'=>true));
+        $array = $this->api_admin->extension_get_list(['installed' => true]);
         $this->assertIsArray($array);
 
-        $array = $this->api_admin->extension_get_list(array('has_settings'=>true));
+        $array = $this->api_admin->extension_get_list(['has_settings' => true]);
         $this->assertIsArray($array);
 
         $array = $this->api_admin->extension_get_latest();
@@ -136,29 +137,29 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
         $this->assertIsArray($array);
     }
 
-    public function testUpdate_Core()
+    public function testUpdateCore()
     {
         $bool = $this->api_admin->extension_update_core();
         $this->assertTrue($bool);
     }
 
-    public function testInstall(){
+    public function testInstall()
+    {
+        $extension = new Model_Extension();
+        $extension->loadBean(new RedBeanPHP\OODBBean());
 
-        $extension =  new Model_Extension();
-        $extension->loadBean(new \RedBeanPHP\OODBBean());
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->onlyMethods(array('downloadAndExtract'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Extension\Service::class)->onlyMethods(['downloadAndExtract'])->getMock();
         $serviceMock->expects($this->any())
             ->method('downloadAndExtract')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock->setDi($this->di);
 
-        $data = array(
-            'id'    =>  'branding',
-            'type'  =>  'mod',
-        );
-        $api = new \Box\Mod\Extension\Api\Admin();
+        $data = [
+            'id' => 'branding',
+            'type' => 'mod',
+        ];
+        $api = new Box\Mod\Extension\Api\Admin();
         $api->setService($serviceMock);
         $api->setDi($this->di);
         $arr = $api->install($data);
@@ -167,6 +168,4 @@ class Api_Admin_ExtensionTest extends BBDbApiTestCase
         $expected['success'] = true;
         $this->assertEquals($arr, $expected);
     }
-
-
 }

--- a/tests/integration/bb-modules/mod_extension/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_extension/Api_GuestTest.php
@@ -1,9 +1,10 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_ExtensionTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'extensions.xml';
-    
+
     public function testLists()
     {
         $array = $this->api_guest->extension_languages();
@@ -12,10 +13,10 @@ class Api_Guest_ExtensionTest extends BBDbApiTestCase
         $array = $this->api_guest->extension_theme();
         $this->assertIsArray($array);
 
-        $bool = $this->api_guest->extension_is_on(array('mod'=>'system'));
+        $bool = $this->api_guest->extension_is_on(['mod' => 'system']);
         $this->assertTrue($bool);
 
-        $arr = $this->api_guest->extension_settings(array('ext'=>'mod_email'));
+        $arr = $this->api_guest->extension_settings(['ext' => 'mod_email']);
         $this->assertIsArray($arr);
     }
 }

--- a/tests/integration/bb-modules/mod_extension/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_extension/ServiceTest.php
@@ -1,14 +1,14 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Extension_ServiceTest extends BBDbApiTestCase
 {
     public function testEvents()
     {
-        $event = $this->_bb_event = new Box_Event(null, 'name', array(), $this->api_admin, $this->api_guest);
+        $event = $this->_bb_event = new Box_Event(null, 'name', [], $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
-        $service = new \Box\Mod\Extension\Service();
+        $service = new Box\Mod\Extension\Service();
         $bool = $service->onBeforeAdminCronRun($event);
         $this->assertTrue($bool);
     }
-
 }

--- a/tests/integration/bb-modules/mod_formbuilder/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_formbuilder/Api_AdminTest.php
@@ -1,93 +1,101 @@
 <?php
-/**
- *
- */
+
 class Api_Admin_FormbuilderTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_formbuilder.xml';
 
     /**
-     *  Box_Exception
+     *  Box_Exception.
      */
     public function testFormExceptions()
     {
         try {
-            $this->api_admin->formbuilder_get_form(array('id' => 10000));
+            $this->api_admin->formbuilder_get_form(['id' => 10000]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
+
         try {
-            $this->api_admin->formbuilder_create_form(array('name' => null));
+            $this->api_admin->formbuilder_create_form(['name' => null]);
         } catch (Box_Exception) {
         }
+
         try {
-            $this->api_admin->formbuilder_create_form(array('title' => "Form title", "style" => "not existing style"));
+            $this->api_admin->formbuilder_create_form(['title' => 'Form title', 'style' => 'not existing style']);
         } catch (Box_Exception) {
         }
+
         try {
-            $this->api_admin->formbuilder_add_field(array('id' => 1, 'type' => 'type'));
+            $this->api_admin->formbuilder_add_field(['id' => 1, 'type' => 'type']);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
+
         try {
-            $this->api_admin->formbuilder_add_field(array('id' => 1_000_000_000));
+            $this->api_admin->formbuilder_add_field(['id' => 1_000_000_000]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
+
         try {
-            $this->api_admin->formbuilder_add_field(array(
+            $this->api_admin->formbuilder_add_field([
                 'id' => 1,
                 'form_id' => 1,
-                'type' => 'unexisting type'
-            ));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-        try {
-            $this->api_admin->formbuilder_get_form(array('id' => 10000));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-        try {
-            $this->api_admin->formbuilder_get_form_fields(array('id' => 1));
+                'type' => 'unexisting type',
+            ]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_get_field(array('id' => 1_000_000));
+            $this->api_admin->formbuilder_get_form(['id' => 10000]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_delete_form(array('id' => 1));
-            $this->api_admin->formbuilder_get_form(array('id' => 1));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-        try {
-            $this->api_admin->formbuilder_delete_field(array('id' => 1));
-            $this->api_admin->formbuilder_get_field(array('id' => 1));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-        try {
-            $this->api_admin->formbuilder_delete_field(array('id' => 1));
-            $this->api_admin->formbuilder_get_field(array('id' => 1));
+            $this->api_admin->formbuilder_get_form_fields(['id' => 1]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_update_field(array('id' => 3, 'description' => 'This is very awesome description.', 'name' => ""));
+            $this->api_admin->formbuilder_get_field(['id' => 1_000_000]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
+
         try {
-            $test = $this->api_admin->formbuilder_add_field(array(
+            $this->api_admin->formbuilder_delete_form(['id' => 1]);
+            $this->api_admin->formbuilder_get_form(['id' => 1]);
+            $this->fail('An expected exception has not been raised.');
+        } catch (Box_Exception) {
+        }
+
+        try {
+            $this->api_admin->formbuilder_delete_field(['id' => 1]);
+            $this->api_admin->formbuilder_get_field(['id' => 1]);
+            $this->fail('An expected exception has not been raised.');
+        } catch (Box_Exception) {
+        }
+
+        try {
+            $this->api_admin->formbuilder_delete_field(['id' => 1]);
+            $this->api_admin->formbuilder_get_field(['id' => 1]);
+            $this->fail('An expected exception has not been raised.');
+        } catch (Box_Exception) {
+        }
+
+        try {
+            $this->api_admin->formbuilder_update_field(['id' => 3, 'description' => 'This is very awesome description.', 'name' => '']);
+            $this->fail('An expected exception has not been raised.');
+        } catch (Box_Exception) {
+        }
+
+        try {
+            $test = $this->api_admin->formbuilder_add_field([
                 'description' => 'Form field description',
-                "label" => "Field label",
+                'label' => 'Field label',
                 'id' => 2,
                 'form_id' => 2,
                 'hide_label' => 0,
@@ -97,86 +105,81 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
                 'required' => 0,
                 'hidden' => 1,
                 'readonly' => 0,
-                'options' => array("Key" => "2", "2" => "2"),
+                'options' => ['Key' => '2', '2' => '2'],
                 'show_initial' => 'initial',
                 'show_middle' => 'middle',
                 'show_prefix' => 'prefix',
                 'show_suffix' => 'suffix',
-                'text_size' => 499
-
-
-            ));
+                'text_size' => 499,
+            ]);
             $this->api_admin->formbuilder_update_field($test);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_get_orders_count(array());
+            $this->api_admin->formbuilder_get_orders_count([]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
+
         try {
-            $test = $this->api_admin->formbuilder_update_form_settings(array(
+            $test = $this->api_admin->formbuilder_update_form_settings([
                 'form_id' => 1,
                 'form_name' => 'Second',
                 'type' => 'non_existing type',
-                'show_title' => 'Second'
-            ));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-
-
-        try {
-            $this->api_admin->formbuilder_copy_form(array(
-                'form_id' => 2
-            ));
+                'show_title' => 'Second',
+            ]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_copy_form(array(
-                'form_id' => "non-existing-form",
-                'name' => ''
-            ));
+            $this->api_admin->formbuilder_copy_form([
+                'form_id' => 2,
+            ]);
+            $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
         try {
-            $this->api_admin->formbuilder_update_form_name(array('form_id' => 2));
+            $this->api_admin->formbuilder_copy_form([
+                'form_id' => 'non-existing-form',
+                'name' => '',
+            ]);
+        } catch (Box_Exception) {
+        }
+
+        try {
+            $this->api_admin->formbuilder_update_form_name(['form_id' => 2]);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
     }
 
-
     public function testFormCreate()
     {
-        $id = $this->api_admin->formbuilder_create_form(array(
-            'name' => 'New form'
-        ));
+        $id = $this->api_admin->formbuilder_create_form([
+            'name' => 'New form',
+        ]);
         $this->assertIsInt($id);
-        $id2 = $this->api_admin->formbuilder_create_form(array(
+        $id2 = $this->api_admin->formbuilder_create_form([
             'type' => null,
             'name' => 'Form',
-            'fields' => array(
+            'fields' => [
                 'form_id' => $id,
-                'type' => "checkbox"
-
-            )));
+                'type' => 'checkbox',
+            ]]);
         $this->assertIsInt($id2);
-
     }
 
     public function testFieldAdd()
     {
-        $fieldId = $this->api_admin->formbuilder_add_field(array('form_id' => 1, 'type' => 'text'));
+        $fieldId = $this->api_admin->formbuilder_add_field(['form_id' => 1, 'type' => 'text']);
         $this->assertIsInt($fieldId);
-        $test = $this->api_admin->formbuilder_add_field(array(
+        $test = $this->api_admin->formbuilder_add_field([
             'description' => 'Form field description',
-            "label" => "Field label",
+            'label' => 'Field label',
             'form_id' => 2,
             'hide_label' => 0,
             'name' => 'Field name',
@@ -185,52 +188,49 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
             'required' => 0,
             'hidden' => 1,
             'readonly' => 0,
-            'options' => array("0" => "First json on create", "2" => "Second json on create"),
+            'options' => ['0' => 'First json on create', '2' => 'Second json on create'],
             'show_initial' => 'initial',
             'show_middle' => 'middle',
             'show_prefix' => 'prefix',
             'show_suffix' => 'suffix',
-            'text_size' => 499
-        ));
+            'text_size' => 499,
+        ]);
         $this->assertIsInt($test);
-        $this->api_admin->formbuilder_get_form(array(
+        $this->api_admin->formbuilder_get_form([
             'id' => 1,
             'form_id' => 1,
             'type' => 'text',
-            'options' => array(
+            'options' => [
                 '1' => '1',
-            )
-        ));
-
+            ],
+        ]);
     }
 
     public function testFormGet()
     {
-        $array = $this->api_admin->formbuilder_get_form(array('id' => 1));
+        $array = $this->api_admin->formbuilder_get_form(['id' => 1]);
         $this->assertIsArray($array);
         $this->assertTrue(isset($array['fields']));
         $this->assertNotEmpty($array['fields']);
     }
 
-
     public function testGetForm()
     {
-        $form = $this->api_admin->formbuilder_get_form(array('id' => 1));
+        $form = $this->api_admin->formbuilder_get_form(['id' => 1]);
         $this->assertIsArray($form);
         $this->assertNotEmpty($form);
-
     }
 
     public function testGetFormFields()
     {
-        $test = $this->api_admin->formbuilder_get_form_fields(array('form_id' => 1));
+        $test = $this->api_admin->formbuilder_get_form_fields(['form_id' => 1]);
         $this->assertIsArray($test);
         $this->assertNotEmpty($test);
     }
 
     public function testGetField()
     {
-        $test = $this->api_admin->formbuilder_get_field(array('id' => 1));
+        $test = $this->api_admin->formbuilder_get_field(['id' => 1]);
         $this->assertIsArray($test);
         $this->assertNotEmpty($test);
     }
@@ -240,39 +240,37 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
         $arr = $this->api_admin->formbuilder_get_forms();
         $test = $arr[0];
         $this->assertIsArray($test);
-        $this->assertArrayHasKey('product_count',$test);
-        $this->assertArrayHasKey('order_count',$test);
-        $this->assertArrayHasKey('name',$test);
-        $this->assertArrayHasKey('id',$test);
+        $this->assertArrayHasKey('product_count', $test);
+        $this->assertArrayHasKey('order_count', $test);
+        $this->assertArrayHasKey('name', $test);
+        $this->assertArrayHasKey('id', $test);
     }
 
     public function testDeleteForm()
     {
         $forms_before = count($this->api_admin->formbuilder_get_forms());
-        $test = $this->api_admin->formbuilder_delete_form(array('id' => 1));
+        $test = $this->api_admin->formbuilder_delete_form(['id' => 1]);
         $forms_after = count($this->api_admin->formbuilder_get_forms());
-        $this->assertEquals($forms_before, ($forms_after + 1));
+        $this->assertEquals($forms_before, $forms_after + 1);
         $this->assertTrue($test);
     }
-
 
     public function testDeleteField()
     {
-        $fields_before = count($this->api_admin->formbuilder_get_form_fields(array('form_id' => 1)));
-        $test = $this->api_admin->formbuilder_delete_field(array('id' => 1));
-        $fields_after = count($this->api_admin->formbuilder_get_form_fields(array('form_id' => 1)));
-        $this->assertEquals($fields_before, ($fields_after + 1));
+        $fields_before = count($this->api_admin->formbuilder_get_form_fields(['form_id' => 1]));
+        $test = $this->api_admin->formbuilder_delete_field(['id' => 1]);
+        $fields_after = count($this->api_admin->formbuilder_get_form_fields(['form_id' => 1]));
+        $this->assertEquals($fields_before, $fields_after + 1);
         $this->assertTrue($test);
     }
 
-
     public function testUpdateField()
     {
-        $test = $this->api_admin->formbuilder_update_field(array('id' => 3, 'description' => 'This is very awesome description.', 'name' => "Form name"));
+        $test = $this->api_admin->formbuilder_update_field(['id' => 3, 'description' => 'This is very awesome description.', 'name' => 'Form name']);
         $this->assertIsInt($test);
-        $test = $this->api_admin->formbuilder_add_field(array(
+        $test = $this->api_admin->formbuilder_add_field([
             'description' => 'Form field description',
-            "label" => "Form field label",
+            'label' => 'Form field label',
             'id' => 2,
             'form_id' => 2,
             'hide_label' => 0,
@@ -282,16 +280,14 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
             'required' => 0,
             'hidden' => 1,
             'readonly' => 0,
-            'options' => array("Key" => "2", "2" => "3"),
+            'options' => ['Key' => '2', '2' => '3'],
             'show_initial' => 'initial',
             'show_middle' => 'middle',
             'show_prefix' => 'prefix',
             'show_suffix' => 'suffix',
-            'text_size' => 499
-
-
-        ));
-        $test = $this->api_admin->formbuilder_update_field(array(
+            'text_size' => 499,
+        ]);
+        $test = $this->api_admin->formbuilder_update_field([
             'id' => 5,
             'form_id' => 1,
             'description' => 'This is field description',
@@ -302,38 +298,34 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
             'required' => 1,
             'hidden' => 0,
             'readonly' => 1,
-            'options' => array("1" => "First value", "2" => "second one"),
+            'options' => ['1' => 'First value', '2' => 'second one'],
             'show_initial' => 'aaaaaaa',
             'show_middle' => 'bbbbbbbbb',
             'show_prefix' => 'ccccccccc',
             'show_suffix' => 'ddddd',
-            'text_size' => 500
-
-
-        ));
+            'text_size' => 500,
+        ]);
 
         $this->assertIsInt($test);
-
     }
-
 
     public function testUpdateFormName()
     {
-        $test = $this->api_admin->formbuilder_update_form_settings(array(
+        $test = $this->api_admin->formbuilder_update_form_settings([
             'form_id' => 1,
             'form_name' => 'Second',
             'type' => 'horizontal',
-            'show_title' => '0'
-        ));
+            'show_title' => '0',
+        ]);
         $this->assertIsBool($test);
         $this->assertTrue($test);
     }
 
     public function testCopyForm()
     {
-        $test = $this->api_admin->formbuilder_add_field(array(
+        $test = $this->api_admin->formbuilder_add_field([
             'description' => 'This is awesome description. on create',
-            "label" => "Cre",
+            'label' => 'Cre',
             'form_id' => 2,
             'hide_label' => 0,
             'name' => 'formnameon create',
@@ -342,20 +334,18 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
             'required' => 0,
             'hidden' => 1,
             'readonly' => 0,
-            'options' => array("0" => "First oneon create", "2" => "second jsonon create"),
+            'options' => ['0' => 'First oneon create', '2' => 'second jsonon create'],
             'show_initial' => 'a',
             'show_middle' => 'middle',
             'show_prefix' => 'prefix',
             'show_suffix' => 'suffix',
-            'text_size' => 499
-        ));
-        $test = $this->api_admin->formbuilder_copy_form(array(
+            'text_size' => 499,
+        ]);
+        $test = $this->api_admin->formbuilder_copy_form([
             'form_id' => 1,
-            'name' => 'Second'
-        ));
+            'name' => 'Second',
+        ]);
         $this->assertIsInt($test);
-
-
     }
 
     public function testGetPairs()
@@ -363,6 +353,4 @@ class Api_Admin_FormbuilderTest extends BBDbApiTestCase
         $test = $this->api_admin->formbuilder_get_pairs();
         $this->assertIsArray($test);
     }
-
-
 }

--- a/tests/integration/bb-modules/mod_formbuilder/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_formbuilder/Api_GuestTest.php
@@ -1,41 +1,35 @@
 <?php
-/**
- *
- */
+
 class Api_GUest_FormbuilderTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_formbuilder.xml';
 
     /**
-     *  Box_Exception
+     *  Box_Exception.
      */
     public function testFormGetNonExisting()
     {
         try {
-            $this->api_guest->formbuilder_get(array("id" => "non-existing"));
-            $this->fail('An expected exception has not been raised.');
-        } catch (Box_Exception) {
-        }
-         try {
-            $this->api_guest->formbuilder_get(array("id" => 100000));
+            $this->api_guest->formbuilder_get(['id' => 'non-existing']);
             $this->fail('An expected exception has not been raised.');
         } catch (Box_Exception) {
         }
 
+         try {
+             $this->api_guest->formbuilder_get(['id' => 100000]);
+             $this->fail('An expected exception has not been raised.');
+         } catch (Box_Exception) {
+         }
     }
 
     public function testGet()
     {
-        $test = $this->api_guest->formbuilder_get(array("id" => 2));
+        $test = $this->api_guest->formbuilder_get(['id' => 2]);
         $this->assertIsArray($test);
         $this->assertNotEmpty($test);
 
-        $test = $this->api_guest->formbuilder_get(array("id" => "2"));
+        $test = $this->api_guest->formbuilder_get(['id' => '2']);
         $this->assertIsArray($test);
         $this->assertNotEmpty($test);
-
-
-
     }
-
 }

--- a/tests/integration/bb-modules/mod_hook/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_hook/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Hook_Api_AdminTest extends BBDbApiTestCase
 {
@@ -8,8 +9,8 @@ class Box_Mod_Hook_Api_AdminTest extends BBDbApiTestCase
     {
         $this->assertTrue($this->api_admin->hook_batch_connect());
         $this->assertFalse($this->api_admin->hook_call());
-        $bool = $this->api_admin->hook_call(array('event'=>'onAfterAdminActivateExtension'));
-        $bool = $this->api_admin->hook_call(array('event'=>'onAfterAdminActivateExtension', 'params'=>array('id'=>'2')));
+        $bool = $this->api_admin->hook_call(['event' => 'onAfterAdminActivateExtension']);
+        $bool = $this->api_admin->hook_call(['event' => 'onAfterAdminActivateExtension', 'params' => ['id' => '2']]);
 
         $this->assertTrue($bool);
     }
@@ -17,7 +18,7 @@ class Box_Mod_Hook_Api_AdminTest extends BBDbApiTestCase
     public function testEventReturnData()
     {
         $this->api_admin->hook_batch_connect();
-        $data = $this->api_admin->hook_call(array('event'=>'onBeforeGuestPublicTicketOpen', 'params'=>array('message'=>'msg')));
+        $data = $this->api_admin->hook_call(['event' => 'onBeforeGuestPublicTicketOpen', 'params' => ['message' => 'msg']]);
 
         $this->assertTrue(true);
     }

--- a/tests/integration/bb-modules/mod_invoice/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_invoice/Api_AdminTest.php
@@ -10,24 +10,23 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         $array = $this->api_admin->invoice_tax_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'name'    => 'VAT in United Kingdom',
+        $data = [
+            'name' => 'VAT in United Kingdom',
             'taxrate' => 20,
-        );
-        $id   = $this->api_admin->invoice_tax_create($data);
+        ];
+        $id = $this->api_admin->invoice_tax_create($data);
         $this->assertTrue(is_numeric($id));
 
-
-        $data = array(
+        $data = [
             'id' => $id,
-        );
+        ];
         $bool = $this->api_admin->invoice_tax_delete($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'name'    => 'VAT in United Kingdom',
+        $data = [
+            'name' => 'VAT in United Kingdom',
             'taxrate' => 20,
-        );
+        ];
         $bool = $this->api_admin->invoice_tax_setup_eu($data);
         $this->assertTrue($bool);
     }
@@ -37,29 +36,29 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         $array = $this->api_admin->invoice_subscription_get_list();
         $this->assertIsArray($array);
 
-        $data  = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $array = $this->api_admin->invoice_subscription_get($data);
         $this->assertIsArray($array);
 
         $data['status'] = 'canceled';
-        $bool           = $this->api_admin->invoice_subscription_update($data);
+        $bool = $this->api_admin->invoice_subscription_update($data);
         $this->assertTrue($bool);
 
         $bool = $this->api_admin->invoice_subscription_delete($data);
         $this->assertTrue($bool);
 
-        $sid                = 'TRWEW_@22--2222';
-        $data['sid']        = $sid;
-        $data['client_id']  = 1;
+        $sid = 'TRWEW_@22--2222';
+        $data['sid'] = $sid;
+        $data['client_id'] = 1;
         $data['gateway_id'] = 1;
-        $data['status']     = 'canceled';
-        $data['currency']   = 'USD';
-        $id                 = $this->api_admin->invoice_subscription_create($data);
+        $data['status'] = 'canceled';
+        $data['currency'] = 'USD';
+        $id = $this->api_admin->invoice_subscription_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $array = $this->api_admin->invoice_subscription_get(array('sid' => $sid));
+        $array = $this->api_admin->invoice_subscription_get(['sid' => $sid]);
         $this->assertIsArray($array);
     }
 
@@ -74,36 +73,36 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         $bool = $this->api_admin->invoice_batch_pay_with_credits();
         $this->assertTrue($bool);
 
-        $bool = $this->api_admin->invoice_batch_pay_with_credits(array('client_id' => 1));
+        $bool = $this->api_admin->invoice_batch_pay_with_credits(['client_id' => 1]);
         $this->assertTrue($bool);
 
-        $array = $this->api_admin->invoice_get_statuses(array());
+        $array = $this->api_admin->invoice_get_statuses([]);
         $this->assertIsArray($array);
 
         $array = $this->api_admin->invoice_get_list();
         $this->assertIsArray($array);
 
-        $data  = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $array = $this->api_admin->invoice_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'client_id'  => 1,
+        $data = [
+            'client_id' => 1,
             'gateway_id' => 1,
-        );
-        $id   = $this->api_admin->invoice_prepare($data);
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
         $this->assertTrue(is_numeric($id));
 
-        $data['id']    = $id;
+        $data['id'] = $id;
         $data['serie'] = 'new';
-        $bool          = $this->api_admin->invoice_update($data);
+        $bool = $this->api_admin->invoice_update($data);
         $this->assertTrue($bool);
 
-        $data = array(
+        $data = [
             'id' => $id,
-        );
+        ];
         $bool = $this->api_admin->invoice_approve($data);
         $this->assertTrue($bool);
 
@@ -113,28 +112,28 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testItem()
     {
-        $data = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id   = $this->api_admin->invoice_prepare($data);
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
         $this->assertTrue(is_numeric($id));
 
-        $data['id']       = $id;
-        $data['serie']    = 'new';
-        $data['new_item'] = array(
-            'title'  => 'new item',
-            'price'  => 'new item',
-            'taxed'  => true,
+        $data['id'] = $id;
+        $data['serie'] = 'new';
+        $data['new_item'] = [
+            'title' => 'new item',
+            'price' => 'new item',
+            'taxed' => true,
             'period' => '1W',
-        );
-        $bool             = $this->api_admin->invoice_update($data);
+        ];
+        $bool = $this->api_admin->invoice_update($data);
         $this->assertTrue($bool);
 
         $array = $this->api_admin->invoice_get($data);
         $this->assertEquals(1, count($array['lines']));
 
         $line_data['id'] = $array['lines'][0]['id'];
-        $bool            = $this->api_admin->invoice_item_delete($line_data);
+        $bool = $this->api_admin->invoice_item_delete($line_data);
     }
 
     public function testGatewayInstall()
@@ -142,9 +141,9 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         $array = $this->api_admin->invoice_gateway_get_available();
         $this->assertIsArray($array);
 
-        $data = array(
+        $data = [
             'code' => $array[0],
-        );
+        ];
         $bool = $this->api_admin->invoice_gateway_install($data);
         $this->assertTrue($bool);
     }
@@ -157,28 +156,28 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         $array = $this->api_admin->invoice_gateway_get_pairs();
         $this->assertIsArray($array);
 
-        $data  = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $array = $this->api_admin->invoice_gateway_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'              => 1,
-            'allow_single'    => 1,
+        $data = [
+            'id' => 1,
+            'allow_single' => 1,
             'allow_recurrent' => 1,
-            'enabled'         => 1,
-            'title'           => 'title',
-        );
+            'enabled' => 1,
+            'title' => 'title',
+        ];
         $bool = $this->api_admin->invoice_gateway_update($data);
         $this->assertTrue($bool);
 
         $id = $this->api_admin->invoice_gateway_copy($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
+        $data = [
             'id' => $id,
-        );
+        ];
         $bool = $this->api_admin->invoice_gateway_delete($data);
         $this->assertTrue($bool);
     }
@@ -187,35 +186,35 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     {
         $txn_id = '11--aaa--p';
 
-        $tx    = array(
+        $tx = [
             'skip_validation' => true,
-            'txn_id'          => $txn_id,
-        );
+            'txn_id' => $txn_id,
+        ];
         $tx_id = $this->api_admin->invoice_transaction_create($tx);
-        $list  = $this->api_admin->invoice_transaction_get_list(array('txn_id' => $txn_id));
+        $list = $this->api_admin->invoice_transaction_get_list(['txn_id' => $txn_id]);
         $this->assertEquals(1, count($list['list']));
     }
 
     public function testTransactions()
     {
-        $tx    = array(
+        $tx = [
             'bb_invoice_id' => 1,
             'bb_gateway_id' => 1,
-        );
+        ];
         $tx_id = $this->api_admin->invoice_transaction_create($tx);
 
-        $txu  = array(
-            'id'           => $tx_id,
+        $txu = [
+            'id' => $tx_id,
             'validate_ipn' => '0',
-            'amount'       => 150,
-            'type'         => Payment_Transaction::TXTYPE_PAYMENT,
-            'note'         => 'notes',
-            'gateway_id'   => 1,
-            'currency'     => 'USD',
-            'status'       => Model_Transaction::STATUS_APPROVED,
-            'txn_id'       => uniqid(),
-            'txn_status'   => 'complete',
-        );
+            'amount' => 150,
+            'type' => Payment_Transaction::TXTYPE_PAYMENT,
+            'note' => 'notes',
+            'gateway_id' => 1,
+            'currency' => 'USD',
+            'status' => Model_Transaction::STATUS_APPROVED,
+            'txn_id' => uniqid(),
+            'txn_status' => 'complete',
+        ];
         $bool = $this->api_admin->invoice_transaction_update($txu);
         $this->assertTrue($bool);
 
@@ -249,23 +248,23 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testUpdate()
     {
-        $data = array(
-            'id'     => 1,
+        $data = [
+            'id' => 1,
             'status' => 'unpaid',
-            'notes'  => 'note',
-            'serie'  => 'NEW',
-            'nr'     => 4,
+            'notes' => 'note',
+            'serie' => 'NEW',
+            'nr' => 4,
             'due_at' => date('Y-m-d H:i:s'),
-        );
+        ];
         $bool = $this->api_admin->invoice_update($data);
         $this->assertTrue($bool);
     }
 
     public function testManualPayment()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $bool = $this->api_admin->invoice_mark_as_paid($data);
         $this->assertTrue($bool);
     }
@@ -276,34 +275,34 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
         // date if order has expiation date
 
         $oid = 5;
-        $o   = $this->api_admin->order_get(array('id' => $oid));
+        $o = $this->api_admin->order_get(['id' => $oid]);
         $this->assertEquals('2012-10-10 00:00:00', $o['expires_at']);
-        $id      = $this->api_admin->invoice_renewal_invoice(array('id' => $oid));
-        $invoice = $this->api_admin->invoice_get(array('id' => $id));
+        $id = $this->api_admin->invoice_renewal_invoice(['id' => $oid]);
+        $invoice = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals('2012-10-10 00:00:00', $invoice['due_at']);
 
-        //test event caller
+        // test event caller
         $this->api_admin->invoice_batch_invoke_due_event();
     }
 
     public function testRenewalInvoice()
     {
         $oid = 4;
-        $this->api_admin->order_renew(array('id' => $oid));
+        $this->api_admin->order_renew(['id' => $oid]);
 
-        $o1 = $this->api_admin->order_get(array('id' => $oid));
+        $o1 = $this->api_admin->order_get(['id' => $oid]);
         $this->assertEquals('active', $o1['status']);
 
-        $id      = $this->api_admin->invoice_renewal_invoice(array('id' => $oid));
-        $invoice = $this->api_admin->invoice_get(array('id' => $id));
+        $id = $this->api_admin->invoice_renewal_invoice(['id' => $oid]);
+        $invoice = $this->api_admin->invoice_get(['id' => $id]);
         $this->api_admin->invoice_mark_as_paid($invoice);
 
-        $o2 = $this->api_admin->order_get(array('id' => $oid));
+        $o2 = $this->api_admin->order_get(['id' => $oid]);
         $this->assertEquals('active', $o2['status']);
 
         $this->api_admin->invoice_batch_activate_paid();
 
-        $o3 = $this->api_admin->order_get(array('id' => $oid));
+        $o3 = $this->api_admin->order_get(['id' => $oid]);
         $this->assertEquals('active', $o3['status']);
         $this->assertNotEquals($o2['expires_at'], $o3['expires_at']);
     }
@@ -319,7 +318,7 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testSendReminder()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
         $bool = $this->api_admin->invoice_send_reminder($data);
         $this->assertTrue($bool);
     }
@@ -330,7 +329,7 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
             $bool = $this->api_admin->invoice_transaction_process_all();
             $this->assertTrue($bool);
         } catch (Exception $e) {
-            assertEquals("testProcess failed: ", $e->getMessage());
+            assertEquals('testProcess failed: ', $e->getMessage());
         }
 
         $bool = $this->api_admin->invoice_batch_activate_paid();
@@ -339,82 +338,81 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testNumbering()
     {
-        $data = array(
-            'invoice_series'          => 'UNIT',
-            'invoice_series_paid'     => 'PAID',
+        $data = [
+            'invoice_series' => 'UNIT',
+            'invoice_series_paid' => 'PAID',
             'invoice_starting_number' => 150,
-        );
+        ];
         $this->api_admin->system_update_params($data);
 
-        $data = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id   = $this->api_admin->invoice_prepare($data);
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
+        $data = [
             'id' => $id,
-        );
+        ];
         $this->api_admin->invoice_mark_as_paid($data);
         $array = $this->api_admin->invoice_get($data);
-        $this->assertEquals("150", $array['nr']);
+        $this->assertEquals('150', $array['nr']);
 
-        $data = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id   = $this->api_admin->invoice_prepare($data);
-        $data = array(
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
+        $data = [
             'id' => $id,
-        );
+        ];
         $this->api_admin->invoice_mark_as_paid($data);
         $array = $this->api_admin->invoice_get($data);
-        $this->assertEquals("151", $array['nr']);
+        $this->assertEquals('151', $array['nr']);
 
-        $next = $this->api_admin->system_param(array('key' => 'invoice_starting_number'));
-        $this->assertEquals("152", $next);
+        $next = $this->api_admin->system_param(['key' => 'invoice_starting_number']);
+        $this->assertEquals('152', $next);
     }
 
     public function testRefund()
     {
-        $id   = 3;
-        $data = array(
-            'id'   => $id,
+        $id = 3;
+        $data = [
+            'id' => $id,
             'note' => 'For some reason',
-        );
+        ];
 
-        $bool = $this->api_admin->system_update_params(array('invoice_refund_logic' => 'manual'));
+        $bool = $this->api_admin->system_update_params(['invoice_refund_logic' => 'manual']);
         $null = $this->api_admin->invoice_refund($data);
         $this->assertNull($null);
 
-        $bool                = $this->api_admin->system_update_params(array('invoice_refund_logic' => 'negative_invoice'));
+        $bool = $this->api_admin->system_update_params(['invoice_refund_logic' => 'negative_invoice']);
         $refunded_invoice_id = $this->api_admin->invoice_refund($data);
         $this->assertIsInt($refunded_invoice_id);
 
-        $bool                = $this->api_admin->system_update_params(array('invoice_refund_logic' => 'credit_note'));
+        $bool = $this->api_admin->system_update_params(['invoice_refund_logic' => 'credit_note']);
         $refunded_invoice_id = $this->api_admin->invoice_refund($data);
         $this->assertIsInt($refunded_invoice_id);
 
         try {
-            $this->api_admin->invoice_refund(array('id' => $refunded_invoice_id));
+            $this->api_admin->invoice_refund(['id' => $refunded_invoice_id]);
             $this->fail('Should not refund refunded invoice');
         } catch (Exception) {
-
         }
     }
 
     public function testItemTax()
     {
-        $data = array(
+        $data = [
             'tax_enabled' => 1,
-        );
+        ];
         $this->api_admin->system_update_params($data);
 
-        $data = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id   = $this->api_admin->invoice_prepare($data);
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
 
-        $data['id']                = $id;
+        $data['id'] = $id;
         $data['new_item']['title'] = 'test';
         $data['new_item']['price'] = 40;
         $data['new_item']['taxed'] = 1;
@@ -426,21 +424,21 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     }
 
     /**
-     * Invoice should be marked as paid after adding money to balance
+     * Invoice should be marked as paid after adding money to balance.
      */
     public function testCoverInvoice()
     {
-        $id   = 2;
-        $data = array(
-            'id'          => 1,
-            'amount'      => 100,
+        $id = 2;
+        $data = [
+            'id' => 1,
+            'amount' => 100,
             'description' => 'For invoice payment',
-        );
+        ];
 
         $this->api_admin->client_balance_add_funds($data);
-        $this->api_admin->invoice_pay_with_credits(array('id' => $id));
+        $this->api_admin->invoice_pay_with_credits(['id' => $id]);
 
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals('paid', $array['status']);
     }
 
@@ -451,20 +449,19 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     {
         $id = 5;
         $invoiceModel = $this->di['db']->load('Invoice', 5);
-        $this->assertEquals(\Model_Invoice::STATUS_UNPAID, $invoiceModel->status);
-        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', array($invoiceModel->id));
+        $this->assertEquals(Model_Invoice::STATUS_UNPAID, $invoiceModel->status);
+        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', [$invoiceModel->id]);
         $this->assertEquals(Model_InvoiceItem::TYPE_DEPOSIT, $invoiceItemModel->type);
 
         $balanceBefore = $this->api_client->client_balance_get_total();
-        $this->api_admin->invoice_pay_with_credits(array('id' => $id));
+        $this->api_admin->invoice_pay_with_credits(['id' => $id]);
         $balanceAfter = $this->api_client->client_balance_get_total();
 
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
 
-        $this->assertEquals(\Model_Invoice::STATUS_PAID, $array['status']);
+        $this->assertEquals(Model_Invoice::STATUS_PAID, $array['status']);
         $this->assertEquals($balanceBefore, $balanceAfter);
     }
-
 
     /**
      * After admin marks as paid deposit invoice account balance should increase.
@@ -473,18 +470,18 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     {
         $id = 5;
         $invoiceModel = $this->di['db']->load('Invoice', 5);
-        $this->assertEquals(\Model_Invoice::STATUS_UNPAID, $invoiceModel->status);
-        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', array($invoiceModel->id));
+        $this->assertEquals(Model_Invoice::STATUS_UNPAID, $invoiceModel->status);
+        $invoiceItemModel = $this->di['db']->findOne('InvoiceItem', 'invoice_id = ?', [$invoiceModel->id]);
         $this->assertEquals(Model_InvoiceItem::TYPE_DEPOSIT, $invoiceItemModel->type);
 
         $balanceBefore = $this->api_client->client_balance_get_total();
-        $this->api_admin->invoice_mark_as_paid(array('id' => $id, 'execute' => 1));
+        $this->api_admin->invoice_mark_as_paid(['id' => $id, 'execute' => 1]);
         $balanceAfter = $this->api_client->client_balance_get_total();
 
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
 
-        $this->assertEquals(\Model_Invoice::STATUS_PAID, $array['status']);
-        $this->assertEquals($balanceAfter, $balanceBefore+$invoiceItemModel->price);
+        $this->assertEquals(Model_Invoice::STATUS_PAID, $array['status']);
+        $this->assertEquals($balanceAfter, $balanceBefore + $invoiceItemModel->price);
 
         $accountBalance = $this->di['db']->findOne('ClientBalance', 'order by id desc');
         $this->assertEquals($invoiceItemModel->title, $accountBalance->description);
@@ -492,62 +489,62 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     }
 
     /**
-     * Invoice should be marked as paid after adding money to balance
+     * Invoice should be marked as paid after adding money to balance.
      */
     public function testCredits()
     {
         $id = 2;
         $this->api_admin->invoice_batch_pay_with_credits();
 
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals('unpaid', $array['status']);
         $this->assertEmpty($array['credit']);
 
         $this->api_admin->invoice_batch_pay_with_credits();
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals('unpaid', $array['status']);
 
-        $data = array(
-            'id'          => 1,
-            'amount'      => 100,
+        $data = [
+            'id' => 1,
+            'amount' => 100,
             'description' => 'For invoice payment',
-        );
+        ];
 
         $this->api_admin->client_balance_add_funds($data);
         $this->api_admin->invoice_batch_pay_with_credits();
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals('paid', $array['status']);
     }
 
     public function testPrepareWithoutItems()
     {
-        $data  = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id    = $this->api_admin->invoice_prepare($data);
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals(0, count($array['lines']));
     }
 
     public function testPrepareWithItems()
     {
-        $data  = array(
+        $data = [
             'client_id' => 1,
-            'items'     => array(
-                array(
-                    'title'    => 'first line test title',
-                    'period'   => '1M',
+            'items' => [
+                [
+                    'title' => 'first line test title',
+                    'period' => '1M',
                     'quantity' => 3,
-                    'price'    => 4.65,
-                ),
-                array(
-                    'title'  => 'second line test title',
-                    'period' => '2M'
-                ),
-            ),
-        );
-        $id    = $this->api_admin->invoice_prepare($data);
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+                    'price' => 4.65,
+                ],
+                [
+                    'title' => 'second line test title',
+                    'period' => '2M',
+                ],
+            ],
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
+        $array = $this->api_admin->invoice_get(['id' => $id]);
 
         $this->assertEquals(2, count($array['lines']));
 
@@ -566,24 +563,24 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testTaskHook()
     {
-        $params = json_encode(array('param' => 'value'));
-        $event  = 'onAfterClientCalledExampleModule';
+        $params = json_encode(['param' => 'value']);
+        $event = 'onAfterClientCalledExampleModule';
 
-        $idata      = array(
+        $idata = [
             'client_id' => 1,
-            'items'     => array(
-                array(
-                    'title'  => 'Test custom item activation',
-                    'price'  => 12.22,
-                    'type'   => 'hook_call',
-                    'task'   => $event,
+            'items' => [
+                [
+                    'title' => 'Test custom item activation',
+                    'price' => 12.22,
+                    'type' => 'hook_call',
+                    'task' => $event,
                     'rel_id' => $params,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $invoice_id = $this->api_admin->invoice_prepare($idata);
-        $this->api_admin->invoice_approve(array('id' => $invoice_id));
-        $invoice = $this->api_admin->invoice_get(array('id' => $invoice_id));
+        $this->api_admin->invoice_approve(['id' => $invoice_id]);
+        $invoice = $this->api_admin->invoice_get(['id' => $invoice_id]);
 
         $line0 = $invoice['lines'][0];
         $this->assertEquals('hook_call', $line0['type']);
@@ -592,18 +589,17 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
         // custom hook executes on payment event
         // event hook inseerts data to database to test
-        $this->api_admin->extension_activate(array('type' => 'mod', 'id' => 'example'));
-        $invoice = $this->api_admin->invoice_mark_as_paid(array('id' => $invoice_id, 'execute' => true));
-        //@todo
-        //$b = R::findOne('extension_meta', "extension = 'mod_example' AND meta_key = 'event_params'");
-        //$this->assertEquals($params, $b->meta_value);
+        $this->api_admin->extension_activate(['type' => 'mod', 'id' => 'example']);
+        $invoice = $this->api_admin->invoice_mark_as_paid(['id' => $invoice_id, 'execute' => true]);
+        // @todo
+        // $b = R::findOne('extension_meta', "extension = 'mod_example' AND meta_key = 'event_params'");
+        // $this->assertEquals($params, $b->meta_value);
     }
 
     public function testInvoiceGetList()
     {
         $array = $this->api_admin->invoice_get_list();
         $this->assertIsArray($array);
-
 
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -803,13 +799,13 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testInvoiceBatchDelete()
     {
-        $array = $this->api_admin->invoice_get_list(array());
+        $array = $this->api_admin->invoice_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->invoice_batch_delete(array('ids' => $ids));
-        $array  = $this->api_admin->invoice_get_list(array());
+        $result = $this->api_admin->invoice_batch_delete(['ids' => $ids]);
+        $array = $this->api_admin->invoice_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -817,13 +813,13 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testInvoiceBatchDeleteSubscription()
     {
-        $array = $this->api_admin->invoice_subscription_get_list(array());
+        $array = $this->api_admin->invoice_subscription_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->invoice_batch_delete_subscription(array('ids' => $ids));
-        $array  = $this->api_admin->invoice_subscription_get_list(array());
+        $result = $this->api_admin->invoice_batch_delete_subscription(['ids' => $ids]);
+        $array = $this->api_admin->invoice_subscription_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -831,13 +827,13 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testInvoiceBatchDeleteTransaction()
     {
-        $array = $this->api_admin->invoice_transaction_get_list(array());
+        $array = $this->api_admin->invoice_transaction_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->invoice_batch_delete_transaction(array('ids' => $ids));
-        $array  = $this->api_admin->invoice_transaction_get_list(array());
+        $result = $this->api_admin->invoice_batch_delete_transaction(['ids' => $ids]);
+        $array = $this->api_admin->invoice_transaction_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -845,13 +841,13 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
 
     public function testInvoiceBatchDeleteTax()
     {
-        $array = $this->api_admin->invoice_tax_get_list(array());
+        $array = $this->api_admin->invoice_tax_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->invoice_batch_delete_tax(array('ids' => $ids));
-        $array  = $this->api_admin->invoice_tax_get_list(array());
+        $result = $this->api_admin->invoice_batch_delete_tax(['ids' => $ids]);
+        $array = $this->api_admin->invoice_tax_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -861,25 +857,25 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     {
         $this->assertTrue(true);
 
-        return array(
-            array(100, 100),
-            array('', 1),
-            array(null, 1),
-        );
+        return [
+            [100, 100],
+            ['', 1],
+            [null, 1],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('testPrepareInvoiceDueDateProvider')]
     public function testPrepareInvoiceDueDate($invoice_due_days, $diff)
     {
         if (!is_null($invoice_due_days)) {
-            $this->api_admin->system_update_params(array('invoice_due_days' => $invoice_due_days));
+            $this->api_admin->system_update_params(['invoice_due_days' => $invoice_due_days]);
         }
 
-        $data  = array(
+        $data = [
             'client_id' => 1,
-        );
-        $id    = $this->api_admin->invoice_prepare($data);
-        $array = $this->api_admin->invoice_get(array('id' => $id));
+        ];
+        $id = $this->api_admin->invoice_prepare($data);
+        $array = $this->api_admin->invoice_get(['id' => $id]);
         $this->assertEquals(substr($array['due_at'], 0, 10), date('Y-m-d', strtotime("+ $diff day")));
     }
 
@@ -887,16 +883,15 @@ class Api_Admin_InvoiceTest extends BBDbApiTestCase
     {
         $id = 2;
 
-        $data = array(
+        $data = [
             'id' => $id,
             'name' => 'Updated Tax rule',
             'taxrate' => 99,
-            'country' => 'NL'
-        );
+            'country' => 'NL',
+        ];
         $this->api_admin->invoice_tax_update($data);
 
-
-        $tax = $this->api_admin->invoice_tax_get(array('id' => $id));
+        $tax = $this->api_admin->invoice_tax_get(['id' => $id]);
 
         $this->assertIsArray($tax);
         $this->assertEquals($data['name'], $tax['name']);

--- a/tests/integration/bb-modules/mod_invoice/Api_Client2Test.php
+++ b/tests/integration/bb-modules/mod_invoice/Api_Client2Test.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_InvoiceTest extends BBDbApiTestCase
 {
@@ -6,11 +7,11 @@ class Api_Client_InvoiceTest extends BBDbApiTestCase
 
     public function testProformaInvoices()
     {
-        //prepare expiring order
-        $data = array(
-            'id'            =>  5,
-            'expires_at'    =>  date('Y-m-d H:i:s', strtotime('+1 day')),
-        );
+        // prepare expiring order
+        $data = [
+            'id' => 5,
+            'expires_at' => date('Y-m-d H:i:s', strtotime('+1 day')),
+        ];
         $bool = $this->api_admin->order_update($data);
         $this->assertTrue($bool);
 
@@ -19,28 +20,28 @@ class Api_Client_InvoiceTest extends BBDbApiTestCase
 
         $array = $this->api_client->invoice_get_list();
         $this->assertIsArray($array);
-        
-        $data = array(
-            'hash'    =>  $array['list'][0]['hash'],
-        );
+
+        $data = [
+            'hash' => $array['list'][0]['hash'],
+        ];
         $array = $this->api_client->invoice_get($data);
         $this->assertIsArray($array);
     }
 
     public function testRenewal()
     {
-        $data = array(
-            'order_id'  =>  3,
-        );
+        $data = [
+            'order_id' => 3,
+        ];
         $hash = $this->api_client->invoice_renewal_invoice($data);
         $this->assertIsString($hash);
     }
 
     public function testFunds()
     {
-        $data = array(
-            'amount'  =>  30,
-        );
+        $data = [
+            'amount' => 30,
+        ];
         $hash = $this->api_client->invoice_funds_invoice($data);
         $this->assertIsString($hash);
     }
@@ -51,9 +52,9 @@ class Api_Client_InvoiceTest extends BBDbApiTestCase
         $pf = $invoices[1];
         $hash = $pf->hash;
 
-        $data = array(
-            'hash'          =>  $hash,
-        );
+        $data = [
+            'hash' => $hash,
+        ];
         $bool = $this->api_client->invoice_delete($data);
         $this->assertTrue($bool);
     }

--- a/tests/integration/bb-modules/mod_invoice/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_invoice/Api_ClientTest.php
@@ -1,22 +1,23 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Invoice_Api_ClientTest extends BBModTestCase
 {
     protected $_mod = 'invoice';
     protected $_initialSeedFile = 'mod_invoice.xml';
-    
+
     public function testUpdate()
     {
-        $data = array(
-            'hash'          =>  'hash2',
-        );
+        $data = [
+            'hash' => 'hash2',
+        ];
         $array = $this->api_client->invoice_get($data);
         $this->assertIsArray($array);
-        
+
         $data['gateway_id'] = 1;
         $bool = $this->api_client->invoice_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_client->invoice_get($data);
         $this->assertEquals(1, $array['gateway_id']);
     }

--- a/tests/integration/bb-modules/mod_invoice/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_invoice/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_InvoiceTest extends BBDbApiTestCase
 {
@@ -6,9 +7,9 @@ class Api_Guest_InvoiceTest extends BBDbApiTestCase
 
     public function testGateways()
     {
-        $data = array(
-            'hash'    =>  'hash',
-        );
+        $data = [
+            'hash' => 'hash',
+        ];
         $array = $this->api_guest->invoice_get($data);
         $this->assertIsArray($array);
 
@@ -16,15 +17,15 @@ class Api_Guest_InvoiceTest extends BBDbApiTestCase
         $this->assertIsArray($array);
     }
 
-
-    public static function gateways(){
-        return array(
-            array(1, 1),
-            array(2, 2),
-            array(2, 3),
-            array(2, 4),
-            array(3, 1),
-        );
+    public static function gateways()
+    {
+        return [
+            [1, 1],
+            [2, 2],
+            [2, 3],
+            [2, 4],
+            [3, 1],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('gateways')]
@@ -33,11 +34,11 @@ class Api_Guest_InvoiceTest extends BBDbApiTestCase
         $pf = $this->di['db']->findOne('Invoice', $iid);
         $hash = $pf->hash;
 
-        $data = array(
-            'subscription'  =>  false,
-            'hash'          =>  $hash,
-            'gateway_id'    =>  $id,
-        );
+        $data = [
+            'subscription' => false,
+            'hash' => $hash,
+            'gateway_id' => $id,
+        ];
         $array = $this->api_guest->invoice_payment($data);
         $this->assertIsArray($array);
     }
@@ -49,24 +50,24 @@ class Api_Guest_InvoiceTest extends BBDbApiTestCase
         $pf = $this->di['db']->findOne('Invoice', 1);
         $hash = $pf->hash;
 
-        $data = array(
-            'subscription'  =>  false,
-            'hash'          =>  $hash,
-            'gateway_id'    =>  $gateway_id,
-        );
+        $data = [
+            'subscription' => false,
+            'hash' => $hash,
+            'gateway_id' => $gateway_id,
+        ];
         $form = $this->api_guest->invoice_payment($data);
         $this->assertIsArray($form);
         $this->assertEquals('html', $form['type']);
         $this->assertFalse(empty($form['result']));
-        
-        //subscription
+
+        // subscription
         $pf = $this->di['db']->findOne('Invoice', 2);
         $hash = $pf->hash;
-        $data = array(
-            'subscription'  =>  true,
-            'hash'          =>  $hash,
-            'gateway_id'    =>  $gateway_id,
-        );
+        $data = [
+            'subscription' => true,
+            'hash' => $hash,
+            'gateway_id' => $gateway_id,
+        ];
         $form2 = $this->api_guest->invoice_payment($data);
         $this->assertIsArray($form2);
         $this->assertEquals('html', $form2['type']);
@@ -75,12 +76,11 @@ class Api_Guest_InvoiceTest extends BBDbApiTestCase
 
     public function testupdate()
     {
-        $data = array(
-            'hash' => 'hash'
-        );
+        $data = [
+            'hash' => 'hash',
+        ];
 
         $bool = $this->api_guest->invoice_update($data);
         $this->assertTrue($bool);
     }
-
 }

--- a/tests/integration/bb-modules/mod_invoice/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_invoice/ServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
 {
@@ -7,19 +8,19 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
 
     public function testEvents()
     {
-        $service = new \Box\Mod\Invoice\Service();
+        $service = new Box\Mod\Invoice\Service();
         $service->setDi($this->di);
-        $params = array(
+        $params = [
             'id' => 1,
-        );
+        ];
         $event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
         $bool = $service->onAfterAdminInvoicePaymentReceived($event);
         $this->assertTrue($bool);
 
-        $params = array(
+        $params = [
             'id' => 1,
-        );
+        ];
         $event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
         $bool = $service->onAfterAdminInvoiceApprove($event);
@@ -27,11 +28,11 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
     }
 
     /**
-     * Process Paypal transaction
+     * Process Paypal transaction.
      */
     public function testprocessTransaction()
     {
-        $service = new \Box\Mod\Invoice\ServiceTransaction();
+        $service = new Box\Mod\Invoice\ServiceTransaction();
         $service->setDi($this->di);
 
         $transactionModel = $this->di['db']->load('Transaction', 10);
@@ -41,15 +42,14 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
         $this->assertEquals('PayPalEmail', $gatewayModel->gateway);
 
         $service->processTransaction($transactionModel->id);
-
     }
 
     /**
-     * Process Paypal duplicate transaction
+     * Process Paypal duplicate transaction.
      */
-    public function testcreateAndProcessTransaction_Duplicate()
+    public function testcreateAndProcessTransactionDuplicate()
     {
-        $service = new \Box\Mod\Invoice\ServiceTransaction();
+        $service = new Box\Mod\Invoice\ServiceTransaction();
         $service->setDi($this->di);
 
         $transactionModel = $this->di['db']->load('Transaction', 10);
@@ -62,13 +62,13 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
 
         $transactionIpn = json_decode($transactionModel->ipn, 1);
 
-        $ipn = array(
-            'skip_validation'       =>  true,
-            'bb_invoice_id'         =>  $transactionModel->invoice_id,
-            'bb_gateway_id'         =>  $transactionModel->gateway_id,
-            'get'                   =>  $transactionIpn['get'],
-            'post'                  =>  $transactionIpn['post'],
-        );
+        $ipn = [
+            'skip_validation' => true,
+            'bb_invoice_id' => $transactionModel->invoice_id,
+            'bb_gateway_id' => $transactionModel->gateway_id,
+            'get' => $transactionIpn['get'],
+            'post' => $transactionIpn['post'],
+        ];
 
         $this->expectException(Payment_Exception::class);
         $this->expectExceptionMessage('Cannot process duplicate IPN');
@@ -77,7 +77,6 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
 
         $transactionModel = $this->di['db']->load('Transaction', $newId);
         $this->assertInstanceOf('Model_Transaction', $transactionModel);
-
     }
 
     public function testonAfterAdminCronRun()
@@ -91,7 +90,7 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
         $this->assertEquals($expected, $remove_after_days);
 
         $sql = "SELECT 1 FROM invoice WHERE status = 'unpaid' AND DATEDIFF(NOW(), due_at) > :days";
-        $binigns = array(':days' => $remove_after_days);
+        $binigns = [':days' => $remove_after_days];
         $result = $this->di['db']->getAll($sql, $binigns);
         $invoiceNeedsToBeDeleted = count($result);
 
@@ -99,20 +98,19 @@ class Box_Mod_Invoice_ServiceTest extends BBDbApiTestCase
 
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
-            ->onlyMethods(array('getDi'))
+            ->onlyMethods(['getDi'])
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
             ->willReturn($this->di);
-        $service = new \Box\Mod\Invoice\Service();
+        $service = new Box\Mod\Invoice\Service();
         $service->onAfterAdminCronRun($eventMock);
 
         $result = $this->di['db']->getAll($sql, $binigns);
         $this->assertEquals(0, count($result));
     }
 
-
-    public function testbatch_activate_paid()
+    public function testbatchActivatePaid()
     {
         $invoiceItems = $this->di['mod_service']('Invoice', 'InvoiceItem')->getAllNotExecutePaidItems();
         $this->assertNotEmpty($invoiceItems);

--- a/tests/integration/bb-modules/mod_massmailer/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_massmailer/Api_AdminTest.php
@@ -1,64 +1,65 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Massmailer_Api_AdminTest extends BBModTestCase
 {
     protected $_mod = 'massmailer';
     protected $_initialSeedFile = 'mod_massmailer.xml';
-    
+
     public function testActions()
     {
-        $int = $this->api_admin->massmailer_create(array('subject'=>'Subject', 'content'=>'content'));
+        $int = $this->api_admin->massmailer_create(['subject' => 'Subject', 'content' => 'content']);
         $this->assertIsInt($int);
-        
-        $array = $this->api_admin->massmailer_get(array('id'=>$int));
+
+        $array = $this->api_admin->massmailer_get(['id' => $int]);
         $this->assertIsArray($array);
-        
-        $data = array(
-            'id'=>$int, 
-            'subject'=>"New subject",
-            'content'=>"New content",
-            'status'=>"draft",
-            'from_email'=>"test@mail.com",
-            'from_name'=>"John Doe",
-        );
+
+        $data = [
+            'id' => $int,
+            'subject' => 'New subject',
+            'content' => 'New content',
+            'status' => 'draft',
+            'from_email' => 'test@mail.com',
+            'from_name' => 'John Doe',
+        ];
         $bool = $this->api_admin->massmailer_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_admin->massmailer_preview($data);
         $this->assertIsArray($array);
         $this->assertTrue(isset($array['subject']));
         $this->assertTrue(isset($array['content']));
-        
+
         $array = $this->api_admin->massmailer_receivers($data);
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->massmailer_get_list();
         $this->assertIsArray($array);
         $this->assertEquals(2, $array['total']);
-        
-        $new_id = $this->api_admin->massmailer_copy(array('id'=>$int));
+
+        $new_id = $this->api_admin->massmailer_copy(['id' => $int]);
         $this->assertIsInt($new_id);
-        
-        $bool = $this->api_admin->massmailer_send_test(array('id'=>$new_id));
+
+        $bool = $this->api_admin->massmailer_send_test(['id' => $new_id]);
         $this->assertTrue($bool);
-        
-        $bool = $this->api_admin->massmailer_send(array('id'=>$int));
+
+        $bool = $this->api_admin->massmailer_send(['id' => $int]);
         $this->assertTrue($bool);
-        
-        $bool = $this->api_admin->massmailer_delete(array('id'=>$array['list'][0]['id']));
+
+        $bool = $this->api_admin->massmailer_delete(['id' => $array['list'][0]['id']]);
         $this->assertTrue($bool);
     }
-    
+
     public function testFilter()
     {
-        $filter = array(
-            'client_status' =>  array('suspended', 'canceled'),
-            'client_groups' =>  array('1'),
-            'has_order' =>  array('1', '2'),
-            'has_order_with_status' =>  array('active'),
-        );
-        $this->api_admin->massmailer_update(array('id'=>1, 'filter'=>$filter));
-        $this->api_admin->massmailer_send(array('id'=>1));
+        $filter = [
+            'client_status' => ['suspended', 'canceled'],
+            'client_groups' => ['1'],
+            'has_order' => ['1', '2'],
+            'has_order_with_status' => ['active'],
+        ];
+        $this->api_admin->massmailer_update(['id' => 1, 'filter' => $filter]);
+        $this->api_admin->massmailer_send(['id' => 1]);
 
         $this->assertTrue(is_array($filter));
     }

--- a/tests/integration/bb-modules/mod_news/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_news/Api_AdminTest.php
@@ -1,34 +1,35 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_NewsTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'extension_news.xml';
-    
+
     public function testNews()
     {
         $array = $this->api_admin->news_get_list();
         $this->assertIsArray($array);
 
-        $data = array('id'=>1);
+        $data = ['id' => 1];
         $array = $this->api_admin->news_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'        => 1,
-            'title'     => 'News Title',
-            'slug'      => 'news-title',
-            'status'    => 'draft',
-            'content'   => 'Announcement',
-        );
+        $data = [
+            'id' => 1,
+            'title' => 'News Title',
+            'slug' => 'news-title',
+            'status' => 'draft',
+            'content' => 'Announcement',
+        ];
         $bool = $this->api_admin->news_update($data);
         $this->assertTrue($bool);
 
         $bool = $this->api_admin->news_delete($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'title' =>  'Test',
-        );
+        $data = [
+            'title' => 'Test',
+        ];
         $id = $this->api_admin->news_create($data);
         $this->assertTrue(is_numeric($id));
     }
@@ -64,18 +65,17 @@ class Api_Admin_NewsTest extends BBDbApiTestCase
             $this->assertArrayHasKey('name', $author);
             $this->assertArrayHasKey('email', $author);
         }
-
     }
 
     public function testNewsBatchDelete()
     {
-        $array = $this->api_admin->news_get_list(array());
+        $array = $this->api_admin->news_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->news_batch_delete(array('ids' => $ids));
-        $array  = $this->api_admin->news_get_list(array());
+        $result = $this->api_admin->news_batch_delete(['ids' => $ids]);
+        $array = $this->api_admin->news_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -85,31 +85,31 @@ class Api_Admin_NewsTest extends BBDbApiTestCase
     {
         $this->assertTrue(true);
 
-        return array(
-            array(
+        return [
+            [
                 'This is blog post with<!--more--> tag',
-                'This is blog post with'
-            ),
-            array(
+                'This is blog post with',
+            ],
+            [
                 'This is blog post without more tag',
-                null
-            )
-        );
+                null,
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('testNewsMoreTagProvider')]
     public function testNewsMoreTag($content, $expectedExcerpt)
     {
-        $data = array(
-            'title'   => 'News Title',
-            'slug'    => 'news-title',
-            'status'  => 'draft',
+        $data = [
+            'title' => 'News Title',
+            'slug' => 'news-title',
+            'status' => 'draft',
             'content' => $content,
-        );
+        ];
 
         $id = $this->api_admin->news_create($data);
 
-        $array = $this->api_admin->news_get(array('id' => $id));
+        $array = $this->api_admin->news_get(['id' => $id]);
         $this->assertEquals($array['excerpt'], $expectedExcerpt);
         $this->assertEquals($array['content'], $content);
     }

--- a/tests/integration/bb-modules/mod_news/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_news/Api_GuestTest.php
@@ -7,18 +7,18 @@ class Api_Guest_NewsTest extends BBDbApiTestCase
 
     public function testNews()
     {
-        $data  = array(
-            'page'     => 1,
+        $data = [
+            'page' => 1,
             'per_page' => 1,
-        );
+        ];
         $array = $this->api_guest->news_get_list($data);
         $this->assertIsArray($array);
 
-        $data  = array('id' => 1);
+        $data = ['id' => 1];
         $array = $this->api_guest->news_get($data);
         $this->assertIsArray($array);
 
-        $data  = array('slug' => 'boxbilling-is-customizable');
+        $data = ['slug' => 'boxbilling-is-customizable'];
         $array = $this->api_guest->news_get($data);
         $this->assertIsArray($array);
     }
@@ -54,6 +54,5 @@ class Api_Guest_NewsTest extends BBDbApiTestCase
             $this->assertArrayHasKey('name', $author);
             $this->assertArrayHasKey('email', $author);
         }
-
     }
 }

--- a/tests/integration/bb-modules/mod_notification/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_notification/Api_AdminTest.php
@@ -8,12 +8,12 @@ class Box_Mod_Notification_Api_AdminTest extends BBModTestCase
 
     public function testActions()
     {
-        $this->api_admin->extension_activate(array('id' => 'notification', 'type' => 'mod'));
+        $this->api_admin->extension_activate(['id' => 'notification', 'type' => 'mod']);
 
-        $int = $this->api_admin->notification_add(array('message' => 'Test message'));
+        $int = $this->api_admin->notification_add(['message' => 'Test message']);
         $this->assertIsInt($int);
 
-        $array = $this->api_admin->notification_get(array('id' => $int));
+        $array = $this->api_admin->notification_get(['id' => $int]);
         $this->assertIsArray($array);
 
         $array = $this->api_admin->notification_get_list();
@@ -34,10 +34,9 @@ class Box_Mod_Notification_Api_AdminTest extends BBModTestCase
         $this->assertArrayHasKey('created_at', $item);
         $this->assertArrayHasKey('updated_at', $item);
 
-
-        $bool = $this->api_admin->notification_delete(array('id' => $array['list'][0]['id']));
+        $bool = $this->api_admin->notification_delete(['id' => $array['list'][0]['id']]);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->notification_delete_all();
         $this->assertTrue($bool);
     }

--- a/tests/integration/bb-modules/mod_order/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_order/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_OrderTest extends BBDbApiTestCase
 {
@@ -6,42 +7,42 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
 
     public function testMetaUpdate()
     {
-        $meta = array(
-            'unique'  =>  'search by this field',
-            'param_1'  =>  'value 1',
-            'param_2'  =>  'value 2',
-            'param_3'  =>  'value 3',
-        );
+        $meta = [
+            'unique' => 'search by this field',
+            'param_1' => 'value 1',
+            'param_2' => 'value 2',
+            'param_3' => 'value 3',
+        ];
 
-        $bool = $this->api_admin->order_update(array('id'=>'1', 'meta'=>$meta));
+        $bool = $this->api_admin->order_update(['id' => '1', 'meta' => $meta]);
         $this->assertTrue($bool);
-        $order = $this->api_admin->order_get(array('id'=>1));
+        $order = $this->api_admin->order_get(['id' => 1]);
         $this->assertIsArray($order);
         $this->assertTrue(isset($order['meta']));
         $this->assertEquals('value 1', $order['meta']['param_1']);
         $this->assertEquals('value 2', $order['meta']['param_2']);
         $this->assertEquals('value 3', $order['meta']['param_3']);
 
-        //search test
-        $array = $this->api_admin->order_get_list(array('meta'=> array('unique'=>'search by this')));
+        // search test
+        $array = $this->api_admin->order_get_list(['meta' => ['unique' => 'search by this']]);
         $this->assertEquals(1, $array['total']);
         $this->assertEquals('search by this field', $array['list'][0]['meta']['unique']);
     }
 
     public static function orders()
     {
-        return array(
-            array(1),
-            array(2),
-            array(3),
-            array(4),
-            array(5),
-            array(6),
-            array(7),
-            array(9),
-            //array(12), // solusvm
-            //array(13), // serviceboxbillinglicense
-        );
+        return [
+            [1],
+            [2],
+            [3],
+            [4],
+            [5],
+            [6],
+            [7],
+            [9],
+            // array(12), // solusvm
+            // array(13), // serviceboxbillinglicense
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('orders')]
@@ -53,10 +54,10 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
         $this->assertIsArray($order);
         $this->assertEquals($id, $order['id']);
 
-        $list = $this->api_admin->order_get_list(array());
+        $list = $this->api_admin->order_get_list([]);
         $this->assertIsArray($list);
 
-        $bool = $this->api_admin->order_update(array('id'=>1,'expires_at'=>date('Y-m-d H:i:s', strtotime('+ 2 days'))));
+        $bool = $this->api_admin->order_update(['id' => 1, 'expires_at' => date('Y-m-d H:i:s', strtotime('+ 2 days'))]);
         $this->assertTrue($bool);
 
         $bool = $this->api_admin->order_renew($data);
@@ -92,13 +93,13 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
         $bool = $this->api_admin->order_renew($data);
         $this->assertTrue($bool);
 
-        $data['config'] = array('foo'=>'bar');
+        $data['config'] = ['foo' => 'bar'];
         $bool = $this->api_admin->order_update_config($data);
         $this->assertTrue($bool);
 
         $list = $this->api_admin->order_status_history_get_list($data);
         $this->assertIsArray($list);
-        
+
         $array = $this->api_admin->order_addons($data);
         $this->assertIsArray($array);
 
@@ -110,11 +111,11 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
     {
         $array = $this->api_admin->order_get_invoice_options();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->order_get_status_pairs();
         $this->assertIsArray($array);
 
-        $array = $this->api_admin->order_get_statuses(array());
+        $array = $this->api_admin->order_get_statuses([]);
         $this->assertIsArray($array);
     }
 
@@ -134,49 +135,49 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
     {
         $data['id'] = 3;
         $bool = $this->api_admin->order_renew($data);
-        $this->assertTrue($bool);   
+        $this->assertTrue($bool);
     }
-    
+
     public function testDeleteAddons()
     {
         $data['id'] = 1;
         $addons = $this->api_admin->order_addons($data);
         $this->assertEquals(1, count($addons));
         $addon_id = $addons[0]['id'];
-        
+
         $data['delete_addons'] = true;
         $bool = $this->api_admin->order_delete($data);
-        $this->assertTrue($bool);   
+        $this->assertTrue($bool);
 
         try {
-            $this->api_admin->order_get(array('id'=>$addon_id));
+            $this->api_admin->order_get(['id' => $addon_id]);
             $this->fail('Order addon should be removed');
-        } catch(Exception) {
+        } catch (Exception) {
         }
     }
 
     public function testOrderExpiration()
     {
-        $data = array(
-            'id'            => 8,
-            'period'        => '2Y',
-            'expires_at'    => date('Y-m-d H:i:s', strtotime('2012-01-10')),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '2Y',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('2012-01-10')),
+        ];
         $this->api_admin->order_update($data);
         $ob = $this->api_admin->order_get($data);
         $this->api_admin->order_renew($data);
         $oa = $this->api_admin->order_get($data);
-        
+
         $this->assertEquals(2, date('Y', strtotime($oa['expires_at'])) - date('Y', strtotime($ob['expires_at'])));
     }
 
-    public function testOrderExpiration_SettingFromToday()
+    public function testOrderExpirationSettingFromToday()
     {
-        $data = array(
-            'id'            => 8,
-            'period'        => '1M',
-            'expires_at'    => date('Y-m-d H:i:s', strtotime('2012-01-10')),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '1M',
+            'expires_at' => date('Y-m-d H:i:s', strtotime('2012-01-10')),
+        ];
         $this->api_admin->order_update($data);
 
         $orderConfig = $this->di['mod_config']('Order');
@@ -189,17 +190,17 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
 
         $expectedExpireDate = date('Y-m-d', strtotime('+1 month'));
 
-        $this->assertEquals($expectedExpireDate, date('Y-m-d', strtotime($order['expires_at'])) );
+        $this->assertEquals($expectedExpireDate, date('Y-m-d', strtotime($order['expires_at'])));
     }
 
-    public function testOrderExpiration_SettingFrom_greater_FromTodayIsGreater()
+    public function testOrderExpirationSettingFromGreaterFromTodayIsGreater()
     {
         $orderExpireDate = strtotime('2012-01-10');
-        $data = array(
-            'id'            => 8,
-            'period'        => '1M',
-            'expires_at'    => date('Y-m-d H:i:s', $orderExpireDate),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '1M',
+            'expires_at' => date('Y-m-d H:i:s', $orderExpireDate),
+        ];
         $this->api_admin->order_update($data);
 
         $orderConfig = $this->di['mod_config']('Order');
@@ -212,17 +213,17 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
 
         $expectedExpiryDate = date('Y-m-d', strtotime('+1 month'));
 
-        $this->assertEquals($expectedExpiryDate, date('Y-m-d', strtotime($order['expires_at'])) );
+        $this->assertEquals($expectedExpiryDate, date('Y-m-d', strtotime($order['expires_at'])));
     }
 
-    public function testOrderExpiration_SettingFrom_greater_ExpireIsGreater()
+    public function testOrderExpirationSettingFromGreaterExpireIsGreater()
     {
         $orderExpireDate = strtotime('+1 week');
-        $data = array(
-            'id'            => 8,
-            'period'        => '1M',
-            'expires_at'    => date('Y-m-d H:i:s', $orderExpireDate),
-        );
+        $data = [
+            'id' => 8,
+            'period' => '1M',
+            'expires_at' => date('Y-m-d H:i:s', $orderExpireDate),
+        ];
         $this->api_admin->order_update($data);
 
         $orderConfig = $this->di['mod_config']('Order');
@@ -236,7 +237,7 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
         $date = new DateTime(date('Y-m-d', $orderExpireDate));
         $date->add(new DateInterval('P1M'));
         $expectedExpiryDate = $date->format('Y-m-d');
-        $this->assertEquals($expectedExpiryDate, date('Y-m-d', strtotime($order['expires_at'])) );
+        $this->assertEquals($expectedExpiryDate, date('Y-m-d', strtotime($order['expires_at'])));
     }
 
     public function testDomainOrderExpiration()
@@ -253,80 +254,80 @@ class Api_Admin_OrderTest extends BBDbApiTestCase
 
     public static function products()
     {
-        return array(
-            array(1, array()), //custom
-            array(6, array()), //license
-            array(7, array()), //downloadable
-            array(10, array('action'=>'register', 'register_sld'=>'test', 'register_tld'=>".com", 'register_years'=>'3')), //domain
-            array(10, array('action'=>'transfer', 'transfer_sld'=>'test', 'transfer_tld'=>".com", 'transfer_code'=>'asdasd')), //domain
-            array(10, array('action'=>'owndomain', 'owndomain_sld'=>'test', 'owndomain_tld'=>".com", 'register_years'=>'3')), //domain
-            array(12, array('some'=>'var')), //membership
-            array(8, array('domain'=>array('action'=>'owndomain', 'owndomain_sld'=>'cololo', 'owndomain_tld'=>'.com'))), //hosting
-            
-            array(3, array()), //addon
-        );
+        return [
+            [1, []], // custom
+            [6, []], // license
+            [7, []], // downloadable
+            [10, ['action' => 'register', 'register_sld' => 'test', 'register_tld' => '.com', 'register_years' => '3']], // domain
+            [10, ['action' => 'transfer', 'transfer_sld' => 'test', 'transfer_tld' => '.com', 'transfer_code' => 'asdasd']], // domain
+            [10, ['action' => 'owndomain', 'owndomain_sld' => 'test', 'owndomain_tld' => '.com', 'register_years' => '3']], // domain
+            [12, ['some' => 'var']], // membership
+            [8, ['domain' => ['action' => 'owndomain', 'owndomain_sld' => 'cololo', 'owndomain_tld' => '.com']]], // hosting
+
+            [3, []], // addon
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('products')]
     public function testCreate($pid, $config)
     {
-        $data['client_id']      = 1;
-        $data['product_id']     = $pid;
-        $data['period']         = '1M';
-        $data['group_id']       = 200;
-//        $data['currency']       = 'EUR';
-//        $data['invoice_option'] = 'issue-invoice';
+        $data['client_id'] = 1;
+        $data['product_id'] = $pid;
+        $data['period'] = '1M';
+        $data['group_id'] = 200;
+        //        $data['currency']       = 'EUR';
+        //        $data['invoice_option'] = 'issue-invoice';
         $data['invoice_option'] = 'no-invoice';
         $data['activate'] = 1;
         $data['config'] = $config;
-        
+
         $id = $this->api_admin->order_create($data);
         $this->assertIsInt($id);
     }
-    
+
     /**
      * Test recurent promo for order
      * 1. If promo is recurrent then new invoice is generated with discount
-     * 2. If promo is not recurrent then new invoice is generated for order total price
+     * 2. If promo is not recurrent then new invoice is generated for order total price.
      */
     public function testPromoRec()
     {
-        $data['id']      = 8; //order with recurring promo
+        $data['id'] = 8; // order with recurring promo
         $id = $this->api_admin->invoice_renewal_invoice($data);
-        $invoice = $this->api_admin->invoice_get(array('id'=>$id));
-        $this->assertEquals(15 ,$invoice['lines'][0]['total']);
-        
-        $data['id']      = 10; //order without recurring promo
+        $invoice = $this->api_admin->invoice_get(['id' => $id]);
+        $this->assertEquals(15, $invoice['lines'][0]['total']);
+
+        $data['id'] = 10; // order without recurring promo
         $id = $this->api_admin->invoice_renewal_invoice($data);
-        $invoice = $this->api_admin->invoice_get(array('id'=>$id));
-        $this->assertEquals(30 ,$invoice['lines'][0]['total']);
+        $invoice = $this->api_admin->invoice_get(['id' => $id]);
+        $this->assertEquals(30, $invoice['lines'][0]['total']);
     }
 
     public function testHistory()
     {
-        $data = array(
+        $data = [
             'id' => 1,
             'status' => 'cancelled by phpUnit',
-        );
+        ];
         $result = $this->api_admin->order_status_history_add($data);
         $this->assertTrue($result);
 
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $result = $this->api_admin->order_status_history_delete($data);
         $this->assertTrue($result);
     }
 
     public function testOrderBatchDelete()
     {
-        $array  = $this->api_admin->order_get_list(array());
+        $array = $this->api_admin->order_get_list([]);
 
-        foreach ($array['list'] as $value){
+        foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->order_batch_delete(array('ids' => $ids, 'delete_addons' => true));
-        $array  = $this->api_admin->order_get_list(array());
+        $result = $this->api_admin->order_batch_delete(['ids' => $ids, 'delete_addons' => true]);
+        $array = $this->api_admin->order_get_list([]);
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
     }

--- a/tests/integration/bb-modules/mod_order/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_order/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_OrderTest extends BBDbApiTestCase
 {
@@ -6,24 +7,24 @@ class Api_Client_OrderTest extends BBDbApiTestCase
 
     public function testOrders()
     {
-        $data = array(
-            'page'       =>  1,
-            'per_page'   =>  10,
-        );
+        $data = [
+            'page' => 1,
+            'per_page' => 10,
+        ];
         $array = $this->api_client->order_get_list($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'page'       =>  1,
-            'per_page'   =>  10,
-            'expiring'   =>  1,
-        );
+        $data = [
+            'page' => 1,
+            'per_page' => 10,
+            'expiring' => 1,
+        ];
         $array = $this->api_client->order_get_list($data);
         $this->assertIsArray($array);
-        
-        $data = array(
-            'id'       =>  1,
-        );
+
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_client->order_get($data);
         $this->assertIsArray($array);
 
@@ -33,9 +34,9 @@ class Api_Client_OrderTest extends BBDbApiTestCase
 
     public function testDelete()
     {
-        $data = array(
-            'id'    =>  9,
-        );
+        $data = [
+            'id' => 9,
+        ];
 
         $bool = $this->api_client->order_delete($data);
         $this->assertTrue($bool);
@@ -43,18 +44,17 @@ class Api_Client_OrderTest extends BBDbApiTestCase
 
     public function testService()
     {
-        $data = array(
+        $data = [
             'id' => 8,
-        );
+        ];
 
-        $expected = array(
+        $expected = [
             'id' => 1,
             'client_id' => 1,
             'plugin' => 'Example',
             'updated_at' => null,
             'created_at' => null,
-        );
-
+        ];
 
         $result = $this->api_client->order_service($data);
         $this->assertIsArray($result);
@@ -63,11 +63,11 @@ class Api_Client_OrderTest extends BBDbApiTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testupgradables_NoUpgradablesFound()
+    public function testupgradablesNoUpgradablesFound()
     {
-        $data = array(
+        $data = [
             'id' => 8,
-        );
+        ];
 
         $result = $this->api_client->order_upgradables($data);
         $this->assertIsArray($result);

--- a/tests/integration/bb-modules/mod_page/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_page/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 class Box_Mod_Page_Api_AdminTest extends BBModTestCase
 {
     protected $_mod = 'page';

--- a/tests/integration/bb-modules/mod_paidsupport/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_paidsupport/ServiceTest.php
@@ -2,20 +2,17 @@
 
 class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
 {
-
     public function setup(): void
     {
         parent::setUp();
-        $data = array(
-            'id'    =>  'paidsupport',
-            'type'  =>  'mod',
-        );
+        $data = [
+            'id' => 'paidsupport',
+            'type' => 'mod',
+        ];
         $this->api_admin->extension_activate($data);
 
         $hookService = $this->di['mod_service']('hook');
         $hookService->batchConnect('paidsupport');
-
-
     }
 
     public function testCreatePaidSupportTicket()
@@ -24,28 +21,28 @@ class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
 
         $balance = $this->api_client->client_balance_get_total();
 
-        if ($balance < $ticketPrice){
-            $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit'));
+        if ($balance < $ticketPrice) {
+            $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit']);
         }
 
         $helpdeskId = 1;
         $beforeBalance = $this->api_client->client_balance_get_total();
-        $data = array(
-            'ext'           =>  'mod_paidsupport',
-            'ticket_price'  =>  $ticketPrice,
-            'error_msg'     =>  'Insufficient amount in balance',
-            'helpdesk'      => array($helpdeskId => 1),
-        );
+        $data = [
+            'ext' => 'mod_paidsupport',
+            'ticket_price' => $ticketPrice,
+            'error_msg' => 'Insufficient amount in balance',
+            'helpdesk' => [$helpdeskId => 1],
+        ];
 
         $this->api_admin->extension_config_save($data);
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  $helpdeskId,
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => $helpdeskId,
 
-            'order_id'              =>  '1',
-            'task'                  =>  'cancel',
-        );
+            'order_id' => '1',
+            'task' => 'cancel',
+        ];
         $id = $this->api_client->support_ticket_create($data);
 
         $supportTicket = $this->di['db']->load('SupportTicket', $id);
@@ -58,36 +55,36 @@ class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
         $this->assertEquals(-$ticketPrice, $clientBalanceModel->amount);
     }
 
-    public function testCreatePaidSupportTicket_HelpdeskhasPaidSupport()
+    public function testCreatePaidSupportTicketHelpdeskhasPaidSupport()
     {
         $ticketPrice = 5.5;
 
         $balance = $this->api_client->client_balance_get_total();
 
-        if ($balance < $ticketPrice){
-            $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit'));
+        if ($balance < $ticketPrice) {
+            $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit']);
         }
 
         $beforeBalance = $this->api_client->client_balance_get_total();
 
         $helpdeskId = 1;
 
-        $data = array(
-            'ext'           =>  'mod_paidsupport',
-            'ticket_price'  =>  $ticketPrice,
-            'error_msg'     =>  'Insufficient amount in balance',
-            'helpdesk'      => array($helpdeskId => 1),
-        );
+        $data = [
+            'ext' => 'mod_paidsupport',
+            'ticket_price' => $ticketPrice,
+            'error_msg' => 'Insufficient amount in balance',
+            'helpdesk' => [$helpdeskId => 1],
+        ];
 
         $this->api_admin->extension_config_save($data);
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  $helpdeskId,
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => $helpdeskId,
 
-            'order_id'              =>  '1',
-            'task'                  =>  'cancel',
-        );
+            'order_id' => '1',
+            'task' => 'cancel',
+        ];
         $id = $this->api_client->support_ticket_create($data);
 
         $supportTicket = $this->di['db']->load('SupportTicket', $id);
@@ -100,36 +97,36 @@ class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
         $this->assertEquals(-$ticketPrice, $clientBalanceModel->amount);
     }
 
-    public function testCreatePaidSupportTicket_HelpdesHasNotPaidSupport()
+    public function testCreatePaidSupportTicketHelpdesHasNotPaidSupport()
     {
         $ticketPrice = 5.5;
 
         $balance = $this->api_client->client_balance_get_total();
 
-        if ($balance <= $ticketPrice){
-            $this->api_admin->client_balance_add_funds(array('id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit'));
+        if ($balance <= $ticketPrice) {
+            $this->api_admin->client_balance_add_funds(['id' => 1, 'amount' => $ticketPrice, 'description' => 'Added from PHPUnit']);
         }
 
         $beforeBalance = $this->api_client->client_balance_get_total();
 
         $helpdeskId = 1;
 
-        $data = array(
-            'ext'           =>  'mod_paidsupport',
-            'ticket_price'  =>  $ticketPrice,
-            'error_msg'     =>  'Insufficient amount in balance',
-            'helpdesk'      => array($helpdeskId => 0),
-        );
+        $data = [
+            'ext' => 'mod_paidsupport',
+            'ticket_price' => $ticketPrice,
+            'error_msg' => 'Insufficient amount in balance',
+            'helpdesk' => [$helpdeskId => 0],
+        ];
 
         $this->api_admin->extension_config_save($data);
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  $helpdeskId,
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => $helpdeskId,
 
-            'order_id'              =>  '1',
-            'task'                  =>  'cancel',
-        );
+            'order_id' => '1',
+            'task' => 'cancel',
+        ];
         $id = $this->api_client->support_ticket_create($data);
 
         $supportTicket = $this->di['db']->load('SupportTicket', $id);
@@ -139,7 +136,7 @@ class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
         $this->assertEquals($beforeBalance, $balance);
     }
 
-    public function testCreatePaidSupportTicket_insufficientFunds()
+    public function testCreatePaidSupportTicketInsufficientFunds()
     {
         $balance = $this->api_client->client_balance_get_total();
 
@@ -149,31 +146,30 @@ class Box_Mod_Paidsupport_ServiceTest extends ApiTestCase
 
         $helpdeskId = 1;
 
-        $data = array(
-            'ext'           =>  'mod_paidsupport',
-            'ticket_price'  =>  $ticketPrice,
-            'error_msg'     =>  $errorMessage,
-            'helpdesk'      => array($helpdeskId => 1),
-        );
+        $data = [
+            'ext' => 'mod_paidsupport',
+            'ticket_price' => $ticketPrice,
+            'error_msg' => $errorMessage,
+            'helpdesk' => [$helpdeskId => 1],
+        ];
 
         $this->api_admin->extension_config_save($data);
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  '1',
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => '1',
 
-            'order_id'              =>  '1',
-            'task'                  =>  'cancel',
-        );
+            'order_id' => '1',
+            'task' => 'cancel',
+        ];
 
         $supportTickets = $this->di['db']->find('SupportTicket');
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage($errorMessage);
         $this->api_client->support_ticket_create($data);
 
         $supportTicketsAfterCreate = $this->di['db']->find('SupportTicket');
         $this->assertEquals(count($supportTickets), count($supportTicketsAfterCreate));
     }
-
 }

--- a/tests/integration/bb-modules/mod_product/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_product/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ProductTest extends ApiTestCase
 {
@@ -9,34 +10,34 @@ class Api_Admin_ProductTest extends ApiTestCase
 
         $list = $this->api_admin->product_get_pairs();
         $this->assertIsArray($list);
-        
+
         $list = $this->api_admin->product_get_types();
         $this->assertIsArray($list);
 
-        $data = array(
-            'id'    =>  10,
-        );
+        $data = [
+            'id' => 10,
+        ];
         $array = $this->api_admin->product_get($data);
         $this->assertIsArray($array);
     }
 
     public function testProduct()
     {
-        $data = array(
-            'title'                 => 'title',
-            'type'                  => Model_ProductTable::CUSTOM,
-            'product_category_id'   => 1,
-        );
+        $data = [
+            'title' => 'title',
+            'type' => Model_ProductTable::CUSTOM,
+            'product_category_id' => 1,
+        ];
         $id = $this->api_admin->product_prepare($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'  =>  $id,
-            'title'  =>  'new title',
-        );
+        $data = [
+            'id' => $id,
+            'title' => 'new title',
+        ];
         $bool = $this->api_admin->product_update($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->product_update_config($data);
         $this->assertTrue($bool);
     }
@@ -46,17 +47,16 @@ class Api_Admin_ProductTest extends ApiTestCase
         $array = $this->api_admin->product_addon_get_pairs();
         $this->assertIsArray($array);
 
-
-        $data = array(
-            'title'                 => 'title',
-        );
+        $data = [
+            'title' => 'title',
+        ];
         $id = $this->api_admin->product_addon_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'  =>  $id,
-            'title'  =>  'new title',
-        );
+        $data = [
+            'id' => $id,
+            'title' => 'new title',
+        ];
         $array = $this->api_admin->product_addon_get($data);
         $this->assertIsArray($array);
 
@@ -72,16 +72,16 @@ class Api_Admin_ProductTest extends ApiTestCase
         $array = $this->api_admin->product_category_get_pairs();
         $this->assertIsArray($array);
 
-        $data = array(
-            'title'                 => 'title',
-        );
+        $data = [
+            'title' => 'title',
+        ];
         $id = $this->api_admin->product_category_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'                 => $id,
-            'title'                 => 'title',
-        );
+        $data = [
+            'id' => $id,
+            'title' => 'title',
+        ];
         $array = $this->api_admin->product_category_get($data);
         $this->assertIsArray($array);
 
@@ -90,7 +90,6 @@ class Api_Admin_ProductTest extends ApiTestCase
 
         $bool = $this->api_admin->product_category_delete($data);
         $this->assertTrue($bool);
-
     }
 
     public function testPromos()
@@ -98,18 +97,18 @@ class Api_Admin_ProductTest extends ApiTestCase
         $array = $this->api_admin->product_promo_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'code'                 => 'title',
-            'type'                 => 'percent',
-            'value'                 => '50',
-        );
+        $data = [
+            'code' => 'title',
+            'type' => 'percent',
+            'value' => '50',
+        ];
         $id = $this->api_admin->product_promo_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'                 => $id,
-            'value'                 => '25',
-        );
+        $data = [
+            'id' => $id,
+            'value' => '25',
+        ];
         $array = $this->api_admin->product_promo_get($data);
         $this->assertIsArray($array);
 
@@ -118,7 +117,6 @@ class Api_Admin_ProductTest extends ApiTestCase
 
         $bool = $this->api_admin->product_promo_delete($data);
         $this->assertTrue($bool);
-
     }
 
     public function testProductGetList()
@@ -202,20 +200,18 @@ class Api_Admin_ProductTest extends ApiTestCase
         $this->assertIsArray($item['applies_to']);
     }
 
-
     public function testCreateTwoDomainProducts()
     {
-        $data = array(
-            'title'                 => 'Two domain product check_',
-            'type'                  => Model_ProductTable::DOMAIN,
-        );
+        $data = [
+            'title' => 'Two domain product check_',
+            'type' => Model_ProductTable::DOMAIN,
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(413);
         $this->expectExceptionMessage('You have already created domain product.');
 
-
-        for($i = 0; $i< 2; $i++){
+        for ($i = 0; $i < 2; ++$i) {
             $id = $this->api_admin->product_prepare($data);
         }
     }

--- a/tests/integration/bb-modules/mod_product/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_product/Api_GuestTest.php
@@ -1,9 +1,10 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_ProductTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'orders.xml';
-    
+
     public function testGetAll()
     {
         $list = $this->api_guest->product_get_pairs();
@@ -11,16 +12,16 @@ class Api_Guest_ProductTest extends BBDbApiTestCase
 
         $list = $this->api_guest->product_get_list();
         $this->assertIsArray($list);
-        
+
         $list = $this->api_guest->product_category_get_pairs();
         $this->assertIsArray($list);
 
-        $data = array(
-            'id'    =>  10,
-        );
+        $data = [
+            'id' => 10,
+        ];
         $list = $this->api_guest->product_get($data);
         $this->assertIsArray($list);
-        
+
         $list = $this->api_guest->product_get_slider($data);
         $this->assertIsArray($list);
     }
@@ -102,10 +103,9 @@ class Api_Guest_ProductTest extends BBDbApiTestCase
         $this->assertArrayNotHasKey('category', $item);
     }
 
-    public function testProduct_StartingFromPrice_DomainType()
+    public function testProductStartingFromPriceDomainType()
     {
-        $array = $this->api_guest->product_get(array('id' => 10));
+        $array = $this->api_guest->product_get(['id' => 10]);
         $this->assertTrue($array['price_starting_from'] > 0);
     }
-
 }

--- a/tests/integration/bb-modules/mod_product/PromoTest.php
+++ b/tests/integration/bb-modules/mod_product/PromoTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_PromoTest extends ApiTestCase
 {

--- a/tests/integration/bb-modules/mod_profile/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_profile/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ProfileTest extends BBDbApiTestCase
 {
@@ -12,11 +13,11 @@ class Api_Admin_ProfileTest extends BBDbApiTestCase
         $bool = $this->api_admin->profile_logout();
         $this->assertTrue($bool);
 
-        $data = array(
-            'email'     =>  'demo@fossbilling.org',
-            'name'      =>  'Demo Admin',
-            'signature' =>  'New Signature',
-        );
+        $data = [
+            'email' => 'demo@fossbilling.org',
+            'name' => 'Demo Admin',
+            'signature' => 'New Signature',
+        ];
         $bool = $this->api_admin->profile_update($data);
         $this->assertTrue($bool);
 
@@ -26,15 +27,15 @@ class Api_Admin_ProfileTest extends BBDbApiTestCase
 
     public function testPassword()
     {
-        $data = array(
-            'password' =>  'demo12313123A',
-            'password_confirm' =>  'demo12313123A',
-        );
+        $data = [
+            'password' => 'demo12313123A',
+            'password_confirm' => 'demo12313123A',
+        ];
         $bool = $this->api_admin->profile_change_password($data);
         $this->assertTrue($bool);
 
         $array = $this->api_admin->profile_get();
-        $password = $this->di['db']->getCell('Select pass from admin where id = ?', array($array['id']));
+        $password = $this->di['db']->getCell('Select pass from admin where id = ?', [$array['id']]);
 
         $this->assertTrue($this->di['password']->verify($data['password'], $password));
     }

--- a/tests/integration/bb-modules/mod_profile/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_profile/Api_ClientTest.php
@@ -1,27 +1,28 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ProfileTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_client.xml';
-    
+
     public function testProfile()
     {
         $array = $this->api_client->profile_get();
         $this->assertIsArray($array);
 
-        $data = array(
-            'email'             =>  'email@test.com',
-            'first_name'        =>  'First name',
-            'last_name'         =>  'Last Name',
-            'address_1'         =>  'address 1',
-            'address_2'         =>  'address 2',
-            'country'           =>  'country',
-            'city'              =>  'city',
-            'state'             =>  'n/a',
-            'postcode'          =>  '123456',
-            'phone_cc'          =>  1234,
-            'phone'             =>  1_212_121_212_121,
-        );
+        $data = [
+            'email' => 'email@test.com',
+            'first_name' => 'First name',
+            'last_name' => 'Last Name',
+            'address_1' => 'address 1',
+            'address_2' => 'address 2',
+            'country' => 'country',
+            'city' => 'city',
+            'state' => 'n/a',
+            'postcode' => '123456',
+            'phone_cc' => 1234,
+            'phone' => 1_212_121_212_121,
+        ];
         $bool = $this->api_client->profile_update($data);
         $this->assertTrue($bool);
 
@@ -31,10 +32,10 @@ class Api_Client_ProfileTest extends BBDbApiTestCase
 
     public function testPassword()
     {
-        $data = array(
-            'password' =>  'demo11AA1111',
-            'password_confirm' =>  'demo11AA1111',
-        );
+        $data = [
+            'password' => 'demo11AA1111',
+            'password_confirm' => 'demo11AA1111',
+        ];
         $bool = $this->api_client->profile_change_password($data);
         $this->assertTrue($bool);
     }
@@ -43,11 +44,11 @@ class Api_Client_ProfileTest extends BBDbApiTestCase
     {
         $string = $this->api_client->profile_api_key_reset();
         $this->assertIsString($string);
-        
+
         $string = $this->api_client->profile_api_key_get();
         $this->assertIsString($string);
     }
-    
+
     public function testBalance()
     {
         $array = $this->api_client->client_balance_get_list();
@@ -59,33 +60,33 @@ class Api_Client_ProfileTest extends BBDbApiTestCase
         $bool = $this->api_client->profile_logout();
         $this->assertTrue($bool);
     }
-    
+
     public function testEmailChange()
     {
-        //enable email change
-        $config = array(
-            'ext'                  =>  'mod_client',
-            'disable_change_email'   =>  false,
-        );
+        // enable email change
+        $config = [
+            'ext' => 'mod_client',
+            'disable_change_email' => false,
+        ];
         $bool = $this->api_admin->extension_config_save($config);
         $this->assertTrue($bool);
-        
-        $bool = $this->api_client->profile_update(array('email'=>'test@email.com'));
+
+        $bool = $this->api_client->profile_update(['email' => 'test@email.com']);
         $this->assertTrue($bool);
-        
-        //disable email change
-        $config = array(
-            'ext'                  =>  'mod_client',
-            'disable_change_email'   =>  true,
-        );
+
+        // disable email change
+        $config = [
+            'ext' => 'mod_client',
+            'disable_change_email' => true,
+        ];
         $bool = $this->api_admin->extension_config_save($config);
         $this->assertTrue($bool);
-        
+
         try {
-            $this->api_client->profile_update(array('email'=>'new@email.com'));
+            $this->api_client->profile_update(['email' => 'new@email.com']);
             $this->fail('Email should not changed due to setting');
-        } catch(Exception) {
-            //ok
+        } catch (Exception) {
+            // ok
         }
     }
 }

--- a/tests/integration/bb-modules/mod_redirect/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_redirect/Api_AdminTest.php
@@ -1,32 +1,31 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Redirect_Api_AdminTest extends BBModTestCase
 {
     protected $_mod = 'redirect';
     protected $_initialSeedFile = 'mod_redirect.xml';
 
-
     public function testRedirect()
     {
         $array = $this->api_admin->redirect_get_list();
         $this->assertIsArray($array);
 
-        $int = $this->api_admin->redirect_create(array('path'=>'/knowledgebase', 'target'=>'support/kb'));
+        $int = $this->api_admin->redirect_create(['path' => '/knowledgebase', 'target' => 'support/kb']);
         $this->assertIsInt($int);
 
-        $r = $this->api_admin->redirect_get(array('id'=>$int));
+        $r = $this->api_admin->redirect_get(['id' => $int]);
         $this->assertTrue(isset($r['id']));
         $this->assertTrue(isset($r['path']));
         $this->assertTrue(isset($r['target']));
 
-        $bool = $this->api_admin->redirect_update(array('id'=>$int, 'target'=>'new-target'));
+        $bool = $this->api_admin->redirect_update(['id' => $int, 'target' => 'new-target']);
         $this->assertTrue($bool);
 
-        $bool = $this->api_admin->redirect_update(array('id'=>$int, 'path'=>'/new-path'));
+        $bool = $this->api_admin->redirect_update(['id' => $int, 'path' => '/new-path']);
         $this->assertTrue($bool);
 
-        $bool = $this->api_admin->redirect_delete(array('id'=>$int));
+        $bool = $this->api_admin->redirect_delete(['id' => $int]);
         $this->assertTrue($bool);
-
     }
 }

--- a/tests/integration/bb-modules/mod_serviceboxbillinglicense/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_serviceboxbillinglicense/Api_ClientTest.php
@@ -7,17 +7,17 @@ class Api_Client_ServiceBoxBillinglicenseTest extends BBDbApiTestCase
 
     public function testserviceboxbillinglicense()
     {
-        $data = array(
+        $data = [
             'order_id' => 16,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('Box\Mod\Serviceboxbillinglicense\Service')->getMock();
         $serviceMock->expects($this->any())
             ->method('reset')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $client = new Model_Client();
-        $client->loadBean(new \RedBeanPHP\OODBBean());
+        $client->loadBean(new RedBeanPHP\OODBBean());
         $client->id = 1;
 
         $clientApi = new Box\Mod\Serviceboxbillinglicense\Api\Client();
@@ -29,55 +29,54 @@ class Api_Client_ServiceBoxBillinglicenseTest extends BBDbApiTestCase
         $this->assertTrue($bool);
     }
 
-    public function test_getServiceMissingOrderId()
+    public function testGetServiceMissingOrderId()
     {
-        $data = array();
+        $data = [];
 
         $clientApi = new Box\Mod\Serviceboxbillinglicense\Api\Client();
         $clientApi->setDi($this->di);
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Order id is required');
 
         $bool = $clientApi->reset($data);
     }
 
-
-    public function test_getServiceOrderNotFound()
+    public function testGetServiceOrderNotFound()
     {
-        $data = array(
+        $data = [
             'order_id' => 160,
-        );
+        ];
 
         $client = new Model_Client();
-        $client->loadBean(new \RedBeanPHP\OODBBean());
+        $client->loadBean(new RedBeanPHP\OODBBean());
         $client->id = 1;
 
         $clientApi = new Box\Mod\Serviceboxbillinglicense\Api\Client();
         $clientApi->setDi($this->di);
         $clientApi->setIdentity($client);
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('FOSSBilling license order not found');
 
         $bool = $clientApi->reset($data);
     }
 
-    public function test_getServiceOrderNotActivated()
+    public function testGetServiceOrderNotActivated()
     {
-        $data = array(
+        $data = [
             'order_id' => 17,
-        );
+        ];
 
         $client = new Model_Client();
-        $client->loadBean(new \RedBeanPHP\OODBBean());
+        $client->loadBean(new RedBeanPHP\OODBBean());
         $client->id = 1;
 
         $clientApi = new Box\Mod\Serviceboxbillinglicense\Api\Client();
         $clientApi->setDi($this->di);
         $clientApi->setIdentity($client);
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Order is not activated');
 
         $bool = $clientApi->reset($data);

--- a/tests/integration/bb-modules/mod_serviceboxbillinglicense/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_serviceboxbillinglicense/ServiceTest.php
@@ -5,14 +5,14 @@ class ServiceBoxBillinglicenseTest extends BBDbApiTestCase
 {
     public function testService()
     {
-        $service = new \Box\Mod\Serviceboxbillinglicense\Service();
+        $service = new Box\Mod\Serviceboxbillinglicense\Service();
         $service->setDi($this->di);
         $result = $service->install();
         $this->assertNull($result);
 
-        $data = array(
-            'param' => 'value'
-        );
+        $data = [
+            'param' => 'value',
+        ];
         $result = $service->setModuleConfig($data);
         $this->assertNull($result);
 
@@ -23,17 +23,15 @@ class ServiceBoxBillinglicenseTest extends BBDbApiTestCase
 
     public function testActions()
     {
-
-        $service = new \Box\Mod\Serviceboxbillinglicense\Service();
+        $service = new Box\Mod\Serviceboxbillinglicense\Service();
         $service->setDi($this->di);
 
         $order = $this->di['db']->load('ClientOrder', 1);
 
         $model = $service->create($order);
-        $this->assertInstanceOf('\\' . \RedBeanPHP\OODBBean::class, $model);
+        $this->assertInstanceOf('\\' . RedBeanPHP\OODBBean::class, $model);
 
-
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(7456);
         $this->expectExceptionMessage('Could not activate order. Service was not created');
         $service->activate($order, null);
@@ -41,8 +39,7 @@ class ServiceBoxBillinglicenseTest extends BBDbApiTestCase
         $result = $service->activate($order, $model);
         $this->assertTrue($result);
 
-
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(7456);
         $this->expectExceptionMessage('Could not activate order. Service was not created');
         $service->suspend($order, null);
@@ -50,8 +47,7 @@ class ServiceBoxBillinglicenseTest extends BBDbApiTestCase
         $result = $service->suspend($order, $model);
         $this->assertTrue($result);
 
-
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(7456);
         $this->expectExceptionMessage('Could not activate order. Service was not created');
         $service->unsuspend($order, null);
@@ -79,12 +75,11 @@ class ServiceBoxBillinglicenseTest extends BBDbApiTestCase
 
     public function testUninstall()
     {
-        $service = new \Box\Mod\Serviceboxbillinglicense\Service();
+        $service = new Box\Mod\Serviceboxbillinglicense\Service();
         $service->setDi($this->di);
         $result = $service->uninstall();
         $this->assertNull($result);
 
         $service->install();
     }
-
 }

--- a/tests/integration/bb-modules/mod_servicecustom/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_servicecustom/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ServiceCustomTest extends BBDbApiTestCase
 {
@@ -6,26 +7,26 @@ class Api_Admin_ServiceCustomTest extends BBDbApiTestCase
 
     public function testServiceCustom()
     {
-        $data = array(
-            'order_id'    =>  10,
-        );
+        $data = [
+            'order_id' => 10,
+        ];
         $result = $this->api_admin->servicecustom_return_params($data);
         $this->assertEquals($data, $result);
-        
+
         $result = $this->api_admin->servicecustom_get_config($data);
-        $this->assertEquals(array('param'=>'value'), $result);
-        
+        $this->assertEquals(['param' => 'value'], $result);
+
         try {
             $this->api_admin->servicecustom_non_existing($data);
             $this->fail('Method should not exist on plugin');
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertEquals(3125, $e->getCode());
         }
-        
+
         try {
             $this->api_admin->servicecustom_delete($data);
             $this->fail('Renew method should be forbidden');
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertEquals(403, $e->getCode());
         }
 

--- a/tests/integration/bb-modules/mod_servicecustom/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_servicecustom/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ServiceCustomTest extends BBDbApiTestCase
 {
@@ -6,23 +7,23 @@ class Api_Client_ServiceCustomTest extends BBDbApiTestCase
 
     public function testServiceCustom()
     {
-        $data = array(
-            'order_id'    =>  9,
-        );
+        $data = [
+            'order_id' => 9,
+        ];
         $result = $this->api_client->servicecustom_return_params($data);
         $this->assertEquals($data, $result);
-        
+
         try {
             $this->api_client->servicecustom_non_existing($data);
             $this->fail('Method should not exist on plugin');
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertEquals(3125, $e->getCode());
         }
-        
+
         try {
             $this->api_client->servicecustom_renew($data);
             $this->fail('Renew method should be forbidden');
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->assertEquals(403, $e->getCode());
         }
 

--- a/tests/integration/bb-modules/mod_servicedomain/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/Api_AdminTest.php
@@ -1,9 +1,10 @@
 <?php
+
 class Box_Mod_Servicedomain_Api_AdminTest extends BBModTestCase
 {
     protected $_mod = 'servicedomain';
     protected $_initialSeedFile = 'mod_servicedomain.xml';
-    
+
     public function testSync()
     {
         $bool = $this->api_admin->servicedomain_batch_sync_expiration_dates();

--- a/tests/integration/bb-modules/mod_servicedomain/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ServiceDomainTest extends BBDbApiTestCase
 {
@@ -6,44 +7,44 @@ class Api_Client_ServiceDomainTest extends BBDbApiTestCase
 
     public static function orders()
     {
-        return array(
-            array(3),
-            array(4),
-        );
+        return [
+            [3],
+            [4],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('orders')]
     public function testClientServiceDomain($id)
     {
-        $this->api_admin->order_renew(array('id'=>$id));
+        $this->api_admin->order_renew(['id' => $id]);
 
-        $data = array(
-            'order_id'    =>  $id,
-            'ns1'   =>  'ns1.1freehosting.com',
-            'ns2'   =>  'ns2.1freehosting.com',
-            'ns3'   =>  'ns3.1freehosting.com',
-            'ns4'   =>  'ns4.1freehosting.com',
-        );
+        $data = [
+            'order_id' => $id,
+            'ns1' => 'ns1.1freehosting.com',
+            'ns2' => 'ns2.1freehosting.com',
+            'ns3' => 'ns3.1freehosting.com',
+            'ns4' => 'ns4.1freehosting.com',
+        ];
         $bool = $this->api_client->serviceDomain_update_nameservers($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'order_id'    =>  $id,
-            'contact' =>  array(
-                'first_name'=>  'John',
-                'last_name' =>  'Does',
-                'email'     =>  'email@example.com  ',
-                'company'   =>  'Company',
-                'address1'  =>  'Adress 1',
-                'address2'  =>  'Adress 2',
-                'country'   =>  'US',
-                'city'      =>  'San Jose',
-                'state'     =>  'n/a',
-                'postcode'  =>  '20506',
-                'phone_cc'     =>  '1408',
-                'phone'       =>  '123456',
-            ),
-        );
+        $data = [
+            'order_id' => $id,
+            'contact' => [
+                'first_name' => 'John',
+                'last_name' => 'Does',
+                'email' => 'email@example.com  ',
+                'company' => 'Company',
+                'address1' => 'Adress 1',
+                'address2' => 'Adress 2',
+                'country' => 'US',
+                'city' => 'San Jose',
+                'state' => 'n/a',
+                'postcode' => '20506',
+                'phone_cc' => '1408',
+                'phone' => '123456',
+            ],
+        ];
         $bool = $this->_callOnService('update_contacts', $data);
         $this->assertTrue($bool, 'Failed updating contacts');
 
@@ -65,7 +66,8 @@ class Api_Client_ServiceDomainTest extends BBDbApiTestCase
 
     protected function _callOnService($method, $data)
     {
-        $m = "serviceDomain_".$method;
+        $m = 'serviceDomain_' . $method;
+
         return $this->api_client->{$m}($data);
     }
 }

--- a/tests/integration/bb-modules/mod_servicedomain/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/Api_GuestTest.php
@@ -1,15 +1,16 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_ServiceDomainTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'services.xml';
-    
+
     public function testGuestServiceDomain()
     {
-        $data = array(
-            'sld'   =>  'phpunit',
-            'tld'   =>  '.com',
-        );
+        $data = [
+            'sld' => 'phpunit',
+            'tld' => '.com',
+        ];
         $bool = $this->api_guest->servicedomain_check($data);
         $this->assertTrue($bool);
 

--- a/tests/integration/bb-modules/mod_servicedomain/ServiceDomainTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/ServiceDomainTest.php
@@ -8,44 +8,44 @@ class Api_Admin_ServiceDomainTest extends BBDbApiTestCase
 
     public static function orders()
     {
-        return array(
-            array(3),
-            array(4),
-        );
+        return [
+            [3],
+            [4],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('orders')]
     public function testDomain($id)
     {
-        $this->api_admin->order_renew(array('id'=>$id));
+        $this->api_admin->order_renew(['id' => $id]);
 
-        $data = array(
-            'order_id'    =>  $id,
-            'ns1'   =>  'ns1.1freehosting.com',
-            'ns2'   =>  'ns2.1freehosting.com',
-            'ns3'   =>  'ns3.1freehosting.com',
-            'ns4'   =>  'ns4.1freehosting.com',
-        );
+        $data = [
+            'order_id' => $id,
+            'ns1' => 'ns1.1freehosting.com',
+            'ns2' => 'ns2.1freehosting.com',
+            'ns3' => 'ns3.1freehosting.com',
+            'ns4' => 'ns4.1freehosting.com',
+        ];
         $bool = $this->api_admin->servicedomain_update_nameservers($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'order_id'    =>  $id,
-            'contact' =>  array(
-                'first_name'=>  'John',
-                'last_name' =>  'Does',
-                'email'     =>  'email@example.com  ',
-                'company'   =>  'Company',
-                'address1'  =>  'Adress 1',
-                'address2'  =>  'Adress 2',
-                'country'   =>  'US',
-                'city'      =>  'San Jose',
-                'state'     =>  'n/a',
-                'postcode'  =>  '20506',
-                'phone_cc'     =>  '1408',
-                'phone'       =>  '123456',
-            ),
-        );
+        $data = [
+            'order_id' => $id,
+            'contact' => [
+                'first_name' => 'John',
+                'last_name' => 'Does',
+                'email' => 'email@example.com  ',
+                'company' => 'Company',
+                'address1' => 'Adress 1',
+                'address2' => 'Adress 2',
+                'country' => 'US',
+                'city' => 'San Jose',
+                'state' => 'n/a',
+                'postcode' => '20506',
+                'phone_cc' => '1408',
+                'phone' => '123456',
+            ],
+        ];
         $bool = $this->_callOnService('update_contacts', $data);
         $this->assertTrue($bool, 'Failed updating contacts');
 
@@ -70,13 +70,13 @@ class Api_Admin_ServiceDomainTest extends BBDbApiTestCase
         $array = $this->api_admin->servicedomain_tld_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'tld'               =>  '.ru',
-            'tld_registrar_id'  =>  1,
-            'price_registration'=>  1,
-            'price_renew'       =>  1,
-            'price_transfer'    =>  1,
-        );
+        $data = [
+            'tld' => '.ru',
+            'tld_registrar_id' => 1,
+            'price_registration' => 1,
+            'price_renew' => 1,
+            'price_transfer' => 1,
+        ];
         $id = $this->api_admin->servicedomain_tld_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -94,22 +94,21 @@ class Api_Admin_ServiceDomainTest extends BBDbApiTestCase
 
     public function testRegistrar()
     {
-
         $array = $this->api_admin->servicedomain_registrar_get_pairs();
         $this->assertIsArray($array);
 
         $array = $this->api_admin->servicedomain_registrar_get_available();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $id = $this->api_admin->servicedomain_registrar_copy($data);
         $this->assertTrue(is_numeric($id));
-        
-        $data = array(
-            'id'    => $id,
-        );
+
+        $data = [
+            'id' => $id,
+        ];
         $array = $this->api_admin->servicedomain_registrar_get($data);
         $this->assertIsArray($array);
 
@@ -123,9 +122,9 @@ class Api_Admin_ServiceDomainTest extends BBDbApiTestCase
         $array = $this->api_admin->servicedomain_registrar_get_available();
         $this->assertIsArray($array);
 
-        $data = array(
-            'code'=>$array[0],
-        );
+        $data = [
+            'code' => $array[0],
+        ];
         $bool = $this->api_admin->servicedomain_registrar_install($data);
         $this->assertTrue($bool);
 
@@ -181,7 +180,8 @@ class Api_Admin_ServiceDomainTest extends BBDbApiTestCase
 
     protected function _callOnService($method, $data)
     {
-        $m = "serviceDomain_".$method;
+        $m = 'serviceDomain_' . $method;
+
         return $this->api_admin->{$m}($data);
     }
 }

--- a/tests/integration/bb-modules/mod_servicedomain/ServiceDownloadableTest.php
+++ b/tests/integration/bb-modules/mod_servicedomain/ServiceDownloadableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ServiceDownloadableTest extends BBDbApiTestCase
 {

--- a/tests/integration/bb-modules/mod_servicedownloadable/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_servicedownloadable/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ServiceDownloadableTest extends BBDbApiTestCase
 {
@@ -6,18 +7,19 @@ class Api_Client_ServiceDownloadableTest extends BBDbApiTestCase
 
     public function testServiceDownload()
     {
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
 
-        $data = array(
-            'order_id'    =>  1,
-        );
+        $data = [
+            'order_id' => 1,
+        ];
         $bool = $this->_callOnService('send_file', $data);
         $this->assertTrue($bool);
     }
 
     protected function _callOnService($method, $data)
     {
-        $m = "serviceDownloadable_".$method;
+        $m = 'serviceDownloadable_' . $method;
+
         return $this->api_client->{$m}($data);
     }
 }

--- a/tests/integration/bb-modules/mod_servicehosting/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_servicehosting/Api_AdminTest.php
@@ -1,46 +1,47 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ServiceHostingTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'services.xml';
-    
+
     public function testAdminServiceHosting()
     {
         $array = $this->api_admin->servicehosting_manager_get_pairs();
         $this->assertIsArray($array);
     }
-    
+
     public function testAccountManagement()
     {
-        $data = array(
-            'order_id'  =>  8,
-            'sld'    =>  'example',
-            'tld'    =>  '.com',
-        );
-        
+        $data = [
+            'order_id' => 8,
+            'sld' => 'example',
+            'tld' => '.com',
+        ];
+
         $bool = $this->api_admin->servicehosting_change_domain($data);
         $this->assertTrue($bool);
-        
+
         $data['plan_id'] = 2;
         $bool = $this->api_admin->servicehosting_change_plan($data);
         $this->assertTrue($bool);
-        
+
         $data['username'] = 'new-username';
         $bool = $this->api_admin->servicehosting_change_username($data);
         $this->assertTrue($bool);
-        
+
         $data['ip'] = 'kitoks';
         $bool = $this->api_admin->servicehosting_change_ip($data);
         $this->assertTrue($bool);
-        
+
         $data['password'] = 'qwerty123';
         $data['password_confirm'] = 'qwerty123';
         $bool = $this->api_admin->servicehosting_change_password($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->servicehosting_sync($data);
         $this->assertTrue($bool);
-        
+
         $data['username'] = 'username123';
         $bool = $this->api_admin->servicehosting_update($data);
         $this->assertTrue($bool);
@@ -50,69 +51,69 @@ class Api_Admin_ServiceHostingTest extends BBDbApiTestCase
     {
         $array = $this->api_admin->servicehosting_hp_get_list();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->servicehosting_hp_get_pairs();
         $this->assertIsArray($array);
-        
-        $data = array(
-            'name'  =>  'test',
-        );
+
+        $data = [
+            'name' => 'test',
+        ];
         $id = $this->api_admin->servicehosting_hp_create($data);
         $this->assertTrue(is_numeric($id));
-        
+
         $data['id'] = $id;
         $array = $this->api_admin->servicehosting_hp_get($data);
         $this->assertIsArray($array);
-        
+
         $data['quota'] = 12345;
         $bool = $this->api_admin->servicehosting_hp_update($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->servicehosting_hp_delete($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testServer()
     {
         $array = $this->api_admin->servicehosting_server_get_pairs();
         $this->assertIsArray($array);
-        
-        $data = array(
-            'name'  =>  'test',
-            'ip'  =>  '127.15.15.1',
-            'manager'  =>  'Custom',
-        );
+
+        $data = [
+            'name' => 'test',
+            'ip' => '127.15.15.1',
+            'manager' => 'Custom',
+        ];
         $id = $this->api_admin->servicehosting_server_create($data);
         $this->assertTrue(is_numeric($id));
-        
+
         $data['id'] = $id;
         $array = $this->api_admin->servicehosting_server_get($data);
         $this->assertIsArray($array);
-        
+
         $bool = $this->api_admin->servicehosting_server_test_connection($data);
         $this->assertTrue($bool);
-        
+
         $data['quota'] = 12345;
         $bool = $this->api_admin->servicehosting_server_update($data);
         $this->assertTrue($bool);
-        
+
         $bool = $this->api_admin->servicehosting_server_delete($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testServerIps()
     {
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->servicehosting_server_get($data);
         $this->assertIsArray($array);
         $this->assertIsArray($array['assigned_ips']);
 
-        $data['assigned_ips'] = '127.85.81.156'.PHP_EOL.'189.156.45.78'.PHP_EOL;
+        $data['assigned_ips'] = '127.85.81.156' . PHP_EOL . '189.156.45.78' . PHP_EOL;
         $bool = $this->api_admin->servicehosting_server_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_admin->servicehosting_server_get($data);
         $this->assertIsArray($array['assigned_ips']);
         $this->assertEquals(2, count($array['assigned_ips']));
@@ -120,7 +121,7 @@ class Api_Admin_ServiceHostingTest extends BBDbApiTestCase
 
     public function testServicehostingServerGetList()
     {
-        $array = $this->api_admin->servicehosting_server_get_list(array());
+        $array = $this->api_admin->servicehosting_server_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -156,7 +157,7 @@ class Api_Admin_ServiceHostingTest extends BBDbApiTestCase
 
     public function testServicehostingHpGetList()
     {
-        $array = $this->api_admin->servicehosting_hp_get_list(array());
+        $array = $this->api_admin->servicehosting_hp_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];

--- a/tests/integration/bb-modules/mod_servicehosting/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_servicehosting/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ServiceHostingTest extends BBDbApiTestCase
 {
@@ -12,44 +13,45 @@ class Api_Client_ServiceHostingTest extends BBDbApiTestCase
 
     public static function orders()
     {
-        return array(
-            array(5),
-            array(6),
-        );
+        return [
+            [5],
+            [6],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('orders')]
     public function testServiceHosting($id)
     {
-        $this->api_admin->order_renew(array('id'=>$id));
+        $this->api_admin->order_renew(['id' => $id]);
 
-        $data = array(
-            'order_id'    =>  $id,
-            'password'   =>  'test',
-            'password_confirm'   =>  'test',
-        );
+        $data = [
+            'order_id' => $id,
+            'password' => 'test',
+            'password_confirm' => 'test',
+        ];
         $bool = $this->_callOnService('change_password', $data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'order_id'   =>  $id,
-            'username'   =>  'John',
-        );
+        $data = [
+            'order_id' => $id,
+            'username' => 'John',
+        ];
         $bool = $this->_callOnService('change_username', $data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'order_id'      =>  $id,
-            'sld'        =>  'mynewdomain',
-            'tld'        =>  '.com',
-        );
+        $data = [
+            'order_id' => $id,
+            'sld' => 'mynewdomain',
+            'tld' => '.com',
+        ];
         $bool = $this->_callOnService('change_domain', $data);
         $this->assertTrue($bool);
     }
 
     protected function _callOnService($method, $data)
     {
-        $m = "serviceHosting_".$method;
+        $m = 'serviceHosting_' . $method;
+
         return $this->api_client->{$m}($data);
     }
 }

--- a/tests/integration/bb-modules/mod_servicelicense/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_servicelicense/Api_AdminTest.php
@@ -1,26 +1,27 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ServiceLicenseTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'services.xml';
-    
+
     public function testAdminServiceLicense()
     {
         $array = $this->api_admin->servicelicense_plugin_get_pairs();
         $this->assertIsArray($array);
 
-        $data = array(
-            'order_id'   =>  2,
-            'validate_ip'   =>  0,
-            'validate_host'   =>  0,
-            'validate_version'   =>  0,
-            'validate_path'   =>  0,
-            'versions'   =>  '1'.PHP_EOL.'2',
-        );
+        $data = [
+            'order_id' => 2,
+            'validate_ip' => 0,
+            'validate_host' => 0,
+            'validate_version' => 0,
+            'validate_path' => 0,
+            'versions' => '1' . PHP_EOL . '2',
+        ];
         $bool = $this->api_admin->servicelicense_update($data);
         $this->assertTrue($bool);
 
-        $service = $this->api_admin->order_service(array('id'=>2));
+        $service = $this->api_admin->order_service(['id' => 2]);
         $this->assertEquals(2, count($service['versions']));
     }
 }

--- a/tests/integration/bb-modules/mod_servicelicense/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_servicelicense/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_ServiceLicenseTest extends BBDbApiTestCase
 {
@@ -8,18 +9,19 @@ class Api_Client_ServiceLicenseTest extends BBDbApiTestCase
     {
         $id = 2;
 
-        $service = $this->api_client->order_service(array('id'=>$id));
+        $service = $this->api_client->order_service(['id' => $id]);
 
-        $data = array(
-            'order_id'    =>  $id,
-        );
+        $data = [
+            'order_id' => $id,
+        ];
         $bool = $this->_callOnService('reset', $data);
         $this->assertTrue($bool);
     }
 
     protected function _callOnService($method, $data)
     {
-        $m = "serviceLicense_".$method;
+        $m = 'serviceLicense_' . $method;
+
         return $this->api_client->{$m}($data);
     }
 }

--- a/tests/integration/bb-modules/mod_servicelicense/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_servicelicense/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_ServiceLicenseTest extends BBDbApiTestCase
 {
@@ -6,36 +7,36 @@ class Api_Guest_ServiceLicenseTest extends BBDbApiTestCase
 
     public static function variations()
     {
-        return array(
-            array(array(
-                'fail'       =>  '',
-                'legacy'        =>   1,
-            ), false),
-            
-            array(array(
-                'license'       =>  'BOX-NOT-EXISTS',
-                'host'          =>  'tests.com',
-                'path'          =>  __DIR__,
-                'version'       =>  '0.0.2',
-                'legacy'        =>   1,
-            ), false),
+        return [
+            [[
+                'fail' => '',
+                'legacy' => 1,
+            ], false],
 
-            array(array(
-                'license'       =>  'no_validation',
-                'host'          =>  'tests.com',
-                'path'          =>  __DIR__,
-                'version'       =>  '0.0.2',
-                'legacy'        =>   1,
-            ), false),
+            [[
+                'license' => 'BOX-NOT-EXISTS',
+                'host' => 'tests.com',
+                'path' => __DIR__,
+                'version' => '0.0.2',
+                'legacy' => 1,
+            ], false],
 
-            array(array(
-                'license'       =>  'valid',
-                'host'          =>  'www.tests.com',
-                'path'          =>  __DIR__,
-                'version'       =>  '0.0.2',
-                'legacy'        =>   1,
-            ), true),
-        );
+            [[
+                'license' => 'no_validation',
+                'host' => 'tests.com',
+                'path' => __DIR__,
+                'version' => '0.0.2',
+                'legacy' => 1,
+            ], false],
+
+            [[
+                'license' => 'valid',
+                'host' => 'www.tests.com',
+                'path' => __DIR__,
+                'version' => '0.0.2',
+                'legacy' => 1,
+            ], true],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('variations')]

--- a/tests/integration/bb-modules/mod_servicelicense/ServerTest.php
+++ b/tests/integration/bb-modules/mod_servicelicense/ServerTest.php
@@ -7,63 +7,63 @@ class Box_Mod_Servicelicense_ServerTest extends BBDbApiTestCase
 
     public static function variations()
     {
-        return array(
+        return [
 //            array(array(
 //                'fail'       =>  '',
 //            ), false),
 
-            array(array(
+            [[
                 'license' => 'BOX-NOT-EXISTS',
-                'host'    => 'tests.com',
-                'path'    => __DIR__,
+                'host' => 'tests.com',
+                'path' => __DIR__,
                 'version' => '0.0.2',
-            ), false, false),
+            ], false, false],
 
-            array(array(
+            [[
                 'license' => 'no_validation',
-                'host'    => 'tests.com',
-                'path'    => __DIR__,
+                'host' => 'tests.com',
+                'path' => __DIR__,
                 'version' => '0.0.2',
-            ), false, false),
-            array(array(
+            ], false, false],
+            [[
                 'license' => 'valid',
-                'host'    => 'www.tests.com',
-                'path'    => __DIR__,
+                'host' => 'www.tests.com',
+                'path' => __DIR__,
                 'version' => '0.0.2',
-            ), true, true),
-        );
+            ], true, true],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('variations')]
     public function testLicenseServer($data, $valid, $validation)
     {
-        $service = $this->getMockBuilder(\Box\Mod\Servicelicense\Service::class)->getMock();
+        $service = $this->getMockBuilder(Box\Mod\Servicelicense\Service::class)->getMock();
         $service->expects($this->any())
             ->method('isLicenseActive')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         if ($validation) {
             $service->expects($this->atLeastOnce())
                 ->method('isValidIp')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
             $service->expects($this->atLeastOnce())
                 ->method('isValidHost')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
             $service->expects($this->atLeastOnce())
                 ->method('isValidVersion')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
             $service->expects($this->atLeastOnce())
                 ->method('isValidPath')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $this->di['db'];
-        $di['logger']      = new Box_Log();
-        $di['mod']         = $di->protect(fn() => new Box_Mod('servicelicense'));
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new Pimple\Container();
+        $di['db'] = $this->di['db'];
+        $di['logger'] = new Box_Log();
+        $di['mod'] = $di->protect(fn () => new Box_Mod('servicelicense'));
+        $di['mod_service'] = $di->protect(fn () => $service);
 
-        $server = new \Box\Mod\Servicelicense\Server($di['logger']);
+        $server = new Box\Mod\Servicelicense\Server($di['logger']);
         $server->setDi($di);
         $result = $server->handle_deprecated(json_encode($data));
         $this->assertEquals($valid, $result['valid'], print_r($result, 1));
@@ -73,102 +73,101 @@ class Box_Mod_Servicelicense_ServerTest extends BBDbApiTestCase
     {
         $this->assertTrue(true);
 
-        return array(
-            array(array(
+        return [
+            [[
                 'license' => 'validation_fail',
-                'host'    => 'tests.com',
-                'path'    => __DIR__,
+                'host' => 'tests.com',
+                'path' => __DIR__,
                 'version' => '0.0.2',
-            ), false),
-            array(array(
+            ], false],
+            [[
                 'license' => 'valid',
-                'host'    => 'www.tests.com',
-                'path'    => __DIR__,
+                'host' => 'www.tests.com',
+                'path' => __DIR__,
                 'version' => '0.0.2',
-            ), true),
-        );
+            ], true],
+        ];
     }
 
     public function testLicenseServerProcess()
     {
-        $data = array(
+        $data = [
             'license' => 'valid',
-            'host'    => 'tests.com',
-            'path'    => __DIR__,
+            'host' => 'tests.com',
+            'path' => __DIR__,
             'version' => '0.0.2',
-        );
+        ];
 
         $valid = true;
 
-        $service = $this->getMockBuilder(\Box\Mod\Servicelicense\Service::class)->getMock();
+        $service = $this->getMockBuilder(Box\Mod\Servicelicense\Service::class)->getMock();
         $service->expects($this->any())
             ->method('isLicenseActive')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->atLeastOnce())
             ->method('isValidIp')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->atLeastOnce())
             ->method('isValidHost')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->atLeastOnce())
             ->method('isValidVersion')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->atLeastOnce())
             ->method('isValidPath')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $this->di['db'];
-        $di['logger']      = $this->di['logger'];
-        $di['mod']         = $di->protect(fn() => new Box_Mod('servicelicense'));
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new Pimple\Container();
+        $di['db'] = $this->di['db'];
+        $di['logger'] = $this->di['logger'];
+        $di['mod'] = $di->protect(fn () => new Box_Mod('servicelicense'));
+        $di['mod_service'] = $di->protect(fn () => $service);
 
-        $server = new \Box\Mod\Servicelicense\Server($this->di['logger']);
+        $server = new Box\Mod\Servicelicense\Server($this->di['logger']);
         $server->setDi($di);
 
         $result = $server->process(json_encode($data));
         $this->assertEquals($valid, $result['valid'], print_r($result, 1));
     }
 
-
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      */
     public function testLicenseServerProcessNotFound()
     {
-        $data = array(
+        $data = [
             'license' => 'non_existing',
-            'host'    => 'tests.com',
-            'path'    => __DIR__,
+            'host' => 'tests.com',
+            'path' => __DIR__,
             'version' => '0.0.2',
-        );
+        ];
 
         $valid = true;
 
-        $service = $this->getMockBuilder(\Box\Mod\Servicelicense\Service::class)->getMock();
+        $service = $this->getMockBuilder(Box\Mod\Servicelicense\Service::class)->getMock();
         $service->expects($this->never())
             ->method('isLicenseActive')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->never())
             ->method('isValidIp')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->never())
             ->method('isValidHost')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->never())
             ->method('isValidVersion')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $service->expects($this->never())
             ->method('isValidPath')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $this->di['db'];
-        $di['logger']      = $this->di['logger'];
-        $di['mod']         = $di->protect(fn() => new Box_Mod('servicelicense'));
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new Pimple\Container();
+        $di['db'] = $this->di['db'];
+        $di['logger'] = $this->di['logger'];
+        $di['mod'] = $di->protect(fn () => new Box_Mod('servicelicense'));
+        $di['mod_service'] = $di->protect(fn () => $service);
 
-        $server = new \Box\Mod\Servicelicense\Server($this->di['logger']);
+        $server = new Box\Mod\Servicelicense\Server($this->di['logger']);
         $server->setDi($di);
 
         $result = $server->process(json_encode($data));
@@ -179,66 +178,64 @@ class Box_Mod_Servicelicense_ServerTest extends BBDbApiTestCase
     {
         $this->assertTrue(true);
 
-        return array(
-            array(false, false, false, false, false, array(
-                $this->atLeastOnce(), $this->never(), $this->never(), $this->never(), $this->never()
-            )),
-            array(true, false, false, false, false, array(
-                $this->atLeastOnce(), $this->atLeastOnce(), $this->never(), $this->never(), $this->never()
-            )),
-            array(true, true, false, false, false, array(
-                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->never(), $this->never()
-            )),
-            array(true, true, true, false, false, array(
-                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->never()
-            )),
-            array(true, true, true, true, false, array(
-                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce()
-            )),
-
-        );
+        return [
+            [false, false, false, false, false, [
+                $this->atLeastOnce(), $this->never(), $this->never(), $this->never(), $this->never(),
+            ]],
+            [true, false, false, false, false, [
+                $this->atLeastOnce(), $this->atLeastOnce(), $this->never(), $this->never(), $this->never(),
+            ]],
+            [true, true, false, false, false, [
+                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->never(), $this->never(),
+            ]],
+            [true, true, true, false, false, [
+                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->never(),
+            ]],
+            [true, true, true, true, false, [
+                $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(), $this->atLeastOnce(),
+            ]],
+        ];
     }
 
-
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('testLicenseServerProcessValidationFailProvider')]
     public function testLicenseServerProcessValidationFail($isActive, $validIp, $validHost, $validVersion, $validPath, $called)
     {
-        $data = array(
+        $data = [
             'license' => 'valid',
-            'host'    => 'tests.com',
-            'path'    => __DIR__,
+            'host' => 'tests.com',
+            'path' => __DIR__,
             'version' => '0.0.2',
-        );
+        ];
 
         $valid = true;
 
-        $service = $this->getMockBuilder(\Box\Mod\Servicelicense\Service::class)->getMock();
+        $service = $this->getMockBuilder(Box\Mod\Servicelicense\Service::class)->getMock();
         $service->expects($called[0])
             ->method('isLicenseActive')
-            ->will($this->returnValue($isActive));
+            ->willReturn($isActive);
         $service->expects($called[1])
             ->method('isValidIp')
-            ->will($this->returnValue($validIp));
+            ->willReturn($validIp);
         $service->expects($called[2])
             ->method('isValidHost')
-            ->will($this->returnValue($validHost));
+            ->willReturn($validHost);
         $service->expects($called[3])
             ->method('isValidVersion')
-            ->will($this->returnValue($validVersion));
+            ->willReturn($validVersion);
         $service->expects($called[4])
             ->method('isValidPath')
-            ->will($this->returnValue($validPath));
+            ->willReturn($validPath);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $this->di['db'];
-        $di['logger']      = $this->di['logger'];
-        $di['mod']         = $di->protect(fn() => new Box_Mod('servicelicense'));
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new Pimple\Container();
+        $di['db'] = $this->di['db'];
+        $di['logger'] = $this->di['logger'];
+        $di['mod'] = $di->protect(fn () => new Box_Mod('servicelicense'));
+        $di['mod_service'] = $di->protect(fn () => $service);
 
-        $server = new \Box\Mod\Servicelicense\Server($this->di['logger']);
+        $server = new Box\Mod\Servicelicense\Server($this->di['logger']);
         $server->setDi($di);
 
         $result = $server->process(json_encode($data));

--- a/tests/integration/bb-modules/mod_spamchecker/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_spamchecker/ServiceTest.php
@@ -1,18 +1,19 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Spamchecker_ServiceTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_spamchecker.xml';
-    
+
     public function testOnAfterClientSignUp()
     {
-        $parameters = array(
-            'ip'    =>  '127.0.0.1',
-        );
+        $parameters = [
+            'ip' => '127.0.0.1',
+        ];
         $event = new Box_Event(null, 'any', $parameters, $this->api_admin);
         $event->setDi($this->di);
 
-        $object = new \Box\Mod\Spamchecker\Service();
+        $object = new Box\Mod\Spamchecker\Service();
         $object->onBeforeClientSignUp($event);
     }
 }

--- a/tests/integration/bb-modules/mod_staff/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_staff/Api_AdminTest.php
@@ -1,22 +1,23 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_StaffTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'admins.xml';
-    
+
     public function testStaff()
     {
-        $array = $this->api_admin->staff_get_list(array('status'=>'active'));
+        $array = $this->api_admin->staff_get_list(['status' => 'active']);
         $this->assertIsArray($array);
 
-        $data = array(
+        $data = [
             'admin_group_id' => 1,
-            'email' =>  random_int(5, 8_787_878).'_test@admin.com',
-            'password' =>  'dem2123123AAo',
-            'name' =>  'John Doe',
-            'signature' =>  'this is test sig',
+            'email' => random_int(5, 8_787_878) . '_test@admin.com',
+            'password' => 'dem2123123AAo',
+            'name' => 'John Doe',
+            'signature' => 'this is test sig',
             'status' => 'active',
-        );
+        ];
         $id = $this->api_admin->staff_create($data);
         $this->assertIsInt($id);
 
@@ -28,7 +29,7 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
         $this->assertIsArray($array);
 
         $data['id'] = $id;
-        $data['email']  =   'new@email.com';
+        $data['email'] = 'new@email.com';
         $bool = $this->api_admin->staff_update($data);
         $this->assertTrue($bool);
 
@@ -39,7 +40,7 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
 
         $staffModel = $this->di['db']->load('Admin', $id);
         $this->assertNotEquals($data['password'], $staffModel->pass);
-        
+
         $bool = $this->api_admin->staff_delete($data);
         $this->assertTrue($bool);
 
@@ -47,14 +48,15 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
         $this->isNull();
     }
 
-    public function testChangePasswordException(){
-        $this->expectException(\FOSSBilling\Exception::class);
+    public function testChangePasswordException()
+    {
+        $this->expectException(FOSSBilling\Exception::class);
 
-        $data = array(
+        $data = [
             'id' => 1,
-            'password'=> 'new123123',
-            'password_confirm' => 'wrong_confirmation'
-        );
+            'password' => 'new123123',
+            'password_confirm' => 'wrong_confirmation',
+        ];
 
         $data['password'] = 'new123123';
         $data['password_confirm'] = 'wrong_confirmation';
@@ -64,39 +66,39 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
 
     public function testPermissions()
     {
-        $data = array(
-            'id'            =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->staff_permissions_get($data);
         $this->assertIsArray($array);
-        
-        $perms = array();
+
+        $perms = [];
         $perms['activity'] = 1;
-        
-        $data = array(
-            'id'            =>  1,
-            'permissions'            =>  $perms,
-        );
+
+        $data = [
+            'id' => 1,
+            'permissions' => $perms,
+        ];
         $bool = $this->api_admin->staff_permissions_update($data);
         $this->assertTrue($bool);
-        
+
         $array = $this->api_admin->staff_permissions_get($data);
         $this->assertIsArray($array);
         $this->assertEquals($perms, $array);
     }
-    
+
     public function testGroups()
     {
-        $data = array(
+        $data = [
             'name' => 'Support',
-        );
+        ];
         $id = $this->api_admin->staff_group_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'  =>  $id,
-            'name'  =>  'Staff',
-        );
+        $data = [
+            'id' => $id,
+            'name' => 'Staff',
+        ];
         $bool = $this->api_admin->staff_group_update($data);
         $this->assertTrue($bool);
 
@@ -112,15 +114,15 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
         $bool = $this->api_admin->staff_group_delete($data);
         $this->assertTrue($bool);
     }
-    
+
     public function testHistory()
     {
         $array = $this->api_admin->staff_login_history_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    => 1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->staff_login_history_get($data);
         $this->assertIsArray($array);
 
@@ -130,7 +132,7 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
 
     public function testStaffActivityHistoryList()
     {
-        $array = $this->api_admin->staff_login_history_get_list(array('status' => 'active'));
+        $array = $this->api_admin->staff_login_history_get_list(['status' => 'active']);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -152,9 +154,8 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
 
     public function testStaffGroupGetList()
     {
-        $array = $this->api_admin->staff_group_get_list(array());
+        $array = $this->api_admin->staff_group_get_list([]);
         $this->assertIsArray($array);
-
 
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -166,15 +167,16 @@ class Api_Admin_StaffTest extends BBDbApiTestCase
         $this->assertArrayHasKey('created_at', $item);
         $this->assertArrayHasKey('updated_at', $item);
     }
+
     public function testBatchDelete()
     {
-        $array = $this->api_admin->staff_login_history_get_list(array());
+        $array = $this->api_admin->staff_login_history_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->staff_batch_delete_logs(array('ids' => $ids));
-        $array  = $this->api_admin->staff_login_history_get_list(array());
+        $result = $this->api_admin->staff_batch_delete_logs(['ids' => $ids]);
+        $array = $this->api_admin->staff_login_history_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);

--- a/tests/integration/bb-modules/mod_staff/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_staff/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_StaffTest extends BBDbApiTestCase
 {
@@ -6,14 +7,13 @@ class Api_Guest_StaffTest extends BBDbApiTestCase
 
     public function testCreate()
     {
-        $data = array(
-            'email'    => 'admin@fossbilling.org',
+        $data = [
+            'email' => 'admin@fossbilling.org',
             'password' => 'adminPa55word',
-        );
+        ];
 
-        $this->api_admin->staff_delete(array('id' => 1));
+        $this->api_admin->staff_delete(['id' => 1]);
         $this->api_guest->staff_create($data);
-
     }
 
     public function testCreateException()
@@ -25,13 +25,13 @@ class Api_Guest_StaffTest extends BBDbApiTestCase
             $this->assertEquals(55, $e->getCode());
         }
     }
-    
+
     public function testLogin()
     {
-        $data  = array(
-            'email'    => 'admin@fossbilling.org',
+        $data = [
+            'email' => 'admin@fossbilling.org',
             'password' => 'demo',
-        );
+        ];
         $array = $this->api_guest->staff_login($data);
         $this->assertIsArray($array);
         $this->assertIsArray($this->session->get('admin'));

--- a/tests/integration/bb-modules/mod_staff/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_staff/ServiceTest.php
@@ -1,17 +1,17 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Staff_ServiceTest extends ApiTestCase
 {
     public function testEvents()
     {
-        $params = array(
+        $params = [
             'id' => 1,
-        );
+        ];
         $event = $this->_bb_event = new Box_Event(null, 'name', $params, $this->api_admin, $this->api_guest);
         $event->setDi($this->di);
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Box\Mod\Staff\Service();
         $bool = $service->onAfterClientSignUp($event);
         $this->assertTrue($bool);
     }
-
 }

--- a/tests/integration/bb-modules/mod_stats/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_stats/Api_AdminTest.php
@@ -1,9 +1,10 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_StatsTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'orders.xml';
-    
+
     public function testSummary()
     {
         $array = $this->api_admin->stats_get_summary();
@@ -17,7 +18,7 @@ class Api_Admin_StatsTest extends BBDbApiTestCase
 
         $array = $this->api_admin->stats_get_income_vs_refunds();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->stats_get_product_summary();
         $this->assertIsArray($array);
 
@@ -35,19 +36,19 @@ class Api_Admin_StatsTest extends BBDbApiTestCase
     {
         $array = $this->api_admin->stats_get_orders();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->stats_get_clients();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->stats_get_invoices();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->stats_get_refunds();
         $this->assertIsArray($array);
 
         $array = $this->api_admin->stats_get_income();
         $this->assertIsArray($array);
-        
+
         $array = $this->api_admin->stats_get_tickets();
         $this->assertIsArray($array);
     }

--- a/tests/integration/bb-modules/mod_support/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_support/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_SupportTest extends BBDbApiTestCase
 {
@@ -16,9 +17,9 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $item = $list[0];
         $this->assertArrayHasKey('category', $item);
 
-        $data = array(
-            'id'    =>  '1',
-        );
+        $data = [
+            'id' => '1',
+        ];
 
         $data['category_id'] = 1;
         $data['title'] = 'new canned title';
@@ -42,9 +43,9 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $array = $this->api_admin->support_canned_category_pairs();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    =>  '1',
-        );
+        $data = [
+            'id' => '1',
+        ];
         $array = $this->api_admin->support_canned_category_get($data);
         $this->assertIsArray($array);
 
@@ -74,12 +75,12 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $bool = $this->api_admin->support_batch_public_ticket_auto_close();
         $this->assertTrue($bool);
 
-        $data = array(
-            'name'  =>  'This is me',
-            'email'  =>  'email@email.com',
-            'subject'  =>  'subject',
-            'message'  =>  'Message',
-        );
+        $data = [
+            'name' => 'This is me',
+            'email' => 'email@email.com',
+            'subject' => 'subject',
+            'message' => 'Message',
+        ];
         $id = $this->api_admin->support_public_ticket_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -111,15 +112,15 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $bool = $this->api_admin->support_batch_ticket_auto_close();
         $this->assertTrue($bool);
 
-        $array = $this->api_admin->support_ticket_get_statuses(array());
+        $array = $this->api_admin->support_ticket_get_statuses([]);
         $this->assertIsArray($array);
 
-        $data = array(
-            'client_id'      =>  1,
-            'support_helpdesk_id'      =>  1,
-            'subject'      =>  'this is subject',
-            'content'      =>  'this is content',
-        );
+        $data = [
+            'client_id' => 1,
+            'support_helpdesk_id' => 1,
+            'subject' => 'this is subject',
+            'content' => 'this is content',
+        ];
         $id = $this->api_admin->support_ticket_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -134,7 +135,7 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $mid = $this->api_admin->support_ticket_reply($data);
         $this->assertTrue(is_numeric($mid));
 
-        $bool = $this->api_admin->support_ticket_message_update(array('id'=>$mid, 'content'=>'This is a new content'));
+        $bool = $this->api_admin->support_ticket_message_update(['id' => $mid, 'content' => 'This is a new content']);
         $this->assertTrue($bool);
 
         $bool = $this->api_admin->support_ticket_close($data);
@@ -144,10 +145,10 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $bool = $this->api_admin->support_ticket_update($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'ticket_id' =>  $id,
-            'note'      =>  'this is note',
-        );
+        $data = [
+            'ticket_id' => $id,
+            'note' => 'this is note',
+        ];
         $nid = $this->api_admin->support_note_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -162,9 +163,9 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
     public function testHelpdesk()
     {
-        $data = array(
-            'name'  =>  'title',
-        );
+        $data = [
+            'name' => 'title',
+        ];
         $id = $this->api_admin->support_helpdesk_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -192,44 +193,44 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
     public function testExpirePublicTicket()
     {
-        $data = array(
-            'name'  =>  'Me',
-            'email'  =>  'test@test.com',
-            'subject'  =>  'test@test.com',
-            'message'  =>  'test@test.com',
-        );
+        $data = [
+            'name' => 'Me',
+            'email' => 'test@test.com',
+            'subject' => 'test@test.com',
+            'message' => 'test@test.com',
+        ];
         $hash = $this->api_guest->support_ticket_create($data);
 
-        $ticket = $this->api_guest->support_ticket_get(array('hash'=>$hash));
+        $ticket = $this->api_guest->support_ticket_get(['hash' => $hash]);
 
-        $model = $this->di['db']->load('SupportPTicket',$ticket['id']);
+        $model = $this->di['db']->load('SupportPTicket', $ticket['id']);
         $model->status = 'on_hold';
         $model->updated_at = date('Y-m-d H:i:s', strtotime('-50 days'));
         $this->di['db']->store($model);
 
         $bool = $this->api_admin->support_batch_public_ticket_auto_close();
 
-        $array = $this->api_admin->support_public_ticket_get_list(array('status'=>'on_hold'));
+        $array = $this->api_admin->support_public_ticket_get_list(['status' => 'on_hold']);
         $this->assertIsArray($array);
         $this->assertTrue(empty($array['list']));
     }
 
     public function testTicketTask()
     {
-        $data = array(
-            'support_helpdesk_id'  =>  1,
-            'subject'  =>  'test@test.com',
-            'content'  =>  'test@test.com',
+        $data = [
+            'support_helpdesk_id' => 1,
+            'subject' => 'test@test.com',
+            'content' => 'test@test.com',
 
-            'rel_type'  =>  'order',
-            'rel_task'  =>  'cancel',
-        );
+            'rel_type' => 'order',
+            'rel_task' => 'cancel',
+        ];
 
         $id = $this->api_client->support_ticket_create($data);
 
-        $data = array(
+        $data = [
             'id' => $id,
-        );
+        ];
 
         $bool = $this->api_admin->support_task_complete($data);
         $this->assertTrue($bool);
@@ -237,7 +238,7 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
     public function testSupportTicketGetList()
     {
-        $array = $this->api_admin->support_ticket_get_list(array());
+        $array = $this->api_admin->support_ticket_get_list([]);
         $this->assertIsArray($array);
         $this->assertArrayHasKey('list', $array);
         $list = $array['list'];
@@ -266,7 +267,7 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
             $this->assertArrayHasKey('helpdesk', $item);
             $helpdesk = $item['helpdesk'];
-            if (count($helpdesk)){
+            if (count($helpdesk)) {
                 $this->assertIsArray($helpdesk);
                 $this->assertArrayHasKey('id', $helpdesk);
                 $this->assertArrayHasKey('name', $helpdesk);
@@ -291,13 +292,13 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
     public function testTicketBatchDelete()
     {
-        $array = $this->api_admin->support_ticket_get_list(array());
+        $array = $this->api_admin->support_ticket_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->support_batch_delete(array('ids' => $ids));
-        $array  = $this->api_admin->support_ticket_get_list(array());
+        $result = $this->api_admin->support_batch_delete(['ids' => $ids]);
+        $array = $this->api_admin->support_ticket_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -305,13 +306,13 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
 
     public function testPublicTicketBatchDelete()
     {
-        $array = $this->api_admin->support_public_ticket_get_list(array());
+        $array = $this->api_admin->support_public_ticket_get_list([]);
 
         foreach ($array['list'] as $value) {
             $ids[] = $value['id'];
         }
-        $result = $this->api_admin->support_batch_delete_public(array('ids' => $ids));
-        $array  = $this->api_admin->support_public_ticket_get_list(array());
+        $result = $this->api_admin->support_batch_delete_public(['ids' => $ids]);
+        $array = $this->api_admin->support_public_ticket_get_list([]);
 
         $this->assertEquals(0, count($array['list']));
         $this->assertTrue($result);
@@ -325,15 +326,15 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $array = $this->api_admin->support_kb_category_get_pairs();
         $this->assertIsArray($array);
 
-        $data = array(
-            'title'    =>      'test',
-        );
+        $data = [
+            'title' => 'test',
+        ];
         $id = $this->api_admin->support_kb_category_create($data);
         $this->assertTrue(is_numeric($id));
 
-        $data = array(
-            'id'    =>$id,
-        );
+        $data = [
+            'id' => $id,
+        ];
         $array = $this->api_admin->support_kb_category_get($data);
         $this->assertIsArray($array);
 
@@ -351,16 +352,16 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
         $array = $this->api_admin->support_kb_article_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_admin->support_kb_article_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'kb_article_category_id'    =>      1,
-            'title'                     =>      'test',
-        );
+        $data = [
+            'kb_article_category_id' => 1,
+            'title' => 'test',
+        ];
         $id = $this->api_admin->support_kb_article_create($data);
         $this->assertTrue(is_numeric($id));
 
@@ -420,14 +421,13 @@ class Api_Admin_SupportTest extends BBDbApiTestCase
             $this->assertArrayHasKey('articles', $item);
 
             $articles = $item['articles'];
-            if (count($articles)){
+            if (count($articles)) {
                 $article = $articles[0];
                 $this->assertIsArray($article);
                 $this->assertArrayHasKey('id', $article);
                 $this->assertArrayHasKey('slug', $article);
                 $this->assertArrayHasKey('title', $article);
             }
-
         }
     }
 }

--- a/tests/integration/bb-modules/mod_support/Api_ClientTest.php
+++ b/tests/integration/bb-modules/mod_support/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Client_SupportTest extends BBDbApiTestCase
 {
@@ -6,31 +7,31 @@ class Api_Client_SupportTest extends BBDbApiTestCase
 
     public function testAutoresponder()
     {
-        //enable autoresponder
-        $config = array(
-            'ext'                  =>  'mod_support',
-            'autorespond_enable'   =>  true,
-            'autorespond_message_id'  =>  1,
-        );
+        // enable autoresponder
+        $config = [
+            'ext' => 'mod_support',
+            'autorespond_enable' => true,
+            'autorespond_message_id' => 1,
+        ];
         $bool = $this->api_admin->extension_config_save($config);
         $this->assertTrue($bool);
-        
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  '1',
-        );
+
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => '1',
+        ];
         $id = $this->api_client->support_ticket_create($data);
         $this->assertIsInt($id);
-        
-        $data = array(
-            'id'    => $id,
-        );
+
+        $data = [
+            'id' => $id,
+        ];
         $array = $this->api_client->support_ticket_get($data);
         $this->assertIsArray($array);
         $this->assertEquals(2, count($array['messages']));
     }
-    
+
     public function testSupport()
     {
         $array = $this->api_client->support_ticket_get_list();
@@ -39,44 +40,44 @@ class Api_Client_SupportTest extends BBDbApiTestCase
         $array = $this->api_client->support_helpdesk_get_pairs();
         $this->assertIsArray($array);
 
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  '1',
-        );
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => '1',
+        ];
         $id = $this->api_client->support_ticket_create($data);
         $this->assertIsInt($id);
 
-        $data = array(
-            'id'    => $id,
-        );
+        $data = [
+            'id' => $id,
+        ];
         $array = $this->api_client->support_ticket_get($data);
         $this->assertIsArray($array);
-        
-        $data = array(
-            'id'        =>  $id,
-            'content'   =>  'This is reply message',
-        );
+
+        $data = [
+            'id' => $id,
+            'content' => 'This is reply message',
+        ];
         $bool = $this->api_client->support_ticket_reply($data);
         $this->assertTrue($bool);
 
-        $data = array(
-            'id'                    =>  $id,
-        );
+        $data = [
+            'id' => $id,
+        ];
         $bool = $this->api_client->support_ticket_close($data);
         $this->assertTrue($bool);
     }
 
     public function testTicketTask()
     {
-        $data = array(
-            'subject'               =>  'Subject',
-            'content'               =>  'content',
-            'support_helpdesk_id'   =>  '1',
+        $data = [
+            'subject' => 'Subject',
+            'content' => 'content',
+            'support_helpdesk_id' => '1',
 
-            'order_id'              =>  '1',
-            'task'                  =>  'cancel',
-        );
+            'order_id' => '1',
+            'task' => 'cancel',
+        ];
         $id = $this->api_client->support_ticket_create($data);
         $this->assertIsInt($id);
     }
@@ -87,34 +88,34 @@ class Api_Client_SupportTest extends BBDbApiTestCase
     public function testCanSubmitTicketException()
     {
         $this->api_admin->extension_config_save(
-            array(
-                'ext'      => 'mod_support',
+            [
+                'ext' => 'mod_support',
                 'wait_hours' => 24,
-            ));
-        $data = array(
-            'client_id'           => 1,
+            ]);
+        $data = [
+            'client_id' => 1,
             'support_helpdesk_id' => 1,
-            'subject'             => 'this is subject',
-            'content'             => 'this is content',
-        );
+            'subject' => 'this is subject',
+            'content' => 'this is content',
+        ];
         $this->api_client->support_ticket_create($data);
-        $this->api_client->support_ticket_create($data); //should throw an exception because 1 ticket per 24 hours is allowed
+        $this->api_client->support_ticket_create($data); // should throw an exception because 1 ticket per 24 hours is allowed
     }
 
     public function testCanSubmitTicket()
     {
         $this->api_admin->extension_config_save(
-            array(
-                'ext'      => 'mod_support',
+            [
+                'ext' => 'mod_support',
                 'wait_hours' => '',
-            ));
-        $data = array(
-            'client_id'           => 1,
+            ]);
+        $data = [
+            'client_id' => 1,
             'support_helpdesk_id' => 1,
-            'subject'             => 'this is subject',
-            'content'             => 'this is content',
-        );
+            'subject' => 'this is subject',
+            'content' => 'this is content',
+        ];
         $this->api_client->support_ticket_create($data);
-        $this->api_client->support_ticket_create($data); //should not throw an exception as delay time is not set
+        $this->api_client->support_ticket_create($data); // should not throw an exception as delay time is not set
     }
 }

--- a/tests/integration/bb-modules/mod_support/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_support/Api_GuestTest.php
@@ -1,28 +1,29 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_SupportTest extends ApiTestCase
 {
     public function testContact()
     {
-        $data = array(
-            'name'  =>  'This is me',
-            'email'  =>  'email@email.com',
-            'subject'  =>  'subject',
-            'message'  =>  'Message',
-        );
+        $data = [
+            'name' => 'This is me',
+            'email' => 'email@email.com',
+            'subject' => 'subject',
+            'message' => 'Message',
+        ];
         $hash = $this->api_guest->support_ticket_create($data);
         $this->assertIsString($hash);
 
-        $data = array(
-            'hash'    => $hash,
-        );
+        $data = [
+            'hash' => $hash,
+        ];
         $array = $this->api_guest->support_ticket_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'hash'    => $hash,
+        $data = [
+            'hash' => $hash,
             'message' => 'Hello',
-        );
+        ];
         $hash = $this->api_guest->support_ticket_reply($data);
         $this->assertIsString($hash);
 
@@ -38,26 +39,26 @@ class Api_Guest_SupportTest extends ApiTestCase
         $array = $this->api_guest->support_kb_category_get_list();
         $this->assertIsArray($array);
 
-        $data = array(
-            'id'    =>  1,
-        );
+        $data = [
+            'id' => 1,
+        ];
         $array = $this->api_guest->support_kb_article_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'slug'    =>  'how-to-contact-support',
-        );
+        $data = [
+            'slug' => 'how-to-contact-support',
+        ];
         $array = $this->api_guest->support_kb_article_get($data);
         $this->assertIsArray($array);
 
-        $data = array(
-            'slug'    =>  'discuss-about-everything',
-        );
+        $data = [
+            'slug' => 'discuss-about-everything',
+        ];
         $array = $this->api_guest->support_kb_category_get($data);
         $this->assertIsArray($array);
     }
 
-    public function testKbCategory_get_pairs()
+    public function testKbCategoryGetPairs()
     {
         $array = $this->api_guest->support_kb_category_get_pairs();
         $this->assertIsArray($array);

--- a/tests/integration/bb-modules/mod_system/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_system/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_SystemTest extends BBDbApiTestCase
 {

--- a/tests/integration/bb-modules/mod_system/Api_GuestTest.php
+++ b/tests/integration/bb-modules/mod_system/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Guest_SystemTest extends BBDbApiTestCase
 {

--- a/tests/integration/bb-modules/mod_theme/ApiAdminTest.php
+++ b/tests/integration/bb-modules/mod_theme/ApiAdminTest.php
@@ -1,25 +1,25 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Api_Admin_ThemeTest extends BBDbApiTestCase
 {
     protected $_initialSeedFile = 'mod_theme.xml';
-    
+
     public function testLists()
     {
         $code = 'boxbilling';
-        $array = $this->api_admin->theme_get(array('code'=> $code));
+        $array = $this->api_admin->theme_get(['code' => $code]);
         $this->assertIsArray($array);
         $this->assertEquals($array['code'], $code);
 
         $array = $this->api_admin->theme_get_list();
         $this->assertIsArray($array);
 
-        $bool = $this->api_admin->theme_select(array('code'=>'boxbilling'));
+        $bool = $this->api_admin->theme_select(['code' => 'boxbilling']);
         $this->assertTrue($bool);
-        
-        $array = $this->api_admin->theme_get_list(array('type'=>'admin'));
-        $this->assertIsArray($array);
 
+        $array = $this->api_admin->theme_get_list(['type' => 'admin']);
+        $this->assertIsArray($array);
     }
 
     /**
@@ -27,17 +27,15 @@ class Api_Admin_ThemeTest extends BBDbApiTestCase
      */
     public function testThemeNotFound()
     {
-        $this->api_admin->theme_get(array('code'=> 'non-existing-theme'));
+        $this->api_admin->theme_get(['code' => 'non-existing-theme']);
     }
 
     public function testPresets()
     {
-
-        $bool = $this->api_admin->theme_preset_select(array('code'=>'boxbilling', 'preset'=>'Default'));
+        $bool = $this->api_admin->theme_preset_select(['code' => 'boxbilling', 'preset' => 'Default']);
         $this->assertTrue($bool);
 
-        $bool = $this->api_admin->theme_preset_delete(array('code'=>'boxbilling', 'preset'=>'Default'));
+        $bool = $this->api_admin->theme_preset_delete(['code' => 'boxbilling', 'preset' => 'Default']);
         $this->assertTrue($bool);
-
     }
 }

--- a/tests/integration/bb-modules/mod_theme/Model_ThemeTest.php
+++ b/tests/integration/bb-modules/mod_theme/Model_ThemeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Mode_ThemeTest extends PHPUnit\Framework\TestCase
 {
@@ -6,15 +7,15 @@ class Mode_ThemeTest extends PHPUnit\Framework\TestCase
 
     public function setup(): void
     {
-        $this->model = new \Box\Mod\Theme\Model\Theme('boxbilling');
+        $this->model = new Box\Mod\Theme\Model\Theme('boxbilling');
     }
 
     public function testTypes()
     {
-        $theme1 = new \Box\Mod\Theme\Model\Theme('boxbilling');
+        $theme1 = new Box\Mod\Theme\Model\Theme('boxbilling');
         $this->assertFalse($theme1->isAdminAreaTheme());
 
-        $theme2 = new \Box\Mod\Theme\Model\Theme('admin_default');
+        $theme2 = new Box\Mod\Theme\Model\Theme('admin_default');
         $this->assertTrue($theme2->isAdminAreaTheme());
     }
 

--- a/tests/integration/bb-modules/mod_theme/ServiceTest.php
+++ b/tests/integration/bb-modules/mod_theme/ServiceTest.php
@@ -1,11 +1,11 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 {
-
     public function testgetCurrentThemePreset()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
         $themeModel = $service->getTheme('huraga');
         $result = $service->getCurrentThemePreset($themeModel);
@@ -15,7 +15,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testgetThemePresets()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
         $themeModel = $service->getTheme('huraga');
         $result = $service->getThemePresets($themeModel);
@@ -25,7 +25,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testgetThemeSettings()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
         $themeModel = $service->getTheme('huraga');
         $result = $service->getThemeSettings($themeModel);
@@ -34,13 +34,13 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testupdateSettings()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
 
         $themeModel = $service->getTheme('huraga');
 
         $preset = 'phpUnit';
-        $params = array();
+        $params = [];
 
         $result = $service->updateSettings($themeModel, $preset, $params);
         $this->assertTrue($result);
@@ -48,7 +48,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testregenerateThemeSettingsDataFile()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
 
         $themeModel = $service->getTheme('huraga');
@@ -59,7 +59,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testregenerateThemeCssAndJsFiles()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
 
         $themeModel = $service->getTheme('huraga');
@@ -71,7 +71,7 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testgetCurrentAdminAreaTheme()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
 
         $result = $service->getCurrentAdminAreaTheme();
@@ -82,11 +82,11 @@ class Box_Mod_Theme_ServiceTest extends BBDbApiTestCase
 
     public function testgetCurrentClientAreaTheme()
     {
-        $service = new \Box\Mod\Theme\Service();
+        $service = new Box\Mod\Theme\Service();
         $service->setDi($this->di);
 
         $result = $service->getCurrentClientAreaTheme();
-        $this->assertInstanceOf('\\' . \Box\Mod\Theme\Model\Theme::class, $result);
+        $this->assertInstanceOf('\\' . Box\Mod\Theme\Model\Theme::class, $result);
         $this->assertEquals('huraga', $result->getName());
     }
 }

--- a/tests/library/Box/Box_CryptTest.php
+++ b/tests/library/Box/Box_CryptTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_CryptTest extends PHPUnit\Framework\TestCase
 {

--- a/tests/library/Box/Box_EventManagerTest.php
+++ b/tests/library/Box/Box_EventManagerTest.php
@@ -1,12 +1,13 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_EventManagerTest extends PHPUnit\Framework\TestCase
 {
-	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testEmptyFire()
     {
         $manager = new Box_EventManager();
-        $manager->fire(array());
+        $manager->fire([]);
     }
 
     public function testFire()
@@ -14,17 +15,15 @@ class Box_EventManagerTest extends PHPUnit\Framework\TestCase
         $db_mock = $this->getMockBuilder('Box_Database')->getMock();
         $db_mock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['logger'] = new Box_Log();
         $di['db'] = $db_mock;
-
 
         $manager = new Box_EventManager();
         $manager->setDi($di);
 
-        $manager->fire(array('event'=>'onBeforeClientSignup'));
+        $manager->fire(['event' => 'onBeforeClientSignup']);
     }
 }

--- a/tests/library/Box/Box_ExceptionTest.php
+++ b/tests/library/Box/Box_ExceptionTest.php
@@ -1,11 +1,11 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_ExceptionTest extends PHPUnit\Framework\TestCase
 {
-
     public function testException()
     {
-        $e = new Box_Exception('php :msg', array(':msg'=>'unit'), 789);
+        $e = new Box_Exception('php :msg', [':msg' => 'unit'], 789);
         $this->assertEquals('php unit', $e->getMessage());
         $this->assertEquals(789, $e->getCode());
     }

--- a/tests/library/Box/Box_ModTest.php
+++ b/tests/library/Box/Box_ModTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_ModTest extends PHPUnit\Framework\TestCase
 {
@@ -7,33 +8,33 @@ class Box_ModTest extends PHPUnit\Framework\TestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di = new \Pimple\Container();
-        $di['config'] = array('salt'=>'salt');
+        $di = new Pimple\Container();
+        $di['config'] = ['salt' => 'salt'];
         $di['db'] = $db;
 
         $mod = new Box_Mod('api');
         $mod->setDi($di);
         $array = $mod->getConfig();
-        $this->assertEquals(array(), $array);
+        $this->assertEquals([], $array);
     }
 
     public function testCoreMod()
     {
         $mod = new Box_Mod('api');
         $this->assertTrue($mod->isCore());
-        
+
         $array = $mod->getCoreModules();
         $this->assertIsArray($array);
-        
+
         $mod = new Box_Mod('Cookieconsent');
         $this->assertFalse($mod->isCore());
     }
-    
+
     public function testManifest()
     {
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['url'] = new Box_Url();
 
         $mod = new Box_Mod('Cookieconsent');
@@ -50,13 +51,11 @@ class Box_ModTest extends PHPUnit\Framework\TestCase
     {
         $mod = new Box_Mod('Invoice');
         $subServiceName = 'transaction';
-        
-        $di = new \Pimple\Container();
+
+        $di = new Pimple\Container();
         $mod->setDi($di);
 
         $subService = $mod->getService($subServiceName);
-        $this->assertInstanceOf(\Box\Mod\Invoice\ServiceTransaction::class, $subService);
-
+        $this->assertInstanceOf(Box\Mod\Invoice\ServiceTransaction::class, $subService);
     }
-
 }

--- a/tests/library/Box/Box_PasswordTest.php
+++ b/tests/library/Box/Box_PasswordTest.php
@@ -1,8 +1,7 @@
 <?php
 
-
-class Box_PasswordTest extends PHPUnit\Framework\TestCase {
-
+class Box_PasswordTest extends PHPUnit\Framework\TestCase
+{
     public function testsetAlgo()
     {
         $boxPassword = new Box_Password();
@@ -15,9 +14,9 @@ class Box_PasswordTest extends PHPUnit\Framework\TestCase {
     public function testSetOptions()
     {
         $boxPassword = new Box_Password();
-        $options = array(
+        $options = [
             'cost' => 12,
-        );
+        ];
         $boxPassword->setOptions($options);
         $result = $boxPassword->getOptions();
         $this->assertEquals($options, $result);
@@ -48,7 +47,7 @@ class Box_PasswordTest extends PHPUnit\Framework\TestCase {
         $this->assertIsString($hash);
         $this->assertNotEmpty($hash);
 
-        $newOptions = array('cost' => 15);
+        $newOptions = ['cost' => 15];
         $boxPassword->setOptions($newOptions);
 
         $needRehashing = $boxPassword->needsRehash($hash);
@@ -56,4 +55,3 @@ class Box_PasswordTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue($needRehashing);
     }
 }
- 

--- a/tests/library/Box/Box_PeriodTest.php
+++ b/tests/library/Box/Box_PeriodTest.php
@@ -3,17 +3,16 @@
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_PeriodTest extends PHPUnit\Framework\TestCase
 {
-
     public function testException()
     {
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Invalid period code. Period definition must be 2 chars length');
         $p = new Box_Period('1');
     }
 
     public function testException2()
     {
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Period Error. Unit Z is not defined');
         $p = new Box_Period('1Z');
     }

--- a/tests/library/Box/Box_TranslateTest.php
+++ b/tests/library/Box/Box_TranslateTest.php
@@ -1,11 +1,12 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_TranslateTest extends PHPUnit\Framework\TestCase
 {
     public function testsetLocale()
     {
         $locale = 'en_US';
-        $translateObj = new \Box_Translate();
+        $translateObj = new Box_Translate();
         $translateObj->setLocale($locale);
         $result = $translateObj->getLocale();
 
@@ -14,16 +15,16 @@ class Box_TranslateTest extends PHPUnit\Framework\TestCase
 
     public function testDi()
     {
-        $di = new \Pimple\Container();
-        $translateObj = new \Box_Translate();
+        $di = new Pimple\Container();
+        $translateObj = new Box_Translate();
         $translateObj->setDi($di);
         $getDi = $translateObj->getDi();
         $this->assertEquals($di, $getDi);
     }
 
-    public function testDomain_setterAndGetter()
+    public function testDomainSetterAndGetter()
     {
-        $translateObj = new \Box_Translate();
+        $translateObj = new Box_Translate();
 
         $default = 'messages';
         $result = $translateObj->getDomain();
@@ -41,5 +42,4 @@ class Box_TranslateTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals($text, $result);
     }
-
 }

--- a/tests/library/Box/Box_TwigLoaderTest.php
+++ b/tests/library/Box/Box_TwigLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Box_TwigLoaderTest extends PHPUnit\Framework\TestCase
 {

--- a/tests/library/FOSSBilling/FOSSBilling_ValidateTest.php
+++ b/tests/library/FOSSBilling/FOSSBilling_ValidateTest.php
@@ -5,66 +5,64 @@ class FOSSBilling_ValidateTest extends PHPUnit\Framework\TestCase
 {
     public static function domains()
     {
-        return array(
-            array('google', true),
-            array('1goo-gle', true),
+        return [
+            ['google', true],
+            ['1goo-gle', true],
 
-            //punny code
-            array('xn--bcher-kva', true),
+            // punny code
+            ['xn--bcher-kva', true],
 
-            array('qqq45%%%', false),
-            array('()1google', false),
-            array('//asdasd()()', false),
-            array('--asdasd()()', false),
-        );
+            ['qqq45%%%', false],
+            ['()1google', false],
+            ['//asdasd()()', false],
+            ['--asdasd()()', false],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('domains')]
     public function testValidator($domain, $valid)
     {
-        $v = new \FOSSBilling\Validate();
+        $v = new FOSSBilling\Validate();
         $this->assertEquals($valid, $v->isSldValid($domain));
     }
 
     public function testCheckRequiredParamsForArray()
     {
-        $data     = array(
-            'id'  => random_int(1, 10),
-            'key' => 'KEY must be set'
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY must be set'
-        );
-        $v        = new \FOSSBilling\Validate();
+        $data = [
+            'id' => random_int(1, 10),
+            'key' => 'KEY must be set',
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY must be set',
+        ];
+        $v = new FOSSBilling\Validate();
         $this->assertNull($v->checkRequiredParamsForArray($required, $data));
     }
 
-
     public function testCheckRequiredParamsForArrayNotExist()
     {
-        $data     = array();
-        $required = array(
-            'id' => 'ID must be set'
-        );
-        $v        = new \FOSSBilling\Validate();
+        $data = [];
+        $required = [
+            'id' => 'ID must be set',
+        ];
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('ID must be set');
         $v->checkRequiredParamsForArray($required, $data);
     }
 
-
     public function testCheckRequiredParamsForArrayOneKeyNotExists()
     {
-        $data     = array(
-            'id' => random_int(1, 10)
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY must be set'
-        );
-        $v        = new \FOSSBilling\Validate();
+        $data = [
+            'id' => random_int(1, 10),
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY must be set',
+        ];
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('KEY must be set');
@@ -73,16 +71,16 @@ class FOSSBilling_ValidateTest extends PHPUnit\Framework\TestCase
 
     public function testCheckRequiredParamsForArrayMessagePlaceholder()
     {
-        $data     = array(
-            'id' => random_int(1, 10)
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY :key must be set'
-        );
+        $data = [
+            'id' => random_int(1, 10),
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY :key must be set',
+        ];
 
-        $variables = array(':key' => 'placeholder_key');
-        $v         = new \FOSSBilling\Validate();
+        $variables = [':key' => 'placeholder_key'];
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('KEY placeholder_key must be set');
@@ -91,38 +89,37 @@ class FOSSBilling_ValidateTest extends PHPUnit\Framework\TestCase
 
     public function testCheckRequiredParamsForArrayMessagePlaceholders()
     {
-        $data     = array(
-            'id' => random_int(1, 10)
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY :key must be set for array :array'
-        );
+        $data = [
+            'id' => random_int(1, 10),
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY :key must be set for array :array',
+        ];
 
-        $variables = array(
-            ':key'   => 'placeholder_key',
-            ':array' => 'config'
-        );
-        $v         = new \FOSSBilling\Validate();
+        $variables = [
+            ':key' => 'placeholder_key',
+            ':array' => 'config',
+        ];
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(0);
         $this->expectExceptionMessage('KEY placeholder_key must be set for array config');
         $v->checkRequiredParamsForArray($required, $data, $variables);
     }
 
-
     public function testCheckRequiredParamsForArrayErrorCode()
     {
-        $data     = array(
-            'id' => random_int(1, 10)
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY :key must be set'
-        );
+        $data = [
+            'id' => random_int(1, 10),
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY :key must be set',
+        ];
 
-        $variables = array(':key' => 'placeholder_key');
-        $v         = new \FOSSBilling\Validate();
+        $variables = [':key' => 'placeholder_key'];
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(12345);
         $this->expectExceptionMessage('KEY placeholder_key must be set');
@@ -131,70 +128,68 @@ class FOSSBilling_ValidateTest extends PHPUnit\Framework\TestCase
 
     public function testCheckRequiredParamsForArrayErrorCodeVariablesNotSet()
     {
-        $data     = array(
-            'id' => random_int(1, 10)
-        );
-        $required = array(
-            'id'  => 'ID must be set',
-            'key' => 'KEY must be set'
-        );
+        $data = [
+            'id' => random_int(1, 10),
+        ];
+        $required = [
+            'id' => 'ID must be set',
+            'key' => 'KEY must be set',
+        ];
 
-        $v = new \FOSSBilling\Validate();
+        $v = new FOSSBilling\Validate();
         $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionCode(54321);
         $this->expectExceptionMessage('KEY must be set');
-        $v->checkRequiredParamsForArray($required, $data, array(), 54321);
+        $v->checkRequiredParamsForArray($required, $data, [], 54321);
     }
 
-    public function testcheckRequiredParamsForArray_KeyValueIsZero()
+    public function testcheckRequiredParamsForArrayKeyValueIsZero()
     {
-        $data     = array(
-            'amount' => 0
-        );
-        $required = array(
-            'amount'  => 'amount must be set',
-        );
+        $data = [
+            'amount' => 0,
+        ];
+        $required = [
+            'amount' => 'amount must be set',
+        ];
 
-        $v = new \FOSSBilling\Validate();
+        $v = new FOSSBilling\Validate();
         $v->checkRequiredParamsForArray($required, $data);
 
-        //add needed assert, set to true if no exception called in $v->checkRequiredParamsForArray
+        // add needed assert, set to true if no exception called in $v->checkRequiredParamsForArray
         $this->assertTrue(true);
     }
 
-    public function testcheckRequiredParamsForArray_EmptyString()
+    public function testcheckRequiredParamsForArrayEmptyString()
     {
-        $data     = array(
-            'message' => ''
-        );
-        $required = array(
-            'message'  => 'message must be set',
-        );
+        $data = [
+            'message' => '',
+        ];
+        $required = [
+            'message' => 'message must be set',
+        ];
 
-        $v = new \FOSSBilling\Validate();
+        $v = new FOSSBilling\Validate();
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage($required['message']);
 
         $v->checkRequiredParamsForArray($required, $data);
     }
 
-
-    public function testcheckRequiredParamsForArray_EmptyStringFilledWithSpaces()
+    public function testcheckRequiredParamsForArrayEmptyStringFilledWithSpaces()
     {
-        $data     = array(
-            'message' => '    '
-        );
-        $required = array(
-            'message'  => 'message must be set',
-        );
+        $data = [
+            'message' => '    ',
+        ];
+        $required = [
+            'message' => 'message must be set',
+        ];
 
-        $v = new \FOSSBilling\Validate();
+        $v = new FOSSBilling\Validate();
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->expectExceptionMessage($required['message']);
 
         $v->checkRequiredParamsForArray($required, $data);
     }
-
 }

--- a/tests/library/Registrar/Adapter/Registrar_Adapter_ResellerclubTest.php
+++ b/tests/library/Registrar/Adapter/Registrar_Adapter_ResellerclubTest.php
@@ -1,45 +1,47 @@
 <?php
+
 #[\PHPUnit\Framework\Attributes\Group('Core')]
 class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
 {
     private function getAdapter()
     {
-        $options = array(
+        $options = [
             'userid' => '12345',
-            'api-key' => 'api-token'
-        );
-        return new \Registrar_Adapter_Resellerclub($options);
+            'api-key' => 'api-token',
+        ];
+
+        return new Registrar_Adapter_Resellerclub($options);
     }
 
-    public function testConstruction_MissingUserId()
+    public function testConstructionMissingUserId()
     {
-        $options = array();
+        $options = [];
 
         $this->expectException(Registrar_Exception::class);
         $this->expectExceptionMessage('ResellerClub" domain registrar is not fully configured. Please configure the ResellerClub Reseller ID');
 
-        $adapter = new \Registrar_Adapter_Resellerclub($options);
+        $adapter = new Registrar_Adapter_Resellerclub($options);
     }
 
-    public function testConstruction_MissingApiKey()
+    public function testConstructionMissingApiKey()
     {
-        $options = array(
+        $options = [
             'userid' => '12345',
-        );
+        ];
 
         $this->expectException(Registrar_Exception::class);
         $this->expectExceptionMessage('The "ResellerClub" domain registrar is not fully configured. Please configure the ResellerClub API Key');
 
-        new \Registrar_Adapter_Resellerclub($options);
+        new Registrar_Adapter_Resellerclub($options);
     }
 
     public function testConstruction()
     {
-        $options = array(
+        $options = [
             'userid' => '12345',
-            'api-key' => 'api-key Token'
-        );
-        $adapter = new \Registrar_Adapter_Resellerclub($options);
+            'api-key' => 'api-key Token',
+        ];
+        $adapter = new Registrar_Adapter_Resellerclub($options);
 
         $this->assertEquals($options['userid'], $adapter->config['userid']);
         $this->assertEquals($options['api-key'], $adapter->config['api-key']);
@@ -66,16 +68,16 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $this->assertIsArray($result);
     }
 
-    public function testisDomainAvailable_foundInArray()
+    public function testisDomainAvailableFoundInArray()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
         $registrarDomain->setSld('example')->setTld('.com');
 
-        $requestResult = array();
+        $requestResult = [];
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->with('domains/available')
@@ -85,16 +87,16 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($result);
     }
 
-    public function testisDomainAvailable_StatusAvailable()
+    public function testisDomainAvailableStatusAvailable()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
         $registrarDomain->setSld('example')->setTld('.com');
 
-        $requestResult = array($registrarDomain->getName() => array( 'status' => 'available'));
+        $requestResult = [$registrarDomain->getName() => ['status' => 'available']];
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->with('domains/available')
@@ -104,16 +106,16 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($result);
     }
 
-    public function testisDomainAvailable_isNotAvailable()
+    public function testisDomainAvailableIsNotAvailable()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
         $registrarDomain->setSld('example')->setTld('.com');
 
-        $requestResult = array($registrarDomain->getName() => array());
+        $requestResult = [$registrarDomain->getName() => []];
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->with('domains/available')
@@ -126,7 +128,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     public function testisDomaincanBeTransferred()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
@@ -146,7 +148,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     public function testmodifyNs()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
@@ -155,9 +157,9 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->willReturnCallback(function (...$args) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'domains/orderid' => 1,
-                    'domains/modify-ns'=> ['status' => 'Success']
+                    'domains/modify-ns' => ['status' => 'Success']
                 };
 
                 return $value;
@@ -171,7 +173,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     public function testmodifyContact()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
@@ -180,7 +182,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->willReturnCallback(function (...$args) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'customers/details' => ['customerid' => 1],
                     'contacts/default' => ['Contact' => ['registrant' => 1]],
                     'contacts/modify' => ['status' => 'Success']
@@ -197,7 +199,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     public function testtransferDomain()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
@@ -206,7 +208,7 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->willReturnCallback(function (...$args) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'customers/details' => ['customerid' => 1],
                     'contacts/default' => ['Contact' => ['registrant' => 1]],
                     'domains/transfer' => ['status' => 'Success']
@@ -222,17 +224,17 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     public function testregisterDomain()
     {
         $adapterMock = $this->getMockBuilder('Registrar_Adapter_Resellerclub')->disableOriginalConstructor()
-            ->onlyMethods(array('_makeRequest'))
+            ->onlyMethods(['_makeRequest'])
             ->getMock();
 
         $registrarDomain = new Registrar_Domain();
         $registrarDomain->setSld('example')->setTld('.com')->setContactRegistrar(new Registrar_Domain_Contact());
 
-        $requestResult = array('status' => 'Success');
+        $requestResult = ['status' => 'Success'];
         $adapterMock->expects($this->atLeastOnce())
             ->method('_makeRequest')
             ->willReturnCallback(function (...$args) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'domains/orderid' => 1,
                     'domains/details' => ['currentstatus' => ''],
                     'customers/details' => ['customerid' => 1],
@@ -250,30 +252,30 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($result);
     }
 
-    public function testincludeAuthorizationParams_ApiKeyProvided()
+    public function testincludeAuthorizationParamsApiKeyProvided()
     {
-        $options = array(
+        $options = [
             'userid' => '12345',
-            'api-key' => 'password'
-        );
-        $adapter = new \Registrar_Adapter_Resellerclub($options);
+            'api-key' => 'password',
+        ];
+        $adapter = new Registrar_Adapter_Resellerclub($options);
 
-        $params = array();
+        $params = [];
         $result = $adapter->includeAuthorizationParams($params);
         $this->assertArrayHasKey('auth-userid', $result);
         $this->assertArrayHasKey('api-key', $result);
     }
 
-    public function testincludeAuthorizationParams_BothProvided_ApiKeyIsUsed()
+    public function testincludeAuthorizationParamsBothProvidedApiKeyIsUsed()
     {
-        $options = array(
+        $options = [
             'userid' => '12345',
             'password' => 'password',
-            'api-key' => 'password'
-        );
-        $adapter = new \Registrar_Adapter_Resellerclub($options);
+            'api-key' => 'password',
+        ];
+        $adapter = new Registrar_Adapter_Resellerclub($options);
 
-        $params = array();
+        $params = [];
         $result = $adapter->includeAuthorizationParams($params);
         $this->assertArrayHasKey('auth-userid', $result);
         $this->assertArrayHasKey('api-key', $result);
@@ -303,10 +305,10 @@ class Registrar_Adapter_ResellerclubTest extends PHPUnit\Framework\TestCase
     {
         $options = [
             'userid' => 'TEST',
-            'api-key' => 'TEST'
+            'api-key' => 'TEST',
         ];
 
-        $regAdapter = new \Registrar_Adapter_Resellerclub($options);
+        $regAdapter = new Registrar_Adapter_Resellerclub($options);
         $result = $regAdapter->isKeyValueNotEmpty($array, $key);
 
         $this->assertEquals($expected, $result);

--- a/tests/library/bootstrap.php
+++ b/tests/library/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
+
 require_once __DIR__ . '/../../src/load.php';
-$di = include __DIR__. '/../../src/di.php';
+$di = include __DIR__ . '/../../src/di.php';

--- a/tests/modules/Activity/Api/AdminTest.php
+++ b/tests/modules/Activity/Api/AdminTest.php
@@ -2,36 +2,36 @@
 
 namespace Box\Tests\Mod\Activity\Api;
 
-class AdminTest extends \BBTestCase {
-
-    public function test_log_get_list()
+class AdminTest extends \BBTestCase
+{
+    public function testLogGetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array(
+        $simpleResultArr = [
+            'list' => [
+                [
                     'id' => 1,
                     'staff_id' => 1,
                     'staff_name' => 'Joe',
-                    'staff_email' => 'example@example.com'
-                ),
-            ),
-        );
+                    'staff_email' => 'example@example.com',
+                ],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
                     ->method('getSimpleResultSet')
-                    ->will($this->returnValue($simpleResultArr));
+                    ->willReturn($simpleResultArr);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Activity\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
                 ->method('getSearchQuery')
-                ->will($this->returnValue('String'));
+                ->willReturn('String');
 
         $model = new \Model_ActivitySystem();
         $model->loadBean(new \DummyBean());
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $api = new \Api_Handler(new \Model_Admin());
         $api->setDi($di);
@@ -40,37 +40,37 @@ class AdminTest extends \BBTestCase {
         $activity = new \Box\Mod\Activity\Api\Admin();
         $activity->setDi($di);
         $activity->setService($service);
-        $activity->log_get_list(array());
+        $activity->log_get_list([]);
     }
 
-    public function test_log_get_list_ItemUserClient()
+    public function testLogGetListItemUserClient()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array(
+        $simpleResultArr = [
+            'list' => [
+                [
                     'id' => 1,
                     'client_id' => 1,
                     'client_name' => 'Joe',
-                    'client_email' => 'example@example.com'
-                ),
-            ),
-        );
+                    'client_email' => 'example@example.com',
+                ],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
                     ->method('getSimpleResultSet')
-                    ->will($this->returnValue($simpleResultArr));
+                    ->willReturn($simpleResultArr);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Activity\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
                 ->method('getSearchQuery')
-                ->will($this->returnValue('String'));
+                ->willReturn('String');
 
         $model = new \Model_ActivitySystem();
         $model->loadBean(new \DummyBean());
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $api = new \Api_Handler(new \Model_Admin());
         $api->setDi($di);
@@ -79,7 +79,7 @@ class AdminTest extends \BBTestCase {
         $activity = new \Box\Mod\Activity\Api\Admin();
         $activity->setDi($di);
         $activity->setService($service);
-        $activity->log_get_list(array());
+        $activity->log_get_list([]);
     }
 
     public function testlogEmptyMParam()
@@ -88,82 +88,82 @@ class AdminTest extends \BBTestCase {
 
         $activity = new \Box\Mod\Activity\Api\Admin();
         $activity->setDi($di);
-        $result = $activity->log(array());
-        $this->assertEquals(false, $result, 'Empty array key m');
+        $result = $activity->log([]);
+        $this->assertFalse($result, 'Empty array key m');
     }
 
-    public function testlog_email()
+    public function testlogEmail()
     {
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Activity\Service::class)->onlyMethods(array('logEmail'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Activity\Service::class)->onlyMethods(['logEmail'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('logEmail')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
 
         $adminApi = new \Box\Mod\Activity\Api\Admin();
         $adminApi->setService($service);
         $adminApi->setDi($di);
-        $result = $adminApi->log_email(array('subject' => 'Proper subject'));
+        $result = $adminApi->log_email(['subject' => 'Proper subject']);
 
-        $this->assertEquals(true, $result, 'Log_email did not returned true');
+        $this->assertTrue($result, 'Log_email did not returned true');
     }
 
-    public function testlog_email_WithoutSubject()
+    public function testlogEmailWithoutSubject()
     {
         $activity = new \Box\Mod\Activity\Api\Admin();
-        $result = $activity->log_email(array());
-        $this->assertEquals(false, $result);
+        $result = $activity->log_email([]);
+        $this->assertFalse($result);
     }
 
-    public function testlog_delete()
+    public function testlogDelete()
     {
         $di = new \Pimple\Container();
 
         $databaseMock = $this->getMockBuilder('Box_Database')->getMock();
         $databaseMock->expects($this->atLeastOnce())->
             method('getExistingModelById')->
-            will($this->returnValue(new \Model_ActivitySystem()));
+            willReturn(new \Model_ActivitySystem());
 
         $databaseMock->expects($this->atLeastOnce())->
             method('trash');
 
-        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')->onlyMethods(array('hasPermission'))->getMock();
-            $serviceMock->expects($this->atLeastOnce())
-                ->method('hasPermission')
-                ->willReturn(true);
+        $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')->onlyMethods(['hasPermission'])->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('hasPermission')
+            ->willReturn(true);
 
         $di['db'] = $databaseMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
 
         $activity = new \Box\Mod\Activity\Api\Admin();
         $activity->setDi($di);
 
-        $result = $activity->log_delete(array('id' => 1));
-        $this->assertEquals(true, $result);
+        $result = $activity->log_delete(['id' => 1]);
+        $this->assertTrue($result);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Activity\Api\Admin::class)->onlyMethods(array('log_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('log_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Activity\Api\Admin::class)->onlyMethods(['log_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('log_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 }

--- a/tests/modules/Activity/Controller/AdminTest.php
+++ b/tests/modules/Activity/Controller/AdminTest.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Box\Tests\Mod\Activity\Controller;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testDi()
     {
         $controller = new \Box\Mod\Activity\Controller\Admin();
@@ -42,13 +40,13 @@ class AdminTest extends \BBTestCase {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->atLeastOnce())
             ->method('get')
-            ->with('/activity', 'get_index', array(), \Box\Mod\Activity\Controller\Admin::class);
+            ->with('/activity', 'get_index', [], \Box\Mod\Activity\Controller\Admin::class);
 
         $controllerAdmin = new \Box\Mod\Activity\Controller\Admin();
         $controllerAdmin->register($boxAppMock);
     }
 
-    public function testget_index()
+    public function testgetIndex()
     {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->atLeastOnce())
@@ -64,4 +62,3 @@ class AdminTest extends \BBTestCase {
         $controllerAdmin->get_index($boxAppMock);
     }
 }
- 

--- a/tests/modules/Activity/ServiceTest.php
+++ b/tests/modules/Activity/ServiceTest.php
@@ -4,7 +4,6 @@ namespace Box\Tests\Mod\Activity;
 
 class ServiceTest extends \BBTestCase
 {
-
     public function testDi()
     {
         $service = new \Box\Mod\Activity\Service();
@@ -20,15 +19,15 @@ class ServiceTest extends \BBTestCase
 
     public static function searchFilters()
     {
-        return array(
-            array(array(), 'FROM activity_system ', TRUE),
-            array(array('only_clients' => 'yes'), 'm.client_id IS NOT NULL', TRUE),
-            array(array('only_staff' => 'yes'), 'm.admin_id IS NOT NULL', TRUE),
-            array(array('priority' => '2'), 'm.priority =', TRUE),
-            array(array('search' => 'keyword'), 'm.message LIKE ', TRUE),
-            array(array('no_info' => true), 'm.priority < :priority ', TRUE),
-            array(array('no_debug' => true), 'm.priority < :priority ', TRUE),
-        );
+        return [
+            [[], 'FROM activity_system ', true],
+            [['only_clients' => 'yes'], 'm.client_id IS NOT NULL', true],
+            [['only_staff' => 'yes'], 'm.admin_id IS NOT NULL', true],
+            [['priority' => '2'], 'm.priority =', true],
+            [['search' => 'keyword'], 'm.message LIKE ', true],
+            [['no_info' => true], 'm.priority < :priority ', true],
+            [['no_debug' => true], 'm.priority < :priority ', true],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchFilters')]
@@ -37,7 +36,7 @@ class ServiceTest extends \BBTestCase
         $di = new \Pimple\Container();
         $service = new \Box\Mod\Activity\Service();
         $service->setDi($di);
-        $result  = $service->getSearchQuery($filterKey);
+        $result = $service->getSearchQuery($filterKey);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
         $this->assertTrue(str_contains($result[0], $search), $expected);
@@ -46,14 +45,14 @@ class ServiceTest extends \BBTestCase
     public function testLogEmail()
     {
         $service = new \Box\Mod\Activity\Service();
-        $data = array(
-            'client_id'    => random_int(1, 100),
-            'sender'       => 'sender',
-            'recipients'   => 'recipients',
-            'subject'      => 'subject',
+        $data = [
+            'client_id' => random_int(1, 100),
+            'sender' => 'sender',
+            'recipients' => 'recipients',
+            'subject' => 'subject',
             'content_html' => 'html',
             'content_text' => 'text',
-        );
+        ];
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
@@ -62,10 +61,10 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di['db'] = $db;
         $service->setDi($di);
@@ -121,8 +120,8 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->with('ActivitySystem', 'client_id = ?', array($clientModel->id))
-            ->willReturn(array($activitySystemModel));
+            ->with('ActivitySystem', 'client_id = ?', [$clientModel->id])
+            ->willReturn([$activitySystemModel]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
             ->with($activitySystemModel);
@@ -135,6 +134,4 @@ class ServiceTest extends \BBTestCase
 
         $service->rmByClient($clientModel);
     }
-
 }
-

--- a/tests/modules/Api/ServiceTest.php
+++ b/tests/modules/Api/ServiceTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Api;
 
-
-class ServiceTest extends \BBTestCase {
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Api\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Api\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -33,7 +32,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($requestNumber));
+            ->willReturn($requestNumber);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -43,6 +42,5 @@ class ServiceTest extends \BBTestCase {
 
         $this->assertIsInt($result);
         $this->assertEquals($requestNumber, $result);
-
     }
 }

--- a/tests/modules/Branding/ServiceTest.php
+++ b/tests/modules/Branding/ServiceTest.php
@@ -1,12 +1,9 @@
 <?php
 
-
 namespace Box\Tests\Mod\Branding;
-
 
 class ServiceTest extends \BBTestCase
 {
-
     public function testDi()
     {
         $service = new \Box\Mod\Branding\Service();
@@ -19,6 +16,4 @@ class ServiceTest extends \BBTestCase
         $result = $service->getDi();
         $this->assertEquals($di, $result);
     }
-
 }
- 

--- a/tests/modules/Cart/Api/AdminTest.php
+++ b/tests/modules/Cart/Api/AdminTest.php
@@ -7,42 +7,42 @@ class AdminTest extends \BBTestCase
     /**
      * @var \Box\Mod\Cart\Api\Admin
      */
-    protected $adminApi = null;
+    protected $adminApi;
 
     public function setup(): void
     {
         $this->adminApi = new \Box\Mod\Cart\Api\Admin();
     }
 
-    public function testGet_list()
+    public function testGetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array('id' => 1),
-            ),
-        );
+        $simpleResultArr = [
+            'list' => [
+                ['id' => 1],
+            ],
+        ];
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSearchQuery', 'toApiArray'))->getMock();
+            ->onlyMethods(['getSearchQuery', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_Cart();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
         $di['db'] = $dbMock;
 
@@ -50,7 +50,7 @@ class AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->get_list($data);
 
         $this->assertIsArray($result);
@@ -61,55 +61,53 @@ class AdminTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Cart()));
+            ->willReturn(new \Model_Cart());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+            ->onlyMethods(['toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->get($data);
 
         $this->assertIsArray($result);
     }
 
-
-    public function testBatch_expire()
+    public function testBatchExpire()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array(random_int(1, 100), date('Y-m-d H:i:s'))));
+            ->willReturn([random_int(1, 100), date('Y-m-d H:i:s')]);
         $dbMock->expects($this->atLeastOnce())
             ->method('exec')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->adminApi->setDi($di);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->batch_expire($data);
 
         $this->assertTrue($result);
     }
-
 }

--- a/tests/modules/Cart/Api/ClientTest.php
+++ b/tests/modules/Cart/Api/ClientTest.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Box\Tests\Mod\Cart\Api;
 
-
-class ClientTest extends \BBTestCase {
+class ClientTest extends \BBTestCase
+{
     /**
      * @var \Box\Mod\Cart\Api\Client
      */
-    protected $clientApi = null;
+    protected $clientApi;
 
     public function setup(): void
     {
@@ -18,21 +19,21 @@ class ClientTest extends \BBTestCase {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
 
-       $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'checkoutCart'))
-           ->getMock();
-       $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
+             ->onlyMethods(['getSessionCart', 'checkoutCart'])
+            ->getMock();
+        $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
+             ->willReturn($cart);
 
-        $checkOutCartResult =  array (
-            'gateway_id'   => 1,
+        $checkOutCartResult = [
+            'gateway_id' => 1,
             'invoice_hash' => null,
-            'order_id'     => 1,
-            'orders'       => 1,
-        );
+            'order_id' => 1,
+            'orders' => 1,
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('checkoutCart')
-            ->will($this->returnValue($checkOutCartResult));
+            ->willReturn($checkOutCartResult);
 
         $this->clientApi->setService($serviceMock);
 
@@ -41,9 +42,9 @@ class ClientTest extends \BBTestCase {
 
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $di = new \Pimple\Container();
 
         $this->clientApi->setDi($di);

--- a/tests/modules/Cart/Api/GuestTest.php
+++ b/tests/modules/Cart/Api/GuestTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Cart\Api;
 
+namespace Box\Tests\Mod\Cart\Api;
 
 class GuestTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Cart\Api\Guest
      */
-    protected $guestApi = null;
+    protected $guestApi;
 
     public function setup(): void
     {
@@ -17,11 +17,11 @@ class GuestTest extends \BBTestCase
     public function testGet()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'toApiArray'))->getMock();
+            ->onlyMethods(['getSessionCart', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue(new \Model_Cart()));
+            ->willReturn(new \Model_Cart());
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->guestApi->setService($serviceMock);
 
@@ -33,11 +33,11 @@ class GuestTest extends \BBTestCase
     public function testReset()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'resetCart'))->getMock();
+            ->onlyMethods(['getSessionCart', 'resetCart'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue(new \Model_Cart()));
+            ->willReturn(new \Model_Cart());
         $serviceMock->expects($this->atLeastOnce())->method('resetCart')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->guestApi->setService($serviceMock);
 
@@ -46,71 +46,69 @@ class GuestTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testSet_currency()
+    public function testSetCurrency()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'changeCartCurrency'))->getMock();
+            ->onlyMethods(['getSessionCart', 'changeCartCurrency'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue(new \Model_Cart()));
+            ->willReturn(new \Model_Cart());
         $serviceMock->expects($this->atLeastOnce())->method('changeCartCurrency')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
-            ->onlyMethods(array('getByCode'))->getMock();
+            ->onlyMethods(['getByCode'])->getMock();
         $currencyServiceMock->expects($this->atLeastOnce())->method('getByCode')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
-        $di                = new \Pimple\Container();
-        $di['validator']   = $validatorMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyServiceMock);
+        $di = new \Pimple\Container();
+        $di['validator'] = $validatorMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyServiceMock);
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'currency' => 'EUR'
-        );
+        $data = [
+            'currency' => 'EUR',
+        ];
         $result = $this->guestApi->set_currency($data);
 
         $this->assertTrue($result);
     }
 
-    public function testSet_currencyNotFoundException()
+    public function testSetCurrencyNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'changeCartCurrency'))->getMock();
+            ->onlyMethods(['getSessionCart', 'changeCartCurrency'])->getMock();
         $serviceMock->expects($this->never())->method('getSessionCart')
-            ->will($this->returnValue(new \Model_Cart()));
+            ->willReturn(new \Model_Cart());
         $serviceMock->expects($this->never())->method('changeCartCurrency')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
-            ->onlyMethods(array('getByCode'))->getMock();
+            ->onlyMethods(['getByCode'])->getMock();
         $currencyServiceMock->expects($this->atLeastOnce())->method('getByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['validator']   = $validatorMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyServiceMock);
+        $di = new \Pimple\Container();
+        $di['validator'] = $validatorMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyServiceMock);
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'currency' => 'EUR'
-        );
+        $data = [
+            'currency' => 'EUR',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Currency not found');
@@ -118,194 +116,192 @@ class GuestTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testGet_currency()
+    public function testGetCurrency()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart',))->getMock();
+            ->onlyMethods(['getSessionCart'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
-
+            ->willReturn($cart);
 
         $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
-            ->onlyMethods(array('toApiArray', 'getDefault'))->getMock();
+            ->onlyMethods(['toApiArray', 'getDefault'])->getMock();
         $currencyServiceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $currencyServiceMock->expects($this->never())->method('getDefault')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyServiceMock);
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'currency' => 'EUR'
-        );
+        $data = [
+            'currency' => 'EUR',
+        ];
         $result = $this->guestApi->get_currency();
 
         $this->assertIsArray($result);
     }
 
-    public function testGet_currencyNotFound()
+    public function testGetCurrencyNotFound()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart',))->getMock();
+            ->onlyMethods(['getSessionCart'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
-
+            ->willReturn($cart);
 
         $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
-            ->onlyMethods(array('toApiArray', 'getDefault'))->getMock();
+            ->onlyMethods(['toApiArray', 'getDefault'])->getMock();
         $currencyServiceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $currencyServiceMock->expects($this->atLeastOnce())->method('getDefault')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyServiceMock);
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'currency' => 'EUR'
-        );
+        $data = [
+            'currency' => 'EUR',
+        ];
         $result = $this->guestApi->get_currency();
 
         $this->assertIsArray($result);
     }
 
-    public function testApply_promo()
+    public function testApplyPromo()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'))->getMock();
+            ->onlyMethods(['getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->atLeastOnce())->method('applyPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('findActivePromoByCode')
-            ->will($this->returnValue(new \Model_Promo()));
+            ->willReturn(new \Model_Promo());
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('isPromoAvailableForClientGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'promocode' => 'CODE'
-        );
+        $data = [
+            'promocode' => 'CODE',
+        ];
         $result = $this->guestApi->apply_promo($data);
 
         $this->assertTrue($result);
     }
 
-    public function testApply_promoNotFoundException()
+    public function testApplyPromoNotFoundException()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'))->getMock();
+            ->onlyMethods(['getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'])->getMock();
         $serviceMock->expects($this->never())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->never())->method('applyPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('findActivePromoByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('promoCanBeApplied')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->never())->method('isPromoAvailableForClientGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'promocode' => 'CODE'
-        );
+        $data = [
+            'promocode' => 'CODE',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->guestApi->apply_promo($data);
         $this->assertTrue($result);
     }
 
-    public function testApply_promoCanNotBeApplied()
+    public function testApplyPromoCanNotBeApplied()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'))->getMock();
+            ->onlyMethods(['getSessionCart', 'applyPromo', 'findActivePromoByCode', 'promoCanBeApplied', 'isPromoAvailableForClientGroup'])->getMock();
         $serviceMock->expects($this->never())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->never())->method('applyPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('findActivePromoByCode')
-            ->will($this->returnValue(new \Model_Promo()));
+            ->willReturn(new \Model_Promo());
         $serviceMock->expects($this->atLeastOnce())->method('isPromoAvailableForClientGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'promocode' => 'CODE'
-        );
+        $data = [
+            'promocode' => 'CODE',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->guestApi->apply_promo($data);
@@ -313,37 +309,37 @@ class GuestTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testApply_promoCanNotBeAppliedForUser()
+    public function testApplyPromoCanNotBeAppliedForUser()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'applyPromo', 'findActivePromoByCode', 'isPromoAvailableForClientGroup'))->getMock();
+            ->onlyMethods(['getSessionCart', 'applyPromo', 'findActivePromoByCode', 'isPromoAvailableForClientGroup'])->getMock();
         $serviceMock->expects($this->never())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->never())->method('applyPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('findActivePromoByCode')
-            ->will($this->returnValue(new \Model_Promo()));
+            ->willReturn(new \Model_Promo());
         $serviceMock->expects($this->atLeastOnce())->method('isPromoAvailableForClientGroup')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'promocode' => 'CODE'
-        );
+        $data = [
+            'promocode' => 'CODE',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->guestApi->apply_promo($data);
@@ -351,19 +347,18 @@ class GuestTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
-    public function testRemove_promo()
+    public function testRemovePromo()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'removePromo'))->getMock();
+            ->onlyMethods(['getSessionCart', 'removePromo'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->atLeastOnce())->method('removePromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->guestApi->setService($serviceMock);
 
@@ -372,126 +367,122 @@ class GuestTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testRemove_item()
+    public function testRemoveItem()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'removeProduct'))->getMock();
+            ->onlyMethods(['getSessionCart', 'removeProduct'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->atLeastOnce())->method('removeProduct')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $result = $this->guestApi->remove_item($data);
 
         $this->assertTrue($result);
     }
 
-    public function testAdd_item()
+    public function testAddItem()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'addItem'))->getMock();
+            ->onlyMethods(['getSessionCart', 'addItem'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->atLeastOnce())->method('addItem')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Product()));
+            ->willReturn(new \Model_Product());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->guestApi->setDi($di);
 
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
-            'id'       => random_int(1, 100),
-            'multiple' => true
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'multiple' => true,
+        ];
 
         $result = $this->guestApi->add_item($data);
 
         $this->assertTrue($result);
     }
 
-    public function testAdd_itemSingle()
+    public function testAddItemSingle()
     {
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
         $cart->currency_id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getSessionCart', 'addItem'))->getMock();
+            ->onlyMethods(['getSessionCart', 'addItem'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSessionCart')
-            ->will($this->returnValue($cart));
+            ->willReturn($cart);
         $serviceMock->expects($this->atLeastOnce())->method('addItem')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Api\Guest::class)
-            ->onlyMethods(array('reset'))->getMock();
+            ->onlyMethods(['reset'])->getMock();
         $apiMock->expects($this->atLeastOnce())->method('reset')
-            ->will($this->returnValue($cart));
-
+            ->willReturn($cart);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Product()));
+            ->willReturn(new \Model_Product());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $apiMock->setDi($di);
 
         $apiMock->setService($serviceMock);
 
-        $data = array(
-            'id'       => random_int(1, 100),
-            'multiple' => false //should reset cart before adding
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'multiple' => false, // should reset cart before adding
+        ];
 
         $result = $apiMock->add_item($data);
 
         $this->assertTrue($result);
     }
-
-
 }

--- a/tests/modules/Cart/ServiceTest.php
+++ b/tests/modules/Cart/ServiceTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Cart;
 
+namespace Box\Tests\Mod\Cart;
 
 class ServiceTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Cart\Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
@@ -30,7 +30,7 @@ class ServiceTest extends \BBTestCase
     public function testGetSearchQuery()
     {
         $service = new \Box\Mod\Cart\Service();
-        $result  = $service->getSearchQuery(array());
+        $result = $service->getSearchQuery([]);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
         $this->assertNotFalse(strpos($result[0], 'SELECT cart.id FROM cart'));
@@ -49,17 +49,17 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $sessionMock = $this->getMockBuilder('\\' . \FOSSBilling\Session::class)
             ->disableOriginalConstructor()
             ->getMock();
         $sessionMock->expects($this->atLeastOnce())
-            ->method("getId")
-            ->will($this->returnValue($session_id));
+            ->method('getId')
+            ->willReturn($session_id);
 
-        $di            = new \Pimple\Container();
-        $di['db']      = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['session'] = $sessionMock;
         $service->setDi($di);
 
@@ -73,18 +73,18 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
+        return [
+            [
                 100,
                 $self->atLeastOnce(),
-                $self->never()
-            ),
-            array(
+                $self->never(),
+            ],
+            [
                 null,
                 $self->never(),
-                $self->atLeastOnce()
-            )
-        );
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getSessionCartDoesNotExistProvider')]
@@ -97,42 +97,42 @@ class ServiceTest extends \BBTestCase
         $curencyModel->id = random_int(0, 1000);
 
         $session_id = 'rrcpqo7tkjh14d2vmf0car64k7';
-        $model      = null; //Does not exist in database
-        $dbMock     = $this->getMockBuilder('Box_Database')->getMock();
+        $model = null; // Does not exist in database
+        $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $modelCart = new \Model_Cart();
         $modelCart->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($modelCart));
+            ->willReturn($modelCart);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $sessionMock = $this->getMockBuilder('\\' . \FOSSBilling\Session::class)
             ->disableOriginalConstructor()
             ->getMock();
         $sessionMock->expects($this->atLeastOnce())
-            ->method("getId")
-            ->will($this->returnValue($session_id));
+            ->method('getId')
+            ->willReturn($session_id);
         $sessionMock->expects($this->atLeastOnce())
-            ->method("get")
-            ->will($this->returnValue($sessionGetWillReturn));
+            ->method('get')
+            ->willReturn($sessionGetWillReturn);
 
-        $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getCurrencyByClientId', 'getDefault'))->getMock();
+        $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getCurrencyByClientId', 'getDefault'])->getMock();
         $currencyServiceMock->expects($getCurrencyByClientIdExpects)
-            ->method("getCurrencyByClientId")
-            ->will($this->returnValue($curencyModel));
+            ->method('getCurrencyByClientId')
+            ->willReturn($curencyModel);
         $currencyServiceMock->expects($getDefaultExpects)
-            ->method("getDefault")
-            ->will($this->returnValue($curencyModel));
+            ->method('getDefault')
+            ->willReturn($curencyModel);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['session']     = $sessionMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['session'] = $sessionMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyServiceMock);
         $service->setDi($di);
 
         $result = $service->getSessionCart();
@@ -146,7 +146,7 @@ class ServiceTest extends \BBTestCase
     {
         $product = new \Model_Product();
         $product->loadBean(new \DummyBean());
-        $product->stock_control     = true;
+        $product->stock_control = true;
         $product->quantity_in_stock = 5;
 
         $result = $this->service->isStockAvailable($product, 6);
@@ -157,7 +157,7 @@ class ServiceTest extends \BBTestCase
     {
         $product = new \Model_Product();
         $product->loadBean(new \DummyBean());
-        $product->stock_control     = false;
+        $product->stock_control = false;
         $product->quantity_in_stock = 5;
 
         $result = $this->service->isStockAvailable($product, 6);
@@ -168,13 +168,13 @@ class ServiceTest extends \BBTestCase
     {
         $productTable = $this->getMockBuilder('\Model_ProductTable')->getMock();
         $productTable->expects($this->atLeastOnce())->method('getPricingArray')
-            ->will($this->returnValue(array('type' => \Model_ProductPayment::RECURRENT)));
+            ->willReturn(['type' => \Model_ProductPayment::RECURRENT]);
 
         $productModelMock = $this->getMockBuilder('\Model_Product')
-            ->onlyMethods(array('getTable'))->getMock();
+            ->onlyMethods(['getTable'])->getMock();
         $productModelMock->expects($this->atLeastOnce())
             ->method('getTable')
-            ->will($this->returnValue($productTable));
+            ->willReturn($productTable);
 
         $result = $this->service->isRecurrentPricing($productModelMock);
 
@@ -183,24 +183,24 @@ class ServiceTest extends \BBTestCase
 
     public function testIsPeriodEnabledForProduct()
     {
-        $enabled            = false;
-        $pricingArray       = array(
-            'type'      => \Model_ProductPayment::RECURRENT,
-            'recurrent' => array(
-                'monthly' => array(
-                    'enabled' => $enabled
-                )
-            )
-        );
+        $enabled = false;
+        $pricingArray = [
+            'type' => \Model_ProductPayment::RECURRENT,
+            'recurrent' => [
+                'monthly' => [
+                    'enabled' => $enabled,
+                ],
+            ],
+        ];
         $productTable = $this->getMockBuilder('\Model_ProductTable')->getMock();
         $productTable->expects($this->atLeastOnce())->method('getPricingArray')
-            ->will($this->returnValue($pricingArray));
+            ->willReturn($pricingArray);
 
         $productModelMock = $this->getMockBuilder('\Model_Product')
-            ->onlyMethods(array('getTable'))->getMock();
+            ->onlyMethods(['getTable'])->getMock();
         $productModelMock->expects($this->atLeastOnce())
             ->method('getTable')
-            ->will($this->returnValue($productTable));
+            ->willReturn($productTable);
 
         $result = $this->service->isPeriodEnabledForProduct($productModelMock, 'monthly');
 
@@ -210,24 +210,24 @@ class ServiceTest extends \BBTestCase
 
     public function testIsPeriodEnabledForProductNotRecurrent()
     {
-        $enabled            = false;
-        $pricingArray       = array(
-            'type'      => \Model_ProductPayment::FREE,
-            'recurrent' => array(
-                'monthly' => array(
-                    'enabled' => $enabled
-                )
-            )
-        );
+        $enabled = false;
+        $pricingArray = [
+            'type' => \Model_ProductPayment::FREE,
+            'recurrent' => [
+                'monthly' => [
+                    'enabled' => $enabled,
+                ],
+            ],
+        ];
         $productTable = $this->getMockBuilder('\Model_ProductTable')->getMock();
         $productTable->expects($this->atLeastOnce())->method('getPricingArray')
-            ->will($this->returnValue($pricingArray));
+            ->willReturn($pricingArray);
 
         $productModelMock = $this->getMockBuilder('\Model_Product')
-            ->onlyMethods(array('getTable'))->getMock();
+            ->onlyMethods(['getTable'])->getMock();
         $productModelMock->expects($this->atLeastOnce())
             ->method('getTable')
-            ->will($this->returnValue($productTable));
+            ->willReturn($productTable);
 
         $result = $this->service->isPeriodEnabledForProduct($productModelMock, 'monthly');
 
@@ -243,16 +243,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($cartProduct));
+            ->willReturn($cartProduct);
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($cartProduct)));
+            ->willReturn([$cartProduct]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -267,13 +267,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $dbMock->expects($this->never())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -289,7 +289,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
@@ -297,8 +297,8 @@ class ServiceTest extends \BBTestCase
         $currency = new \Model_Currency();
         $currency->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -311,19 +311,19 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_Product(), new \Model_Product())));
+            ->willReturn([new \Model_Product(), new \Model_Product()]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -336,14 +336,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
-
+            ->willReturn(random_int(1, 100));
 
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -356,10 +355,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_CartProduct(), new \Model_CartProduct())));
+            ->willReturn([new \Model_CartProduct(), new \Model_CartProduct()]);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -369,8 +368,8 @@ class ServiceTest extends \BBTestCase
         $cart->loadBean(new \DummyBean());
         $cart->promo_id = 1;
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -378,18 +377,17 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
     public function testApplyPromoAlreadyApplied()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isEmptyCart'))->getMock();
+            ->onlyMethods(['isEmptyCart'])->getMock();
         $serviceMock->expects($this->never())->method('isEmptyCart')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -399,8 +397,8 @@ class ServiceTest extends \BBTestCase
         $cart->loadBean(new \DummyBean());
         $cart->promo_id = 5;
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -413,12 +411,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isEmptyCart'))->getMock();
+            ->onlyMethods(['isEmptyCart'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('isEmptyCart')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -428,8 +426,8 @@ class ServiceTest extends \BBTestCase
         $cart->loadBean(new \DummyBean());
         $cart->promo_id = 1;
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -443,16 +441,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_CartProduct())));
+            ->willReturn([new \Model_CartProduct()]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $cart = new \Model_Cart();
         $cart->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -463,11 +461,11 @@ class ServiceTest extends \BBTestCase
     public function testIsClientAbleToUsePromo()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('promoCanBeApplied', 'clientHadUsedPromo'))->getMock();
+            ->onlyMethods(['promoCanBeApplied', 'clientHadUsedPromo'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('clientHadUsedPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -476,7 +474,7 @@ class ServiceTest extends \BBTestCase
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -487,14 +485,14 @@ class ServiceTest extends \BBTestCase
     public function testClientHadUsedPromo()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('promoCanBeApplied'))->getMock();
+            ->onlyMethods(['promoCanBeApplied'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -503,24 +501,23 @@ class ServiceTest extends \BBTestCase
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
         $result = $serviceMock->isClientAbleToUsePromo($client, $promo);
         $this->assertFalse($result);
     }
 
-
     public function testIsClientAbleToUsePromoOncePerClient()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('promoCanBeApplied', 'clientHadUsedPromo'))->getMock();
+            ->onlyMethods(['promoCanBeApplied', 'clientHadUsedPromo'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->never())->method('clientHadUsedPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -528,7 +525,7 @@ class ServiceTest extends \BBTestCase
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -539,11 +536,11 @@ class ServiceTest extends \BBTestCase
     public function testIsClientAbleToUsePromoCanNotBeApplied()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('promoCanBeApplied', 'clientHadUsedPromo'))->getMock();
+            ->onlyMethods(['promoCanBeApplied', 'clientHadUsedPromo'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('promoCanBeApplied')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->never())->method('clientHadUsedPromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $promo = new \Model_Promo();
         $promo->loadBean(new \DummyBean());
@@ -551,7 +548,7 @@ class ServiceTest extends \BBTestCase
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -567,40 +564,40 @@ class ServiceTest extends \BBTestCase
 
         $promo2 = new \Model_Promo();
         $promo2->loadBean(new \DummyBean());
-        $promo2->active  = true;
+        $promo2->active = true;
         $promo2->maxuses = 5;
-        $promo2->used    = 5;
+        $promo2->used = 5;
 
         $promo3 = new \Model_Promo();
         $promo3->loadBean(new \DummyBean());
-        $promo3->active   = true;
-        $promo3->maxuses  = 10;
-        $promo3->used     = 5;
-        $promo3->start_at = date("c", strtotime("tomorrow"));
+        $promo3->active = true;
+        $promo3->maxuses = 10;
+        $promo3->used = 5;
+        $promo3->start_at = date('c', strtotime('tomorrow'));
 
         $promo4 = new \Model_Promo();
         $promo4->loadBean(new \DummyBean());
-        $promo4->active   = true;
-        $promo4->maxuses  = 10;
-        $promo4->used     = 5;
-        $promo4->start_at = date("c", strtotime("yesterday"));
-        $promo4->end_at   = date("c", strtotime("yesterday"));
+        $promo4->active = true;
+        $promo4->maxuses = 10;
+        $promo4->used = 5;
+        $promo4->start_at = date('c', strtotime('yesterday'));
+        $promo4->end_at = date('c', strtotime('yesterday'));
 
         $promo5 = new \Model_Promo();
         $promo5->loadBean(new \DummyBean());
-        $promo5->active   = true;
-        $promo5->maxuses  = 10;
-        $promo5->used     = 5;
-        $promo5->start_at = date("c", strtotime("yesterday"));
-        $promo5->end_at   = date("c", strtotime("tomorrow"));
+        $promo5->active = true;
+        $promo5->maxuses = 10;
+        $promo5->used = 5;
+        $promo5->start_at = date('c', strtotime('yesterday'));
+        $promo5->end_at = date('c', strtotime('tomorrow'));
 
-        return array(
-            array($promo1, false),
-            array($promo2, false),
-            array($promo3, false),
-            array($promo4, false),
-            array($promo5, true),
-        );
+        return [
+            [$promo1, false],
+            [$promo2, false],
+            [$promo3, false],
+            [$promo4, false],
+            [$promo5, true],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('promoCanBeAppliedProvider')]
@@ -609,10 +606,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -622,13 +619,12 @@ class ServiceTest extends \BBTestCase
 
     public function testGetCartProducts()
     {
-
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_CartProduct(),)));
+            ->willReturn([new \Model_CartProduct()]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -650,24 +646,23 @@ class ServiceTest extends \BBTestCase
         $order->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('createFromCart', 'isClientAbleToUsePromo', 'rm', 'isPromoAvailableForClientGroup'))->getMock();
+            ->onlyMethods(['createFromCart', 'isClientAbleToUsePromo', 'rm', 'isPromoAvailableForClientGroup'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('createFromCart')
-            ->will($this->returnValue(array($order, random_int(1, 100), array(random_int(1, 100)))));
+            ->willReturn([$order, random_int(1, 100), [random_int(1, 100)]]);
         $serviceMock->expects($this->atLeastOnce())->method('isClientAbleToUsePromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('rm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('isPromoAvailableForClientGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-
         $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('getClientAddress')
-            ->will($this->returnValue('1.1.1.1'));
+            ->willReturn('1.1.1.1');
 
         $invoice = new \Model_Invoice();
         $invoice->loadBean(new \DummyBean());
@@ -679,16 +674,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($promo));
+            ->willReturn($promo);
 
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $requestMock;
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $requestMock;
         $serviceMock->setDi($di);
 
         $result = $serviceMock->checkoutCart($cart, $client);
@@ -713,21 +708,21 @@ class ServiceTest extends \BBTestCase
         $order->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isClientAbleToUsePromo'))->getMock();
+            ->onlyMethods(['isClientAbleToUsePromo'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('isClientAbleToUsePromo')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
 
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Promo()));
+            ->willReturn(new \Model_Promo());
 
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -749,9 +744,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -768,9 +763,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($promo));
+            ->willReturn($promo);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -779,7 +774,7 @@ class ServiceTest extends \BBTestCase
         $this->assertInstanceOf('Model_Promo', $result);
     }
 
-    public function testaddItemm_RecurringPaymentPeriodParamMissing()
+    public function testaddItemmRecurringPaymentPeriodParamMissing()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -788,7 +783,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'Custom';
 
-        $data = array();
+        $data = [];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -796,15 +791,15 @@ class ServiceTest extends \BBTestCase
         $serviceHostingServiceMock = $this->getMockBuilder('\Box\Mod\Servicehosting')->getMock();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing'))
+            ->onlyMethods(['isRecurrentPricing'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceHostingServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceHostingServiceMock);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
@@ -818,7 +813,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->addItem($cartModel, $productModel, $data);
     }
 
-    public function testaddItemm_RecurringPaymentPeriodIsNotEnabled()
+    public function testaddItemmRecurringPaymentPeriodIsNotEnabled()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -827,7 +822,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'hosting';
 
-        $data = array('period' => '1W');
+        $data = ['period' => '1W'];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -836,18 +831,18 @@ class ServiceTest extends \BBTestCase
         $serviceHostingServiceMock = $this->getMockBuilder('\Box\Mod\Servicehosting')->getMock();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing', 'isPeriodEnabledForProduct'))
+            ->onlyMethods(['isRecurrentPricing', 'isPeriodEnabledForProduct'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isPeriodEnabledForProduct')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceHostingServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceHostingServiceMock);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
@@ -861,7 +856,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->addItem($cartModel, $productModel, $data);
     }
 
-    public function testaddItemm_OutOfStock()
+    public function testaddItemmOutOfStock()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -870,7 +865,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'hosting';
 
-        $data = array();
+        $data = [];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -879,28 +874,28 @@ class ServiceTest extends \BBTestCase
         $serviceHostingServiceMock = $this->getMockBuilder('\Box\Mod\Servicehosting')->getMock();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing', 'isStockAvailable'))
+            ->onlyMethods(['isRecurrentPricing', 'isStockAvailable'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isStockAvailable')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceHostingServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceHostingServiceMock);
 
         $serviceMock->setDi($di);
         $productModel->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $this->expectExceptionMessage("This item is currently out of stock");
+        $this->expectExceptionMessage('This item is currently out of stock');
         $serviceMock->addItem($cartModel, $productModel, $data);
     }
 
-    public function testaddItemm_TypeHosting()
+    public function testaddItemmTypeHosting()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -909,7 +904,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'hosting';
 
-        $data = array();
+        $data = [];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -917,31 +912,31 @@ class ServiceTest extends \BBTestCase
 
         $productDomainModel = new \Model_ProductDomain();
         $productDomainModel->loadBean(new \DummyBean());
-        $domainProduct = array('config' => array(), 'product' => $productDomainModel );
+        $domainProduct = ['config' => [], 'product' => $productDomainModel];
 
         $serviceHostingServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceHostingServiceMock->expects($this->atLeastOnce())
             ->method('getDomainProductFromConfig')
-            ->will($this->returnValue($domainProduct));
+            ->willReturn($domainProduct);
         $serviceHostingServiceMock->expects($this->atLeastOnce())
             ->method('prependOrderConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing', 'isStockAvailable', 'addProduct'))
+            ->onlyMethods(['isRecurrentPricing', 'isStockAvailable', 'addProduct'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isStockAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())
             ->method('addProduct');
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceHostingServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceHostingServiceMock);
         $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
@@ -952,7 +947,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testaddItemm_TypeLicense()
+    public function testaddItemmTypeLicense()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -961,7 +956,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'license';
 
-        $data = array();
+        $data = [];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -970,32 +965,31 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceLicenseServiceMock->expects($this->atLeastOnce())
             ->method('attachOrderConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceLicenseServiceMock->expects($this->atLeastOnce())
             ->method('validateOrderData')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing', 'isStockAvailable', 'addProduct'))
+            ->onlyMethods(['isRecurrentPricing', 'isStockAvailable', 'addProduct'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isStockAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())
             ->method('addProduct');
-
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($productModel));
+            ->willReturn($productModel);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceLicenseServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceLicenseServiceMock);
         $di['logger'] = new \Box_Log();
         $di['db'] = $dbMock;
 
@@ -1006,7 +1000,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testaddItemm_TypeCustom()
+    public function testaddItemmTypeCustom()
     {
         $cartModel = new \Model_Cart();
         $cartModel->loadBean(new \DummyBean());
@@ -1015,7 +1009,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->type = 'custom';
 
-        $data = array();
+        $data = [];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -1024,33 +1018,33 @@ class ServiceTest extends \BBTestCase
         $serviceCustomServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceCustomServiceMock->expects($this->atLeastOnce())
             ->method('validateCustomForm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('isRecurrentPricing', 'isStockAvailable'))
+            ->onlyMethods(['isRecurrentPricing', 'isStockAvailable'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isRecurrentPricing')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isStockAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $cartProduct = new \Model_CartProduct();
         $cartProduct->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($cartProduct));
+            ->willReturn($cartProduct);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceCustomServiceMock );
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceCustomServiceMock);
         $di['logger'] = new \Box_Log();
         $di['db'] = $dbMock;
 
@@ -1070,18 +1064,18 @@ class ServiceTest extends \BBTestCase
         $cartProductModel->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getCartProducts', 'cartProductToApiArray'))
+            ->onlyMethods(['getCartProducts', 'cartProductToApiArray'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCartProducts')
-            ->will($this->returnValue(array($cartProductModel)));
-        $cartProductApiArray = array(
+            ->willReturn([$cartProductModel]);
+        $cartProductApiArray = [
             'total' => 1,
             'discount_price' => 0,
-        );
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('cartProductToApiArray')
-            ->will($this->returnValue($cartProductApiArray));
+            ->willReturn($cartProductApiArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
@@ -1089,29 +1083,29 @@ class ServiceTest extends \BBTestCase
         $currencyModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($currencyModel));
+            ->willReturn($currencyModel);
 
         $currencyService = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $currencyService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyService);
+        $di['mod_service'] = $di->protect(fn () => $currencyService);
 
         $serviceMock->setDi($di);
 
         $result = $serviceMock->toApiArray($cartModel);
 
-        $expected = array(
+        $expected = [
             'promocode' => null,
-            'discount'  => 0,
-            'total'     => 1,
-            'items'     => array($cartProductApiArray),
-            'currency'  => array(),
-            'subtotal' => 1
-        );
+            'discount' => 0,
+            'total' => 1,
+            'items' => [$cartProductApiArray],
+            'currency' => [],
+            'subtotal' => 1,
+        ];
         $this->assertIsArray($result);
         $this->assertEquals($expected, $result);
     }
@@ -1130,7 +1124,6 @@ class ServiceTest extends \BBTestCase
 
         $discountPrice = 25;
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
@@ -1145,7 +1138,7 @@ class ServiceTest extends \BBTestCase
         $di['db'] = $dbMock;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'))
+            ->onlyMethods(['getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getRelatedItemsDiscount')
@@ -1164,7 +1157,7 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($discountSetup, $result[1]);
     }
 
-    public function testgetProductDiscount_NoPromo()
+    public function testgetProductDiscountNoPromo()
     {
         $cartProductModel = new \Model_CartProduct();
         $cartProductModel->loadBean(new \DummyBean());
@@ -1174,7 +1167,6 @@ class ServiceTest extends \BBTestCase
 
         $promoModel = new \Model_Promo();
         $promoModel->loadBean(new \DummyBean());
-
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -1186,7 +1178,7 @@ class ServiceTest extends \BBTestCase
         $di['db'] = $dbMock;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'))
+            ->onlyMethods(['getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getRelatedItemsDiscount')
@@ -1201,7 +1193,7 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals(0, $result[1]);
     }
 
-    public function testgetProductDiscount_ProductQtyIsSetAndFreeSetup()
+    public function testgetProductDiscountProductQtyIsSetAndFreeSetup()
     {
         $cartProductModel = new \Model_CartProduct();
         $cartProductModel->loadBean(new \DummyBean());
@@ -1230,7 +1222,7 @@ class ServiceTest extends \BBTestCase
         $di['db'] = $dbMock;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)
-            ->onlyMethods(array('getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'))
+            ->onlyMethods(['getRelatedItemsDiscount', 'getItemPromoDiscount', 'getItemConfig'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getRelatedItemsDiscount')
@@ -1253,75 +1245,68 @@ class ServiceTest extends \BBTestCase
     {
         $promo1 = new \Model_Promo();
         $promo1->loadBean(new \DummyBean());
-        $promo1->client_groups = json_encode(array());
+        $promo1->client_groups = json_encode([]);
 
         $client1 = new \Model_Client();
         $client1->loadBean(new \DummyBean());
 
-
         $promo2 = new \Model_Promo();
         $promo2->loadBean(new \DummyBean());
-        $promo2->client_groups = json_encode(array(1, 2));
+        $promo2->client_groups = json_encode([1, 2]);
 
         $client2 = new \Model_Client();
         $client2->loadBean(new \DummyBean());
         $client2->client_group_id = null;
 
-
         $promo3 = new \Model_Promo();
         $promo3->loadBean(new \DummyBean());
-        $promo3->client_groups = json_encode(array(1, 2));
+        $promo3->client_groups = json_encode([1, 2]);
 
         $client3 = new \Model_Client();
         $client3->loadBean(new \DummyBean());
         $client3->client_group_id = 3;
 
-
         $promo4 = new \Model_Promo();
         $promo4->loadBean(new \DummyBean());
-        $promo4->client_groups = json_encode(array(1, 2));
+        $promo4->client_groups = json_encode([1, 2]);
 
         $client4 = new \Model_Client();
         $client4->loadBean(new \DummyBean());
         $client4->client_group_id = 2;
 
-
         $promo5 = new \Model_Promo();
         $promo5->loadBean(new \DummyBean());
-        $promo5->client_groups = json_encode(array());
+        $promo5->client_groups = json_encode([]);
 
         $client5 = null;
 
-
         $promo6 = new \Model_Promo();
         $promo6->loadBean(new \DummyBean());
-        $promo6->client_groups = json_encode(array(1, 2));
+        $promo6->client_groups = json_encode([1, 2]);
 
         $client6 = null;
 
-
-        return array(
-            array($promo1, $client1, true), //No client groups set for Promo, any client should be is valid
-            array($promo2, $client2, false), //Client groups are set for Promo, but client is not assigned to any client group
-            array($promo3, $client3, false), //Client groups are set for Promo, but client group is not included
-            array($promo4, $client4, true), //Client groups are set for Promo and it applies to client
-            array($promo5, null, true), //No client groups set for Promo, guest should be is valid
-            array($promo6, null, false), //Client groups are set for Promo,  guest should be is invalid
-        );
+        return [
+            [$promo1, $client1, true], // No client groups set for Promo, any client should be is valid
+            [$promo2, $client2, false], // Client groups are set for Promo, but client is not assigned to any client group
+            [$promo3, $client3, false], // Client groups are set for Promo, but client group is not included
+            [$promo4, $client4, true], // Client groups are set for Promo and it applies to client
+            [$promo5, null, true], // No client groups set for Promo, guest should be is valid
+            [$promo6, null, false], // Client groups are set for Promo,  guest should be is invalid
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('isPromoAvailableForClientGroupProvider')]
     public function testIsPromoAvailableForClientGroup(\Model_Promo $promo, $client, $expectedResult)
     {
-
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
             ->willReturn(json_decode($promo->client_groups, 1));
 
-        $di                    = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['loggedin_client'] = $client;
-        $di['tools']           = $toolsMock;
+        $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
         $result = $this->service->isPromoAvailableForClientGroup($promo);

--- a/tests/modules/Client/Api/AdminTest.php
+++ b/tests/modules/Client/Api/AdminTest.php
@@ -4,70 +4,67 @@ namespace Box\Tests\Mod\Client\Api;
 
 class AdminTest extends \BBTestCase
 {
-
     public function testgetDi()
     {
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
         $getDi = $admin_Client->getDi();
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array('id' => 1),
-            ),
-        );
-        $pagerMock       = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
+        $simpleResultArr = [
+            'list' => [
+                ['id' => 1],
+            ],
+        ];
+        $pagerMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
         method('getSearchQuery');
         $serviceMock->expects($this->atLeastOnce())->
         method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pagerMock;
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
+        $di['db'] = $dbMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setService($serviceMock);
         $admin_Client->setDi($di);
-        $data = array();
+        $data = [];
 
         $result = $admin_Client->get_list($data);
         $this->assertIsArray($result);
-
     }
 
-    public function test_get_pairs()
+    public function testGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('getPairs')->will($this->returnValue(array()));
+        method('getPairs')->willReturn([]);
 
-
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
 
-        $data   = array('id' => 1);
+        $data = ['id' => 1];
         $result = $admin_Client->get_pairs($data);
         $this->assertIsArray($result);
     }
@@ -79,15 +76,15 @@ class AdminTest extends \BBTestCase
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('get')->will($this->returnValue($model));
+        method('get')->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setService($serviceMock);
 
-        $result = $admin_Client->get(array());
+        $result = $admin_Client->get([]);
         $this->assertIsArray($result);
     }
 
@@ -97,56 +94,56 @@ class AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
-        $sessionArray = array(
-            'id'    => 1,
+        $sessionArray = [
+            'id' => 1,
             'email' => 'email@example.com',
-            'name'  => 'John Smith',
-            'role'  => 'client',
-        );
-        $serviceMock  = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
+            'name' => 'John Smith',
+            'role' => 'client',
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('toSessionArray')->will($this->returnValue($sessionArray));
+        method('toSessionArray')->willReturn($sessionArray);
 
         $sessionMock = $this->getMockBuilder('\\' . \FOSSBilling\Session::class)->disableOriginalConstructor()->getMock();
         $sessionMock->expects($this->atLeastOnce())->
         method('set');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
-        $di['session']     = $sessionMock;
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
+        $di['session'] = $sessionMock;
+        $di['logger'] = new \Box_Log();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
 
-        $data   = array('id' => 1);
+        $data = ['id' => 1];
         $result = $admin_Client->login($data);
         $this->assertIsArray($result);
     }
 
     public function testCreate()
     {
-        $data = array(
-            'email'      => 'email@example.com',
+        $data = [
+            'email' => 'email@example.com',
             'first_name' => 'John',
-        );
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(false));
+        method('emailAlreadyRegistered')->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())->
-        method('adminCreateClient')->will($this->returnValue(1));
+        method('adminCreateClient')->willReturn(1);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -158,7 +155,7 @@ class AdminTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['events_manager'] = $eventMock;
         $di['tools'] = $toolsMock;
@@ -174,21 +171,21 @@ class AdminTest extends \BBTestCase
 
     public function testCreateEmailRegisteredException()
     {
-        $data = array(
-            'email'      => 'email@example.com',
+        $data = [
+            'email' => 'email@example.com',
             'first_name' => 'John',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(true));
+        method('emailAlreadyRegistered')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['tools'] = $toolsMock;
 
@@ -203,34 +200,34 @@ class AdminTest extends \BBTestCase
 
     public function testdelete()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
         method('fire');
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
-            ->onlyMethods(array('remove'))
+            ->onlyMethods(['remove'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('remove')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -242,61 +239,61 @@ class AdminTest extends \BBTestCase
 
     public function testupdate()
     {
-        $data = array(
-            'id'             => 1,
-            'first_name'     => 'John',
-            'last_name'      => 'Smith',
-            'aid'            => '0',
-            'gender'         => 'male',
-            'birthday'       => '1999-01-01',
-            'company'        => 'LTD Testing',
-            'company_vat'    => 'VAT0007',
-            'address_1'      => 'United States',
-            'address_2'      => 'Utah',
-            'phone_cc'       => '+1',
-            'phone'          => '555-345-345',
-            'document_type'  => 'doc',
-            'document_nr'    => '1',
-            'notes'          => 'none',
-            'country'        => 'Moon',
-            'postcode'       => 'IL-11123',
-            'city'           => 'Chicaco',
-            'state'          => 'IL',
-            'currency'       => 'USD',
-            'tax_exempt'     => 'n/a',
-            'created_at'     => '2012-05-10',
-            'email'          => 'test@example.com',
-            'group_id'       => 1,
-            'status'         => 'test status',
+        $data = [
+            'id' => 1,
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+            'aid' => '0',
+            'gender' => 'male',
+            'birthday' => '1999-01-01',
+            'company' => 'LTD Testing',
+            'company_vat' => 'VAT0007',
+            'address_1' => 'United States',
+            'address_2' => 'Utah',
+            'phone_cc' => '+1',
+            'phone' => '555-345-345',
+            'document_type' => 'doc',
+            'document_nr' => '1',
+            'notes' => 'none',
+            'country' => 'Moon',
+            'postcode' => 'IL-11123',
+            'city' => 'Chicaco',
+            'state' => 'IL',
+            'currency' => 'USD',
+            'tax_exempt' => 'n/a',
+            'created_at' => '2012-05-10',
+            'email' => 'test@example.com',
+            'group_id' => 1,
+            'status' => 'test status',
             'company_number' => '1234',
-            'type'           => '',
-            'lang'           => 'en',
-            'custom_1'       => '',
-            'custom_2'       => '',
-            'custom_3'       => '',
-            'custom_4'       => '',
-            'custom_5'       => '',
-            'custom_6'       => '',
-            'custom_7'       => '',
-            'custom_8'       => '',
-            'custom_9'       => '',
-            'custom_10'      => '',
-        );
+            'type' => '',
+            'lang' => 'en',
+            'custom_1' => '',
+            'custom_2' => '',
+            'custom_3' => '',
+            'custom_4' => '',
+            'custom_5' => '',
+            'custom_6' => '',
+            'custom_7' => '',
+            'custom_8' => '',
+            'custom_9' => '',
+            'custom_10' => '',
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
+            ->method('store')->willReturn(1);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(false));
+        method('emailAlreadyRegistered')->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())->
-        method('canChangeCurrency')->will($this->returnValue(true));
+        method('canChangeCurrency')->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -309,12 +306,12 @@ class AdminTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
         $di['events_manager'] = $eventMock;
-        $di['validator']      = $validatorMock;
-        $di['logger']         = new \Box_Log();
+        $di['validator'] = $validatorMock;
+        $di['logger'] = new \Box_Log();
 
         $di['tools'] = $toolsMock;
 
@@ -324,61 +321,61 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testupdate_EmailALreadyRegistered()
+    public function testupdateEmailALreadyRegistered()
     {
-        $data = array(
-            'id'             => 1,
-            'first_name'     => 'John',
-            'last_name'      => 'Smith',
-            'aid'            => '0',
-            'gender'         => 'male',
-            'birthday'       => '1999-01-01',
-            'company'        => 'LTD Testing',
-            'company_vat'    => 'VAT0007',
-            'address_1'      => 'United States',
-            'address_2'      => 'Utah',
-            'phone_cc'       => '+1',
-            'phone'          => '555-345-345',
-            'document_type'  => 'doc',
-            'document_nr'    => '1',
-            'notes'          => 'none',
-            'country'        => 'Moon',
-            'postcode'       => 'IL-11123',
-            'city'           => 'Chicaco',
-            'state'          => 'IL',
-            'currency'       => 'USD',
-            'tax_exempt'     => 'n/a',
-            'created_at'     => '2012-05-10',
-            'email'          => 'test@example.com',
-            'group_id'       => 1,
-            'status'         => 'test status',
+        $data = [
+            'id' => 1,
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+            'aid' => '0',
+            'gender' => 'male',
+            'birthday' => '1999-01-01',
+            'company' => 'LTD Testing',
+            'company_vat' => 'VAT0007',
+            'address_1' => 'United States',
+            'address_2' => 'Utah',
+            'phone_cc' => '+1',
+            'phone' => '555-345-345',
+            'document_type' => 'doc',
+            'document_nr' => '1',
+            'notes' => 'none',
+            'country' => 'Moon',
+            'postcode' => 'IL-11123',
+            'city' => 'Chicaco',
+            'state' => 'IL',
+            'currency' => 'USD',
+            'tax_exempt' => 'n/a',
+            'created_at' => '2012-05-10',
+            'email' => 'test@example.com',
+            'group_id' => 1,
+            'status' => 'test status',
             'company_number' => '1234',
-            'type'           => '',
-            'lang'           => 'en',
-            'custom_1'       => '',
-            'custom_2'       => '',
-            'custom_3'       => '',
-            'custom_4'       => '',
-            'custom_5'       => '',
-            'custom_6'       => '',
-            'custom_7'       => '',
-            'custom_8'       => '',
-            'custom_9'       => '',
-            'custom_10'      => '',
-        );
+            'type' => '',
+            'lang' => 'en',
+            'custom_1' => '',
+            'custom_2' => '',
+            'custom_3' => '',
+            'custom_4' => '',
+            'custom_5' => '',
+            'custom_6' => '',
+            'custom_7' => '',
+            'custom_8' => '',
+            'custom_9' => '',
+            'custom_10' => '',
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(true));
+        method('emailAlreadyRegistered')->willReturn(true);
         $serviceMock->expects($this->never())->
-        method('canChangeCurrency')->will($this->returnValue(true));
+        method('canChangeCurrency')->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->never())->
@@ -388,12 +385,12 @@ class AdminTest extends \BBTestCase
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
         $di['events_manager'] = $eventMock;
-        $di['validator']      = $validatorMock;
-        $di['logger']         = new \Box_Log();
+        $di['validator'] = $validatorMock;
+        $di['logger'] = new \Box_Log();
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
@@ -409,10 +406,10 @@ class AdminTest extends \BBTestCase
 
     public function testUpdateIdException()
     {
-        $data         = array();
+        $data = [];
         $admin_Client = new \Box\Mod\Client\Api\Admin();
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $di['validator'] = new \FOSSBilling\Validate();
         $admin_Client->setDi($di);
@@ -422,23 +419,23 @@ class AdminTest extends \BBTestCase
         $admin_Client->update($data);
     }
 
-    public function testchange_password()
+    public function testchangePassword()
     {
-        $data = array(
-            'id'               => 1,
-            'password'         => 'strongPass',
+        $data = [
+            'id' => 1,
+            'password' => 'strongPass',
             'password_confirm' => 'strongPass',
-        );
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
+            ->method('store')->willReturn(1);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -451,17 +448,17 @@ class AdminTest extends \BBTestCase
 
         $profileService = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
-        $di['password']       = $passwordMock;
+        $di['logger'] = new \Box_Log();
+        $di['password'] = $passwordMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
-        $di['mod_service'] = $di->protect(fn() => $profileService);
+        $di['mod_service'] = $di->protect(fn () => $profileService);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
@@ -470,20 +467,19 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
-    public function testchange_passwordPasswordMismatch()
+    public function testchangePasswordPasswordMismatch()
     {
-        $data         = array(
-            'id'               => 1,
-            'password'         => 'strongPass',
+        $data = [
+            'id' => 1,
+            'password' => 'strongPass',
             'password_confirm' => 'NotIdentical',
-        );
+        ];
         $admin_Client = new \Box\Mod\Client\Api\Admin();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -494,25 +490,25 @@ class AdminTest extends \BBTestCase
         $admin_Client->change_password($data);
     }
 
-    public function testbalance_get_list()
+    public function testbalanceGetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array(
-                    'id'          => 1,
+        $simpleResultArr = [
+            'list' => [
+                [
+                    'id' => 1,
                     'description' => 'Testing',
-                    'amount'      => '1.00',
-                    'currency'    => 'USD',
-                    'created_at'  => date('Y:m:d H:i:s'),
-                ),
-            ),
-        );
+                    'amount' => '1.00',
+                    'currency' => 'USD',
+                    'created_at' => date('Y:m:d H:i:s'),
+                ],
+            ],
+        ];
 
-        $data      = array();
+        $data = [];
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\ServiceBalance::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
@@ -521,9 +517,9 @@ class AdminTest extends \BBTestCase
         $model = new \Model_ClientBalance();
         $model->loadBean(new \DummyBean());
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
-        $di['pager']       = $pagerMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
+        $di['pager'] = $pagerMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
@@ -532,29 +528,29 @@ class AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testbalance_delete()
+    public function testbalanceDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $model = new \Model_ClientBalance();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -564,33 +560,33 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testbalance_add_funds()
+    public function testbalanceAddFunds()
     {
-        $data = array(
-            'id'          => 1,
-            'amount'      => '1.00',
+        $data = [
+            'id' => 1,
+            'amount' => '1.00',
             'description' => 'testDescription',
-        );
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
         method('addFunds');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -600,11 +596,11 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testbatch_expire_password_reminders()
+    public function testbatchExpirePasswordReminders()
     {
-        $expiredArr = array(
+        $expiredArr = [
             new \Model_ClientPasswordReset(),
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -612,12 +608,12 @@ class AdminTest extends \BBTestCase
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('getExpiredPasswordReminders')->will($this->returnValue($expiredArr));
+        method('getExpiredPasswordReminders')->willReturn($expiredArr);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
+        $di['logger'] = new \Box_Log();
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
@@ -626,24 +622,24 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testlogin_history_get_list()
+    public function testloginHistoryGetList()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('getHistorySearchQuery')->will($this->returnValue(array('sql', 'params')));
+        method('getHistorySearchQuery')->willReturn(['sql', 'params']);
 
-        $pagerMock      = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
-        $pagerResultSet = array(
-            'list' => array(),
-        );
+        $pagerMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
+        $pagerResultSet = [
+            'list' => [],
+        ];
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($pagerResultSet));
+            ->willReturn($pagerResultSet);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pagerMock;
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
@@ -653,53 +649,53 @@ class AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testget_statuses()
+    public function testgetStatuses()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('counter')->will($this->returnValue(array()));
+        method('counter')->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
 
-        $result = $admin_Client->get_statuses(array());
+        $result = $admin_Client->get_statuses([]);
         $this->assertIsArray($result);
     }
 
-    public function testgroup_get_pairs()
+    public function testgroupGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
-        method('getGroupPairs')->will($this->returnValue(array()));
+        method('getGroupPairs')->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);
 
-        $result = $admin_Client->group_get_pairs(array());
+        $result = $admin_Client->group_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testgroup_create()
+    public function testgroupCreate()
     {
         $data['title'] = 'test Group';
 
-        $newGroupId  = 1;
+        $newGroupId = 1;
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->
         method('createGroup')
-            ->will($this->returnValue($newGroupId));
+            ->willReturn($newGroupId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -711,10 +707,9 @@ class AdminTest extends \BBTestCase
         $this->assertEquals($newGroupId, $result);
     }
 
-
-    public function testgroup_update()
+    public function testgroupUpdate()
     {
-        $data['id']    = '2';
+        $data['id'] = '2';
         $data['title'] = 'test Group updated';
 
         $model = new \Model_ClientGroup();
@@ -722,19 +717,18 @@ class AdminTest extends \BBTestCase
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
+            ->method('store')->willReturn(1);
 
-
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -745,7 +739,7 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testgroup_delete()
+    public function testgroupDelete()
     {
         $data['id'] = '2';
 
@@ -754,25 +748,25 @@ class AdminTest extends \BBTestCase
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
         $dbMock->expects($this->once())
-            ->method('find')->with('Client', 'client_group_id = :group_id',[':group_id' => $data['id']])
-            ->will($this->returnValue([])); // Return an empty array to simulate no clients assigned to the group
+            ->method('find')->with('Client', 'client_group_id = :group_id', [':group_id' => $data['id']])
+            ->willReturn([]); // Return an empty array to simulate no clients assigned to the group
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
-            ->onlyMethods(array('deleteGroup'))
+            ->onlyMethods(['deleteGroup'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -784,7 +778,7 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testgroup_get()
+    public function testgroupGet()
     {
         $data['id'] = '2';
 
@@ -793,17 +787,17 @@ class AdminTest extends \BBTestCase
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getExistingModelById')->will($this->returnValue($model));
+            ->method('getExistingModelById')->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
-            ->method('toArray')->will($this->returnValue(array()));
+            ->method('toArray')->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
@@ -814,7 +808,7 @@ class AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testlogin_history_delete()
+    public function testloginHistoryDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -822,57 +816,55 @@ class AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ActivityClientHistory()));
+            ->willReturn(new \Model_ActivityClientHistory());
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $admin_Client->setDi($di);
 
-        $data   = array('id' => 1);
+        $data = ['id' => 1];
         $result = $admin_Client->login_history_delete($data);
         $this->assertTrue($result);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Api\Admin::class)->onlyMethods(array('delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Api\Admin::class)->onlyMethods(['delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
-    public function testBatch_delete_log()
+    public function testBatchDeleteLog()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Api\Admin::class)->onlyMethods(array('login_history_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('login_history_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Api\Admin::class)->onlyMethods(['login_history_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('login_history_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_log(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_log(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
-
-
 }

--- a/tests/modules/Client/Api/ClientTest.php
+++ b/tests/modules/Client/Api/ClientTest.php
@@ -1,23 +1,21 @@
 <?php
 
-
 namespace Box\Mod\Client\Api;
 
-
-class ClientTest extends \BBTestCase {
-
+class ClientTest extends \BBTestCase
+{
     public function testgetDi()
     {
         $di = new \Pimple\Container();
-        $client = new \Box\Mod\Client\Api\Client();
+        $client = new Client();
         $client->setDi($di);
         $getDi = $client->getDi();
         $this->assertEquals($di, $getDi);
     }
 
-    public function testbalance_get_list()
+    public function testbalanceGetList()
     {
-        $data = array();
+        $data = [];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
@@ -25,32 +23,32 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\ServiceBalance::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('sql', array())));
+            ->willReturn(['sql', []]);
 
-        $simpleResultArr = array(
-            'list' => array(
-                array('id' => 1),
-            ),
-        );
+        $simpleResultArr = [
+            'list' => [
+                ['id' => 1],
+            ],
+        ];
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
-        $pagerMock ->expects($this->atLeastOnce())
+        $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $model = new \Model_ClientBalance();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
         $di['pager'] = $pagerMock;
         $di['db'] = $dbMock;
 
-        $client = new \Box\Mod\Client\Api\Client();
+        $client = new Client();
         $client->setDi($di);
         $client->setService($serviceMock);
         $client->setIdentity($model);
@@ -58,9 +56,9 @@ class ClientTest extends \BBTestCase {
         $result = $client->balance_get_list($data);
 
         $this->assertIsArray($result);
-}
+    }
 
-    public function testbalance_get_total()
+    public function testbalanceGetTotal()
     {
         $balanceAmount = 0.00;
         $model = new \Model_Client();
@@ -69,12 +67,12 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\ServiceBalance::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getClientBalance')
-            ->will($this->returnValue($balanceAmount));
+            ->willReturn($balanceAmount);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name, $sub) => $serviceMock);
+        $di['mod_service'] = $di->protect(fn ($name, $sub) => $serviceMock);
 
-        $api = new \Box\Mod\Client\Api\Client();
+        $api = new Client();
         $api->setDi($di);
         $api->setIdentity($model);
 
@@ -82,10 +80,9 @@ class ClientTest extends \BBTestCase {
 
         $this->assertIsFloat($result);
         $this->assertEquals($balanceAmount, $result);
-
     }
 
-    public function testis_taxable()
+    public function testisTaxable()
     {
         $clientIsTaxable = true;
 
@@ -97,14 +94,12 @@ class ClientTest extends \BBTestCase {
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
 
-        $api = new \Box\Mod\Client\Api\Client();
+        $api = new Client();
         $api->setService($serviceMock);
         $api->setIdentity($client);
 
         $result = $api->is_taxable();
         $this->assertIsBool($result);
         $this->assertEquals($clientIsTaxable, $result);
-
     }
 }
- 

--- a/tests/modules/Client/Api/GuestTest.php
+++ b/tests/modules/Client/Api/GuestTest.php
@@ -1,16 +1,13 @@
 <?php
 
-
 namespace Box\Mod\Client\Api;
-
 
 class GuestTest extends \BBTestCase
 {
-
     public function testgetDi()
     {
         $di = new \Pimple\Container();
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
         $getDi = $client->getDi();
         $this->assertEquals($di, $getDi);
@@ -18,22 +15,21 @@ class GuestTest extends \BBTestCase
 
     public function testcreate()
     {
-        $configArr = array(
+        $configArr = [
             'disable_signup' => false,
-            'required' => array(),
-        );
-        $data = array(
+            'required' => [],
+        ];
+        $data = [
             'email' => 'test@email.com',
             'first_name' => 'John',
             'password' => 'testpaswword',
             'password_confirm' => 'testpaswword',
-
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('clientAlreadyExists')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
@@ -41,12 +37,11 @@ class GuestTest extends \BBTestCase
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('guestCreateClient')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('checkExtraRequiredFields');
         $serviceMock->expects($this->atLeastOnce())
             ->method('checkCustomFields');
-
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isPasswordStrong');
@@ -54,13 +49,12 @@ class GuestTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => $configArr);
+        $di['mod_config'] = $di->protect(fn ($name) => $configArr);
         $di['validator'] = $validatorMock;
         $di['tools'] = $toolsMock;
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
         $client->setService($serviceMock);
 
@@ -72,21 +66,20 @@ class GuestTest extends \BBTestCase
 
     public function testcreateExceptionClientExists()
     {
-        $configArr = array(
+        $configArr = [
             'disable_signup' => false,
-        );
-        $data = array(
+        ];
+        $data = [
             'email' => 'test@email.com',
             'first_name' => 'John',
             'password' => 'testpaswword',
             'password_confirm' => 'testpaswword',
-
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('clientAlreadyExists')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())
             ->method('checkExtraRequiredFields');
         $serviceMock->expects($this->atLeastOnce())
@@ -100,14 +93,14 @@ class GuestTest extends \BBTestCase
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => $configArr);
+        $di['mod_config'] = $di->protect(fn ($name) => $configArr);
         $di['validator'] = $validatorMock;
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
         $di['tools'] = $toolsMock;
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
         $client->setService($serviceMock);
 
@@ -118,20 +111,19 @@ class GuestTest extends \BBTestCase
 
     public function testCreateSignupDoNotAllowed()
     {
-        $configArr = array(
+        $configArr = [
             'disable_signup' => true,
-        );
-        $data = array(
+        ];
+        $data = [
             'email' => 'test@email.com',
             'first_name' => 'John',
             'password' => 'testpaswword',
             'password_confirm' => 'testpaswword',
+        ];
 
-        );
-
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => $configArr);
+        $di['mod_config'] = $di->protect(fn ($name) => $configArr);
         $client->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
@@ -141,22 +133,22 @@ class GuestTest extends \BBTestCase
 
     public function testCreatePasswordsDoNotMatchException()
     {
-        $configArr = array(
+        $configArr = [
             'disable_signup' => false,
-        );
-        $data = array(
+        ];
+        $data = [
             'email' => 'test@email.com',
             'first_name' => 'John',
             'password' => 'testpaswword',
             'password_confirm' => 'wrongpaswword',
-        );
+        ];
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => $configArr);
+        $di['mod_config'] = $di->protect(fn ($name) => $configArr);
         $di['validator'] = $validatorMock;
         $client->setDi($di);
 
@@ -167,10 +159,10 @@ class GuestTest extends \BBTestCase
 
     public function testlogin()
     {
-        $data = array(
+        $data = [
             'email' => 'test@example.com',
             'password' => 'sezam',
-        );
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
@@ -179,10 +171,10 @@ class GuestTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())
             ->method('authorizeClient')
             ->with($data['email'], $data['password'])
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toSessionArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
@@ -192,15 +184,15 @@ class GuestTest extends \BBTestCase
             ->getMock();
 
         $sessionMock->expects($this->atLeastOnce())
-            ->method("set");
+            ->method('set');
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
-        //$toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
+        // $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
@@ -209,7 +201,7 @@ class GuestTest extends \BBTestCase
         $di['validator'] = $validatorMock;
         $di['tools'] = $toolsMock;
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
         $client->setService($serviceMock);
 
@@ -221,58 +213,55 @@ class GuestTest extends \BBTestCase
     public function testResetPasswordNewFlow()
     {
         $data['email'] = 'John@exmaple.com';
-    
+
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
-    
+
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
-    
+
         $modelPasswordReset = new \Model_ClientPasswordReset();
         $modelPasswordReset->loadBean(new \DummyBean());
-    
+
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-    
+
         // Specify that 'findOne' will be called exactly twice
         $dbMock->expects($this->exactly(2))->method('findOne')
             ->willReturnOnConsecutiveCalls($modelClient, null);
-    
+
         $dbMock->expects($this->once())
-            ->method('dispense')->will($this->returnValue($modelPasswordReset));
-    
+            ->method('dispense')->willReturn($modelPasswordReset);
+
         $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue(1));
-    
+            ->method('store')->willReturn(1);
+
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate');
-    
+
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->once())
-            ->method('validateAndSanitizeEmail')->will($this->returnValue($data['email']));
-    
+            ->method('validateAndSanitizeEmail')->willReturn($data['email']);
+
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->once())
-            ->method('checkRequiredParamsForArray')->will($this->returnValue(null));
-    
+            ->method('checkRequiredParamsForArray')->willReturn(null);
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['events_manager'] = $eventMock;
-        $di['mod_service'] = $di->protect(fn($name) => $emailServiceMock);
+        $di['mod_service'] = $di->protect(fn ($name) => $emailServiceMock);
         $di['logger'] = new \Box_Log();
         $di['tools'] = $toolsMock;
         $di['validator'] = $validatorMock;
-    
-        $client = new \Box\Mod\Client\Api\Guest();
+
+        $client = new Guest();
         $client->setDi($di);
-    
+
         $result = $client->reset_password($data);
         $this->assertTrue($result);
     }
-    
 
-
-
-    public function testreset_passwordEmailNotFound()
+    public function testresetPasswordEmailNotFound()
     {
         $data['email'] = 'joghn@example.eu';
 
@@ -281,7 +270,7 @@ class GuestTest extends \BBTestCase
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('findOne')->will($this->returnValue(null));
+            ->method('findOne')->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -289,14 +278,14 @@ class GuestTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
         $di['tools'] = $toolsMock;
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
 
         // expects true because we don't want to give away if the email exists or not
@@ -306,12 +295,11 @@ class GuestTest extends \BBTestCase
 
     public function testUpdatePassword()
     {
-        $data = array(
+        $data = [
             'hash' => 'hashedString',
             'password' => 'newPassword',
-            'password_confirm' => 'newPassword'
-        );
-
+            'password_confirm' => 'newPassword',
+        ];
 
         // Mocks for dependent services and classes
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
@@ -324,10 +312,10 @@ class GuestTest extends \BBTestCase
         $modelPasswordReset->created_at = date('Y-m-d H:i:s', time() - 300);  // Set timestamp to 5 minutes ago
 
         $dbMock->expects($this->once())
-            ->method('findOne')->will($this->returnValue($modelPasswordReset));
+            ->method('findOne')->willReturn($modelPasswordReset);
 
         $dbMock->expects($this->once())
-            ->method('getExistingModelById')->will($this->returnValue($modelClient));
+            ->method('getExistingModelById')->willReturn($modelClient);
 
         $dbMock->expects($this->once())
             ->method('store');
@@ -346,7 +334,7 @@ class GuestTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->once())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->once())
@@ -358,9 +346,9 @@ class GuestTest extends \BBTestCase
         $di['password'] = $passwordMock;
         $di['validator'] = $validatorMock;
         $di['logger'] = new \Box_Log();
-        $di['mod_service'] =  $di->protect(fn($name) => $emailServiceMock);
+        $di['mod_service'] = $di->protect(fn ($name) => $emailServiceMock);
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
 
         $result = $client->update_password($data);
@@ -369,16 +357,16 @@ class GuestTest extends \BBTestCase
 
     public function testUpdatePasswordResetNotFound()
     {
-        $data = array(
+        $data = [
             'hash' => 'hashedString',
             'password' => 'newPassword',
-            'password_confirm' => 'newPassword'
-        );
+            'password_confirm' => 'newPassword',
+        ];
 
         // Mock for the database service
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->once())
-            ->method('findOne')->will($this->returnValue(null));
+            ->method('findOne')->willReturn(null);
 
         // Mock for the events manager
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
@@ -389,7 +377,7 @@ class GuestTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->once())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // Dependency injection container setup
         $di = new \Pimple\Container();
@@ -397,7 +385,7 @@ class GuestTest extends \BBTestCase
         $di['events_manager'] = $eventMock;
         $di['validator'] = $validatorMock;
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
 
         // Expect a Box_Exception to be thrown with a specific message
@@ -406,15 +394,14 @@ class GuestTest extends \BBTestCase
         $client->update_password($data);
     }
 
-
     public function testrequired()
     {
-        $configArr = array();
+        $configArr = [];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => $configArr);
+        $di['mod_config'] = $di->protect(fn ($name) => $configArr);
 
-        $client = new \Box\Mod\Client\Api\Guest();
+        $client = new Guest();
         $client->setDi($di);
 
         $result = $client->required();

--- a/tests/modules/Client/ServiceBalanceTest.php
+++ b/tests/modules/Client/ServiceBalanceTest.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Box\Tests\Mod\Client;
 
 class ServiceBalanceTest extends \BBTestCase
 {
-
     public function testgetDi()
     {
         $di = new \Pimple\Container();
@@ -31,7 +29,7 @@ class ServiceBalanceTest extends \BBTestCase
             ->method('store')
             ->with($clientBalance);
         $di['db'] = $dbMock;
-        
+
         $service = new \Box\Mod\Client\ServiceBalance();
         $service->setDi($di);
 
@@ -41,9 +39,9 @@ class ServiceBalanceTest extends \BBTestCase
         $description = 'Charged for product';
         $amount = 5.55;
 
-        $extra = array(
+        $extra = [
             'rel_id' => 1,
-        );
+        ];
 
         $result = $service->deductFunds($clientModel, $amount, $description, $extra);
 
@@ -54,7 +52,7 @@ class ServiceBalanceTest extends \BBTestCase
         $this->assertEquals('default', $result->type);
     }
 
-    public function testdeductFunds_InvalidDescription()
+    public function testdeductFundsInvalidDescription()
     {
         $service = new \Box\Mod\Client\ServiceBalance();
 
@@ -64,16 +62,16 @@ class ServiceBalanceTest extends \BBTestCase
         $description = '    ';
         $amount = 5.55;
 
-        $extra = array(
+        $extra = [
             'rel_id' => 1,
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Funds description is invalid');
         $service->deductFunds($clientModel, $amount, $description, $extra);
     }
 
-    public function testdeductFunds_InvalidAmount()
+    public function testdeductFundsInvalidAmount()
     {
         $service = new \Box\Mod\Client\ServiceBalance();
 
@@ -81,15 +79,14 @@ class ServiceBalanceTest extends \BBTestCase
         $clientModel->loadBean(new \DummyBean());
 
         $description = 'Charged';
-        $amount = "5.5adadzxc";
+        $amount = '5.5adadzxc';
 
-        $extra = array(
+        $extra = [
             'rel_id' => 1,
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Funds amount is invalid');
         $service->deductFunds($clientModel, $amount, $description, $extra);
     }
 }
- 

--- a/tests/modules/Client/ServiceTest.php
+++ b/tests/modules/Client/ServiceTest.php
@@ -1,13 +1,9 @@
 <?php
 
-
 namespace Box\Tests\Mod\Client;
 
-
-use \RedBeanPHP\OODBBean;
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     public function testgetDi()
     {
         $di = new \Pimple\Container();
@@ -21,7 +17,7 @@ class ServiceTest extends \BBTestCase {
     {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())
-            ->method('getRow')->will($this->returnValue(array('client_id' => 2, 'id' => 1)));
+            ->method('getRow')->willReturn(['client_id' => 2, 'id' => 1]);
 
         $database->expects($this->atLeastOnce())->method('exec');
 
@@ -39,7 +35,7 @@ class ServiceTest extends \BBTestCase {
     {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())
-            ->method('getRow')->will($this->returnValue(array()));
+            ->method('getRow')->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -59,14 +55,14 @@ class ServiceTest extends \BBTestCase {
 
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())
-            ->method('dispense')->will($this->returnValue($model));
+            ->method('dispense')->willReturn($model);
 
         $database->expects($this->atLeastOnce())->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('url')
-            ->will($this->returnValue('fossbilling.org/index.php/client/confirm-email/'));
+            ->willReturn('fossbilling.org/index.php/client/confirm-email/');
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -84,27 +80,27 @@ class ServiceTest extends \BBTestCase {
 
     public function testonAfterClientSignUp()
     {
-        $eventParams = array (
+        $eventParams = [
             'password' => 'testPassword',
             'id' => 1,
-        );
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())->
-            method('getParameters')->will($this->returnValue($eventParams));
+            method('getParameters')->willReturn($eventParams);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
-        $di['mod_config'] = $di->protect(fn($name) => array ('require_email_confirmation' => false));
+        $di['mod_service'] = $di->protect(fn () => $service);
+        $di['mod_config'] = $di->protect(fn ($name) => ['require_email_confirmation' => false]);
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $clientService = new \Box\Mod\Client\Service();
         $clientService->setDi($di);
@@ -116,37 +112,37 @@ class ServiceTest extends \BBTestCase {
     public function testRequireEmailConfirmonAfterClientSignUp()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
-        $eventParams = array (
+        $eventParams = [
             'password' => 'testPassword',
             'id' => 1,
             'require_email_confirmation' => true,
-        );
+        ];
 
         $eventMock->expects($this->atLeastOnce())->
-            method('getParameters')->will($this->returnValue($eventParams));
+            method('getParameters')->willReturn($eventParams);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->onlyMethods(array('generateEmailConfirmationLink'))->getMock();
+        $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->onlyMethods(['generateEmailConfirmationLink'])->getMock();
         $clientServiceMock->expects($this->atLeastOnce())->
-            method('generateEmailConfirmationLink')->will($this->returnValue('Link_string'));
+            method('generateEmailConfirmationLink')->willReturn('Link_string');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function($serviceName) use ($service, $clientServiceMock) {
-            if ($serviceName == 'email'){
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($service, $clientServiceMock) {
+            if ($serviceName == 'email') {
                 return $service;
             }
-            if ($serviceName == 'client'){
+            if ($serviceName == 'client') {
                 return $clientServiceMock;
             }
         });
-        $di['mod_config'] = $di->protect(fn($name) => array ('require_email_confirmation' => true));
+        $di['mod_config'] = $di->protect(fn ($name) => ['require_email_confirmation' => true]);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $clientService = new \Box\Mod\Client\Service();
         $result = $clientService->onAfterClientSignUp($eventMock);
@@ -156,27 +152,27 @@ class ServiceTest extends \BBTestCase {
 
     public function testExceptiononAfterClientSignUp()
     {
-        $eventParams = array (
+        $eventParams = [
             'password' => 'testPassword',
             'id' => 1,
-        );
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())->
-            method('getParameters')->will($this->returnValue($eventParams));
+            method('getParameters')->willReturn($eventParams);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $service->expects($this->atLeastOnce())->
             method('sendTemplate')->will($this->throwException(new \Exception('exception created in unit test')));
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
-        $di['mod_config'] = $di->protect(function ($name) use($di) {
-            array ('require_email_confirmation' => false);
+        $di['mod_service'] = $di->protect(fn () => $service);
+        $di['mod_config'] = $di->protect(function ($name) {
+            ['require_email_confirmation' => false];
         });
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $clientService = new \Box\Mod\Client\Service();
         $clientService->setDi($di);
@@ -187,70 +183,69 @@ class ServiceTest extends \BBTestCase {
 
     public static function searchQueryData()
     {
-        return array(
-            array(array(), 'SELECT c.*', array()),
-            array(
-                array('id' => 1),
+        return [
+            [[], 'SELECT c.*', []],
+            [
+                ['id' => 1],
                 'c.id = :client_id or c.aid = :alt_client_id',
-                array(':client_id' => '', ':alt_client_id' => '')
-            ),
-            array(
-                array('name' => 'test'),
+                [':client_id' => '', ':alt_client_id' => ''],
+            ],
+            [
+                ['name' => 'test'],
                 '(c.first_name LIKE :first_name or c.last_name LIKE :last_name )',
-                array(':first_name' => '', ':last_name' => '')
-            ),
-            array(
-                array('email' => 'test@example.com'),
+                [':first_name' => '', ':last_name' => ''],
+            ],
+            [
+                ['email' => 'test@example.com'],
                 'c.email LIKE :email',
-                array(':email' => 'test@example.com')
-            ),
-            array(
-                array('company' => 'LTD company'),
+                [':email' => 'test@example.com'],
+            ],
+            [
+                ['company' => 'LTD company'],
                 'c.company LIKE :company',
-                array(':company' => 'LTD company')
-            ),
-            array(
-                array('status' => 'TEST status'),
+                [':company' => 'LTD company'],
+            ],
+            [
+                ['status' => 'TEST status'],
                 'c.status = :status',
-                array(':status' => 'TEST status')
-            ),
-            array(
-                array('group_id' => '1'),
+                [':status' => 'TEST status'],
+            ],
+            [
+                ['group_id' => '1'],
                 'c.client_group_id = :group_id',
-                array(':group_id' => '1')
-            ),
-            array(
-                array('created_at' => '2012-12-12'),
+                [':group_id' => '1'],
+            ],
+            [
+                ['created_at' => '2012-12-12'],
                 "DATE_FORMAT(c.created_at, '%Y-%m-%d') = :created_at",
-                array(':created_at' => '2012-12-12')
-            ),
-            array(
-                array('date_from' => '2012-12-10'),
+                [':created_at' => '2012-12-12'],
+            ],
+            [
+                ['date_from' => '2012-12-10'],
                 'UNIX_TIMESTAMP(c.created_at) >= :date_from',
-                array(':date_from' => '2012-12-10')
-            ),
-            array(
-                array('date_to' => '2012-12-11'),
+                [':date_from' => '2012-12-10'],
+            ],
+            [
+                ['date_to' => '2012-12-11'],
                 'UNIX_TIMESTAMP(c.created_at) <= :date_from',
-                array(':date_to' => '2012-12-11')
-            ),
-            array(
-                array('search' => '2'),
+                [':date_to' => '2012-12-11'],
+            ],
+            [
+                ['search' => '2'],
                 'c.id = :cid or c.aid = :caid',
-                array(':cid' => '2', ':caid' => '2'),
-            ),
-            array(
-                array('search' => 'Keyword'),
+                [':cid' => '2', ':caid' => '2'],
+            ],
+            [
+                ['search' => 'Keyword'],
                 "c.company LIKE :s_company OR c.first_name LIKE :s_first_time OR c.last_name LIKE :s_last_name OR c.email LIKE :s_email OR CONCAT(c.first_name,  ' ', c.last_name ) LIKE  :full_name",
-                array(':s_company' => 'Keyword',
+                [':s_company' => 'Keyword',
                       ':s_first_time' => 'Keyword',
                       ':s_last_name' => 'Keyword',
                       ':s_email' => 'Keyword',
                       ':full_name' => 'Keyword',
-                ),
-            ),
-
-        );
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchQueryData')]
@@ -262,12 +257,12 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsArray($result[1]);
 
         $this->assertTrue(str_contains($result[0], $expectedStr), $result[0]);
-        $this->assertTrue(array_diff_key($result[1], $expectedParams) == array());
+        $this->assertTrue(array_diff_key($result[1], $expectedParams) == []);
     }
 
     public function testgetSearchQueryChangeSelect()
     {
-        $data = array();
+        $data = [];
         $selectStmt = 'c.id, CONCAT(c.first_name, c.last_name) as full_name';
         $clientService = new \Box\Mod\Client\Service();
         $result = $clientService->getSearchQuery($data, $selectStmt);
@@ -279,11 +274,11 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetPairs()
     {
-        $data = array();
+        $data = [];
 
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('getAssoc')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -296,12 +291,12 @@ class ServiceTest extends \BBTestCase {
 
     public function testtoSessionArray()
     {
-        $expectedArrayKeys = array (
+        $expectedArrayKeys = [
             'id' => 1,
             'email' => 'email@example.com',
             'name' => 'John Smith',
             'role' => 'admin',
-        );
+        ];
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
@@ -309,7 +304,7 @@ class ServiceTest extends \BBTestCase {
         $result = $clientService->toSessionArray($model);
 
         $this->assertIsArray($result);
-        $this->assertTrue(array_diff_key($result, $expectedArrayKeys) == array());
+        $this->assertTrue(array_diff_key($result, $expectedArrayKeys) == []);
     }
 
     public function testemailAlreadyRegistered()
@@ -319,7 +314,7 @@ class ServiceTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -342,21 +337,21 @@ class ServiceTest extends \BBTestCase {
 
         $result = $clientService->emailAlreadyRegistered($email, $model);
         $this->assertIsBool($result);
-        $this->assertEquals(false, $result);
+        $this->assertFalse($result);
     }
 
     public function testcanChangeCurrency()
     {
         $currency = 'EUR';
-        $model    = new \Model_Client();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
         $model->currency = 'USD';
 
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $database;
 
         $clientService = new \Box\Mod\Client\Service();
@@ -369,7 +364,7 @@ class ServiceTest extends \BBTestCase {
     public function testcanChangeCurrencyModelCurrencyNotSet()
     {
         $currency = 'EUR';
-        $model    = new \Model_Client();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $database = $this->getMockBuilder('\Box_Database')->getMock();
@@ -385,7 +380,7 @@ class ServiceTest extends \BBTestCase {
     public function testcanChangeCurrencyIdenticalCurrencies()
     {
         $currency = 'EUR';
-        $model    = new \Model_Client();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
         $model->currency = $currency;
 
@@ -402,9 +397,9 @@ class ServiceTest extends \BBTestCase {
     public function testcanChangeCurrencyHasInvoice()
     {
         $currency = 'EUR';
-        $model    = new \Model_Client();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
-        $model->id       = random_int(1, 100);
+        $model->id = random_int(1, 100);
         $model->currency = 'USD';
 
         $invoiceModel = new \Model_Invoice();
@@ -413,9 +408,9 @@ class ServiceTest extends \BBTestCase {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->once())
                  ->method('findOne')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $database;
 
         $clientService = new \Box\Mod\Client\Service();
@@ -429,9 +424,9 @@ class ServiceTest extends \BBTestCase {
     public function testcanChangeCurrencyHasOrder()
     {
         $currency = 'EUR';
-        $model    = new \Model_Client();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
-        $model->id       = random_int(1, 100);
+        $model->id = random_int(1, 100);
         $model->currency = 'USD';
 
         $clientOrderModel = new \Model_ClientOrder();
@@ -441,7 +436,7 @@ class ServiceTest extends \BBTestCase {
         $database->expects($this->exactly(2))->method('findOne')
             ->will($this->onConsecutiveCalls($this->returnValue(null)));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $database;
 
         $clientService = new \Box\Mod\Client\Service();
@@ -452,36 +447,34 @@ class ServiceTest extends \BBTestCase {
 
     public static function searchBalanceQueryData()
     {
-        return array(
-            array(array(), 'FROM client_balance as m', array()),
-            array(
-                array('id' => 1),
+        return [
+            [[], 'FROM client_balance as m', []],
+            [
+                ['id' => 1],
                 'm.id = :id',
-                array(':id' => '1', )
-            ),
-            array(
-                array('client_id' => 1),
+                [':id' => '1'],
+            ],
+            [
+                ['client_id' => 1],
                 'm.client_id = :client_id',
-                array(':client_id' => '1',)
-            ),
-            array(
-                array('date_from' => '2012-12-10'),
+                [':client_id' => '1'],
+            ],
+            [
+                ['date_from' => '2012-12-10'],
                 'm.created_at >= :date_from',
-                array(':date_from' => '2012-12-10')
-            ),
-            array(
-                array('date_to' => '2012-12-11'),
+                [':date_from' => '2012-12-10'],
+            ],
+            [
+                ['date_to' => '2012-12-11'],
                 'm.created_at <= :date_to',
-                array(':date_to' => '2012-12-11')
-            ),
-
-        );
+                [':date_to' => '2012-12-11'],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchBalanceQueryData')]
     public function testgetBalanceSearchQuery($data, $expectedStr, $expectedParams)
     {
-
         $di = new \Pimple\Container();
 
         $clientBalanceService = new \Box\Mod\Client\ServiceBalance();
@@ -492,8 +485,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsArray($params);
 
         $this->assertTrue(str_contains($sql, $expectedStr), $sql);
-        $this->assertTrue(array_diff_key($params, $expectedParams) == array());
-
+        $this->assertTrue(array_diff_key($params, $expectedParams) == []);
     }
 
     public function testaddFunds()
@@ -510,7 +502,7 @@ class ServiceTest extends \BBTestCase {
 
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -521,7 +513,6 @@ class ServiceTest extends \BBTestCase {
         $result = $clientService->addFunds($modelClient, $amount, $description);
         $this->assertTrue($result);
     }
-
 
     public function testaddFundsCurrencyNotDefined()
     {
@@ -536,9 +527,7 @@ class ServiceTest extends \BBTestCase {
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Define clients currency before adding funds.');
         $clientService->addFunds($modelClient, $amount, $description);
-
     }
-
 
     public function testaddFundsAmountMissing()
     {
@@ -556,7 +545,6 @@ class ServiceTest extends \BBTestCase {
         $clientService->addFunds($modelClient, $amount, $description);
     }
 
-
     public function testaddFundsInvalidDescription()
     {
         $modelClient = new \Model_Client();
@@ -565,7 +553,6 @@ class ServiceTest extends \BBTestCase {
 
         $amount = '2.22';
         $description = null;
-
 
         $clientService = new \Box\Mod\Client\Service();
 
@@ -579,7 +566,7 @@ class ServiceTest extends \BBTestCase {
     {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -593,22 +580,22 @@ class ServiceTest extends \BBTestCase {
 
     public static function searchHistoryQueryData()
     {
-        return array(
-            array(array(), 'SELECT ach.*, c.first_name, c.last_name, c.email', array()),
-            array(
-                array('search' => 'sameValue'),
+        return [
+            [[], 'SELECT ach.*, c.first_name, c.last_name, c.email', []],
+            [
+                ['search' => 'sameValue'],
                 'c.first_name LIKE :first_name OR c.last_name LIKE :last_name OR c.id LIKE :id',
-                array(
+                [
                     ':first_name' => '%sameValue%',
                     ':last_name' => '%sameValue%',
-                    ':id' => 'sameValue')
-            ),
-            array(
-                array('client_id' => '1'),
+                    ':id' => 'sameValue'],
+            ],
+            [
+                ['client_id' => '1'],
                 'ach.client_id = :client_id',
-                array(':client_id' => '1')
-            ),
-        );
+                [':client_id' => '1'],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchHistoryQueryData')]
@@ -624,14 +611,14 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsArray($params);
 
         $this->assertTrue(str_contains($sql, $expectedStr), $sql);
-        $this->assertTrue(array_diff_key($params, $expectedParams) == array());
+        $this->assertTrue(array_diff_key($params, $expectedParams) == []);
     }
 
     public function testcounter()
     {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('getAssoc')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -642,19 +629,19 @@ class ServiceTest extends \BBTestCase {
         $result = $clientService->counter();
         $this->assertIsArray($result);
 
-        $expected = array(
+        $expected = [
             'total' => 0,
-            \Model_Client::ACTIVE =>  0,
-            \Model_Client::SUSPENDED =>  0,
-            \Model_Client::CANCELED =>  0,
-        );
+            \Model_Client::ACTIVE => 0,
+            \Model_Client::SUSPENDED => 0,
+            \Model_Client::CANCELED => 0,
+        ];
     }
 
     public function testgetGroupPairs()
     {
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('getAssoc')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -672,7 +659,7 @@ class ServiceTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -690,7 +677,7 @@ class ServiceTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $database = $this->getMockBuilder('\Box_Database')->getMock();
         $database->expects($this->atLeastOnce())->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $database;
@@ -704,22 +691,21 @@ class ServiceTest extends \BBTestCase {
 
     public static function getProvider()
     {
-        return array(
-            array('id', 1),
-            array('email', 'test@email.com'),
-        );
+        return [
+            ['id', 1],
+            ['email', 'test@email.com'],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testget($fieldName, $fieldValue)
     {
-
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('findOne')->will($this->returnValue($model));
+            ->method('findOne')->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -727,7 +713,7 @@ class ServiceTest extends \BBTestCase {
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
-        $data = array($fieldName => $fieldValue);
+        $data = [$fieldName => $fieldValue];
         $result = $service->get($data);
         $this->assertInstanceOf('\Model_Client', $result);
     }
@@ -736,7 +722,7 @@ class ServiceTest extends \BBTestCase {
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('findOne')->will($this->returnValue(array()));
+            ->method('findOne')->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -744,7 +730,7 @@ class ServiceTest extends \BBTestCase {
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
-        $data = array('id' => 0);
+        $data = ['id' => 0];
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Client not found');
         $service->get($data);
@@ -757,7 +743,7 @@ class ServiceTest extends \BBTestCase {
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('getCell')->will($this->returnValue(1.0));
+            ->method('getCell')->willReturn(1.0);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -767,7 +753,6 @@ class ServiceTest extends \BBTestCase {
 
         $result = $service->getClientBalance($model);
         $this->assertIsNumeric($result);
-
     }
 
     public function testtoApiArray()
@@ -782,15 +767,15 @@ class ServiceTest extends \BBTestCase {
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('toArray')->will($this->returnValue(array()));
+            ->method('toArray')->willReturn([]);
         $dbMock->expects($this->atLeastOnce())
-            ->method('load')->will($this->returnValue($clientGroup));
+            ->method('load')->willReturn($clientGroup);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
-            ->onlyMethods(array('getClientBalance'))
+            ->onlyMethods(['getClientBalance'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getClientBalance');
@@ -799,30 +784,30 @@ class ServiceTest extends \BBTestCase {
 
         $result = $serviceMock->toApiArray($model, true, new \Model_Admin());
         $this->assertIsArray($result);
-
     }
 
     public static function testIsClientTaxableProvider()
     {
         $self = new ServiceTest('ServiceTest');
         $self->assertTrue(true);
-        return array(
-            array(
+
+        return [
+            [
                 false,
                 false,
-                false
-            ),
-            array(
+                false,
+            ],
+            [
                 true,
-                true,
-                false
-            ),
-            array(
                 true,
                 false,
-                true
-            )
-        );
+            ],
+            [
+                true,
+                false,
+                true,
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('testIsClientTaxableProvider')]
@@ -831,10 +816,10 @@ class ServiceTest extends \BBTestCase {
         $service = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue($getParamValueReturn));
+            ->willReturn($getParamValueReturn);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
@@ -845,7 +830,6 @@ class ServiceTest extends \BBTestCase {
 
         $result = $service->isClientTaxable($client);
         $this->assertEquals($expected, $result);
-
     }
 
     public function testadminCreateClient()
@@ -854,23 +838,22 @@ class ServiceTest extends \BBTestCase {
         $clientModel->loadBean(new \DummyBean());
         $clientModel->id = 1;
 
-        $data = array(
+        $data = [
             'password' => uniqid(),
             'email' => 'test@unit.vm',
             'first_name' => 'test',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
         $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventManagerMock->expects($this->exactly(2))
             ->method('fire');
-
 
         $passwordMock = $this->getMockBuilder('\Box_Password')->getMock();
         $passwordMock->expects($this->atLeastOnce())
@@ -896,16 +879,16 @@ class ServiceTest extends \BBTestCase {
         $clientModel->loadBean(new \DummyBean());
         $clientModel->id = 1;
 
-        $data = array(
+        $data = [
             'password' => uniqid(),
             'email' => 'test@unit.vm',
             'first_name' => 'test',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
@@ -917,8 +900,7 @@ class ServiceTest extends \BBTestCase {
         $ip = '10.10.10.2';
         $requestMock->expects($this->atLeastOnce())
             ->method('getClientAddress')
-            ->will($this->returnValue($ip));
-
+            ->willReturn($ip);
 
         $passwordMock = $this->getMockBuilder('\Box_Password')->getMock();
         $passwordMock->expects($this->atLeastOnce())
@@ -962,13 +944,13 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testdeleteGroup_groupHasClients()
+    public function testdeleteGroupGroupHasClients()
     {
         $clientModel = new \Model_Client();
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -983,7 +965,7 @@ class ServiceTest extends \BBTestCase {
         $service->deleteGroup($model);
     }
 
-    public function testauthorizeClient_DidntFoundEmail()
+    public function testauthorizeClientDidntFoundEmail()
     {
         $email = 'example@fossbilling.vm';
         $password = '123456';
@@ -1021,13 +1003,13 @@ class ServiceTest extends \BBTestCase {
         $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authMock->expects($this->atLeastOnce())
             ->method('authorizeUser')
-            ->with($clientModel,$password)
+            ->with($clientModel, $password)
             ->willReturn($clientModel);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['auth'] = $authMock;
-        $di['mod_config'] = $di->protect(fn($name) => array ('require_email_confirmation' => false));
+        $di['mod_config'] = $di->protect(fn ($name) => ['require_email_confirmation' => false]);
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
@@ -1037,7 +1019,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testauthorizeClientEmailRequiredConfirmed()
     {
-        $email    = 'example@fossbilling.vm';
+        $email = 'example@fossbilling.vm';
         $password = '123456';
 
         $clientModel = new \Model_Client();
@@ -1056,11 +1038,11 @@ class ServiceTest extends \BBTestCase {
             ->with($clientModel, $password)
             ->willReturn($clientModel);
 
-        $di               = new \Pimple\Container();
-        $di['db']         = $dbMock;
-        $di['auth']       = $authMock;
-        $di['mod_config'] = $di->protect(fn($name) => array('require_email_confirmation' => true));
-        $service          = new \Box\Mod\Client\Service();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['auth'] = $authMock;
+        $di['mod_config'] = $di->protect(fn ($name) => ['require_email_confirmation' => true]);
+        $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
         $result = $service->authorizeClient($email, $password);
@@ -1073,12 +1055,12 @@ class ServiceTest extends \BBTestCase {
         $clientModel->loadBean(new \DummyBean());
         $email = 'client@fossbilling.org';
 
-        $config = array(
+        $config = [
             'disable_change_email' => false,
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
@@ -1086,7 +1068,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testcanChangeEmail_EmailAreTheSame()
+    public function testcanChangeEmailEmailAreTheSame()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -1094,12 +1076,12 @@ class ServiceTest extends \BBTestCase {
 
         $clientModel->email = $email;
 
-        $config = array(
+        $config = [
             'disable_change_email' => false,
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
@@ -1107,16 +1089,16 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testcanChangeEmail_EmptyConfig()
+    public function testcanChangeEmailEmptyConfig()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $email = 'client@fossbilling.org';
 
-        $config = array();
+        $config = [];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
@@ -1124,18 +1106,18 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testcanChangeEmail_CanntChangeEmail()
+    public function testcanChangeEmailCanntChangeEmail()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $email = 'client@fossbilling.org';
 
-        $config = array(
+        $config = [
             'disable_change_email' => true,
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
 
@@ -1146,12 +1128,12 @@ class ServiceTest extends \BBTestCase {
 
     public function testcheckExtraRequiredFields()
     {
-        $required = array('id');
-        $data = array();
+        $required = ['id'];
+        $data = [];
 
         $config['required'] = $required;
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
 
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
@@ -1162,40 +1144,39 @@ class ServiceTest extends \BBTestCase {
 
     public function testcheckCustomFields()
     {
-        $custom_field = array(
-            'custom_field_name' => array(
+        $custom_field = [
+            'custom_field_name' => [
                 'active' => true,
                 'required' => true,
-                'title' => 'custom_field_title'
-            ),
-        );
+                'title' => 'custom_field_title',
+            ],
+        ];
         $config['custom_fields'] = $custom_field;
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
 
-        $data = array();
+        $data = [];
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Field custom_field_title cannot be empty');
         $service->checkCustomFields($data);
-
     }
 
-    public function testcheckCustomFields_notRequired()
+    public function testcheckCustomFieldsNotRequired()
     {
-        $custom_field = array(
-            'custom_field_name' => array(
+        $custom_field = [
+            'custom_field_name' => [
                 'active' => true,
                 'required' => false,
-                'title' => 'custom_field_title'
-            ),
-        );
+                'title' => 'custom_field_title',
+            ],
+        ];
         $config['custom_fields'] = $custom_field;
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($modName) => $config);
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
 
-        $data = array();
+        $data = [];
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);
         $result = $service->checkCustomFields($data);

--- a/tests/modules/Cron/Api/AdminTest.php
+++ b/tests/modules/Cron/Api/AdminTest.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace Box\Mod\Cron\Api;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testgetDi()
     {
         $di = new \Pimple\Container();
-        $api_admin = new \Box\Mod\Cron\Api\Admin();
+        $api_admin = new Admin();
         $api_admin->setDi($di);
         $getDi = $api_admin->getDi();
         $this->assertEquals($di, $getDi);
@@ -18,27 +16,24 @@ class AdminTest extends \BBTestCase {
     public function testinfo()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cron\Service::class)->getMock();
-        $serviceMock->expects($this->atLeastOnce())->method('getCronInfo')->will($this->returnValue(array()));
+        $serviceMock->expects($this->atLeastOnce())->method('getCronInfo')->willReturn([]);
 
-        $api_admin = new \Box\Mod\Cron\Api\Admin();
+        $api_admin = new Admin();
         $api_admin->setService($serviceMock);
 
-        $result = $api_admin->info(array());
+        $result = $api_admin->info([]);
         $this->assertIsArray($result);
     }
 
     public function testrun()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cron\Service::class)->getMock();
-        $serviceMock->expects($this->atLeastOnce())->method('runCrons')->will($this->returnValue(true));
+        $serviceMock->expects($this->atLeastOnce())->method('runCrons')->willReturn(true);
 
-        $api_admin = new \Box\Mod\Cron\Api\Admin();
+        $api_admin = new Admin();
         $api_admin->setService($serviceMock);
 
-        $result = $api_admin->run(array());
+        $result = $api_admin->run([]);
         $this->assertIsBool($result);
     }
-
-
 }
- 

--- a/tests/modules/Cron/Api/GuestTest.php
+++ b/tests/modules/Cron/Api/GuestTest.php
@@ -1,44 +1,40 @@
 <?php
 
-
 namespace Box\Mod\Cron\Api;
 
-
-class GuestTest extends \BBTestCase {
-
+class GuestTest extends \BBTestCase
+{
     public function testgetDi()
     {
         $di = new \Pimple\Container();
-        $api = new \Box\Mod\Cron\Api\Guest();
+        $api = new Guest();
         $api->setDi($di);
         $getDi = $api->getDi();
         $this->assertEquals($di, $getDi);
     }
 
-    public  function testsettings()
+    public function testsettings()
     {
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
-        $modMock->expects($this->atLeastOnce())->method('getConfig')->will($this->returnValue(array()));
+        $modMock->expects($this->atLeastOnce())->method('getConfig')->willReturn([]);
 
-        $api = new \Box\Mod\Cron\Api\Guest();
+        $api = new Guest();
         $api->setMod($modMock);
 
         $result = $api->settings();
         $this->assertIsArray($result);
     }
 
-    public function testis_late()
+    public function testisLate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cron\Service::class)->getMock();
-        $serviceMock->expects($this->atLeastOnce())->method('isLate')->will($this->returnValue(true));
+        $serviceMock->expects($this->atLeastOnce())->method('isLate')->willReturn(true);
 
-        $api = new \Box\Mod\Cron\Api\Guest();
+        $api = new Guest();
         $api->setService($serviceMock);
 
         $result = $api->is_late();
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
-
 }
- 

--- a/tests/modules/Cron/ServiceTest.php
+++ b/tests/modules/Cron/ServiceTest.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace Box\Mod\Cron;
 
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     public function testgetDi()
     {
         $di = new \Pimple\Container();
-        $service = new \Box\Mod\Cron\Service();
+        $service = new Service();
         $service->setDi($di);
         $getDi = $service->getDi();
         $this->assertEquals($di, $getDi);
@@ -21,8 +19,8 @@ class ServiceTest extends \BBTestCase {
         $systemServiceMock->expects($this->atLeastOnce())->method('getParamValue');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $systemServiceMock);
-        $service = new \Box\Mod\Cron\Service();
+        $di['mod_service'] = $di->protect(fn ($name) => $systemServiceMock);
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getCronInfo();
@@ -32,8 +30,8 @@ class ServiceTest extends \BBTestCase {
     public function testrunCrons()
     {
         $apiSystem = new \Api_Handler(new \Model_Admin());
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cron\Service::class)
-            ->onlyMethods(array('_exec'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_exec'])
             ->getMock();
 
         $serviceMock->expects($this->exactly(13))
@@ -52,7 +50,7 @@ class ServiceTest extends \BBTestCase {
                     [[$apiSystem], 'support_batch_public_ticket_auto_close'],
                     [[$apiSystem], 'client_batch_expire_password_reminders'],
                     [[$apiSystem], 'cart_batch_expire'],
-                    [[$apiSystem], 'email_batch_sendmail']
+                    [[$apiSystem], 'email_batch_sendmail'],
                 ];
 
                 [$expectedApiSystem, $expectedMethod] = array_shift($series);
@@ -76,7 +74,7 @@ class ServiceTest extends \BBTestCase {
         $di['logger'] = new \Box_Log();
         $di['events_manager'] = $eventsMock;
         $di['api_system'] = $apiSystem;
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
         $serviceMock->setDi($di);
         $di['db'] = $dbMock;
         $di['cache'] = new \Symfony\Component\Cache\Adapter\FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
@@ -97,11 +95,11 @@ class ServiceTest extends \BBTestCase {
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue('2012-12-12 12:12:12'));
+            ->willReturn('2012-12-12 12:12:12');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $systemServiceMock);
-        $service = new \Box\Mod\Cron\Service();
+        $di['mod_service'] = $di->protect(fn ($name) => $systemServiceMock);
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getLastExecutionTime();
@@ -110,13 +108,13 @@ class ServiceTest extends \BBTestCase {
 
     public function testisLate()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Cron\Service::class)
-            ->onlyMethods(array('getLastExecutionTime'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getLastExecutionTime'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getLastExecutionTime')
-            ->will($this->returnValue(date('Y-m-d H:i:s')));
+            ->willReturn(date('Y-m-d H:i:s'));
 
         $result = $serviceMock->isLate();
         $this->assertIsBool($result);

--- a/tests/modules/Currency/Api/Api_AdminTest.php
+++ b/tests/modules/Currency/Api/Api_AdminTest.php
@@ -4,7 +4,7 @@ namespace Box\Tests\Mod\Currency\Api;
 
 class Api_AdminTest extends \BBTestCase
 {
-    public $availableCurrencies = array(
+    public $availableCurrencies = [
         'AED' => 'AED - United Arab Emirates dirham',
         'AFN' => 'AFN - Afghan afghani',
         'ALL' => 'ALL - Albanian lek',
@@ -158,40 +158,38 @@ class Api_AdminTest extends \BBTestCase
         'ZAR' => 'ZAR - South African rand',
         'ZMK' => 'ZMK - Zambian kwacha',
         'ZWL' => 'ZWL - Zimbabwe dollar',
-    );
-
+    ];
 
     public function testGetList()
     {
         $adminApi = new \Box\Mod\Currency\Api\Admin();
 
-        $willReturn = array(
-            "list" => array('id' => 1),
-        );
+        $willReturn = [
+            'list' => ['id' => 1],
+        ];
 
         $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
-
+            ->willReturn($model);
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['pager']     = $pager;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['pager'] = $pager;
 
         $adminApi->setDi($di);
 
         $service = new \Box\Mod\Currency\Service();
         $adminApi->setService($service);
 
-        $result = $adminApi->get_list(array());
+        $result = $adminApi->get_list([]);
 
         $this->assertIsArray($result);
         $this->assertIsArray($result['list']);
@@ -204,7 +202,7 @@ class Api_AdminTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getAvailableCurrencies')
-            ->will($this->returnValue($this->availableCurrencies));
+            ->willReturn($this->availableCurrencies);
 
         $adminApi->setService($service);
         $result = $adminApi->get_pairs();
@@ -215,27 +213,27 @@ class Api_AdminTest extends \BBTestCase
     public function testGet()
     {
         $adminApi = new \Box\Mod\Currency\Api\Admin();
-        $model    = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
-        $data = array(
-            'code' => 'EUR'
-        );
+        $data = [
+            'code' => 'EUR',
+        ];
         $adminApi->setService($service);
         $adminApi->setDi($di);
         $result = $adminApi->get($data);
@@ -245,35 +243,35 @@ class Api_AdminTest extends \BBTestCase
     public function testGetDefault()
     {
         $adminApi = new \Box\Mod\Currency\Api\Admin();
-        $model    = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
-        $model->code            = 'EUR';
-        $model->title           = 'Euro';
+        $model->code = 'EUR';
+        $model->title = 'Euro';
         $model->conversion_rate = '3.4528';
-        $model->format          = '';
-        $model->price_format    = '';
-        $model->is_default      = 1;
+        $model->format = '';
+        $model->price_format = '';
+        $model->is_default = 1;
 
-        $returnArr = array(
-            'code'            => $model->code,
-            'title'           => $model->title,
-            'conversion_rate' => (float)$model->conversion_rate,
-            'format'          => $model->format,
-            'price_format'    => $model->price_format,
-            'default'         => $model->is_default,
-        );
+        $returnArr = [
+            'code' => $model->code,
+            'title' => $model->title,
+            'conversion_rate' => (float) $model->conversion_rate,
+            'format' => $model->format,
+            'price_format' => $model->price_format,
+            'default' => $model->is_default,
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $service->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($returnArr));
+            ->willReturn($returnArr);
 
         $adminApi->setService($service);
-        $result = $adminApi->get_default(array());
+        $result = $adminApi->get_default([]);
 
         $this->assertIsArray($result);
         $this->assertEquals($result, $returnArr);
@@ -281,11 +279,10 @@ class Api_AdminTest extends \BBTestCase
         $this->assertEquals($model->code, $returnArr['code']);
         $this->assertEquals($model->title, $returnArr['title']);
         $this->assertIsFloat($returnArr['conversion_rate']);
-        $this->assertEquals((float)$model->conversion_rate, $returnArr['conversion_rate']);
+        $this->assertEquals((float) $model->conversion_rate, $returnArr['conversion_rate']);
         $this->assertEquals($model->format, $returnArr['format']);
         $this->assertEquals($model->price_format, $returnArr['price_format']);
         $this->assertEquals($model->is_default, $returnArr['default']);
-
     }
 
     public static function CreateExceptionProvider()
@@ -296,28 +293,26 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        return array(
-            array(
-                array(
-                    'code'   => 'EUR',
-                    'format' => '€{{price}}'
-                ),
+        return [
+            [
+                [
+                    'code' => 'EUR',
+                    'format' => '€{{price}}',
+                ],
                 $self->atLeastOnce(),
-                $model, //currency exists already
+                $model, // currency exists already
                 $self->never(),
-
-            ),
-            array(
-                array(
-                    'code'   => 'NON', //Non existing currency
-                    'format' => '€{{price}}'
-                ),
+            ],
+            [
+                [
+                    'code' => 'NON', // Non existing currency
+                    'format' => '€{{price}}',
+                ],
                 $self->atLeastOnce(),
                 null,
                 $self->atLeastOnce(),
-
-            ),
-        );
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('CreateExceptionProvider')]
@@ -328,48 +323,48 @@ class Api_AdminTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($getByCodeCalled)
             ->method('getByCode')
-            ->will($this->returnValue($getByCodeReturn));
+            ->willReturn($getByCodeReturn);
 
         $service->expects($getAvailableCurrenciesCalled)
             ->method('getAvailableCurrencies')
-            ->will($this->returnValue($this->availableCurrencies));
+            ->willReturn($this->availableCurrencies);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setService($service);
         $adminApi->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $adminApi->create($data); //Expecting \FOSSBilling\Exception every time
+        $adminApi->create($data); // Expecting \FOSSBilling\Exception every time
     }
 
     public function testCreate()
     {
         $adminApi = new \Box\Mod\Currency\Api\Admin();
 
-        $data = array(
-            'code'   => 'EUR',
-            'format' => '€{{price}}'
-        );
+        $data = [
+            'code' => 'EUR',
+            'format' => '€{{price}}',
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $service->expects($this->atLeastOnce())
             ->method('getAvailableCurrencies')
-            ->will($this->returnValue($this->availableCurrencies));
+            ->willReturn($this->availableCurrencies);
         $service->expects($this->atLeastOnce())
             ->method('createCurrency')
-            ->will($this->returnValue($data['code']));
+            ->willReturn($data['code']);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setService($service);
@@ -380,31 +375,30 @@ class Api_AdminTest extends \BBTestCase
         $this->assertIsString($result);
         $this->assertEquals(strlen($result), 3);
         $this->assertEquals($result, $data['code']);
-
     }
 
     public function testUpdate()
     {
         $adminApi = new \Box\Mod\Currency\Api\Admin();
 
-        $data = array(
-            'code'            => 'EUR',
-            'format'          => '€{{price}}',
-            'title'           => 'Euros',
-            'price_format'    => '€{{Price}}',
+        $data = [
+            'code' => 'EUR',
+            'format' => '€{{price}}',
+            'title' => 'Euros',
+            'price_format' => '€{{Price}}',
             'conversion_rate' => 0.6,
-        );
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('updateCurrency')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -414,7 +408,6 @@ class Api_AdminTest extends \BBTestCase
 
         $this->assertIsBool($result);
         $this->assertEquals($result, true);
-
     }
 
     /**
@@ -427,19 +420,19 @@ class Api_AdminTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->never())
             ->method('getByCode')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')->willThrowException(new \FOSSBilling\Exception(''));
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
         $adminApi->setService($service);
         $this->expectException(\FOSSBilling\Exception::class);
-        $adminApi->delete(array()); //Expecting \FOSSBilling\Exception every time
+        $adminApi->delete([]); // Expecting \FOSSBilling\Exception every time
     }
 
     public function testDelete()
@@ -450,21 +443,21 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        $data = array(
-            'code'   => 'EUR',
-            'format' => '€{{price}}'
-        );
+        $data = [
+            'code' => 'EUR',
+            'format' => '€{{price}}',
+        ];
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('deleteCurrencyByCode'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['deleteCurrencyByCode'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('deleteCurrencyByCode')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -484,15 +477,15 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        return array(
-            array(
-                array(
-                    'code' => 'EUR' //model is not instance of \Model_Currency
-                ),
+        return [
+            [
+                [
+                    'code' => 'EUR', // model is not instance of \Model_Currency
+                ],
                 $self->atLeastOnce(),
                 null,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -506,20 +499,20 @@ class Api_AdminTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($getByCodeCalled)
             ->method('getByCode')
-            ->will($this->returnValue($getByCodeReturn));
+            ->willReturn($getByCodeReturn);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
 
         $adminApi->setService($service);
         $this->expectException(\FOSSBilling\Exception::class);
-        $adminApi->set_default($data); //Expecting \FOSSBilling\Exception every time
+        $adminApi->set_default($data); // Expecting \FOSSBilling\Exception every time
     }
 
     public function testSetDefault()
@@ -530,26 +523,26 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        $data = array(
-            'code'   => 'EUR',
-            'format' => '€{{price}}'
-        );
+        $data = [
+            'code' => 'EUR',
+            'format' => '€{{price}}',
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('setAsDefault')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $db              = $this->getMockBuilder('Box_Database')->getMock();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);

--- a/tests/modules/Currency/Api/Api_GuestTest.php
+++ b/tests/modules/Currency/Api/Api_GuestTest.php
@@ -8,19 +8,19 @@ class Api_GuestTest extends \BBTestCase
     {
         $guestApi = new \Box\Mod\Currency\Api\Guest();
 
-        $willReturn = array(
+        $willReturn = [
             'EUR' => 'Euro',
-            'USD' => 'US Dollar'
-        );
+            'USD' => 'US Dollar',
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getPairs')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
         $guestApi->setService($service);
 
-        $result = $guestApi->get_pairs(array());
+        $result = $guestApi->get_pairs([]);
         $this->assertEquals($result, $willReturn);
         $this->assertIsArray($result);
         $this->assertArrayHasKey('EUR', $result);
@@ -33,51 +33,50 @@ class Api_GuestTest extends \BBTestCase
 
         $model = new \Model_Currency();
 
-        return array(
-            array(
-                array(
-                    'code' => 'EUR'
-                ),
+        return [
+            [
+                [
+                    'code' => 'EUR',
+                ],
                 $model,
                 $self->atLeastOnce(),
-                $self->never()
-            ),
-            array(
-                array(),
+                $self->never(),
+            ],
+            [
+                [],
                 $model,
                 $self->never(),
-                $self->atLeastOnce()
-            )
-        );
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
-    
     #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet($data, $model, $expectsGetByCode, $expectsGetDefault)
     {
         $guestApi = new \Box\Mod\Currency\Api\Guest();
 
-        $willReturn = array(
-            'code'            => 'EUR',
-            'title'           => 'Euro',
+        $willReturn = [
+            'code' => 'EUR',
+            'title' => 'Euro',
             'conversion_rate' => 1,
-            'format'          => '{{price}}',
-            'price_format'    => 1,
-            'default'         => 1,
-        );
+            'format' => '{{price}}',
+            'price_format' => 1,
+            'default' => 1,
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($expectsGetByCode)
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $service->expects($expectsGetDefault)
             ->method('getDefault')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $service->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
         $guestApi->setService($service);
 
@@ -90,77 +89,76 @@ class Api_GuestTest extends \BBTestCase
     {
         $guestApi = new \Box\Mod\Currency\Api\Guest();
 
-        $willReturn = array(
-            'code'            => 'EUR',
-            'title'           => 'Euro',
+        $willReturn = [
+            'code' => 'EUR',
+            'title' => 'Euro',
             'conversion_rate' => 1,
-            'format'          => '{{price}}',
-            'price_format'    => 1,
-            'default'         => 1,
-        );
+            'format' => '{{price}}',
+            'price_format' => 1,
+            'default' => 1,
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $service->expects($this->never())
             ->method('getByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $service->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $guestApi->setService($service);
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $guestApi->get(array()); //Expecting \FOSSBilling\Exception
+        $result = $guestApi->get([]); // Expecting \FOSSBilling\Exception
     }
 
     public static function formatPriceFormatProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 1,
-                "€ 60000.00"
-            ),
-            array(
+                '€ 60000.00',
+            ],
+            [
                 2,
-                "€ 60,000.00"
-            ),
-            array(
+                '€ 60,000.00',
+            ],
+            [
                 3,
-                "€ 60.000,00"
-            ),
-            array(
+                '€ 60.000,00',
+            ],
+            [
                 4,
-                "€ 60,000"
-            ),
-            array(
+                '€ 60,000',
+            ],
+            [
                 5,
-                "€ 60000"
-            ),
-        );
+                '€ 60000',
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('formatPriceFormatProvider')]
     public function testFormatPriceFormat($price_format, $expectedResult)
     {
-
-        $willReturn = array(
-            'code'            => 'EUR',
-            'title'           => 'Euro',
+        $willReturn = [
+            'code' => 'EUR',
+            'title' => 'Euro',
             'conversion_rate' => 0.6,
-            'format'          => '€ {{price}}',
-            'price_format'    => $price_format,
-            'default'         => 1,
-        );
+            'format' => '€ {{price}}',
+            'price_format' => $price_format,
+            'default' => 1,
+        ];
 
-        $data     = array(
-            'code'             => 'EUR',
-            'price'            => 100000,
+        $data = [
+            'code' => 'EUR',
+            'price' => 100000,
             'without_currency' => false,
-        );
-        $guestApi = $this->getMockBuilder('\\' . \Box\Mod\Currency\Api\Guest::class)->onlyMethods(array('get'))->getMock();
+        ];
+        $guestApi = $this->getMockBuilder('\\' . \Box\Mod\Currency\Api\Guest::class)->onlyMethods(['get'])->getMock();
         $guestApi->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
 
@@ -175,50 +173,48 @@ class Api_GuestTest extends \BBTestCase
 
     public static function formatProvider()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'code' => 'EUR',
-                ),
-                "€ 0.00" //price is not set, so result should be 0
-            ),
-            array(
-                array(
-                    'code'    => 'EUR',
-                    'price'   => 100000,
-                    'convert' => false //Should not convert
-                ),
-                "€ 100000.00"
-            ),
-            array(
-                array(
-                    'code'             => 'EUR',
-                    'price'            => 100000,
-                    'without_currency' => true, //Should return number only
-                ),
-                "60000.00"
-            ),
-        );
+                ],
+                '€ 0.00', // price is not set, so result should be 0
+            ],
+            [
+                [
+                    'code' => 'EUR',
+                    'price' => 100000,
+                    'convert' => false, // Should not convert
+                ],
+                '€ 100000.00',
+            ],
+            [
+                [
+                    'code' => 'EUR',
+                    'price' => 100000,
+                    'without_currency' => true, // Should return number only
+                ],
+                '60000.00',
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('formatProvider')]
     public function testFormat($data, $expectedResult)
     {
-
-        $willReturn = array(
-            'code'            => 'EUR',
-            'title'           => 'Euro',
+        $willReturn = [
+            'code' => 'EUR',
+            'title' => 'Euro',
             'conversion_rate' => 0.6,
-            'format'          => '€ {{price}}',
-            'price_format'    => 1,
-            'default'         => 1,
-        );
+            'format' => '€ {{price}}',
+            'price_format' => 1,
+            'default' => 1,
+        ];
 
-
-        $guestApi = $this->getMockBuilder('\\' . \Box\Mod\Currency\Api\Guest::class)->onlyMethods(array('get'))->getMock();
+        $guestApi = $this->getMockBuilder('\\' . \Box\Mod\Currency\Api\Guest::class)->onlyMethods(['get'])->getMock();
         $guestApi->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
 

--- a/tests/modules/Currency/Controller/AdminTest.php
+++ b/tests/modules/Currency/Controller/AdminTest.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace Box\Mod\Currency\Controller;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testDi()
     {
-        $controller = new \Box\Mod\Currency\Controller\Admin();
+        $controller = new Admin();
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -24,10 +22,9 @@ class AdminTest extends \BBTestCase {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->once())
             ->method('get')
-            ->with('/currency/manage/:code', 'get_manage', array('code'=>'[a-zA-Z]+'), \Box\Mod\Currency\Controller\Admin::class);
+            ->with('/currency/manage/:code', 'get_manage', ['code' => '[a-zA-Z]+'], Admin::class);
 
-        $controllerAdmin = new \Box\Mod\Currency\Controller\Admin();
+        $controllerAdmin = new Admin();
         $controllerAdmin->register($boxAppMock);
     }
 }
- 

--- a/tests/modules/Currency/ServiceTest.php
+++ b/tests/modules/Currency/ServiceTest.php
@@ -1,10 +1,9 @@
 <?php
-namespace Box\Tests\Mod\Currency;
 
+namespace Box\Tests\Mod\Currency;
 
 class ServiceTest extends \BBTestCase
 {
-
     public function testDi()
     {
         $service = new \Box\Mod\Currency\Service();
@@ -21,26 +20,26 @@ class ServiceTest extends \BBTestCase
     public function testGetSearchQuery()
     {
         $service = new \Box\Mod\Currency\Service();
-        $result  = $service->getSearchQuery();
+        $result = $service->getSearchQuery();
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
-        $this->assertEquals("SELECT * FROM currency WHERE 1", $result[0]);
+        $this->assertEquals('SELECT * FROM currency WHERE 1', $result[0]);
     }
 
     public function testGetBaseCurrencyRate()
     {
-        $service  = new \Box\Mod\Currency\Service();
-        $rate     = 0.6;
+        $service = new \Box\Mod\Currency\Service();
+        $rate = 0.6;
         $expected = 1 / $rate;
-        $di       = new \Pimple\Container();
-        $db       = $this->getMockBuilder('Box_Database')->getMock();
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($rate));
+            ->willReturn($rate);
 
         $di['db'] = $db;
         $service->setDi($di);
-        $code   = 'EUR';
+        $code = 'EUR';
         $result = $service->getBaseCurrencyRate($code);
         $this->assertEquals($expected, $result);
     }
@@ -53,44 +52,43 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
         $di['db'] = $db;
         $service->setDi($di);
         $code = 'EUR';
         $this->expectException(\FOSSBilling\Exception::class);
-        $service->getBaseCurrencyRate($code); //Expecting exception
+        $service->getBaseCurrencyRate($code); // Expecting exception
     }
-
 
     public static function toBaseCurrencyProvider()
     {
-        return array(
-            array('EUR', 'USD', 100, 0.73, 73), // 100 USD ~ 72.99 EUR
-            array('USD', 'EUR', 100, 1.37, 137), // 100 Eur  ~ 136.99 USD
-            array('EUR', 'EUR', 100, 0.5, 100), //should return same amount
-        );
+        return [
+            ['EUR', 'USD', 100, 0.73, 73], // 100 USD ~ 72.99 EUR
+            ['USD', 'EUR', 100, 1.37, 137], // 100 Eur  ~ 136.99 USD
+            ['EUR', 'EUR', 100, 0.5, 100], // should return same amount
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('toBaseCurrencyProvider')]
     public function testToBaseCurrency($defaultCode, $foreignCode, $amount, $rate, $expected)
     {
-        $model      = new \Model_Currency();
-        $bean       = new \DummyBean();
+        $model = new \Model_Currency();
+        $bean = new \DummyBean();
         $bean->code = $defaultCode;
         $model->loadBean($bean);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
-            ->onlyMethods(array('getDefault', 'getBaseCurrencyRate'))
+            ->onlyMethods(['getDefault', 'getBaseCurrencyRate'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock->expects($this->any()) // will not be called when currencies are the same, so using any()
             ->method('getBaseCurrencyRate')
-            ->will($this->returnValue($rate));
+            ->willReturn($rate);
 
         $result = $serviceMock->toBaseCurrency($foreignCode, $amount);
 
@@ -102,23 +100,23 @@ class ServiceTest extends \BBTestCase
         $self = new ServiceTest('ServiceTest');
 
         $model = new \Model_Currency();
-        $bean  = new \DummyBean();
+        $bean = new \DummyBean();
         $model->loadBean($bean);
 
-        return array(
-            array(
+        return [
+            [
                 $model,
                 'USD',
                 $self->atLeastOnce(),
-                $self->never()
-            ),
-            array(
+                $self->never(),
+            ],
+            [
                 $model,
                 null,
                 $self->never(),
-                $self->atLeastOnce()
-            ),
-        );
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getCurrencyByClientIdProvider')]
@@ -129,17 +127,17 @@ class ServiceTest extends \BBTestCase
 
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($currency));
+            ->willReturn($currency);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getDefault', 'getByCode'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getDefault', 'getByCode'])->getMock();
 
         $serviceMock->expects($getDefaultCalled)
             ->method('getDefault')
-            ->will($this->returnValue($row));
+            ->willReturn($row);
 
         $serviceMock->expects($expectsGetByCode)
             ->method('getByCode')
-            ->will($this->returnValue($row));
+            ->willReturn($row);
 
         $di['db'] = $db;
         $serviceMock->setDi($di);
@@ -157,17 +155,17 @@ class ServiceTest extends \BBTestCase
 
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getDefault', 'getByCode'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getDefault', 'getByCode'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue(new \Model_Currency()));
+            ->willReturn(new \Model_Currency());
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di['db'] = $db;
         $serviceMock->setDi($di);
@@ -179,11 +177,11 @@ class ServiceTest extends \BBTestCase
 
     public function testgetByCode()
     {
-        $di         = new \Pimple\Container();
-        $service    = new \Box\Mod\Currency\Service();
-        $bean       = new \DummyBean();
+        $di = new \Pimple\Container();
+        $service = new \Box\Mod\Currency\Service();
+        $bean = new \DummyBean();
         $bean->code = 'EUR';
-        $model      = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean($bean);
 
         $currency = 'EUR';
@@ -191,7 +189,7 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di['db'] = $db;
         $service->setDi($di);
@@ -205,11 +203,11 @@ class ServiceTest extends \BBTestCase
 
     public static function getRateByCodeProvider()
     {
-        return array(
-            array('EUR', 0.6, 0.6),
-            array('GBP', null, 1),
-            array('GBP', 'rate', 1),
-        );
+        return [
+            ['EUR', 0.6, 0.6],
+            ['GBP', null, 1],
+            ['GBP', 'rate', 1],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getRateByCodeProvider')]
@@ -221,28 +219,27 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($returns));
+            ->willReturn($returns);
 
         $di['db'] = $db;
         $service->setDi($di);
         $result = $service->getRateByCode($code);
         $this->assertEquals($expected, $result);
-
     }
 
     public function testGetDefault()
     {
         $service = new \Box\Mod\Currency\Service();
 
-        $bean  = new \DummyBean();
+        $bean = new \DummyBean();
         $model = new \Model_Currency();
         $model->loadBean($bean);
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
-       $db->expects($this->atLeastOnce())
-           ->method('findOne')
-           ->willReturn(array());
+        $db->expects($this->atLeastOnce())
+            ->method('findOne')
+            ->willReturn([]);
         $db->expects($this->atLeastOnce())
             ->method('load')
             ->willReturn($model);
@@ -258,20 +255,19 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        $firstModel              = new \Model_Currency();
+        $firstModel = new \Model_Currency();
         $firstModel->loadBean(new \DummyBean());
-        $firstModel->code        = 'USD';
-        $firstModel->is_default  = 0;
-        $secondModel             = new \Model_Currency();
+        $firstModel->code = 'USD';
+        $firstModel->is_default = 0;
+        $secondModel = new \Model_Currency();
         $secondModel->loadBean(new \DummyBean());
-        $secondModel->code       = 'USD';
+        $secondModel->code = 'USD';
         $secondModel->is_default = 1;
 
-
-        return array(
-            array($firstModel, $self->atLeastOnce()),
-            array($secondModel, $self->never()),
-        );
+        return [
+            [$firstModel, $self->atLeastOnce()],
+            [$secondModel, $self->never()],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('setAsDefaultProvider')]
@@ -283,14 +279,14 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($expects)
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di['db']     = $db;
+        $di['db'] = $db;
         $di['logger'] = new \Box_Log();
         $service->setDi($di);
         $result = $service->setAsDefault($model);
 
-        $this->assertEquals(true, $result);
+        $this->assertTrue($result);
     }
 
     public function testSetAsDefaultException()
@@ -301,33 +297,33 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->never())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $model             = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->is_default = 0;
-        $model->code       = null;
+        $model->code = null;
 
         $di['db'] = $db;
         $service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $service->setAsDefault($model); //Currency code is null, should throw an \FOSSBilling\Exception
+        $service->setAsDefault($model); // Currency code is null, should throw an \FOSSBilling\Exception
     }
 
     public function testgetPairs()
     {
         $service = new \Box\Mod\Currency\Service();
 
-        $pairs = array(
+        $pairs = [
             'USD' => 'US Dollar',
             'EUR' => 'Euro',
-            'GBP' => 'Pound Sterling'
-        );
-        $di    = new \Pimple\Container();
-        $db    = $this->getMockBuilder('Box_Database')->getMock();
+            'GBP' => 'Pound Sterling',
+        ];
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($pairs));
+            ->willReturn($pairs);
 
         $di['db'] = $db;
         $service->setDi($di);
@@ -340,7 +336,7 @@ class ServiceTest extends \BBTestCase
     {
         $service = new \Box\Mod\Currency\Service();
 
-        $availableCurrencies = array(
+        $availableCurrencies = [
             'AED' => 'AED - United Arab Emirates dirham',
             'AFN' => 'AFN - Afghan afghani',
             'ALL' => 'ALL - Albanian lek',
@@ -494,7 +490,7 @@ class ServiceTest extends \BBTestCase
             'ZAR' => 'ZAR - South African rand',
             'ZMK' => 'ZMK - Zambian kwacha',
             'ZWL' => 'ZWL - Zimbabwe dollar',
-        );
+        ];
 
         $result = $service->getAvailableCurrencies();
 
@@ -509,19 +505,18 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->never())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $model             = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
-        $model->code       = 'EUR';
+        $model->code = 'EUR';
         $model->is_default = 1;
 
         $di['db'] = $db;
         $service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $service->rm($model); //will throw \FOSSBilling\Exception because default currency can not be removed
+        $service->rm($model); // will throw \FOSSBilling\Exception because default currency can not be removed
     }
-
 
     public function testRm()
     {
@@ -531,11 +526,11 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $model             = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
-        $model->code       = 'EUR';
+        $model->code = 'EUR';
         $model->is_default = 0;
 
         $di['db'] = $db;
@@ -553,17 +548,17 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->never())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $model             = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->is_default = 0;
-        $model->code       = null;
+        $model->code = null;
 
         $di['db'] = $db;
         $service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $service->rm($model); //will throw \FOSSBilling\Exception because currency code is not set
+        $service->rm($model); // will throw \FOSSBilling\Exception because currency code is not set
     }
 
     public function testToApiArray()
@@ -573,22 +568,21 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
 
-        $model->code            = 'EUR';
-        $model->title           = 'Euro';
+        $model->code = 'EUR';
+        $model->title = 'Euro';
         $model->conversion_rate = '3.4528';
-        $model->format          = '';
-        $model->price_format    = '';
-        $model->is_default      = 1;
+        $model->format = '';
+        $model->price_format = '';
+        $model->is_default = 1;
 
-
-        $expected = array(
-            'code'            => $model->code,
-            'title'           => $model->title,
-            'conversion_rate' => (float)$model->conversion_rate,
-            'format'          => $model->format,
-            'price_format'    => $model->price_format,
-            'default'         => $model->is_default,
-        );
+        $expected = [
+            'code' => $model->code,
+            'title' => $model->title,
+            'conversion_rate' => (float) $model->conversion_rate,
+            'format' => $model->format,
+            'price_format' => $model->price_format,
+            'default' => $model->is_default,
+        ];
 
         $result = $service->toApiArray($model);
         $this->assertEquals($result, $expected);
@@ -598,13 +592,13 @@ class ServiceTest extends \BBTestCase
     {
         $service = new \Box\Mod\Currency\Service();
 
-        $code   = 'EUR';
+        $code = 'EUR';
         $format = '€{{price}}';
 
-        $systemService= $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->onlyMethods(array('checkLimits'))->getMock();
+        $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->onlyMethods(['checkLimits'])->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('checkLimits')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $currencyModel = new \Model_Tld();
         $currencyModel->loadBean(new \DummyBean());
@@ -612,16 +606,15 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($currencyModel));
+            ->willReturn($currencyModel);
 
-
-        $di                = new \Pimple\Container();
-        $di['logger']      = new \Box_Log();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemService);
         $service->setDi($di);
 
         $result = $service->createCurrency($code, $format, 'Euros', 0.6);
@@ -629,48 +622,46 @@ class ServiceTest extends \BBTestCase
         $this->assertIsString($result);
         $this->assertEquals(strlen($result), 3);
         $this->assertEquals($result, $code);
-
     }
 
     public function testUpdateCurrency()
     {
-        $code            = 'EUR';
-        $format          = '€{{price}}';
-        $title           = 'Euros';
-        $price_format    = '€{{Price}}';
+        $code = 'EUR';
+        $format = '€{{price}}';
+        $title = 'Euros';
+        $price_format = '€{{Price}}';
         $conversion_rate = 0.6;
 
-        $model       = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getByCode'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getByCode'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di           = new \Pimple\Container();
-        $db           = $this->getMockBuilder('Box_Database')->getMock();
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $di['logger'] = new \Box_Log();
-        $di['db']     = $db;
+        $di['db'] = $db;
         $service->setDi($di);
 
         $result = $service->updateCurrency($code, $format, $title, $price_format, $conversion_rate);
 
         $this->assertIsBool($result);
         $this->assertEquals($result, true);
-
     }
 
     public function testUpdateCurrencyNotFoundException()
     {
-        $code            = 'EUR';
-        $format          = '€{{price}}';
-        $title           = 'Euros';
-        $price_format    = '€{{Price}}';
+        $code = 'EUR';
+        $format = '€{{price}}';
+        $title = 'Euros';
+        $price_format = '€{{Price}}';
         $conversion_rate = 0.6;
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getByCode'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getByCode'])->getMock();
         $di = new \Pimple\Container();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -680,23 +671,23 @@ class ServiceTest extends \BBTestCase
 
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue(false));
-            $this->expectException(\FOSSBilling\Exception::class);
+            ->willReturn(false);
+        $this->expectException(\FOSSBilling\Exception::class);
 
-        $service->updateCurrency($code, $format, $title, $price_format, $conversion_rate); //Expecting \FOSSBilling\Exception every time
+        $service->updateCurrency($code, $format, $title, $price_format, $conversion_rate); // Expecting \FOSSBilling\Exception every time
     }
 
     public function testUpdateConversionRateException()
     {
-        $code            = 'EUR';
-        $format          = '€{{price}}';
-        $title           = 'Euros';
-        $price_format    = '€{{Price}}';
+        $code = 'EUR';
+        $format = '€{{price}}';
+        $title = 'Euros';
+        $price_format = '€{{Price}}';
         $conversion_rate = 0;
 
-        $model       = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getByCode'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getByCode'])->getMock();
         $di = new \Pimple\Container();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -706,90 +697,87 @@ class ServiceTest extends \BBTestCase
 
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $service->updateCurrency($code, $format, $title, $price_format, $conversion_rate); //Expecting \FOSSBilling\Exception every time
+        $service->updateCurrency($code, $format, $title, $price_format, $conversion_rate); // Expecting \FOSSBilling\Exception every time
     }
 
     public function testUpdateCurrencyRates()
     {
-        $model       = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getDefault', '_getRate'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getDefault', '_getRate'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('_getRate')
-            ->will($this->returnValue(random_int(1, 50) / 10));
+            ->willReturn(random_int(1, 50) / 10);
 
-        $bean             = new \DummyBean();
+        $bean = new \DummyBean();
         $bean->is_default = 1;
-        $bean->code       = 'EUR';
+        $bean->code = 'EUR';
 
-        $bean2             = new \DummyBean();
+        $bean2 = new \DummyBean();
         $bean2->is_default = 0;
-        $bean2->code       = 'USD';
+        $bean2->code = 'USD';
 
-
-        $beansArray = array(
-            $bean, $bean2
-        );
+        $beansArray = [
+            $bean, $bean2,
+        ];
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue($beansArray));
+            ->willReturn($beansArray);
 
         $di['logger'] = new \Box_Log();
-        $di['db']     = $db;
+        $di['db'] = $db;
         $service->setDi($di);
 
-        $result = $service->updateCurrencyRates(array());
+        $result = $service->updateCurrencyRates([]);
 
         $this->assertIsBool($result);
         $this->assertEquals($result, true);
     }
 
-
     public function testUpdateCurrencyRatesRateNotNumeric()
     {
-        $model       = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getDefault', '_getRate'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getDefault', '_getRate'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('_getRate')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $bean             = new \DummyBean();
+        $bean = new \DummyBean();
         $bean->is_default = 0;
-        $bean->code       = 'EUR';
+        $bean->code = 'EUR';
 
-
-        $beansArray = array(
-            $bean
-        );
+        $beansArray = [
+            $bean,
+        ];
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue($beansArray));
+            ->willReturn($beansArray);
 
         $di['logger'] = new \Box_Log();
-        $di['db']     = $db;
+        $di['db'] = $db;
         $service->setDi($di);
 
-        $result = $service->updateCurrencyRates(array());
+        $result = $service->updateCurrencyRates([]);
 
         $this->assertIsBool($result);
         $this->assertEquals($result, true);
@@ -797,31 +785,29 @@ class ServiceTest extends \BBTestCase
 
     public function testDelete()
     {
-        $model       = new \Model_Currency();
+        $model = new \Model_Currency();
         $model->loadBean(new \DummyBean());
         $model->code = 'EUR';
 
-
         $code = 'EUR';
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getByCode', 'rm'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getByCode', 'rm'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('rm')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $manager = $this->getMockBuilder('Box_EventManager')->getMock();
         $manager->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-
-        $di                   = new \Pimple\Container();
-        $db                   = $this->getMockBuilder('Box_Database')->getMock();
-        $di['logger']         = new \Box_Log();
-        $di['db']             = $db;
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $db;
         $di['events_manager'] = $manager;
 
         $service->setDi($di);
@@ -836,10 +822,10 @@ class ServiceTest extends \BBTestCase
     {
         $code = 'EUR';
 
-        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(array('getByCode', 'rm'))->getMock();
+        $service = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->onlyMethods(['getByCode', 'rm'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $service->deleteCurrencyByCode($code);
@@ -855,5 +841,4 @@ class ServiceTest extends \BBTestCase
         $this->expectException(\Exception::class);
         $service->validateCurrencyFormat('$$$');
     }
-
 }

--- a/tests/modules/Email/Api/Api_AdminTest.php
+++ b/tests/modules/Email/Api/Api_AdminTest.php
@@ -1,28 +1,27 @@
 <?php
+
 namespace Box\Tests\Mod\Email\Api;
 
 class Api_AdminTest extends \BBTestCase
 {
-
-    public function testEmail_get_list()
+    public function testEmailGetList()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
         $emailService = new \Box\Mod\Email\Service();
 
-        $willReturn = array(
-            "list" => array(
-                'id' => 1
-            ),
-        );
-
+        $willReturn = [
+            'list' => [
+                'id' => 1,
+            ],
+        ];
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pager;
+        $di = new \Pimple\Container();
+        $di['pager'] = $pager;
 
         $adminApi->setDi($di);
         $emailService->setDi($di);
@@ -30,68 +29,67 @@ class Api_AdminTest extends \BBTestCase
         $service = $emailService;
         $adminApi->setService($service);
 
-        $result = $adminApi->email_get_list(array());
+        $result = $adminApi->email_get_list([]);
         $this->assertIsArray($result);
 
         $this->assertArrayHasKey('list', $result);
         $this->assertIsArray($result['list']);
     }
 
-
-    public function testEmail_get()
+    public function testEmailGet()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data         = array(
-            'id' => 1
-        );
-        $id           = 10;
-        $client_id    = 5;
-        $sender       = 'sender@example.com';
-        $recipients   = 'recipient@example.com';
-        $subject      = 'Subject';
+        $data = [
+            'id' => 1,
+        ];
+        $id = 10;
+        $client_id = 5;
+        $sender = 'sender@example.com';
+        $recipients = 'recipient@example.com';
+        $subject = 'Subject';
         $content_html = 'HTML';
         $content_text = 'TEXT';
-        $created      = date('Y-m-d H:i:s', time() - 86400);
-        $updated      = date('Y-m-d H:i:s');
+        $created = date('Y-m-d H:i:s', time() - 86400);
+        $updated = date('Y-m-d H:i:s');
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
-        $model->id           = $id;
-        $model->client_id    = $client_id;
-        $model->sender       = $sender;
-        $model->recipients   = $recipients;
-        $model->subject      = $subject;
+        $model->id = $id;
+        $model->client_id = $client_id;
+        $model->sender = $sender;
+        $model->recipients = $recipients;
+        $model->subject = $subject;
         $model->content_html = $content_html;
         $model->content_text = $content_text;
-        $model->created_at   = $created;
-        $model->updated_at   = $updated;
+        $model->created_at = $created;
+        $model->updated_at = $updated;
 
-        $expected = array(
-            'id'           => $id,
-            'client_id'    => $client_id,
-            'sender'       => $sender,
-            'recipients'   => $recipients,
-            'subject'      => $subject,
+        $expected = [
+            'id' => $id,
+            'client_id' => $client_id,
+            'sender' => $sender,
+            'recipients' => $recipients,
+            'subject' => $subject,
             'content_html' => $content_html,
             'content_text' => $content_text,
-            'created_at'   => $created,
-            'updated_at'   => $updated,
-        );
+            'created_at' => $created,
+            'updated_at' => $updated,
+        ];
 
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('getEmailById', 'toApiArray'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['getEmailById', 'toApiArray'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getEmailById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -107,27 +105,27 @@ class Api_AdminTest extends \BBTestCase
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'to'        => 'to@example.com',
-            'to_name'   => 'Recipient Name',
-            'from'      => 'from@example.com',
+        $data = [
+            'to' => 'to@example.com',
+            'to_name' => 'Recipient Name',
+            'from' => 'from@example.com',
             'from_name' => 'Sender Name',
-            'subject'   => 'Subject',
-            'content'   => 'Content'
-        );
+            'subject' => 'Subject',
+            'content' => 'Content',
+        ];
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
         $model->id = 1;
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('sendMail'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['sendMail'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('sendMail')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
-        $validatorMock   = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray');
         $di['validator'] = $validatorMock;
 
@@ -143,9 +141,9 @@ class Api_AdminTest extends \BBTestCase
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
@@ -154,22 +152,22 @@ class Api_AdminTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('resend'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['resend'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('resend')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi->setService($emailService);
 
@@ -178,25 +176,25 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testResend_ExceptionEmailNotFound()
+    public function testResendExceptionEmailNotFound()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -205,27 +203,25 @@ class Api_AdminTest extends \BBTestCase
         $adminApi->email_resend($data);
     }
 
-
-    public function testDelete_ExceptionEmailNotFound()
+    public function testDeleteExceptionEmailNotFound()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -234,15 +230,14 @@ class Api_AdminTest extends \BBTestCase
         $adminApi->email_delete($data);
     }
 
-
-    public function testEmail_delete()
+    public function testEmailDelete()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
         $emailService = new \Box\Mod\Email\Service();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
@@ -251,21 +246,20 @@ class Api_AdminTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $db->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-
         $loggerMock = $this->getMockBuilder('Box_Log')->getMock();
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
-        $di['logger']    = $loggerMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $di['logger'] = $loggerMock;
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -276,27 +270,26 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
-    public function testTemplate_get_list()
+    public function testTemplateGetList()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
         $emailService = new \Box\Mod\Email\Service();
 
-        $willReturn = array(
-            "list" => array(
-                array(
+        $willReturn = [
+            'list' => [
+                [
                 'id' => 1,
-                )
-            ),
-        );
+                ],
+            ],
+        ];
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pager;
+        $di = new \Pimple\Container();
+        $di['pager'] = $pager;
 
         $adminApi->setDi($di);
         $emailService->setDi($di);
@@ -304,20 +297,20 @@ class Api_AdminTest extends \BBTestCase
         $service = $emailService;
         $adminApi->setService($service);
 
-        $result = $adminApi->template_get_list(array());
+        $result = $adminApi->template_get_list([]);
         $this->assertIsArray($result);
 
         $this->assertArrayHasKey('list', $result);
         $this->assertIsArray($result['list']);
     }
 
-    public function testTemplate_get()
+    public function testTemplateGet()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $model = new \Model_EmailTemplate();
         $model->loadBean(new \DummyBean());
@@ -325,34 +318,34 @@ class Api_AdminTest extends \BBTestCase
         $db = $this->getMockBuilder('\Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('templateToApiArray'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['templateToApiArray'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('templateToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($emailService);
 
         $result = $adminApi->template_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testTemplate_delete()
+    public function testTemplateDelete()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $model = new \Model_EmailTemplate();
         $model->loadBean(new \DummyBean());
@@ -361,7 +354,7 @@ class Api_AdminTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $loggerMock = $this->getMockBuilder('Box_Log')->getMock();
 
@@ -369,35 +362,35 @@ class Api_AdminTest extends \BBTestCase
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
-        $di['logger']    = $loggerMock;
+        $di['logger'] = $loggerMock;
         $adminApi->setDi($di);
 
         $result = $adminApi->template_delete($data);
         $this->assertTrue($result);
     }
 
-    public function testtemplate_delete_TemplateNotFound()
+    public function testtemplateDeleteTemplateNotFound()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -406,8 +399,7 @@ class Api_AdminTest extends \BBTestCase
         $adminApi->template_delete($data);
     }
 
-
-    public function testTemplate_create()
+    public function testTemplateCreate()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
@@ -417,22 +409,22 @@ class Api_AdminTest extends \BBTestCase
         $templateModel->loadBean(new \DummyBean());
         $templateModel->id = $modelId;
 
-        $data = array(
+        $data = [
             'action_code' => 'Action_code',
-            'subject'     => 'Subject',
-            'content'     => 'Content'
-        );
+            'subject' => 'Subject',
+            'content' => 'Content',
+        ];
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('templateCreate'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['templateCreate'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('templateCreate')
-            ->will($this->returnValue($templateModel));
+            ->willReturn($templateModel);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -442,56 +434,56 @@ class Api_AdminTest extends \BBTestCase
         $this->assertEquals($result, $modelId);
     }
 
-    public function testTemplate_sendToNotSetException()
+    public function testTemplateSendToNotSetException()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $adminApi->template_send(array('code' => 'code'));
+        $adminApi->template_send(['code' => 'code']);
     }
 
-    public function testTemplate_update()
+    public function testTemplateUpdate()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $id   = random_int(1, 100);
-        $data = array(
-            'id'          => $id,
-            'enabled'     => '1',
-            'category'    => 'Category',
+        $id = random_int(1, 100);
+        $data = [
+            'id' => $id,
+            'enabled' => '1',
+            'category' => 'Category',
             'action_code' => 'Action_code',
-            'category'    => '',
-            'subject'     => 'Subject',
-            'content'     => 'Content'
-        );
+            'category' => '',
+            'subject' => 'Subject',
+            'content' => 'Content',
+        ];
 
         $emailTemplateModel = new \Model_EmailTemplate();
         $emailTemplateModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($emailTemplateModel));
+            ->willReturn($emailTemplateModel);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('updateTemplate'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['updateTemplate'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('updateTemplate')
             ->with($emailTemplateModel, $data['enabled'], $data['category'], $data['subject'], $data['content'])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $adminApi->setService($emailService);
         $adminApi->setDi($di);
 
@@ -499,24 +491,24 @@ class Api_AdminTest extends \BBTestCase
         $this->assertEquals($result, true);
     }
 
-    public function testTemplate_reset()
+    public function testTemplateReset()
     {
         $adminApi = new \Box\Mod\Email\Api\Admin();
 
-        $id   = random_int(1, 100);
-        $data = array(
-            'code' => 'CODE'
-        );
+        $id = random_int(1, 100);
+        $data = [
+            'code' => 'CODE',
+        ];
 
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('resetTemplateByCode'))->getMock();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['resetTemplateByCode'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('resetTemplateByCode')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -526,13 +518,13 @@ class Api_AdminTest extends \BBTestCase
         $this->assertEquals($result, $id);
     }
 
-    public function testBatch_template_generate()
+    public function testBatchTemplateGenerate()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('templateBatchGenerate'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['templateBatchGenerate'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('templateBatchGenerate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi->setService($emailService);
 
@@ -540,63 +532,63 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testBatch_template_disable()
+    public function testBatchTemplateDisable()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('templateBatchDisable'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['templateBatchDisable'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('templateBatchDisable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi->setService($emailService);
 
-        $result = $adminApi->batch_template_disable(array());
+        $result = $adminApi->batch_template_disable([]);
         $this->assertTrue($result);
     }
 
-    public function testBatch_template_enable()
+    public function testBatchTemplateEnable()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('templateBatchEnable'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['templateBatchEnable'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('templateBatchEnable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi->setService($emailService);
 
-        $result = $adminApi->batch_template_enable(array());
+        $result = $adminApi->batch_template_enable([]);
         $this->assertTrue($result);
     }
 
-    public function testSend_test()
+    public function testSendTest()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('sendTemplate'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['sendTemplate'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi->setService($emailService);
 
-        $result = $adminApi->send_test(array());
+        $result = $adminApi->send_test([]);
         $this->assertTrue($result);
     }
 
-    public function testBatch_sendmail()
+    public function testBatchSendmail()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('batchSend'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['batchSend'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('batchSend')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $extension = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->getMock();
         $extension->expects($this->atLeastOnce())
             ->method('isExtensionActive')
-            ->will($this->returnValue($isExtensionActiveReturn));
+            ->willReturn($isExtensionActiveReturn);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $extension);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $extension);
 
         $adminApi->setService($emailService);
         $adminApi->setDi($di);
@@ -605,18 +597,18 @@ class Api_AdminTest extends \BBTestCase
         $this->assertNull($result);
     }
 
-    public function testTemplate_send()
+    public function testTemplateSend()
     {
-        $adminApi     = new \Box\Mod\Email\Api\Admin();
-        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('sendTemplate'))->getMock();
+        $adminApi = new \Box\Mod\Email\Api\Admin();
+        $emailService = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['sendTemplate'])->getMock();
         $emailService->expects($this->atLeastOnce())
             ->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -624,61 +616,59 @@ class Api_AdminTest extends \BBTestCase
 
         $adminApi->setService($emailService);
 
-        $data = array(
-            'code'                => 'mod_email_test',
-            'to'                  => 'example@example.com',
-            'default_subject'     => 'SUBJECT',
-            'default_template'    => 'TEMPLATE',
+        $data = [
+            'code' => 'mod_email_test',
+            'to' => 'example@example.com',
+            'default_subject' => 'SUBJECT',
+            'default_template' => 'TEMPLATE',
             'default_description' => 'DESCRIPTION',
-        );
+        ];
 
         $result = $adminApi->template_send($data);
         $this->assertTrue($result);
     }
 
-    public function testTemplate_render()
+    public function testTemplateRender()
     {
-
-        $adminApi = $this->getMockBuilder(\Box\Mod\Email\Api\Admin::class)->onlyMethods(array('template_get'))->getMock();
+        $adminApi = $this->getMockBuilder(\Box\Mod\Email\Api\Admin::class)->onlyMethods(['template_get'])->getMock();
         $adminApi->expects($this->atLeastOnce())
             ->method('template_get')
-            ->will($this->returnValue(array('vars' => array(), 'content' => 'content')));
+            ->willReturn(['vars' => [], 'content' => 'content']);
 
         $loader = new \Twig\Loader\ArrayLoader();
-        $twig = $this->getMockBuilder(\Twig\Environment::class)->setConstructorArgs([$loader,['debug' => false]])->getMock();
+        $twig = $this->getMockBuilder(\Twig\Environment::class)->setConstructorArgs([$loader, ['debug' => false]])->getMock();
 
-        $di         = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['twig'] = $twig;
 
         $systemService = $this->getMockBuilder(\Box\Mod\System\Service::class)->onlyMethods(['renderString'])->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('renderString')
-            ->will($this->returnValue('rendered'));
+            ->willReturn('rendered');
 
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di['mod_service'] = $di->protect(fn () => $systemService);
 
         $adminApi->setDi($di);
 
-        $result = $adminApi->template_render(array('id' => 5));
+        $result = $adminApi->template_render(['id' => 5]);
         $this->assertEquals($result, 'rendered');
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Api\Admin::class)->onlyMethods(array('email_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('email_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Api\Admin::class)->onlyMethods(['email_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('email_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
-
 }

--- a/tests/modules/Email/Api/Api_ClientTest.php
+++ b/tests/modules/Email/Api/Api_ClientTest.php
@@ -1,25 +1,25 @@
 <?php
-namespace Box\Tests\Mod\Email\Api;
 
+namespace Box\Tests\Mod\Email\Api;
 
 class Api_ClientTest extends \BBTestCase
 {
-    public function testGet_list()
+    public function testGetList()
     {
-        $clientApi    = new \Box\Mod\Email\Api\Client();
+        $clientApi = new \Box\Mod\Email\Api\Client();
         $emailService = new \Box\Mod\Email\Service();
 
-        $willReturn = array(
-            "list"     => array(
-                'id' => 1
-            ),
-        );
+        $willReturn = [
+            'list' => [
+                'id' => 1,
+            ],
+        ];
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $pager;
 
         $clientApi->setDi($di);
@@ -28,12 +28,12 @@ class Api_ClientTest extends \BBTestCase
         $service = $emailService;
         $clientApi->setService($service);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
         $clientApi->setIdentity($client);
 
-        $result = $clientApi->get_list(array());
+        $result = $clientApi->get_list([]);
         $this->assertIsArray($result);
 
         $this->assertArrayHasKey('list', $result);
@@ -44,47 +44,45 @@ class Api_ClientTest extends \BBTestCase
     {
         $clientApi = new \Box\Mod\Email\Api\Client();
 
-
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById', 'toApiArray'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById', 'toApiArray'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $clientApi->setService($service);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $clientApi->setDi($di);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
         $clientApi->setIdentity($client);
 
-        $result = $clientApi->get(array('id' => 1));
+        $result = $clientApi->get(['id' => 1]);
         $this->assertIsArray($result);
-
     }
 
     public function testGetNotFoundException()
     {
         $clientApi = new \Box\Mod\Email\Api\Client();
 
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
         $clientApi->setIdentity($client);
@@ -92,7 +90,7 @@ class Api_ClientTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -101,9 +99,8 @@ class Api_ClientTest extends \BBTestCase
         $clientApi->setService($service);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $clientApi->get(array('id' => 1));
+        $result = $clientApi->get(['id' => 1]);
         $this->assertIsArray($result);
-
     }
 
     public function testResend()
@@ -113,15 +110,15 @@ class Api_ClientTest extends \BBTestCase
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
 
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById', 'resend'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById', 'resend'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('resend')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
         $clientApi->setIdentity($client);
@@ -129,7 +126,7 @@ class Api_ClientTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -137,21 +134,20 @@ class Api_ClientTest extends \BBTestCase
 
         $clientApi->setService($service);
 
-        $result = $clientApi->resend(array('id' => 1));
+        $result = $clientApi->resend(['id' => 1]);
         $this->assertTrue($result);
-
     }
 
     public function testResendNotFoundException()
     {
         $clientApi = new \Box\Mod\Email\Api\Client();
 
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
 
@@ -160,7 +156,7 @@ class Api_ClientTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -169,9 +165,8 @@ class Api_ClientTest extends \BBTestCase
         $clientApi->setService($service);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $clientApi->resend(array('id' => 1));
+        $result = $clientApi->resend(['id' => 1]);
         $this->assertIsArray($result);
-
     }
 
     public function testDelete()
@@ -182,15 +177,15 @@ class Api_ClientTest extends \BBTestCase
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById', 'rm'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById', 'rm'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $service->expects($this->atLeastOnce())
             ->method('rm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
         $clientApi->setIdentity($client);
@@ -198,27 +193,26 @@ class Api_ClientTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $clientApi->setDi($di);
 
         $clientApi->setService($service);
 
-        $result = $clientApi->delete(array('id' => 1));
+        $result = $clientApi->delete(['id' => 1]);
         $this->assertTrue($result);
-
     }
 
     public function testDeleteNotFoundException()
     {
         $clientApi = new \Box\Mod\Email\Api\Client();
 
-        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(array('findOneForClientById'))->getMock();
+        $service = $this->getMockBuilder(\Box\Mod\Email\Service::class)->onlyMethods(['findOneForClientById'])->getMock();
         $service->expects($this->atLeastOnce())
             ->method('findOneForClientById')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
 
@@ -227,7 +221,7 @@ class Api_ClientTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -236,10 +230,7 @@ class Api_ClientTest extends \BBTestCase
         $clientApi->setService($service);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $clientApi->delete(array('id' => 1));
+        $result = $clientApi->delete(['id' => 1]);
         $this->assertIsArray($result);
-
     }
-
-
 }

--- a/tests/modules/Email/Controller/AdminTest.php
+++ b/tests/modules/Email/Controller/AdminTest.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace Box\Mod\Email\Controller;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testDi()
     {
-        $controller = new \Box\Mod\Email\Controller\Admin();
+        $controller = new Admin();
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -25,18 +23,18 @@ class AdminTest extends \BBTestCase {
         $boxAppMock->expects($this->exactly(5))
             ->method('get');
 
-        $controllerAdmin = new \Box\Mod\Email\Controller\Admin();
+        $controllerAdmin = new Admin();
         $controllerAdmin->register($boxAppMock);
     }
 
-    public function testget_index()
+    public function testgetIndex()
     {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->atLeastOnce())
             ->method('render')
             ->with('mod_email_history');
 
-        $controllerAdmin = new \Box\Mod\Email\Controller\Admin();
+        $controllerAdmin = new Admin();
         $di = new \Pimple\Container();
         $di['is_admin_logged'] = true;
 
@@ -45,4 +43,3 @@ class AdminTest extends \BBTestCase {
         $controllerAdmin->get_history($boxAppMock);
     }
 }
- 

--- a/tests/modules/Email/ServiceTest.php
+++ b/tests/modules/Email/ServiceTest.php
@@ -20,50 +20,50 @@ class ServiceTest extends \BBTestCase
 
     public static function getSearchQueryProvider()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 'SELECT * FROM activity_client_email ORDER BY id DESC',
-                array(),
-            ),
-            array(
-                array(
-                    'search' => "search_query"
-                ),
+                [],
+            ],
+            [
+                [
+                    'search' => 'search_query',
+                ],
                 'SELECT * FROM activity_client_email WHERE (sender LIKE :sender OR recipients LIKE :recipient OR subject LIKE :subject OR content_text LIKE :content_text OR content_html LIKE :content_html) ORDER BY id DESC',
-                array(
-                    ':sender'       => '%search_query%',
-                    ':recipient'    => '%search_query%',
-                    ':subject'      => '%search_query%',
+                [
+                    ':sender' => '%search_query%',
+                    ':recipient' => '%search_query%',
+                    ':subject' => '%search_query%',
                     ':content_text' => '%search_query%',
                     ':content_html' => '%search_query%',
-                ),
-            ),
-            array(
-                array(
-                    'client_id' => 5
-                ),
+                ],
+            ],
+            [
+                [
+                    'client_id' => 5,
+                ],
                 'SELECT * FROM activity_client_email WHERE client_id = :client_id ORDER BY id DESC',
-                array(
+                [
                     ':client_id' => 5,
-                ),
-            ),
-            array(
-                array(
-                    'search'    => "search_query",
-                    'client_id' => 5
-                ),
+                ],
+            ],
+            [
+                [
+                    'search' => 'search_query',
+                    'client_id' => 5,
+                ],
                 'SELECT * FROM activity_client_email WHERE (sender LIKE :sender OR recipients LIKE :recipient OR subject LIKE :subject OR content_text LIKE :content_text OR content_html LIKE :content_html) AND client_id = :client_id ORDER BY id DESC',
-                array(
-                    ':sender'       => '%search_query%',
-                    ':recipient'    => '%search_query%',
-                    ':subject'      => '%search_query%',
+                [
+                    ':sender' => '%search_query%',
+                    ':recipient' => '%search_query%',
+                    ':subject' => '%search_query%',
                     ':content_text' => '%search_query%',
                     ':content_html' => '%search_query%',
-                    ':client_id'    => 5,
-                )
-            ),
-        );
+                    ':client_id' => 5,
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getSearchQueryProvider')]
@@ -84,28 +84,27 @@ class ServiceTest extends \BBTestCase
 
     public function testEmailFindOneForClientById()
     {
-        $service   = new \Box\Mod\Email\Service();
-        $di        = new \Pimple\Container();
-        $id        = 5;
+        $service = new \Box\Mod\Email\Service();
+        $di = new \Pimple\Container();
+        $id = 5;
         $client_id = 1;
 
-        $activityEmail            = new \Model_ActivityClientEmail();
+        $activityEmail = new \Model_ActivityClientEmail();
         $activityEmail->loadBean(new \DummyBean());
         $activityEmail->client_id = $client_id;
-        $activityEmail->id        = $id;
+        $activityEmail->id = $id;
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($activityEmail));
+            ->willReturn($activityEmail);
 
         $di['db'] = $db;
         $service->setDi($di);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = $client_id;
-
 
         $result = $service->findOneForClientById($client, $id);
 
@@ -118,8 +117,7 @@ class ServiceTest extends \BBTestCase
     public function testEmailRmByClient()
     {
         $service = new \Box\Mod\Email\Service();
-        $di      = new \Pimple\Container();
-
+        $di = new \Pimple\Container();
 
         $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
@@ -127,19 +125,18 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($model)));
+            ->willReturn([$model]);
 
         $db->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di['db'] = $db;
         $service->setDi($di);
 
-        $client     = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 1;
-
 
         $result = $service->rmByClient($client);
         $this->assertTrue($result);
@@ -148,17 +145,17 @@ class ServiceTest extends \BBTestCase
     public function testEmailRm()
     {
         $service = new \Box\Mod\Email\Service();
-        $di      = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di['db'] = $db;
         $service->setDi($di);
 
-        $email     = new \Model_ActivityClientEmail();
+        $email = new \Model_ActivityClientEmail();
         $email->loadBean(new \DummyBean());
         $email->id = 1;
 
@@ -170,40 +167,39 @@ class ServiceTest extends \BBTestCase
     {
         $service = new \Box\Mod\Email\Service();
 
-        $id           = 10;
-        $client_id    = 5;
-        $sender       = 'sender@example.com';
-        $recipients   = 'recipient@example.com';
-        $subject      = 'Subject';
+        $id = 10;
+        $client_id = 5;
+        $sender = 'sender@example.com';
+        $recipients = 'recipient@example.com';
+        $subject = 'Subject';
         $content_html = 'HTML';
         $content_text = 'TEXT';
-        $created      = date('Y-m-d H:i:s', time() - 86400);
-        $updated      = date('Y-m-d H:i:s');
+        $created = date('Y-m-d H:i:s', time() - 86400);
+        $updated = date('Y-m-d H:i:s');
 
-        $model               = new \Model_ActivityClientEmail();
+        $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
-        $model->id           = $id;
-        $model->client_id    = $client_id;
-        $model->sender       = $sender;
-        $model->recipients   = $recipients;
-        $model->subject      = $subject;
+        $model->id = $id;
+        $model->client_id = $client_id;
+        $model->sender = $sender;
+        $model->recipients = $recipients;
+        $model->subject = $subject;
         $model->content_html = $content_html;
         $model->content_text = $content_text;
-        $model->created_at   = $created;
-        $model->updated_at   = $updated;
+        $model->created_at = $created;
+        $model->updated_at = $updated;
 
-        $expected = array(
-            'id'           => $id,
-            'client_id'    => $client_id,
-            'sender'       => $sender,
-            'recipients'   => $recipients,
-            'subject'      => $subject,
+        $expected = [
+            'id' => $id,
+            'client_id' => $client_id,
+            'sender' => $sender,
+            'recipients' => $recipients,
+            'subject' => $subject,
             'content_html' => $content_html,
             'content_text' => $content_text,
-            'created_at'   => $created,
-            'updated_at'   => $updated,
-        );
-
+            'created_at' => $created,
+            'updated_at' => $updated,
+        ];
 
         $result = $service->toApiArray($model);
         $this->assertIsArray($result);
@@ -222,16 +218,15 @@ class ServiceTest extends \BBTestCase
             ->method('encrypt');
         $configMock = ['salt' => md5(random_bytes(13))];
 
-
         $di['db'] = $db;
         $di['crypt'] = $cryptMock;
         $di['config'] = $configMock;
         $service->setDi($di);
 
-        $t    = new \stdClass();
-        $vars = array(
-            'param1' => 'value1'
-        );
+        $t = new \stdClass();
+        $vars = [
+            'param1' => 'value1',
+        ];
 
         $result = $service->setVars($t, $vars);
         $this->assertTrue($result);
@@ -248,11 +243,11 @@ class ServiceTest extends \BBTestCase
         $cryptMock->expects($this->atLeastOnce())
             ->method('decrypt');
         $configMock = ['salt' => md5(random_bytes(13))];
-        $expected = array('param1' => 'value1');
+        $expected = ['param1' => 'value1'];
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $di['db'] = $db;
         $di['tools'] = $toolsMock;
@@ -260,7 +255,7 @@ class ServiceTest extends \BBTestCase
         $di['config'] = $configMock;
         $service->setDi($di);
 
-        $t       = new \stdClass();
+        $t = new \stdClass();
         $t->vars = 'haNUZYeNjo1oXhH6OkoKuHGPxakyKY10qR3O/DSy9Og=';
 
         $result = $service->getVars($t);
@@ -271,14 +266,14 @@ class ServiceTest extends \BBTestCase
     public function testSendTemplateNotExists()
     {
         $service = new \Box\Mod\Email\Service();
-        $di      = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
-        $data = array(
-            'code'                => 'mod_email_test_not_existing',
-            'to'                  => 'example@example.com',
-            'default_subject'     => 'SUBJECT',
+        $data = [
+            'code' => 'mod_email_test_not_existing',
+            'to' => 'example@example.com',
+            'default_subject' => 'SUBJECT',
             'default_description' => 'DESCRIPTION',
-        );
+        ];
 
         $emailTemplate = new \Model_EmailTemplate();
         $emailTemplate->loadBean(new \DummyBean());
@@ -286,17 +281,17 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($emailTemplate));
+            ->willReturn($emailTemplate);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $cryptMock = $this->getMockBuilder('\Box_Crypt')->getMock();
         $cryptMock->expects($this->atLeastOnce())
             ->method('encrypt');
         $configMock = ['salt' => md5(random_bytes(13))];
 
-        $di['db']        = $db;
+        $di['db'] = $db;
         $di['crypt'] = $cryptMock;
         $di['config'] = $configMock;
         $di['api_admin'] = function () use ($di) {
@@ -309,7 +304,7 @@ class ServiceTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $service->setDi($di);
 
@@ -320,21 +315,21 @@ class ServiceTest extends \BBTestCase
 
     public function testSendTemplateExists()
     {
-        $data    = array(
-            'code'                => 'mod_email_test',
-            'to'                  => 'example@example.com',
-            'default_subject'     => 'SUBJECT',
-            'default_template'    => 'TEMPLATE',
+        $data = [
+            'code' => 'mod_email_test',
+            'to' => 'example@example.com',
+            'default_subject' => 'SUBJECT',
+            'default_template' => 'TEMPLATE',
             'default_description' => 'DESCRIPTION',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendMail'))
+            ->onlyMethods(['sendMail'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('sendMail')
             ->willReturn(true);
 
-        $di      = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $emailTemplate = new \Model_EmailTemplate();
         $emailTemplate->loadBean(new \DummyBean());
@@ -342,16 +337,15 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($emailTemplate));
+            ->willReturn($emailTemplate);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $systemService = $this->getMockBuilder(\Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue('value'));
-
+            ->willReturn('value');
 
         $twig = $this->getMockBuilder('\\' . \Twig\Environment::class)->disableOriginalConstructor()->getMock();
 
@@ -364,7 +358,7 @@ class ServiceTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $cryptMock = $this->getMockBuilder('\Box_Crypt')
@@ -373,10 +367,10 @@ class ServiceTest extends \BBTestCase
         $cryptMock->expects($this->atLeastOnce())
             ->method('encrypt');
         $configMock = ['salt' => md5(random_bytes(13))];
-        $di['db']          = $db;
-        $di['crypt']       = $cryptMock;
+        $di['db'] = $db;
+        $di['crypt'] = $cryptMock;
         $di['config'] = $configMock;
-        $di['twig']        = $twig;
+        $di['twig'] = $twig;
         $di['mod_service'] = $di->protect(fn () => $systemService);
         $di['tools'] = new \FOSSBilling\Tools();
 
@@ -387,51 +381,49 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
     public static function sendTemplateExistsStaffProvider()
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
-                array(
-                    'code'                => 'mod_email_test',
-                    'to'                  => 'example@example.com',
-                    'default_subject'     => 'SUBJECT',
-                    'default_template'    => 'TEMPLATE',
+        return [
+            [
+                [
+                    'code' => 'mod_email_test',
+                    'to' => 'example@example.com',
+                    'default_subject' => 'SUBJECT',
+                    'default_template' => 'TEMPLATE',
                     'default_description' => 'DESCRIPTION',
-                    'to_staff'            => 1,
-                ),
+                    'to_staff' => 1,
+                ],
                 $self->never(),
                 $self->atLeastOnce(),
-            ),
-            array(
-                array(
-                    'code'                => 'mod_email_test',
-                    'to'                  => 'example@example.com',
-                    'default_subject'     => 'SUBJECT',
-                    'default_template'    => 'TEMPLATE',
+            ],
+            [
+                [
+                    'code' => 'mod_email_test',
+                    'to' => 'example@example.com',
+                    'default_subject' => 'SUBJECT',
+                    'default_template' => 'TEMPLATE',
                     'default_description' => 'DESCRIPTION',
-                    'to_client'           => 1
-                ),
+                    'to_client' => 1,
+                ],
                 $self->atLeastOnce(),
                 $self->never(),
-            ),
-
-        );
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('sendTemplateExistsStaffProvider')]
     public function testSendTemplateExistsStaff($data, $clientGetExpects, $staffgetListExpects)
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendMail'))
+            ->onlyMethods(['sendMail'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('sendMail')
             ->willReturn(true);
 
-        $di      = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $emailTemplate = new \Model_EmailTemplate();
         $emailTemplate->loadBean(new \DummyBean());
@@ -439,35 +431,34 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($emailTemplate));
+            ->willReturn($emailTemplate);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $system = $this->getMockBuilder(\Box\Mod\System\Service::class)->getMock();
         $system->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue('value'));
+            ->willReturn('value');
 
         $system->expects($this->atLeastOnce())
             ->method('renderString')
-            ->will($this->returnValue('value'));
-
+            ->willReturn('value');
 
         $staffServiceMock = $this->getMockBuilder(\Box\Mod\Staff\Service::class)->getMock();
         $staffServiceMock->expects($staffgetListExpects)
             ->method('getList')
-            ->will($this->returnValue(
-                array(
-                    'list' => array(
-                        0 => array(
-                            'id'    => 1,
+            ->willReturn(
+                [
+                    'list' => [
+                        0 => [
+                            'id' => 1,
                             'email' => 'staff@fossbilling.org',
-                            'name'  => 'George'
-                        )
-                    )
-                )
-            ));
+                            'name' => 'George',
+                        ],
+                    ],
+                ]
+            );
 
         $clientServiceMock = $this->getMockBuilder(\Box\Mod\Client\Service::class)->getMock();
 
@@ -475,20 +466,19 @@ class ServiceTest extends \BBTestCase
         $clientModel->loadBean(new \DummyBean());
         $clientServiceMock->expects($clientGetExpects)
             ->method('get')
-            ->will($this->returnValue($clientModel));
-        $clientApiArray = array(
-            'id'         => 1,
-            'email'      => 'staff@fossbilling.org',
+            ->willReturn($clientModel);
+        $clientApiArray = [
+            'id' => 1,
+            'email' => 'staff@fossbilling.org',
             'first_name' => 'John',
-            'last_name'  => 'Smith'
-        );
+            'last_name' => 'Smith',
+        ];
         $clientServiceMock->expects($clientGetExpects)
             ->method('toApiArray')
-            ->will($this->returnValue($clientApiArray));
+            ->willReturn($clientApiArray);
 
         $loader = new \Twig\Loader\ArrayLoader();
         $twig = $this->getMockBuilder(\Twig\Environment::class)->setConstructorArgs([$loader, ['debug' => false]])->getMock();
-
 
         $cryptMock = $this->getMockBuilder('\Box_Crypt')
             ->disableOriginalConstructor()
@@ -508,13 +498,13 @@ class ServiceTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
-        $di['db']          = $db;
-        $di['twig']        = $twig;
-        $di['crypt']       = $cryptMock;
-        $di['config']      = $configMock;
+        $di['db'] = $db;
+        $di['twig'] = $twig;
+        $di['crypt'] = $cryptMock;
+        $di['config'] = $configMock;
         $di['mod_service'] = $di->protect(function ($name) use ($system, $staffServiceMock, $clientServiceMock) {
             if ($name == 'staff') {
                 return $staffServiceMock;
@@ -537,38 +527,38 @@ class ServiceTest extends \BBTestCase
     {
         $service = new \Box\Mod\Email\Service();
 
-        $di       = new \Pimple\Container();
-        $db       = $this->getMockBuilder('Box_Database')->getMock();
+        $di = new \Pimple\Container();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
 
-        $emailSettings = array(
-            'mailer'              => 'sendmail',
+        $emailSettings = [
+            'mailer' => 'sendmail',
             'smtp_authentication' => 'login',
-            'smtp_host'           => NULL,
-            'smtp_security'       => NULL,
-            'smtp_port'           => NULL,
-            'smtp_username'       => NULL,
-            'smtp_password'       => NULL,
-        );
+            'smtp_host' => null,
+            'smtp_security' => null,
+            'smtp_port' => null,
+            'smtp_username' => null,
+            'smtp_password' => null,
+        ];
 
-        $di['db']          = $db;
+        $di['db'] = $db;
         $extension = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->getMock();
         $extension->expects($this->atLeastOnce())
             ->method('isExtensionActive')
-            ->will($this->returnValue($isExtensionActiveReturn));
+            ->willReturn($isExtensionActiveReturn);
 
-        $config = array();
-        $di['mod_config']  = $di->protect(fn ($modName) => $config);
+        $config = [];
+        $di['mod_config'] = $di->protect(fn ($modName) => $config);
         $di['mod_service'] = $di->protect(fn () => $extension);
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $service->setDi($di);
 
-        $model               = new \Model_ActivityClientEmail();
+        $model = new \Model_ActivityClientEmail();
         $model->loadBean(new \DummyBean());
-        $model->client_id    = 1;
-        $model->sender       = 'sender@exemple.com';
-        $model->recipients   = 'recipient@example.com';
-        $model->subject      = 'Email Title';
+        $model->client_id = 1;
+        $model->sender = 'sender@exemple.com';
+        $model->recipients = 'recipient@example.com';
+        $model->subject = 'Email Title';
         $model->content_html = '<b>Content</b>';
         $model->content_text = 'Content';
 
@@ -579,47 +569,46 @@ class ServiceTest extends \BBTestCase
 
     public static function templateGetSearchQueryProvider()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 'SELECT * FROM email_template ORDER BY category ASC',
-                array()
-            ),
-            array(
-                array(
-                    'search' => 'keyword'
-                ),
-                'SELECT * FROM email_template WHERE (action_code LIKE :action_code OR subject LIKE :subject OR content LIKE :content) ORDER BY category ASC',
-                array(
-                    ':action_code' => '%keyword%',
-                    ':subject'     => '%keyword%',
-                    ':content'     => '%keyword%',
-                ),
-            ),
-            array(
-                array(
+                [],
+            ],
+            [
+                [
                     'search' => 'keyword',
-                    'code'   => 'code'
-                ),
-                'SELECT * FROM email_template WHERE action_code LIKE :code AND (action_code LIKE :action_code OR subject LIKE :subject OR content LIKE :content) ORDER BY category ASC',
-                array(
-                    ':code'        => '%code%',
+                ],
+                'SELECT * FROM email_template WHERE (action_code LIKE :action_code OR subject LIKE :subject OR content LIKE :content) ORDER BY category ASC',
+                [
                     ':action_code' => '%keyword%',
-                    ':subject'     => '%keyword%',
-                    ':content'     => '%keyword%',
-                ),
-            ),
-            array(
-                array(
-                    'code' => 'code'
-                ),
-                'SELECT * FROM email_template WHERE action_code LIKE :code ORDER BY category ASC',
-                array(
+                    ':subject' => '%keyword%',
+                    ':content' => '%keyword%',
+                ],
+            ],
+            [
+                [
+                    'search' => 'keyword',
+                    'code' => 'code',
+                ],
+                'SELECT * FROM email_template WHERE action_code LIKE :code AND (action_code LIKE :action_code OR subject LIKE :subject OR content LIKE :content) ORDER BY category ASC',
+                [
                     ':code' => '%code%',
-                ),
-            ),
-
-        );
+                    ':action_code' => '%keyword%',
+                    ':subject' => '%keyword%',
+                    ':content' => '%keyword%',
+                ],
+            ],
+            [
+                [
+                    'code' => 'code',
+                ],
+                'SELECT * FROM email_template WHERE action_code LIKE :code ORDER BY category ASC',
+                [
+                    ':code' => '%code%',
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('templateGetSearchQueryProvider')]
@@ -640,37 +629,35 @@ class ServiceTest extends \BBTestCase
 
     public function testTemplateToApiArray()
     {
-        $id          = 1;
+        $id = 1;
         $action_code = 'code';
-        $category    = 'category';
-        $enabled     = 1;
-        $subject     = 'Subject';
+        $category = 'category';
+        $enabled = 1;
+        $subject = 'Subject';
         $description = 'Description';
-        $content     = 'content';
+        $content = 'content';
 
-        $model              = new \Model_EmailTemplate();
+        $model = new \Model_EmailTemplate();
         $model->loadBean(new \DummyBean());
-        $model->id          = $id;
+        $model->id = $id;
         $model->action_code = $action_code;
-        $model->category    = $category;
-        $model->enabled     = $enabled;
-        $model->subject     = $subject;
+        $model->category = $category;
+        $model->enabled = $enabled;
+        $model->subject = $subject;
         $model->description = $description;
-        $model->content     = $content;
+        $model->content = $content;
 
-
-        $expected = array(
-            'id'          => $id,
+        $expected = [
+            'id' => $id,
             'action_code' => $action_code,
-            'category'    => $category,
-            'enabled'     => $enabled,
-            'subject'     => $subject,
+            'category' => $category,
+            'enabled' => $enabled,
+            'subject' => $subject,
             'description' => $description,
-        );
-
+        ];
 
         $service = new \Box\Mod\Email\Service();
-        $result  = $service->templateToApiArray($model);
+        $result = $service->templateToApiArray($model);
 
         $this->assertIsArray($result);
         $this->assertEquals($result, $expected);
@@ -678,43 +665,41 @@ class ServiceTest extends \BBTestCase
 
     public function testTemplateToApiArrayDeep()
     {
-        $id          = 1;
+        $id = 1;
         $action_code = 'code';
-        $category    = 'category';
-        $enabled     = 1;
-        $subject     = 'Subject';
+        $category = 'category';
+        $enabled = 1;
+        $subject = 'Subject';
         $description = 'Description';
-        $content     = 'content';
+        $content = 'content';
 
-        $model              = new \Model_EmailTemplate();
+        $model = new \Model_EmailTemplate();
         $model->loadBean(new \DummyBean());
-        $model->id          = $id;
+        $model->id = $id;
         $model->action_code = $action_code;
-        $model->category    = $category;
-        $model->enabled     = $enabled;
-        $model->subject     = $subject;
+        $model->category = $category;
+        $model->enabled = $enabled;
+        $model->subject = $subject;
         $model->description = $description;
-        $model->content     = $content;
+        $model->content = $content;
 
-
-        $expected = array(
-            'id'          => $id,
+        $expected = [
+            'id' => $id,
             'action_code' => $action_code,
-            'category'    => $category,
-            'enabled'     => $enabled,
-            'subject'     => $subject,
+            'category' => $category,
+            'enabled' => $enabled,
+            'subject' => $subject,
             'description' => $description,
-            'content'     => $content,
-            'vars'        => array(
-                'param1' => 'value1'
-            )
-        );
+            'content' => $content,
+            'vars' => [
+                'param1' => 'value1',
+            ],
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->onlyMethods(array('getVars'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->onlyMethods(['getVars'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getVars')
-            ->will($this->returnValue(array('param1' => 'value1')));
-
+            ->willReturn(['param1' => 'value1']);
 
         $result = $serviceMock->templateToApiArray($model, true);
 
@@ -729,35 +714,35 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
-                array(
-                    'id'       => 5,
-                    'enabled'  => 1,
+        return [
+            [
+                [
+                    'id' => 5,
+                    'enabled' => 1,
                     'category' => 'Category',
-                    'subject'  => null,
-                    'content'  => null
-                ),
-                $self->never()
-            ),
-            array(
-                array(
-                    'id'       => 5,
-                    'enabled'  => 1,
+                    'subject' => null,
+                    'content' => null,
+                ],
+                $self->never(),
+            ],
+            [
+                [
+                    'id' => 5,
+                    'enabled' => 1,
                     'category' => 'Category',
-                    'subject'  => 'Subject',
-                    'content'  => 'Content'
-                ),
-                $self->atLeastOnce()
-            ),
-        );
+                    'subject' => 'Subject',
+                    'content' => 'Content',
+                ],
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('template_updateProvider')]
-    public function testTemplate_update($data, $templateRenderExpects)
+    public function testTemplateUpdate($data, $templateRenderExpects)
     {
-        $id        = random_int(1, 100);
-        $model     = new \Model_EmailTemplate();
+        $id = random_int(1, 100);
+        $model = new \Model_EmailTemplate();
         $model->loadBean(new \DummyBean());
         $model->id = $id;
 
@@ -776,17 +761,17 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $twigMock = $this->getMockBuilder(\Twig\Environment::class)->disableOriginalConstructor()->getMock();
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $loggerMock;
-        $di['tools']  = $toolsMock;
-        $di['crypt']  = $cryptMock;
+        $di['tools'] = $toolsMock;
+        $di['crypt'] = $cryptMock;
         $di['config'] = $configMock;
-        $di['twig']   = $twigMock;
+        $di['twig'] = $twigMock;
 
         $systemServiceMock = $this->getMockBuilder(\Box\Mod\System\Service::class)->getMock();
 
@@ -813,9 +798,9 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -831,9 +816,9 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -853,24 +838,24 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($id));
+            ->willReturn($id);
         $emailTemplateModel = new \Model_EmailTemplate();
         $emailTemplateModel->loadBean(new \DummyBean());
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($emailTemplateModel));
+            ->willReturn($emailTemplateModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
-        $data = array(
+        $data = [
             'action_code' => 'Action_code',
-            'subject'     => 'Subject',
-            'content'     => 'Content',
-            'category'    => 'category'
-        );
+            'subject' => 'Subject',
+            'content' => 'Content',
+            'category' => 'category',
+        ];
 
         $result = $service->templateCreate($data['action_code'], $data['subject'], $data['content'], 1, $data['category']);
 
@@ -881,12 +866,13 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(true, false, $self->never(), $self->never()),
-            array(false, true, $self->atLeastOnce(), $self->atLeastOnce()),
-            array(true, true, $self->atLeastOnce(), $self->never()),
-        );
+        return [
+            [true, false, $self->never(), $self->never()],
+            [false, true, $self->atLeastOnce(), $self->atLeastOnce()],
+            [true, true, $self->atLeastOnce(), $self->never()],
+        ];
     }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('batchTemplateGenerateProvider')]
     public function testBatchTemplateGenerate($findOneReturn, $isExtensionActiveReturn, $findOneExpects, $dispenseExpects)
     {
@@ -895,27 +881,25 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($findOneExpects)
             ->method('findOne')
-            ->will($this->returnValue($findOneReturn));
+            ->willReturn($findOneReturn);
 
         $emailTemplateModel = new \Model_EmailTemplate();
         $emailTemplateModel->loadBean(new \DummyBean());
         $db->expects($dispenseExpects)
             ->method('dispense')
-            ->will($this->returnValue($emailTemplateModel));
+            ->willReturn($emailTemplateModel);
 
         $extension = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->getMock();
         $extension->expects($this->atLeastOnce())
             ->method('isExtensionActive')
-            ->will($this->returnValue($isExtensionActiveReturn));
+            ->willReturn($isExtensionActiveReturn);
 
-
-        $di                = new \Pimple\Container();
-        $di['db']          = $db;
-        $di['logger']      = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['mod_service'] = $di->protect(fn () => $extension);
 
         $service->setDi($di);
-
 
         $result = $service->templateBatchGenerate();
 
@@ -929,10 +913,10 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
@@ -948,13 +932,12 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('exec')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
-
 
         $result = $service->templateBatchEnable();
 
@@ -978,27 +961,26 @@ class ServiceTest extends \BBTestCase
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->exactly(1))
-            ->method('findAll')->will($this->returnValue([$queueModel]));
+            ->method('findAll')->willReturn([$queueModel]);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array(
+            ->willReturn([
                 'log_enabled' => 1,
-                'cancel_after' => 1
-            )));
+                'cancel_after' => 1,
+            ]);
 
         $extension = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->getMock();
         $extension->expects($this->atLeastOnce())
             ->method('isExtensionActive')
-            ->will($this->returnValue($isExtensionActiveReturn));
+            ->willReturn($isExtensionActiveReturn);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['mod_service'] = $di->protect(function ($name) use ($extension) {
             if ($name == 'extension') {
@@ -1026,7 +1008,7 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($templateModel));
+            ->willReturn($templateModel);
 
         $cryptMock = $this->getMockBuilder('\Box_Crypt')->getMock();
         $cryptMock->expects($this->atLeastOnce())
@@ -1035,17 +1017,17 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $twigMock = $this->getMockBuilder(\Twig\Environment::class)->disableOriginalConstructor()->getMock();
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
-        $di['tools']  = $toolsMock;
-        $di['crypt']  = $cryptMock;
+        $di['tools'] = $toolsMock;
+        $di['crypt'] = $cryptMock;
         $di['config'] = $configMock;
-        $di['twig']   = $twigMock;
+        $di['twig'] = $twigMock;
 
         $systemService = $this->getMockBuilder(\Box\Mod\System\Service::class)->getMock();
 
@@ -1065,9 +1047,9 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -1094,10 +1076,9 @@ class ServiceTest extends \BBTestCase
 
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['mod'] = $di->protect(fn () => $modMock);
-        $di['mod_service'] = $di->protect(function ($name) use ($systemService, $extension) {
+        $di['mod_service'] = $di->protect(function ($name) use ($extension) {
             if ($name == 'system') {
-                $systemService;
-            } else if ($name == "extension") {
+            } elseif ($name == 'extension') {
                 return $extension;
             }
         });

--- a/tests/modules/Extension/Api/AdminTest.php
+++ b/tests/modules/Extension/Api/AdminTest.php
@@ -1,27 +1,24 @@
 <?php
 
-
 namespace Box\Mod\Extension\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
      * @var \Box\Mod\Extension\Service
      */
-    protected $service = null;
+    protected $service;
 
     /**
-     * @var \Box\Mod\Extension\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
-
+    protected $api;
 
     public function setup(): void
     {
         $this->service = new \Box\Mod\Extension\Service();
-        $this->api = new \Box\Mod\Extension\Api\Admin();
+        $this->api = new Admin();
     }
-
 
     public function testgetDi()
     {
@@ -31,14 +28,14 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getExtensionsList')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -46,15 +43,15 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_latest()
+    public function testgetLatest()
     {
-        $data = array();
+        $data = [];
 
         $extensionMock = $this->getMockBuilder('\\' . \FOSSBilling\ExtensionManager::class)->getMock();
 
         $extensionMock->expects($this->atLeastOnce())
             ->method('getExtensionList')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
@@ -64,9 +61,9 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_latestException()
+    public function testgetLatestException()
     {
-        $data = array('type' => 'mod');
+        $data = ['type' => 'mod'];
 
         $extensionMock = $this->getMockBuilder('\\' . \FOSSBilling\ExtensionManager::class)->getMock();
 
@@ -80,17 +77,17 @@ class AdminTest extends \BBTestCase {
         $this->api->setDi($di);
         $result = $this->api->get_latest($data);
         $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
-    public function testget_navigation()
+    public function testgetNavigation()
     {
-        $data = array('url' =>'billing');
+        $data = ['url' => 'billing'];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdminNavigation')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $this->api->setIdentity(new \Model_Admin());
@@ -108,19 +105,19 @@ class AdminTest extends \BBTestCase {
 
     public function testupdateExtensionNotFound()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensioTYpe',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findExtension')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -134,20 +131,20 @@ class AdminTest extends \BBTestCase {
 
     public function testactivate()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('activateExistingExtension')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -161,10 +158,10 @@ class AdminTest extends \BBTestCase {
 
     public function testdeactivate()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
@@ -175,7 +172,7 @@ class AdminTest extends \BBTestCase {
             ->will($this->onConsecutiveCalls($model));
         $serviceMock->expects($this->atLeastOnce())
             ->method('deactivate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -188,7 +185,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -200,10 +197,10 @@ class AdminTest extends \BBTestCase {
 
     public function testuninstall()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
@@ -211,10 +208,10 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findExtension')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('uninstall')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -226,7 +223,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -238,16 +235,16 @@ class AdminTest extends \BBTestCase {
 
     public function testinstall()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
-        $expected = array(
-            'success'   =>  true,
-            'id'        =>  $data['id'],
-            'type'      =>  $data['type'],
-        );
+        $expected = [
+            'success' => true,
+            'id' => $data['id'],
+            'type' => $data['type'],
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
@@ -255,7 +252,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('downloadAndExtract')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -267,7 +264,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -280,16 +277,16 @@ class AdminTest extends \BBTestCase {
 
     public function testinstallExceptionActivate()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
-        $expected = array(
-            'success'   =>  true,
-            'id'        =>  $data['id'],
-            'type'      =>  $data['type'],
-        );
+        $expected = [
+            'success' => true,
+            'id' => $data['id'],
+            'type' => $data['type'],
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
@@ -297,7 +294,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('downloadAndExtract')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->
@@ -313,7 +310,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -324,21 +321,21 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($expected, $result);
     }
 
-    public function testconfig_get()
+    public function testconfigGet()
     {
-        $data = array(
+        $data = [
             'ext' => 'extensionName',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -350,16 +347,16 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testconfig_save()
+    public function testconfigSave()
     {
-        $data = array(
+        $data = [
             'ext' => 'extensionName',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('setConfig')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock->expects($this->never())
             ->method('getConfig');
@@ -367,7 +364,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -378,6 +375,4 @@ class AdminTest extends \BBTestCase {
 
         $this->assertTrue($result);
     }
-
-
 }

--- a/tests/modules/Extension/Api/GuestTest.php
+++ b/tests/modules/Extension/Api/GuestTest.php
@@ -1,27 +1,24 @@
 <?php
 
-
 namespace Box\Mod\Extension\Api;
 
-
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
     /**
      * @var \Box\Mod\Extension\Service
      */
-    protected $service = null;
+    protected $service;
 
     /**
-     * @var \Box\Mod\Extension\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
-
+    protected $api;
 
     public function setup(): void
     {
         $this->service = new \Box\Mod\Extension\Service();
-        $this->api = new \Box\Mod\Extension\Api\Guest();
+        $this->api = new Guest();
     }
-
 
     public function testgetDi()
     {
@@ -33,37 +30,37 @@ class GuestTest extends \BBTestCase {
 
     public static function is_onProvider()
     {
-        return array(
-            array(
-                array('mod' => 'testModule'),
-                array(),
-            ),
-            array(
-                array(
+        return [
+            [
+                ['mod' => 'testModule'],
+                [],
+            ],
+            [
+                [
                     'id' => 'extensionId',
                     'type' => 'extensionType',
-                ),
-                array()
-            ),
-        );
+                ],
+                [],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('is_onProvider')]
-    public function testis_on($data, $expected)
+    public function testisOn($data, $expected)
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('isExtensionActive')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $result = $this->api->is_on($data);
         $this->assertEquals($expected, $result);
     }
 
-    public function testis_onInvalidDataArray()
+    public function testisOnInvalidDataArray()
     {
-        $data = array();
+        $data = [];
         $result = $this->api->is_on($data);
         $this->assertTrue($result);
     }
@@ -73,10 +70,10 @@ class GuestTest extends \BBTestCase {
         $themeServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $themeServiceMock->expects($this->atLeastOnce())
             ->method('getThemeConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $themeServiceMock);
+        $di['mod_service'] = $di->protect(fn ($name) => $themeServiceMock);
 
         $this->api->setDi($di);
         $result = $this->api->theme();
@@ -90,7 +87,7 @@ class GuestTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $result = $this->api->settings($data);
@@ -99,12 +96,11 @@ class GuestTest extends \BBTestCase {
 
     public function testsettingsExtExtension()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Parameter ext is missing');
         $this->api->settings($data);
-
     }
 
     public function testlanguages()

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -1,9 +1,6 @@
 <?php
 
-
 namespace Box\Mod\Extension;
-
-use \Symfony\Component\HttpClient\MockHttpClient;
 
 class PdoMock extends \PDO
 {
@@ -20,15 +17,14 @@ class PdoStatmentsMock extends \PDOStatement
 
 class ServiceTest extends \BBTestCase
 {
-
     /**
-     * @var \Box\Mod\Extension\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Extension\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -41,14 +37,14 @@ class ServiceTest extends \BBTestCase
 
     public function testisCoreModule()
     {
-        $coreModules = array('extension', 'cron', 'staff');
+        $coreModules = ['extension', 'cron', 'staff'];
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue($coreModules));
+            ->willReturn($coreModules);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
         $this->service->setDi($di);
 
@@ -59,20 +55,20 @@ class ServiceTest extends \BBTestCase
 
     public function testisExtensionActiveModNotFound()
     {
-        $coreModules = array('extension', 'cron', 'staff');
+        $coreModules = ['extension', 'cron', 'staff'];
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue($coreModules));
+            ->willReturn($coreModules);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
         $this->service->setDi($di);
 
@@ -94,11 +90,11 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($model)));
+            ->willReturn([$model]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
         $this->service->setDi($di);
 
@@ -109,12 +105,11 @@ class ServiceTest extends \BBTestCase
 
     public static function searchQueryData()
     {
-        return array(
-            array(array(), 'SELECT * FROM extension', array()),
-            array(array('type' => 'mod'), 'AND type = :type', array(':type' => 'mod')),
-            array(array('search' => 'FindUp'), 'AND name LIKE :search', array(':search' => 'FindUp')),
-
-        );
+        return [
+            [[], 'SELECT * FROM extension', []],
+            [['type' => 'mod'], 'AND type = :type', [':type' => 'mod']],
+            [['search' => 'FindUp'], 'AND name LIKE :search', [':search' => 'FindUp']],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchQueryData')]
@@ -129,16 +124,15 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($params);
 
         $this->assertTrue(str_contains($sql, $expectedStr), $sql);
-        $this->assertTrue(array_diff_key($params, $expectedParams) == array());
+        $this->assertTrue(array_diff_key($params, $expectedParams) == []);
     }
-
 
     public function testgetExtensionsList()
     {
-        $data = array(
+        $data = [
             'has_settings' => true,
             'active' => true,
-        );
+        ];
 
         $model['manifest'] = '{"J":5,"0":"N"}';
         $model['type'] = 'mod';
@@ -153,27 +147,27 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array($model)));
+            ->willReturn([$model]);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($modelFind)));
+            ->willReturn([$modelFind]);
 
-        $coreModules = array('extension', 'cron', 'staff');
+        $coreModules = ['extension', 'cron', 'staff'];
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue($coreModules));
+            ->willReturn($coreModules);
         $modMock->expects($this->atLeastOnce())
             ->method('getManifest')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $modMock->expects($this->atLeastOnce())
             ->method('hasSettingsPage')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
         $this->service->setDi($di);
 
@@ -183,9 +177,9 @@ class ServiceTest extends \BBTestCase
 
     public function testgetExtensionsListOnlyInstalled()
     {
-        $data = array(
+        $data = [
             'installed' => true,
-        );
+        ];
 
         $model['manifest'] = '{"J":5,"0":"N"}';
         $model['type'] = 'mod';
@@ -197,27 +191,26 @@ class ServiceTest extends \BBTestCase
         $modelFind->loadBean(new \DummyBean());
         $modelFind->name = 'extensionName';
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array($model)));
+            ->willReturn([$model]);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($modelFind)));
+            ->willReturn([$modelFind]);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getManifest')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $modMock->expects($this->atLeastOnce())
             ->method('hasSettingsPage')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
         $this->service->setDi($di);
 
@@ -227,27 +220,27 @@ class ServiceTest extends \BBTestCase
 
     public function testgetAdminNavigation()
     {
-        $extensionServiceMock = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->onlyMethods(['getConfig'])->getMock();
+        $extensionServiceMock = $this->getMockBuilder(Service::class)->onlyMethods(['getConfig'])->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $staffServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $staffServiceMock->expects($this->atLeastOnce())
             ->method('hasPermission')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $pdoStatment = $this->getMockBuilder('\\' . \Box\Mod\Extension\PdoStatmentsMock::class)->getMock();
+        $pdoStatment = $this->getMockBuilder('\\' . PdoStatmentsMock::class)->getMock();
         $pdoStatment->expects($this->atLeastOnce())
             ->method('execute');
         $pdoStatment->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatment));
+            ->willReturn($pdoStatment);
 
         $link = 'extension';
 
@@ -261,6 +254,7 @@ class ServiceTest extends \BBTestCase
         $di['mod'] = $di->protect(function ($name) use ($di) {
             $mod = new \Box_Mod($name);
             $mod->setDi($di);
+
             return $mod;
         });
         $di['tools'] = new \FOSSBilling\Tools();
@@ -280,13 +274,12 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-
     public function testfindExtension()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_Extension()));
+            ->willReturn(new \Model_Extension());
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -307,11 +300,11 @@ class ServiceTest extends \BBTestCase
         $extensionMock = $this->getMockBuilder('\\' . \FOSSBilling\ExtensionManager::class)->getMock();
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
@@ -327,38 +320,38 @@ class ServiceTest extends \BBTestCase
         $ext->type = 'mod';
         $ext->name = 'testExtension';
 
-        $expectedResult = array(
-            'id'        => $ext->name,
-            'type'      => $ext->type,
-            'redirect'  => true,
-            'has_settings'  => true,
-        );
+        $expectedResult = [
+            'id' => $ext->name,
+            'type' => $ext->type,
+            'redirect' => true,
+            'has_settings' => true,
+        ];
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getManifest')
-            ->will($this->returnValue(array('version' => 1)));
+            ->willReturn(['version' => 1]);
 
         $modMock->expects($this->atLeastOnce())
             ->method('hasAdminController')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $modMock->expects($this->atLeastOnce())
             ->method('hasSettingsPage')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
         $result = $this->service->activate($ext);
@@ -380,20 +373,20 @@ class ServiceTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $modMock->expects($this->atLeastOnce())
             ->method('uninstall')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
 
@@ -411,15 +404,15 @@ class ServiceTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue(array($ext->name)));
+            ->willReturn([$ext->name]);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
 
@@ -440,19 +433,19 @@ class ServiceTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $modMock->expects($this->atLeastOnce())
             ->method('uninstall')
             ->willThrowException(new \FOSSBilling\Exception($exceptionMessage));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
 
@@ -473,11 +466,11 @@ class ServiceTest extends \BBTestCase
             ->method('trash');
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
         $result = $this->service->deactivate($ext);
@@ -498,20 +491,20 @@ class ServiceTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getCoreModules')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $modMock->expects($this->atLeastOnce())
             ->method('uninstall')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn($name) => $modMock);
+        $di['mod'] = $di->protect(fn ($name) => $modMock);
 
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
 
@@ -525,14 +518,14 @@ class ServiceTest extends \BBTestCase
 
         $extensionMock->expects($this->atLeastOnce())
             ->method('getLatestExtensionRelease')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->will($this->returnValue(true));
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
-        $di['mod_service'] = $di->protect(fn() => $staffService);
+        $di['mod_service'] = $di->protect(fn () => $staffService);
 
         $this->service->setDi($di);
         $this->expectException(\Exception::class);
@@ -542,55 +535,53 @@ class ServiceTest extends \BBTestCase
 
     public function testgetInstalledMods()
     {
-        $pdoStatment = $this->getMockBuilder(\Box\Mod\Extension\PdoStatmentsMock::class)->getMock();
+        $pdoStatment = $this->getMockBuilder(PdoStatmentsMock::class)->getMock();
         $pdoStatment->expects($this->atLeastOnce())
             ->method('execute');
         $pdoStatment->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatment));
-
+            ->willReturn($pdoStatment);
 
         $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
         $result = $this->service->getInstalledMods();
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
     public function testactivateExistingExtension()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)
-            ->onlyMethods(array('findExtension', 'activate'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['findExtension', 'activate'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findExtension')
             ->will($this->onConsecutiveCalls(null, $model));
         $serviceMock->expects($this->atLeastOnce())
             ->method('activate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder(\Box_Database::class)->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $eventMock = $this->getMockBuilder(\Box_EventManager::class)->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
@@ -608,20 +599,20 @@ class ServiceTest extends \BBTestCase
 
     public function testactivateException()
     {
-        $data = array(
+        $data = [
             'id' => 'extensionId',
             'type' => 'extensionType',
-        );
+        ];
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)
-            ->onlyMethods(array('findExtension', 'activate'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['findExtension', 'activate'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findExtension')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('activate')
             ->will($this->throwException(new \Exception()));
@@ -640,9 +631,9 @@ class ServiceTest extends \BBTestCase
 
     public function testgetConfig()
     {
-        $data = array(
+        $data = [
             'ext' => 'extensionName',
-        );
+        ];
 
         $model = new \Model_ExtensionMeta();
         $model->loadBean(new \DummyBean());
@@ -650,7 +641,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder(\Box_Database::class)->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $cryptMock = $this->getMockBuilder(\Box_Crypt::class)->getMock();
         $cryptMock->expects($this->atLeastOnce())
@@ -659,13 +650,13 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder(\FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['crypt'] = $cryptMock;
         $di['tools'] = $toolsMock;
-        $di['config'] = array('salt' => '');
+        $di['config'] = ['salt' => ''];
         $di['cache'] = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
 
         $this->service->setDi($di);
@@ -676,9 +667,9 @@ class ServiceTest extends \BBTestCase
 
     public function testgetConfigExtensionMetaNotFound()
     {
-        $data = array(
+        $data = [
             'ext' => 'extensionName',
-        );
+        ];
 
         $model = new \Model_ExtensionMeta();
         $model->loadBean(new \DummyBean());
@@ -686,13 +677,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder(\Box_Database::class)->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -702,33 +693,33 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->getConfig($data['ext']);
 
         $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
     public function testsetConfig()
     {
-        $data = array(
+        $data = [
             'ext' => 'extensionName',
-        );
+        ];
 
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Extension\Service::class)->onlyMethods(['getConfig', 'getCoreAndActiveModulesAndPermissions'])->getMock();
+        $serviceMock = $this->getMockBuilder(Service::class)->onlyMethods(['getConfig', 'getCoreAndActiveModulesAndPermissions'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $toolsMock = $this->getMockBuilder(\FOSSBilling\Tools::class)->getMock();
 
         $cryptMock = $this->getMockBuilder(\Box_Crypt::class)->getMock();
         $cryptMock->expects($this->atLeastOnce())
             ->method('encrypt')
-            ->will($this->returnValue('encryptedConfig'));
+            ->willReturn('encryptedConfig');
 
         $model = new \Model_ExtensionMeta();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder(\Box_Database::class)->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('exec')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $eventMock = $this->getMockBuilder(\Box_EventManager::class)->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
@@ -744,9 +735,9 @@ class ServiceTest extends \BBTestCase
         $di['crypt'] = $cryptMock;
         $di['events_manager'] = $eventMock;
         $di['logger'] = new \Box_Log();
-        $di['config'] = array('salt' => '');
-        $di['mod'] = $di->protect(fn() => $modMock);
-        $di['mod_service'] = $di->protect(fn() => $staffMock);
+        $di['config'] = ['salt' => ''];
+        $di['mod'] = $di->protect(fn () => $modMock);
+        $di['mod_service'] = $di->protect(fn () => $staffMock);
         $di['cache'] = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
 
         $serviceMock->setDi($di);

--- a/tests/modules/Extension/ServiceTest.php
+++ b/tests/modules/Extension/ServiceTest.php
@@ -300,7 +300,7 @@ class ServiceTest extends \BBTestCase
         $extensionMock = $this->getMockBuilder('\\' . \FOSSBilling\ExtensionManager::class)->getMock();
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
@@ -328,7 +328,7 @@ class ServiceTest extends \BBTestCase
         ];
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
@@ -380,7 +380,7 @@ class ServiceTest extends \BBTestCase
             ->willReturn(true);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -407,7 +407,7 @@ class ServiceTest extends \BBTestCase
             ->willReturn([$ext->name]);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['mod'] = $di->protect(fn ($name) => $modMock);
@@ -440,7 +440,7 @@ class ServiceTest extends \BBTestCase
             ->willThrowException(new \FOSSBilling\Exception($exceptionMessage));
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['mod'] = $di->protect(fn ($name) => $modMock);
@@ -466,7 +466,7 @@ class ServiceTest extends \BBTestCase
             ->method('trash');
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -498,7 +498,7 @@ class ServiceTest extends \BBTestCase
             ->willReturn(true);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -521,7 +521,7 @@ class ServiceTest extends \BBTestCase
             ->willReturn([]);
 
         $staffService = $this->getMockBuilder('Box\Mod\Staff\Service')->getMock();
-        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException')->willReturn(true);
+        $staffService->expects($this->atLeastOnce())->method('checkPermissionsAndThrowException');
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;

--- a/tests/modules/Formbuilder/Api/AdminTest.php
+++ b/tests/modules/Formbuilder/Api/AdminTest.php
@@ -1,20 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Formbuilder\Api;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     /**
      * @var \Box\Mod\Formbuilder\Service
      */
-    protected $service = null;
+    protected $service;
 
     /**
-     * @var \Box\Mod\Formbuilder\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function getServiceMock()
     {
@@ -24,9 +22,8 @@ class AdminTest extends \BBTestCase {
     public function setup(): void
     {
         $this->service = new \Box\Mod\Formbuilder\Service();
-        $this->api = new \Box\Mod\Formbuilder\Api\Admin();
+        $this->api = new Admin();
     }
-
 
     public function testgetDi()
     {
@@ -36,22 +33,22 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testcreate_form()
+    public function testcreateForm()
     {
-        $data = array('name' => 'testForm');
+        $data = ['name' => 'testForm'];
         $createdFormId = 1;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('addNewForm')
-            ->will($this->returnValue($createdFormId));
+            ->willReturn($createdFormId);
 
         $this->api->setService($serviceMock);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -62,16 +59,16 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($createdFormId, $result);
     }
 
-    public function testcreate_formTypeIsNotInList()
+    public function testcreateFormTypeIsNotInList()
     {
-        $data = array(
+        $data = [
             'name' => 'testName',
             'type' => 'custom',
-        );
+        ];
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -81,27 +78,27 @@ class AdminTest extends \BBTestCase {
         $this->api->create_form($data);
     }
 
-    public function testadd_field()
+    public function testaddField()
     {
-        $data = array(
+        $data = [
             'type' => 'text',
-            'options' => array('sameValue'),
+            'options' => ['sameValue'],
             'form_id' => 1,
-        );
+        ];
         $newFieldId = 2;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('typeValidation')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('isArrayUnique')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('addNewField')
-            ->will($this->returnValue($newFieldId));
+            ->willReturn($newFieldId);
 
         $this->api->setService($serviceMock);
 
@@ -110,21 +107,21 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newFieldId, $result);
     }
 
-    public function testadd_fieldMissingType()
+    public function testaddFieldMissingType()
     {
-        $data = array();
+        $data = [];
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(2684);
         $this->expectExceptionMessage('Form field type is invalid');
         $this->api->add_field($data);
     }
 
-    public function testadd_fieldOptionsNotUnique()
+    public function testaddFieldOptionsNotUnique()
     {
-        $data = array(
+        $data = [
             'type' => 'text',
-            'options' => array('sameValue', 'sameValue'),
-        );
+            'options' => ['sameValue', 'sameValue'],
+        ];
 
         $this->api->setService($this->service);
         $this->expectException(\FOSSBilling\Exception::class);
@@ -133,12 +130,12 @@ class AdminTest extends \BBTestCase {
         $this->api->add_field($data);
     }
 
-    public function testadd_fieldMissingFormId()
+    public function testaddFieldMissingFormId()
     {
-        $data = array(
+        $data = [
             'type' => 'text',
-            'options' => array('sameValue'),
-        );
+            'options' => ['sameValue'],
+        ];
 
         $this->api->setService($this->service);
 
@@ -148,19 +145,19 @@ class AdminTest extends \BBTestCase {
         $this->api->add_field($data);
     }
 
-    public function testget_form()
+    public function testgetForm()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getForm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -171,19 +168,19 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_form_fields()
+    public function testgetFormFields()
     {
         $data['form_id'] = 1;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getFormFields')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -194,19 +191,19 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_field()
+    public function testgetField()
     {
         $data['id'] = 3;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getField')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -218,12 +215,12 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_forms()
+    public function testgetForms()
     {
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getForms')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -231,19 +228,19 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testdelete_form()
+    public function testdeleteForm()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('removeForm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -255,19 +252,19 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testdelete_field()
+    public function testdeleteField()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('removeField')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -279,26 +276,26 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testupdate_field()
+    public function testupdateField()
     {
         $updatedFieldId = 1;
-        $data = array (
+        $data = [
             'id' => $updatedFieldId,
-            'options' => array('sameValue'),
-        );
+            'options' => ['sameValue'],
+        ];
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateField')
-            ->will($this->returnValue($updatedFieldId));
+            ->willReturn($updatedFieldId);
         $serviceMock->expects($this->atLeastOnce())
             ->method('isArrayUnique')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -311,13 +308,13 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($updatedFieldId, $result);
     }
 
-    public function testget_pairs()
+    public function testgetPairs()
     {
-        $data = array();
+        $data = [];
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getFormPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -325,18 +322,18 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testcopy_form()
+    public function testcopyForm()
     {
         $newFormId = 2;
-        $data = array(
+        $data = [
             'form_id' => 1,
             'name' => 'testForm',
-        );
+        ];
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('duplicateForm')
-            ->will($this->returnValue($newFormId));
+            ->willReturn($newFormId);
 
         $this->api->setService($serviceMock);
         $result = $this->api->copy_form($data);
@@ -344,9 +341,9 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newFormId, $result);
     }
 
-    public function testcopy_formMissingId()
+    public function testcopyFormMissingId()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(9958);
@@ -354,9 +351,9 @@ class AdminTest extends \BBTestCase {
         $this->api->copy_form($data);
     }
 
-    public function testcopy_formMissingName()
+    public function testcopyFormMissingName()
     {
-        $data = array('form_id' => 1);
+        $data = ['form_id' => 1];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(9842);
@@ -364,59 +361,46 @@ class AdminTest extends \BBTestCase {
         $this->api->copy_form($data);
     }
 
-    public function testupdate_form_settings()
+    public function testupdateFormSettings()
     {
-        $data = array(
+        $data = [
             'form_id' => 1,
             'form_name' => 'testForm',
             'type' => 'default',
-
-        );
+        ];
 
         $serviceMock = $this->getServiceMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateFormSettings')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
         $result = $this->api->update_form_settings($data);
         $this->assertTrue($result);
     }
 
-
     public static function form_settings_data()
     {
-        return array(
-            array('form_id', 'Form id was not passed', 1654),
-            array('form_name', 'Form name was not passed', 9241),
-            array('type', 'Form type was not passed', 3794),
-            array('', 'Field type not supported', 3207),
-        );
+        return [
+            ['form_id', 'Form id was not passed', 1654],
+            ['form_name', 'Form name was not passed', 9241],
+            ['type', 'Form type was not passed', 3794],
+            ['', 'Field type not supported', 3207],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('form_settings_data')]
-    public function testupdate_form_settingsExceptions($missingField, $exceptionMessage, $exceptionCode)
+    public function testupdateFormSettingsExceptions($missingField, $exceptionMessage, $exceptionCode)
     {
-        $data = array(
+        $data = [
             'form_id' => 1,
             'form_name' => 'testForm',
             'type' => 'customType',
-
-        );
-        unset($data[ $missingField ]);
+        ];
+        unset($data[$missingField]);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage($exceptionMessage);
         $this->api->update_form_settings($data);
     }
-
-
-
-
-
-
-
-
-
 }
-

--- a/tests/modules/Formbuilder/Api/GuestTest.php
+++ b/tests/modules/Formbuilder/Api/GuestTest.php
@@ -1,16 +1,13 @@
 <?php
 
-
 namespace Box\Mod\Formbuilder\Api;
 
-
-class GuestTest extends \BBTestCase {
-
+class GuestTest extends \BBTestCase
+{
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Formbuilder\Api\Guest();
+        $this->api = new Guest();
     }
-
 
     public function testgetDi()
     {
@@ -27,12 +24,12 @@ class GuestTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getForm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -42,5 +39,4 @@ class GuestTest extends \BBTestCase {
         $result = $this->api->get($data);
         $this->assertIsArray($result);
     }
-
 }

--- a/tests/modules/Formbuilder/ServiceTest.php
+++ b/tests/modules/Formbuilder/ServiceTest.php
@@ -1,22 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Formbuilder;
 
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Formbuilder\Service
+     * @var Service
      */
-    protected $service = null;
-
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Formbuilder\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -28,13 +24,13 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetFormFieldsTypes()
     {
-        $expected = array(
-            "text" => 'Text input',
-            "select" => 'Dropdown',
-            "radio" => 'Radio select',
-            "checkbox" => 'Checkbox',
-            "textarea" => 'Text area'
-        );
+        $expected = [
+            'text' => 'Text input',
+            'select' => 'Dropdown',
+            'radio' => 'Radio select',
+            'checkbox' => 'Checkbox',
+            'textarea' => 'Text area',
+        ];
 
         $result = $this->service->getFormFieldsTypes();
         $this->assertEquals($expected, $result);
@@ -42,10 +38,10 @@ class ServiceTest extends \BBTestCase {
 
     public static function typeValidationData()
     {
-        return array(
-            array('select', true),
-            array('custom', false),
-        );
+        return [
+            ['select', true],
+            ['custom', false],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('typeValidationData')]
@@ -57,11 +53,11 @@ class ServiceTest extends \BBTestCase {
 
     public static function isArrayUniqueData()
     {
-        return array(
-            array(array('sameValue', 'sameValue'), false),
-            array(array('sameValue', 'DiffValue'), true),
-            array(array(), true),
-        );
+        return [
+            [['sameValue', 'sameValue'], false],
+            [['sameValue', 'DiffValue'], true],
+            [[], true],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('isArrayUniqueData')]
@@ -74,10 +70,10 @@ class ServiceTest extends \BBTestCase {
     public function testaddNewForm()
     {
         $newFormId = 1;
-        $data = array(
+        $data = [
             'name' => 'testName',
-            'style' => array(),
-        );
+            'style' => [],
+        ];
 
         $model = new \Model_Form();
         $model->loadBean(new \DummyBean());
@@ -85,11 +81,11 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newFormId));
+            ->willReturn($newFormId);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -106,10 +102,10 @@ class ServiceTest extends \BBTestCase {
     public function testaddNewField()
     {
         $newFieldId = 1;
-        $data = array(
+        $data = [
             'form_id' => 1,
-            'type' => 'select'
-        );
+            'type' => 'select',
+        ];
 
         $model = new \Model_FormField();
         $model->loadBean(new \DummyBean());
@@ -118,15 +114,15 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newFieldId));
+            ->willReturn($newFieldId);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -142,63 +138,62 @@ class ServiceTest extends \BBTestCase {
 
     public static function updateFieldTypeData()
     {
-        return array(
-            array('select'),
-            array('textarea'),
-        );
+        return [
+            ['select'],
+            ['textarea'],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('updateFieldTypeData')]
     public function testupdateField($fieldType)
     {
         $updateFIeldId = 2;
-        $data = array(
+        $data = [
             'id' => $updateFIeldId,
             'form_id' => 1,
             'type' => $fieldType,
             'default_value' => 'defaultTestValue',
-            'values' => array('test'),
-            'labels' => array('labels'),
+            'values' => ['test'],
+            'labels' => ['labels'],
             'name' => 'testFIeld',
-            'textarea_size' => array(64), // @TODO WHY ARRAY??
-            'textarea_option' => array(''), //textarea_size & textarea_option should have an equal number of elements
-        );
+            'textarea_size' => [64], // @TODO WHY ARRAY??
+            'textarea_option' => [''], // textarea_size & textarea_option should have an equal number of elements
+        ];
 
         $model = new \Model_FormField();
         $model->loadBean(new \DummyBean());
 
-        $modelArray = array(
+        $modelArray = [
             'id' => $updateFIeldId,
             'form_id' => 1,
             'options' => '{"hidden":"hidden"}',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($updateFIeldId));
+            ->willReturn($updateFIeldId);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue($modelArray));
+            ->willReturn($modelArray);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
-
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->service->setDi($di);
@@ -210,20 +205,20 @@ class ServiceTest extends \BBTestCase {
 
     public function testupdateFieldExists()
     {
-        $data = array(
+        $data = [
             'id' => 2,
             'form_id' => 1,
             'name' => 'testFIeld',
             'type' => 'select',
-        );
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)
-            ->onlyMethods(array('formFieldNameExists', 'getField'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['formFieldNameExists', 'getField'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('formFieldNameExists')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getField');
@@ -236,83 +231,83 @@ class ServiceTest extends \BBTestCase {
 
     public function testupdateFieldValuesNotUnique()
     {
-        $data = array(
+        $data = [
             'id' => 2,
             'form_id' => 1,
             'type' => 'select',
             'default_value' => 'defaultTestValue',
-            'values' => array('test', 'test'),
-            'labels' => array('labels'),
+            'values' => ['test', 'test'],
+            'labels' => ['labels'],
             'name' => 'testFIeld',
-        );
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)
-            ->onlyMethods(array('formFieldNameExists', 'getField'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['formFieldNameExists', 'getField'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('formFieldNameExists')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getField');
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(1597);
-        $this->expectExceptionMessage(ucfirst($data['type']).' values must be unique');
+        $this->expectExceptionMessage(ucfirst($data['type']) . ' values must be unique');
         $serviceMock->updateField($data);
     }
 
     public function testupdateFieldLabelsNotUnique()
     {
-        $data = array(
+        $data = [
             'id' => 2,
             'form_id' => 1,
             'type' => 'select',
             'default_value' => 'defaultTestValue',
-            'values' => array('test'),
-            'labels' => array('labels', 'labels'),
+            'values' => ['test'],
+            'labels' => ['labels', 'labels'],
             'name' => 'testFIeld',
-        );
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)
-            ->onlyMethods(array('formFieldNameExists', 'getField'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['formFieldNameExists', 'getField'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('formFieldNameExists')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getField');
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(1598);
-        $this->expectExceptionMessage(ucfirst($data['type']).' labels must be unique');
+        $this->expectExceptionMessage(ucfirst($data['type']) . ' labels must be unique');
         $serviceMock->updateField($data);
     }
 
     public function testupdateFieldTextAreaSizeException()
     {
-        $data = array(
+        $data = [
             'id' => 2,
             'form_id' => 1,
             'type' => 'textarea',
             'default_value' => 'defaultTestValue',
-            'values' => array('test'),
-            'labels' => array('labels'),
+            'values' => ['test'],
+            'labels' => ['labels'],
             'name' => 'testFIeld',
-            'textarea_size' => array(''), // @TODO WHY ARRAY??
-            'textarea_option' => array(''), //textarea_size & textarea_option should have an equal number of elements
-        );
+            'textarea_size' => [''], // @TODO WHY ARRAY??
+            'textarea_option' => [''], // textarea_size & textarea_option should have an equal number of elements
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)
-            ->onlyMethods(array('formFieldNameExists', 'getField'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['formFieldNameExists', 'getField'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('formFieldNameExists')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getField');
@@ -325,16 +320,16 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetForm()
     {
-        $modelArray = array(
+        $modelArray = [
             'style' => '',
             'id' => 1,
-        );
-        $getAllResult = array(
-            array(
+        ];
+        $getAllResult = [
+            [
                 'options' => '{"options":["hidden"]}',
-                'default_value' => 'TestingValue'
-            ),
-        );
+                'default_value' => 'TestingValue',
+            ],
+        ];
 
         $model = new \Model_Form();
         $model->loadBean(new \DummyBean());
@@ -343,14 +338,14 @@ class ServiceTest extends \BBTestCase {
 
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue($modelArray));
+            ->willReturn($modelArray);
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($getAllResult));
+            ->willReturn($getAllResult);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -368,11 +363,10 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-
 
         $this->service->setDi($di);
         $result = $this->service->getFormFields($formId);
@@ -385,7 +379,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -401,7 +395,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -414,10 +408,10 @@ class ServiceTest extends \BBTestCase {
     public function testgetField()
     {
         $fieldId = 2;
-        $modelArray = array(
+        $modelArray = [
             'id' => 2,
             'options' => '{"options":["hidden"]}',
-        );
+        ];
 
         $expectedArray = $modelArray;
         $expectedArray['options'] = json_decode($expectedArray['options']);
@@ -428,16 +422,16 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue($modelArray));
+            ->willReturn($modelArray);
 
         $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
 
@@ -465,7 +459,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testremoveField()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_FormField();
         $model->loadBean(new \DummyBean());
@@ -473,7 +467,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
@@ -489,16 +483,16 @@ class ServiceTest extends \BBTestCase {
 
     public function testformFieldNameExists()
     {
-        $data = array(
+        $data = [
             'field_name' => 'testingName',
             'form_id' => 2,
             'field_id' => 10,
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_FormField()));
+            ->willReturn(new \Model_FormField());
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -513,7 +507,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -525,32 +519,32 @@ class ServiceTest extends \BBTestCase {
 
     public function testduplicateForm()
     {
-        $data = array(
+        $data = [
             'form_id' => 1,
             'name' => 'testForm',
-        );
+        ];
 
         $newFormId = 3;
         $newFieldId = 4;
-        $fields = array(
-            'options' => array(),
-        );
+        $fields = [
+            'options' => [],
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)
-            ->onlyMethods(array('getFormFields', 'addNewForm', 'addNewField'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getFormFields', 'addNewForm', 'addNewField'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getFormFields')
-            ->will($this->returnValue($fields));
+            ->willReturn($fields);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('addNewForm')
-            ->will($this->returnValue($newFormId));
+            ->willReturn($newFormId);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('addNewField')
-            ->will($this->returnValue($newFieldId));
+            ->willReturn($newFieldId);
 
         $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
@@ -563,11 +557,11 @@ class ServiceTest extends \BBTestCase {
 
     public function testupdateFormSettings()
     {
-        $data = array(
+        $data = [
             'type' => 'default',
             'form_name' => 'testForm',
             'form_id' => 1,
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->exactly(2))
@@ -581,7 +575,4 @@ class ServiceTest extends \BBTestCase {
         $result = $this->service->updateFormSettings($data);
         $this->assertTrue($result);
     }
-
-
 }
-

--- a/tests/modules/Hook/Api/AdminTest.php
+++ b/tests/modules/Hook/Api/AdminTest.php
@@ -1,21 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Hook\Api;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Hook\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Hook\Api\Admin();
+        $this->api = new Admin();
     }
-
 
     public function testgetDi()
     {
@@ -25,26 +22,25 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Hook\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
 
-
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
         $this->assertIsArray($result);
     }
 
@@ -52,20 +48,19 @@ class AdminTest extends \BBTestCase {
     {
         $data['event'] = 'testEvent';
 
-        $configMock = array('debug_and_monitoring' => ['debug' => true]);
+        $configMock = ['debug_and_monitoring' => ['debug' => true]];
 
         $logMock = $this->getMockBuilder('\Box_log')->getMock();
 
         $eventManager = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventManager->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $di = new \Pimple\Container();
         $di['config'] = $configMock;
         $di['logger'] = new \Box_Log();
         $di['events_manager'] = $eventManager;
-
 
         $this->api->setDi($di);
         $result = $this->api->call($data);
@@ -81,21 +76,20 @@ class AdminTest extends \BBTestCase {
         $this->assertFalse($result);
     }
 
-    public function testbatch_connect()
+    public function testbatchConnect()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Hook\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('batchConnect')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $di = new \Pimple\Container();
 
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->batch_connect(array());
+        $result = $this->api->batch_connect([]);
         $this->assertNotEmpty($result);
     }
 }
- 

--- a/tests/modules/Hook/ServiceTest.php
+++ b/tests/modules/Hook/ServiceTest.php
@@ -1,21 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Hook;
 
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Hook\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Hook\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -27,59 +24,57 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetSearchQuery()
     {
-        [$sql, $params] = $this->service->getSearchQuery(array());
+        [$sql, $params] = $this->service->getSearchQuery([]);
 
         $this->assertIsString($sql);
         $this->assertIsArray($params);
 
         $this->assertTrue(str_contains($sql, 'SELECT id, rel_type, rel_id, meta_value as event, created_at, updated_at'));
-        $this->assertEquals($params, array());
-
+        $this->assertEquals($params, []);
     }
 
     public function testtoApiArray()
     {
-        $arrMock = array('testing' => 'okey');
+        $arrMock = ['testing' => 'okey'];
         $result = $this->service->toApiArray($arrMock);
         $this->assertEquals($arrMock, $result);
     }
 
     public function testonAfterAdminActivateExtension()
     {
-        $eventParams = array(
+        $eventParams = [
             'id' => 1,
-        );
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')
-            ->onlyMethods(array('getParameters', 'getDi'))
+            ->onlyMethods(['getParameters', 'getDi'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($eventParams));
+            ->willReturn($eventParams);
 
         $model = new \Model_Extension();
         $model->loadBean(new \DummyBean());
         $model->id = 1;
         $model->type = 'mod';
 
-
-        $dbMock =$this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $hookService = $this->getMockBuilder('\\' . \Box\Mod\Hook\Service::class)->getMock();
+        $hookService = $this->getMockBuilder('\\' . Service::class)->getMock();
         $hookService->expects($this->atLeastOnce())
             ->method('batchConnect');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $hookService);
+        $di['mod_service'] = $di->protect(fn ($name) => $hookService);
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $this->service->setDi($di);
         $this->service->onAfterAdminActivateExtension($eventMock);
@@ -89,15 +84,15 @@ class ServiceTest extends \BBTestCase {
 
     public function testonAfterAdminActivateExtensionMissingId()
     {
-        $eventParams = array();
+        $eventParams = [];
 
         $eventMock = $this->getMockBuilder('\Box_Event')
-            ->onlyMethods(array('getParameters'))
+            ->onlyMethods(['getParameters'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($eventParams));
+            ->willReturn($eventParams);
 
         $this->service->onAfterAdminActivateExtension($eventMock);
         $result = $eventMock->getReturnValue();
@@ -106,20 +101,20 @@ class ServiceTest extends \BBTestCase {
 
     public function testonAfterAdminDeactivateExtension()
     {
-        $eventParams = array(
+        $eventParams = [
             'type' => 'mod',
             'id' => 1,
-        );
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')
-            ->onlyMethods(array('getParameters', 'getDi'))
+            ->onlyMethods(['getParameters', 'getDi'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($eventParams));
+            ->willReturn($eventParams);
 
-        $dbMock =$this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('exec');
 
@@ -128,7 +123,7 @@ class ServiceTest extends \BBTestCase {
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $this->service->setDi($di);
         $this->service->onAfterAdminDeactivateExtension($eventMock);
@@ -140,19 +135,19 @@ class ServiceTest extends \BBTestCase {
     {
         $mod = 'activity';
 
-        $data['mods'] = array($mod);
+        $data['mods'] = [$mod];
 
-        $dbMock =$this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $extensionModel = new \Model_ExtensionMeta();
         $extensionModel->loadBean(new \DummyBean());
 
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($extensionModel));
+            ->willReturn($extensionModel);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
@@ -160,48 +155,47 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne');
 
-        $returnArr = array(
-            array(
+        $returnArr = [
+            [
                 'id' => 2,
                 'rel_id' => 1,
                 'meta_value' => 'testValue',
-            ),
-        );
+            ],
+        ];
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($returnArr));
-
+            ->willReturn($returnArr);
 
         $activityServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Activity\Service::class)->getMock();
 
         $boxModMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $boxModMock->expects($this->atLeastOnce())
             ->method('hasService')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $boxModMock->expects($this->any())
             ->method('getService')
-            ->will($this->returnValue($activityServiceMock));
+            ->willReturn($activityServiceMock);
         $boxModMock->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('activity'));
+            ->willReturn('activity');
 
         $extensionServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
-        $extensionServiceMock->expects(($this->atLeastOnce()))
+        $extensionServiceMock->expects($this->atLeastOnce())
             ->method('isCoreModule')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod'] = $di->protect(fn() => $boxModMock);
-        $di['mod_service'] = $di->protect(function ($name) use($extensionServiceMock){
-            if ($name == 'extension'){
+        $di['mod'] = $di->protect(fn () => $boxModMock);
+        $di['mod_service'] = $di->protect(function ($name) use ($extensionServiceMock) {
+            if ($name == 'extension') {
                 return $extensionServiceMock;
             }
         });
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
         $result = $this->service->batchConnect($mod);

--- a/tests/modules/Index/Controller/AdminTest.php
+++ b/tests/modules/Index/Controller/AdminTest.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace Box\Mod\Index\Controller;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testDi()
     {
-        $controller = new \Box\Mod\Index\Controller\Admin();
+        $controller = new Admin();
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -25,11 +23,11 @@ class AdminTest extends \BBTestCase {
         $boxAppMock->expects($this->exactly(4))
             ->method('get');
 
-        $controller = new \Box\Mod\Index\Controller\Admin();
+        $controller = new Admin();
         $controller->register($boxAppMock);
     }
 
-    public function testget_index_AdminIsLogged()
+    public function testgetIndexAdminIsLogged()
     {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->atLeastOnce())
@@ -38,15 +36,14 @@ class AdminTest extends \BBTestCase {
 
         $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authorizationMock->expects($this->atLeastOnce())
-            ->method("isAdminLoggedIn")
+            ->method('isAdminLoggedIn')
             ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['auth'] = $authorizationMock;
 
-        $controller = new \Box\Mod\Index\Controller\Admin();
+        $controller = new Admin();
         $controller->setDi($di);
         $controller->get_index($boxAppMock);
     }
 }
- 

--- a/tests/modules/Invoice/Api/AdminTest.php
+++ b/tests/modules/Invoice/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-    * @var \Box\Mod\Invoice\Api\Admin
-    */
-    protected $api = null;
+     * @var Admin
+     */
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Invoice\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,26 +22,25 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
 
-
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
         $this->assertIsArray($result);
     }
 
@@ -51,7 +49,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -62,7 +60,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -77,17 +75,17 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testmark_as_paid()
+    public function testmarkAsPaid()
     {
-        $data = array(
+        $data = [
             'id' => 1,
             'execute' => true,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('markAsPaid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -98,12 +96,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $serviceMock);
+        $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
 
@@ -111,13 +109,11 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-
-
     public function testprepare()
     {
-        $data = array(
+        $data = [
             'client_id' => 1,
-        );
+        ];
         $newInvoiceId = 1;
 
         $invoiceModel = new \Model_Invoice();
@@ -127,7 +123,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('prepareInvoice')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -138,7 +134,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -154,14 +150,14 @@ class AdminTest extends \BBTestCase {
 
     public function testapprove()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('approveInvoice')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -172,7 +168,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -188,14 +184,14 @@ class AdminTest extends \BBTestCase {
 
     public function testrefund()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $newNegativeInvoiceId = 2;
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('refundInvoice')
-            ->will($this->returnValue($newNegativeInvoiceId));
+            ->willReturn($newNegativeInvoiceId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -206,12 +202,11 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -223,14 +218,14 @@ class AdminTest extends \BBTestCase {
 
     public function testupdate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateInvoice')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -241,7 +236,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -255,16 +250,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testitem_delete()
+    public function testitemDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $invoiceItemService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
         $invoiceItemService->expects($this->atLeastOnce())
             ->method('remove')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -276,12 +271,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $invoiceItemService);
+        $di['mod_service'] = $di->protect(fn () => $invoiceItemService);
 
         $this->api->setDi($di);
 
@@ -292,14 +287,14 @@ class AdminTest extends \BBTestCase {
 
     public function testdelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteInvoiceByAdmin')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -311,7 +306,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -325,16 +320,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testrenewal_invoice()
+    public function testrenewalInvoice()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $newInvoiceId = 3;
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('renewInvoice')
-            ->will($this->returnValue($newInvoiceId));
+            ->willReturn($newInvoiceId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -347,7 +342,7 @@ class AdminTest extends \BBTestCase {
         $model->price = 10;
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -360,11 +355,12 @@ class AdminTest extends \BBTestCase {
         $this->assertIsInt($result);
         $this->assertEquals($newInvoiceId, $result);
     }
-    public function testrenewal_invoiceOrderIsFree()
+
+    public function testrenewalInvoiceOrderIsFree()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -378,7 +374,7 @@ class AdminTest extends \BBTestCase {
         $model->price = 0;
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -391,30 +387,30 @@ class AdminTest extends \BBTestCase {
         $this->api->renewal_invoice($data);
     }
 
-    public function testbatch_pay_with_credits()
+    public function testbatchPayWithCredits()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('doBatchPayWithCredits')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->batch_pay_with_credits(array());
+        $result = $this->api->batch_pay_with_credits([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testpay_with_credits()
+    public function testpayWithCredits()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('payInvoiceWithCredits')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -426,7 +422,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -440,12 +436,12 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testbatch_generate()
+    public function testbatchGenerate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('generateInvoicesForExpiringOrders')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
@@ -454,12 +450,12 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testbatch_activate_paid()
+    public function testbatchActivatePaid()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('doBatchPaidInvoiceActivation')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
@@ -468,45 +464,44 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testbatch_send_reminders()
+    public function testbatchSendReminders()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('doBatchRemindersSend')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->batch_send_reminders(array());
+        $result = $this->api->batch_send_reminders([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testbatch_invoke_due_event()
+    public function testbatchInvokeDueEvent()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('doBatchInvokeDueEvent')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->batch_invoke_due_event(array());
+        $result = $this->api->batch_invoke_due_event([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-
-    public function testsend_reminder()
+    public function testsendReminder()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('sendInvoiceReminder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -518,7 +513,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -532,45 +527,45 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testget_statuses()
+    public function testgetStatuses()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('counter')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->get_statuses(array());
+        $result = $this->api->get_statuses([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_process_all()
+    public function testtransactionProcessAll()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('proccessReceivedATransactions')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
-        $result = $this->api->transaction_process_all(array());
+        $result = $this->api->transaction_process_all([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testtransaction_process()
+    public function testtransactionProcess()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('preProcessTransaction')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -582,7 +577,7 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $eventsMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventsMock->expects($this->atLeastOnce())
@@ -593,7 +588,7 @@ class AdminTest extends \BBTestCase {
         $di['db'] = $dbMock;
         $di['events_manager'] = $eventsMock;
         $di['logger'] = new \Box_Log();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
@@ -602,16 +597,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtransaction_update()
+    public function testtransactionUpdate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -623,12 +618,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
@@ -637,33 +632,33 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtransaction_create()
+    public function testtransactionCreate()
     {
         $newTransactionId = 1;
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('create')
-            ->will($this->returnValue($newTransactionId));
+            ->willReturn($newTransactionId);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_create(array());
+        $result = $this->api->transaction_create([]);
         $this->assertIsInt($result);
         $this->assertEquals($newTransactionId, $result);
     }
 
-    public function testtransaction_delete()
+    public function testtransactionDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -675,12 +670,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
@@ -689,16 +684,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtransaction_get()
+    public function testtransactionGet()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -710,12 +705,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
@@ -723,170 +718,168 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_get_list()
+    public function testtransactionGetList()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
-
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
-        $result = $this->api->transaction_get_list(array());
+        $result = $this->api->transaction_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_get_statuses()
+    public function testtransactionGetStatuses()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('counter')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_get_statuses(array());
+        $result = $this->api->transaction_get_statuses([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_get_statuses_pairs()
+    public function testtransactionGetStatusesPairs()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getStatusPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_get_statuses_pairs(array());
+        $result = $this->api->transaction_get_statuses_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_statuses()
+    public function testtransactionStatuses()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getStatuses')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_statuses(array());
+        $result = $this->api->transaction_statuses([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_gateway_statuses()
+    public function testtransactionGatewayStatuses()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getGatewayStatuses')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_gateway_statuses(array());
+        $result = $this->api->transaction_gateway_statuses([]);
         $this->assertIsArray($result);
     }
 
-    public function testtransaction_types()
+    public function testtransactionTypes()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getTypes')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->transaction_types(array());
+        $result = $this->api->transaction_types([]);
         $this->assertIsArray($result);
     }
 
-    public function testgateway_get_list()
+    public function testgatewayGetList()
     {
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
-
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
 
         $this->api->setDi($di);
-        $result = $this->api->gateway_get_list(array());
+        $result = $this->api->gateway_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testgateway_get_pairs()
+    public function testgatewayGetPairs()
     {
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('getPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
         $this->api->setDi($di);
 
-        $result = $this->api->gateway_get_pairs(array());
+        $result = $this->api->gateway_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testgateway_get_available()
+    public function testgatewayGetAvailable()
     {
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('getAvailable')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
         $this->api->setDi($di);
 
-        $result = $this->api->gateway_get_available(array());
+        $result = $this->api->gateway_get_available([]);
         $this->assertIsArray($result);
     }
 
-    public function testgateway_install()
+    public function testgatewayInstall()
     {
-        $data = array(
+        $data = [
             'code' => 'PP',
-        );
+        ];
 
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('install')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -894,7 +887,7 @@ class AdminTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
         $this->api->setDi($di);
 
         $result = $this->api->gateway_install($data);
@@ -902,16 +895,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testgateway_get()
+    public function testgatewayGet()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -923,12 +916,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
 
         $this->api->setDi($di);
 
@@ -936,16 +929,16 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testgateway_copy()
+    public function testgatewayCopy()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $newGatewayId = 1;
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('copy')
-            ->will($this->returnValue($newGatewayId));
+            ->willReturn($newGatewayId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -957,12 +950,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
 
         $this->api->setDi($di);
 
@@ -971,16 +964,16 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newGatewayId, $result);
     }
 
-    public function testgateway_update()
+    public function testgatewayUpdate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -992,12 +985,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
 
         $this->api->setDi($di);
 
@@ -1006,16 +999,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testgateway_delete()
+    public function testgatewayDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $gatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayService->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1027,12 +1020,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $gatewayService);
+        $di['mod_service'] = $di->protect(fn () => $gatewayService);
 
         $this->api->setDi($di);
 
@@ -1046,35 +1039,34 @@ class AdminTest extends \BBTestCase {
         $subscriptionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
         $subscriptionService->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $subscriptionService);
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
 
         $this->api->setDi($di);
-        $result = $this->api->subscription_get_list(array());
+        $result = $this->api->subscription_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testsubscription_create()
+    public function testsubscriptionCreate()
     {
-        $data = array(
+        $data = [
             'client_id' => 1,
             'gateway_id' => 1,
             'currency' => 'EU',
-
-        );
+        ];
         $newSubscriptionId = 1;
         $subscriptionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
         $subscriptionService->expects($this->atLeastOnce())
             ->method('create')
-            ->will($this->returnValue($newSubscriptionId));
+            ->willReturn($newSubscriptionId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1095,7 +1087,7 @@ class AdminTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $subscriptionService);
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
 
         $this->api->setDi($di);
 
@@ -1104,14 +1096,13 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newSubscriptionId, $result);
     }
 
-    public function testsubscription_createCurrencyMismatch()
+    public function testsubscriptionCreateCurrencyMismatch()
     {
-        $data = array(
+        $data = [
             'client_id' => 1,
             'gateway_id' => 1,
             'currency' => 'EU',
-
-        );
+        ];
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1139,16 +1130,16 @@ class AdminTest extends \BBTestCase {
         $this->api->subscription_create($data);
     }
 
-    public function testsubscription_update()
+    public function testsubscriptionUpdate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $subscriptionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
         $subscriptionService->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1160,12 +1151,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $subscriptionService);
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
 
         $this->api->setDi($di);
 
@@ -1174,28 +1165,28 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testsubscription_get()
+    public function testsubscriptionGet()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $subscriptionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
         $subscriptionService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-       $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
 
         $model = new \Model_Subscription();
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $subscriptionService);
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
 
         $this->api->setDi($di);
 
@@ -1203,16 +1194,16 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testsubscription_delete()
+    public function testsubscriptionDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $subscriptionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
         $subscriptionService->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1224,12 +1215,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $subscriptionService);
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
 
         $this->api->setDi($di);
 
@@ -1238,16 +1229,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtax_delete()
+    public function testtaxDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
         $taxService->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1259,12 +1250,12 @@ class AdminTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $taxService);
+        $di['mod_service'] = $di->protect(fn () => $taxService);
 
         $this->api->setDi($di);
 
@@ -1273,25 +1264,24 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtax_create()
+    public function testtaxCreate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
         $newTaxId = 1;
         $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
         $taxService->expects($this->atLeastOnce())
             ->method('create')
-            ->will($this->returnValue($newTaxId));
+            ->willReturn($newTaxId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['mod_service'] = $di->protect(fn() => $taxService);
+        $di['mod_service'] = $di->protect(fn () => $taxService);
 
         $this->api->setDi($di);
 
@@ -1305,95 +1295,94 @@ class AdminTest extends \BBTestCase {
         $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
         $taxService->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $taxService);
+        $di['mod_service'] = $di->protect(fn () => $taxService);
 
         $this->api->setDi($di);
 
-        $result = $this->api->tax_get_list(array());
+        $result = $this->api->tax_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Api\Admin::class)->onlyMethods(array('delete'))->getMock();
+        $activityMock = $this->getMockBuilder('\\' . Admin::class)->onlyMethods(['delete'])->getMock();
         $activityMock->expects($this->atLeastOnce())->
         method('delete')->
-        will($this->returnValue(true));
+        willReturn(true);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
-    public function testBatch_delete_subscription()
+    public function testBatchDeleteSubscription()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Api\Admin::class)->onlyMethods(array('subscription_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('subscription_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . Admin::class)->onlyMethods(['subscription_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('subscription_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_subscription(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_subscription(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
-    public function testBatch_delete_transaction()
+    public function testBatchDeleteTransaction()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Api\Admin::class)->onlyMethods(array('transaction_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('transaction_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . Admin::class)->onlyMethods(['transaction_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('transaction_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_transaction(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_transaction(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
-
-    public function testBatch_delete_tax()
+    public function testBatchDeleteTax()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Api\Admin::class)->onlyMethods(array('tax_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('tax_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . Admin::class)->onlyMethods(['tax_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('tax_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_tax(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_tax(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
     public function testgetTax()
@@ -1405,29 +1394,28 @@ class AdminTest extends \BBTestCase {
         $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
         $taxService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $model  = new \Model_Tax();
+        $model = new \Model_Tax();
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di                = new \Pimple\Container();
-        $di['validator']   = $validatorMock;
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $taxService);
+        $di = new \Pimple\Container();
+        $di['validator'] = $validatorMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $taxService);
 
         $this->api->setDi($di);
         $this->api->setService($taxService);
         $this->api->setIdentity(new \Model_Admin());
 
         $data['id'] = 1;
-        $result     = $this->api->tax_get($data);
+        $result = $this->api->tax_get($data);
         $this->assertIsArray($result);
     }
-
 
     public function testupdateTax()
     {
@@ -1438,28 +1426,27 @@ class AdminTest extends \BBTestCase {
         $taxService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
         $taxService->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $model  = new \Model_Tax();
+        $model = new \Model_Tax();
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di                = new \Pimple\Container();
-        $di['validator']   = $validatorMock;
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $taxService);
+        $di = new \Pimple\Container();
+        $di['validator'] = $validatorMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $taxService);
 
         $this->api->setDi($di);
         $this->api->setService($taxService);
         $this->api->setIdentity(new \Model_Admin());
 
         $data['id'] = 1;
-        $result     = $this->api->tax_update($data);
+        $result = $this->api->tax_update($data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
-
 }

--- a/tests/modules/Invoice/Api/ClientTest.php
+++ b/tests/modules/Invoice/Api/ClientTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice\Api;
 
-
-class ClientTest extends \BBTestCase {
+class ClientTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Invoice\Api\Client
+     * @var Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Invoice\Api\Client();
+        $this->api = new Client();
     }
 
     public function testgetDi()
@@ -28,7 +27,7 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -39,7 +38,7 @@ class ClientTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -65,7 +64,7 @@ class ClientTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -85,7 +84,7 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateInvoice')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -96,7 +95,7 @@ class ClientTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -123,7 +122,7 @@ class ClientTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -150,7 +149,7 @@ class ClientTest extends \BBTestCase {
         $model->status = 'paid';
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -165,7 +164,7 @@ class ClientTest extends \BBTestCase {
         $this->api->update($data);
     }
 
-    public function testrenewal_invoice()
+    public function testrenewalInvoice()
     {
         $generatedHash = 'generatedHashString';
 
@@ -176,7 +175,7 @@ class ClientTest extends \BBTestCase {
         $model->hash = $generatedHash;
         $serviceMock->expects($this->atLeastOnce())
             ->method('generateForOrder')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('approveInvoice');
 
@@ -191,7 +190,7 @@ class ClientTest extends \BBTestCase {
 
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientOrder));
+            ->willReturn($clientOrder);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -210,7 +209,7 @@ class ClientTest extends \BBTestCase {
         $this->assertEquals($generatedHash, $result);
     }
 
-    public function testrenewal_invoiceOrderIsFree()
+    public function testrenewalInvoiceOrderIsFree()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -224,7 +223,7 @@ class ClientTest extends \BBTestCase {
 
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientOrder));
+            ->willReturn($clientOrder);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -241,10 +240,9 @@ class ClientTest extends \BBTestCase {
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage(sprintf('Order %d is free. No need to generate invoice.', $clientOrder->id));
         $this->api->renewal_invoice($data);
-
     }
 
-    public function testrenewal_invoiceOrderNotFound()
+    public function testrenewalInvoiceOrderNotFound()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -257,7 +255,7 @@ class ClientTest extends \BBTestCase {
 
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -275,7 +273,7 @@ class ClientTest extends \BBTestCase {
         $this->api->renewal_invoice($data);
     }
 
-    public function testfunds_invoice()
+    public function testfundsInvoice()
     {
         $generatedHash = 'generatedHashString';
 
@@ -290,7 +288,7 @@ class ClientTest extends \BBTestCase {
         $model->hash = $generatedHash;
         $serviceMock->expects($this->atLeastOnce())
             ->method('generateFundsInvoice')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('approveInvoice');
 
@@ -319,7 +317,7 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteInvoiceByClient')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $model = new \Model_Invoice();
@@ -327,13 +325,12 @@ class ClientTest extends \BBTestCase {
 
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
-
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -347,33 +344,32 @@ class ClientTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtransaction_get_list()
+    public function testtransactionGetList()
     {
         $transactionService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)->getMock();
         $transactionService->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod_service'] = $di->protect(fn() => $transactionService);
-
+        $di['mod_service'] = $di->protect(fn () => $transactionService);
 
         $this->api->setDi($di);
 
         $identity = new \Model_Client();
         $identity->loadBean(new \DummyBean());
         $this->api->setIdentity($identity);
-        $result = $this->api->transaction_get_list(array());
+        $result = $this->api->transaction_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testget_tax_rate()
+    public function testgetTaxRate()
     {
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
@@ -386,11 +382,10 @@ class ClientTest extends \BBTestCase {
             ->method('getTaxRateForClient')
             ->willReturn($taxRate);
 
-
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function ($service, $sub) use($invoiceTaxService){
-            if ($service == 'Invoice' && $sub == 'Tax'){
-                return  $invoiceTaxService;
+        $di['mod_service'] = $di->protect(function ($service, $sub) use ($invoiceTaxService) {
+            if ($service == 'Invoice' && $sub == 'Tax') {
+                return $invoiceTaxService;
             }
         });
         $this->api->setDi($di);
@@ -399,7 +394,4 @@ class ClientTest extends \BBTestCase {
         $result = $this->api->get_tax_rate();
         $this->assertEquals($taxRate, $result);
     }
-
-
-
 }

--- a/tests/modules/Invoice/Api/GuestTest.php
+++ b/tests/modules/Invoice/Api/GuestTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice\Api;
 
-
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Invoice\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Invoice\Api\Guest();
+        $this->api = new Guest();
     }
 
     public function testgetDi()
@@ -28,7 +27,7 @@ class GuestTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -39,7 +38,7 @@ class GuestTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -65,7 +64,7 @@ class GuestTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -85,7 +84,7 @@ class GuestTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateInvoice')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -96,7 +95,7 @@ class GuestTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -123,7 +122,7 @@ class GuestTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -150,7 +149,7 @@ class GuestTest extends \BBTestCase {
         $model->status = 'paid';
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -170,27 +169,27 @@ class GuestTest extends \BBTestCase {
         $gatewayServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
         $gatewayServiceMock->expects($this->atLeastOnce())
             ->method('getActive')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $gatewayServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $gatewayServiceMock);
 
         $this->api->setDi($di);
 
-        $result = $this->api->gateways(array());
+        $result = $this->api->gateways([]);
         $this->assertIsArray($result);
     }
 
     public function testpayment()
     {
-        $data = array(
+        $data = [
             'hash' => '',
             'gateway_id' => '',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('processInvoice')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -200,9 +199,9 @@ class GuestTest extends \BBTestCase {
 
     public function testpaymentMissingHashParam()
     {
-        $data = array(
+        $data = [
             'gateway_id' => '',
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(810);
@@ -212,9 +211,9 @@ class GuestTest extends \BBTestCase {
 
     public function testpaymentMissingGatewayIdParam()
     {
-        $data = array(
+        $data = [
             'hash' => '',
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(811);
@@ -224,9 +223,9 @@ class GuestTest extends \BBTestCase {
 
     public function testpdf()
     {
-        $data = array(
+        $data = [
             'hash' => '',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('generatePDF');
@@ -234,7 +233,7 @@ class GuestTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;

--- a/tests/modules/Invoice/ServiceInvoiceItemTest.php
+++ b/tests/modules/Invoice/ServiceInvoiceItemTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
-
 
 class ServiceInvoiceItemTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Invoice\ServiceInvoiceItem
+     * @var ServiceInvoiceItem
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\ServiceInvoiceItem();
+        $this->service = new ServiceInvoiceItem();
     }
 
     public function testgetDi()
@@ -29,8 +27,8 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('creditInvoiceItem', 'getOrderId'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['creditInvoiceItem', 'getOrderId'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('creditInvoiceItem');
@@ -54,9 +52,9 @@ class ServiceInvoiceItemTest extends \BBTestCase
             ->method('load')
             ->willReturn($clientOrder);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
         $serviceMock->setDi($di);
 
         $serviceMock->markAsPaid($invoiceItemModel);
@@ -77,21 +75,21 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
         $invoiceItemModel->type = \Model_InvoiceItem::TYPE_ORDER;
-        $orderId                = 22;
+        $orderId = 22;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('getOrderId'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['getOrderId'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderId')
-            ->will($this->returnValue($orderId));
+            ->willReturn($orderId);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -104,11 +102,11 @@ class ServiceInvoiceItemTest extends \BBTestCase
     {
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
-        $invoiceItemModel->type   = \Model_InvoiceItem::TYPE_HOOK_CALL;
+        $invoiceItemModel->type = \Model_InvoiceItem::TYPE_HOOK_CALL;
         $invoiceItemModel->rel_id = '{}';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('markAsExecuted'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['markAsExecuted'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('markAsExecuted');
@@ -117,7 +115,7 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventManagerMock;
         $serviceMock->setDi($di);
 
@@ -141,14 +139,14 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $di['db'] = $dbMock;
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
-        $di['mod_service'] = $di->protect(function ($serviceName) use ($clientServiceMock){
-            if ($serviceName == 'Client'){
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($clientServiceMock) {
+            if ($serviceName == 'Client') {
                 return $clientServiceMock;
             }
         });
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('markAsExecuted'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['markAsExecuted'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('markAsExecuted');
@@ -163,8 +161,8 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceItemModel->loadBean(new \DummyBean());
         $invoiceItemModel->type = \Model_InvoiceItem::TYPE_CUSTOM;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('markAsExecuted'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['markAsExecuted'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('markAsExecuted');
@@ -174,10 +172,9 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testaddNew()
     {
-        $data             = array(
+        $data = [
             'title' => 'Guacamole',
-
-        );
+        ];
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
         $newId = 1;
@@ -185,16 +182,16 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($invoiceItemModel));
+            ->willReturn($invoiceItemModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $periodMock = $this->getMockBuilder('\Box_Period')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -208,11 +205,11 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testgetTotal()
     {
-        $price            = 5;
-        $quantity         = 3;
+        $price = 5;
+        $quantity = 3;
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
-        $invoiceItemModel->price    = $price;
+        $invoiceItemModel->price = $price;
         $invoiceItemModel->quantity = $quantity;
 
         $expected = $price * $quantity;
@@ -224,25 +221,25 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testgetTax()
     {
-        $rate             = 0.21;
-        $price            = 12;
+        $rate = 0.21;
+        $price = 12;
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
         $invoiceItemModel->invoice_id = 2;
-        $invoiceItemModel->taxed      = true;
-        $invoiceItemModel->price      = $price;
+        $invoiceItemModel->taxed = true;
+        $invoiceItemModel->price = $price;
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($rate));
+            ->willReturn($rate);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
-        $result   = $this->service->getTax($invoiceItemModel);
-        $expected = round(($price * $rate / 100), 2);
+        $result = $this->service->getTax($invoiceItemModel);
+        $expected = round($price * $rate / 100, 2);
         $this->assertIsFloat($result);
         $this->assertEquals($expected, $result);
     }
@@ -252,17 +249,17 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'title' => 'New Engine',
             'price' => 12,
             'taxed' => true,
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -275,18 +272,18 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'title' => 'New Engine',
             'price' => 12,
             'taxed' => true,
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
         $this->service->setDi($di);
 
@@ -300,15 +297,14 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $invoiceModel->loadBean(new \DummyBean());
         $amount = 11;
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -317,12 +313,12 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testcreditInvoiceItem()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('getTotalWithTax'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['getTotalWithTax'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTotalWithTax')
-            ->will($this->returnValue(11.2));
+            ->willReturn(11.2);
 
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
@@ -339,17 +335,17 @@ class ServiceInvoiceItemTest extends \BBTestCase
             ->will($this->onConsecutiveCalls($invoiceModel, $clientModel));
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($clientBalanceModel));
+            ->willReturn($clientBalanceModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $invoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
+        $invoiceServiceMock = $this->getMockBuilder('\\' . Service::class)->getMock();
         $invoiceServiceMock->expects($this->atLeastOnce())
             ->method('addNote');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $invoiceServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $invoiceServiceMock);
 
         $serviceMock->setDi($di);
         $serviceMock->creditInvoiceItem($invoiceItemModel);
@@ -357,22 +353,22 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testgetTotalWithTax()
     {
-        $total    = 5;
-        $tax      = 0.5;
+        $total = 5;
+        $tax = 0.5;
         $quantity = 3;
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
         $invoiceItemModel->quantity = $quantity;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
-            ->onlyMethods(array('getTotal', 'getTax'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
+            ->onlyMethods(['getTotal', 'getTax'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTotal')
-            ->will($this->returnValue($total));
+            ->willReturn($total);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTax')
-            ->will($this->returnValue($tax));
+            ->willReturn($tax);
 
         $result = $serviceMock->getTotalWithTax($invoiceItemModel);
         $this->assertIsFloat($result);
@@ -382,11 +378,11 @@ class ServiceInvoiceItemTest extends \BBTestCase
 
     public function testgetOrderId()
     {
-        $orderId          = 2;
+        $orderId = 2;
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
         $invoiceItemModel->rel_id = $orderId;
-        $invoiceItemModel->type   = \Model_InvoiceItem::TYPE_ORDER;
+        $invoiceItemModel->type = \Model_InvoiceItem::TYPE_ORDER;
 
         $result = $this->service->getOrderId($invoiceItemModel);
         $this->assertIsInt($result);
@@ -411,7 +407,7 @@ class ServiceInvoiceItemTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $di['db'] = $dbMock;
         $this->service->setDi($di);

--- a/tests/modules/Invoice/ServicePayGatewayTest.php
+++ b/tests/modules/Invoice/ServicePayGatewayTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
 
-
-class ServicePayGatewayTest extends \BBTestCase {
-
+class ServicePayGatewayTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Invoice\ServicePayGateway
+     * @var ServicePayGateway
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\ServicePayGateway();
+        $this->service = new ServicePayGateway();
     }
 
     public function testgetDi()
@@ -29,12 +27,12 @@ class ServicePayGatewayTest extends \BBTestCase {
         $di = new \Pimple\Container();
 
         $this->service->setDi($di);
-        $data = array();
+        $data = [];
         $result = $this->service->getSearchQuery($data);
         $this->assertIsArray($result);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
-        $this->assertEquals(array(), $result[1]);
+        $this->assertEquals([], $result[1]);
     }
 
     public function testgetSearchQueryWithAdditionalParams()
@@ -42,8 +40,8 @@ class ServicePayGatewayTest extends \BBTestCase {
         $di = new \Pimple\Container();
 
         $this->service->setDi($di);
-        $data = array('search' => 'keyword');
-        $expectedParams = array(':search' => "%$data[search]%");
+        $data = ['search' => 'keyword'];
+        $expectedParams = [':search' => "%$data[search]%"];
 
         $result = $this->service->getSearchQuery($data);
         $this->assertIsArray($result);
@@ -55,21 +53,21 @@ class ServicePayGatewayTest extends \BBTestCase {
 
     public function testgetPairs()
     {
-        $expected = array(
+        $expected = [
             1 => 'Custom',
-        );
+        ];
 
-        $queryResult = array(
-            array(
+        $queryResult = [
+            [
                 'id' => 1,
                 'name' => 'Custom',
-            ),
-        );
+            ],
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($queryResult));
+            ->willReturn($queryResult);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -86,7 +84,7 @@ class ServicePayGatewayTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -100,19 +98,19 @@ class ServicePayGatewayTest extends \BBTestCase {
     {
         $code = 'PP';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAvailable'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAvailable'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAvailable')
-            ->will($this->returnValue(array($code)));
+            ->willReturn([$code]);
 
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($payGatewayModel));
+            ->willReturn($payGatewayModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
@@ -127,16 +125,16 @@ class ServicePayGatewayTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testinstall_GatewayNotAvailable()
+    public function testinstallGatewayNotAvailable()
     {
         $code = 'PP';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAvailable'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAvailable'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAvailable')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Payment gateway is not available for installation.');
@@ -148,14 +146,14 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array(
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods([
                 'getAdapterConfig', 'getAcceptedCurrencies', 'getFormElements',
-                'getDescription'))
+                'getDescription'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAcceptedCurrencies');
         $serviceMock->expects($this->atLeastOnce())
@@ -164,25 +162,25 @@ class ServicePayGatewayTest extends \BBTestCase {
             ->method('getDescription');
 
         $url = 'http://localhost/';
-        $expected = array(
-            'id'                         => null,
-            'code'                       => null,
-            'title'                      => null,
-            'allow_single'               => null,
-            'allow_recurrent'            => null,
-            'accepted_currencies'        => null,
+        $expected = [
+            'id' => null,
+            'code' => null,
+            'title' => null,
+            'allow_single' => null,
+            'allow_recurrent' => null,
+            'accepted_currencies' => null,
             'supports_one_time_payments' => false,
-            'supports_subscriptions'     => false,
-            'config'                     => [],
-            'form'                       => null,
-            'description'                => null,
-            'enabled'                    => null,
-            'test_mode'                  => null,
-            'callback'                   => $url.'ipn.php?',
-        );
+            'supports_subscriptions' => false,
+            'config' => [],
+            'form' => null,
+            'description' => null,
+            'enabled' => null,
+            'test_mode' => null,
+            'callback' => $url . 'ipn.php?',
+        ];
 
         $di = new \Pimple\Container();
-        $di['config'] = array('url' => $url);
+        $di['config'] = ['url' => $url];
 
         $serviceMock->setDi($di);
 
@@ -198,12 +196,12 @@ class ServicePayGatewayTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($payGatewayModel));
+            ->willReturn($payGatewayModel);
 
         $expected = 2;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -231,15 +229,15 @@ class ServicePayGatewayTest extends \BBTestCase {
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'title' => '',
             'config' => '',
-            'accepted_currencies' => array(),
+            'accepted_currencies' => [],
             'enabled' => '',
             'allow_single' => '',
             'allow_recurrent' => '',
             'test_mode' => '',
-        );
+        ];
         $result = $this->service->update($payGatewayModel, $data);
         $this->assertTrue($result);
     }
@@ -271,14 +269,14 @@ class ServicePayGatewayTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($payGatewayModel)));
+            ->willReturn([$payGatewayModel]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
 
-        $data = array('format' => 'pairs');
+        $data = ['format' => 'pairs'];
         $result = $this->service->getActive($data);
         $this->assertIsArray($result);
     }
@@ -304,62 +302,62 @@ class ServicePayGatewayTest extends \BBTestCase {
         $invoiceModel->loadBean(new \DummyBean());
         $expected = 'Payment_Adapter_Custom';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->addMethods(['getConfig'])
             ->onlyMethods(['getAdapterClassName'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterClassName')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $urlMock = $this->getMockBuilder('\Box_Url')->getMock();
         $urlMock->expects($this->atLeastOnce())
             ->method('link');
 
         $di = new \Pimple\Container();
-        $di['config'] = array('url' => 'http://fossbilling.vm/', 'debug' => true);
+        $di['config'] = ['url' => 'http://fossbilling.vm/', 'debug' => true];
         $di['tools'] = $toolsMock;
         $di['url'] = $urlMock;
         $serviceMock->setDi($di);
 
-        $optional = array(
+        $optional = [
             'auto_redirect' => '',
-        );
+        ];
         $result = $serviceMock->getPaymentAdapter($payGatewayModel, $invoiceModel, $optional);
         $this->assertInstanceOf($expected, $result);
     }
 
-    public function testgetPaymentAdapter_PaymentGatewayNotFound()
+    public function testgetPaymentAdapterPaymentGatewayNotFound()
     {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->addMethods(['getConfig'])
             ->onlyMethods(['getAdapterClassName'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterClassName')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $urlMock = $this->getMockBuilder('\Box_Url')->getMock();
         $urlMock->expects($this->atLeastOnce())
             ->method('link');
 
         $di = new \Pimple\Container();
-        $di['config'] = array('url' => 'http://fossbilling.vm/', 'debug' => true);
+        $di['config'] = ['url' => 'http://fossbilling.vm/', 'debug' => true];
         $di['tools'] = $toolsMock;
         $di['url'] = $urlMock;
         $serviceMock->setDi($di);
@@ -376,13 +374,13 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel->gateway = 'Custom';
 
         $expected = '\Payment_Adapter_Custom';
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->addMethods(['getConfig'])
             ->onlyMethods(['getAdapterClassName'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterClassName')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $result = $serviceMock->getAdapterConfig($payGatewayModel);
         $this->assertIsArray($result);
@@ -395,16 +393,16 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel->gateway = 'Custom';
 
         $expected = 'Payment_Adapter_ClassDoesNotExists';
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->addMethods(['getConfig'])
             ->onlyMethods(['getAdapterClassName'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterClassName')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $this->expectExceptionMessage(sprintf("Payment gateway class %s was not found", $expected));
+        $this->expectExceptionMessage(sprintf('Payment gateway class %s was not found', $expected));
         $serviceMock->getAdapterConfig($payGatewayModel);
     }
 
@@ -414,7 +412,7 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel->loadBean(new \DummyBean());
         $payGatewayModel->gateway = 'Unknown';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->addMethods(['getConfig'])
             ->onlyMethods(['getAdapterClassName'])
             ->getMock();
@@ -422,7 +420,7 @@ class ServicePayGatewayTest extends \BBTestCase {
             ->method('getAdapterClassName');
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $this->expectExceptionMessage(sprintf("Payment gateway %s was not found", $payGatewayModel->gateway));
+        $this->expectExceptionMessage(sprintf('Payment gateway %s was not found', $payGatewayModel->gateway));
         $serviceMock->getAdapterConfig($payGatewayModel);
     }
 
@@ -454,13 +452,13 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAdapterConfig'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAdapterConfig'])
             ->getMock();
-        $config = array('form' => array());
+        $config = ['form' => []];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         $result = $serviceMock->getFormElements($payGatewayModel);
         $this->assertIsArray($result);
@@ -471,17 +469,17 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAdapterConfig'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAdapterConfig'])
             ->getMock();
-        $config = array();
+        $config = [];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         $result = $serviceMock->getFormElements($payGatewayModel);
         $this->assertIsArray($result);
-        $emptyArray = array();
+        $emptyArray = [];
         $this->assertEquals($emptyArray, $result);
     }
 
@@ -490,13 +488,13 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAdapterConfig'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAdapterConfig'])
             ->getMock();
-        $config = array('description' => '');
+        $config = ['description' => ''];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         $result = $serviceMock->getDescription($payGatewayModel);
         $this->assertIsString($result);
@@ -507,13 +505,13 @@ class ServicePayGatewayTest extends \BBTestCase {
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
-            ->onlyMethods(array('getAdapterConfig'))
+        $serviceMock = $this->getMockBuilder('\\' . ServicePayGateway::class)
+            ->onlyMethods(['getAdapterConfig'])
             ->getMock();
-        $config = array();
+        $config = [];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdapterConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         $result = $serviceMock->getDescription($payGatewayModel);
         $this->assertNull($result);

--- a/tests/modules/Invoice/ServiceSubscriptionTest.php
+++ b/tests/modules/Invoice/ServiceSubscriptionTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
-
 
 class ServiceSubscriptionTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Invoice\ServiceSubscription
+     * @var ServiceSubscription
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\ServiceSubscription();
+        $this->service = new ServiceSubscription();
     }
 
     public function testgetDi()
@@ -34,27 +32,27 @@ class ServiceSubscriptionTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($subscriptionModel));
+            ->willReturn($subscriptionModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $eventsMock = $this->getMockBuilder('\Box_EventManager')
             ->getMock();
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $eventsMock;
 
         $this->service->setDi($di);
 
-        $data = array(
-            'client_id'  => 1,
+        $data = [
+            'client_id' => 1,
             'gateway_id' => 2,
-        );
+        ];
 
         $result = $this->service->create(new \Model_Client(), new \Model_PayGateway(), $data);
         $this->assertIsInt($result);
@@ -65,22 +63,22 @@ class ServiceSubscriptionTest extends \BBTestCase
     {
         $subscriptionModel = new \Model_Subscription();
         $subscriptionModel->loadBean(new \DummyBean());
-        $data = array(
-            'status'   => '',
-            'sid'      => '',
-            'period'   => '',
-            'amount'   => '',
+        $data = [
+            'status' => '',
+            'sid' => '',
+            'period' => '',
+            'amount' => '',
             'currency' => '',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
@@ -108,15 +106,15 @@ class ServiceSubscriptionTest extends \BBTestCase
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $payGatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)
+        $payGatewayService = $this->getMockBuilder('\\' . ServicePayGateway::class)
             ->getMock();
         $payGatewayService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($clientServiceMock, $payGatewayService) {
             if ($serviceName == 'Client') {
                 return $clientServiceMock;
@@ -125,21 +123,21 @@ class ServiceSubscriptionTest extends \BBTestCase
                 return $payGatewayService;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
-        $expected = array(
-            'id'         => '',
-            'sid'        => '',
-            'period'     => '',
-            'amount'     => '',
-            'currency'   => '',
-            'status'     => '',
+        $expected = [
+            'id' => '',
+            'sid' => '',
+            'period' => '',
+            'amount' => '',
+            'currency' => '',
+            'status' => '',
             'created_at' => '',
             'updated_at' => '',
-            'client'     => array(),
-            'gateway'    => array(),
-        );
+            'client' => [],
+            'gateway' => [],
+        ];
 
         $result = $this->service->toApiArray($subscriptionModel);
         $this->assertIsArray($result);
@@ -163,9 +161,9 @@ class ServiceSubscriptionTest extends \BBTestCase
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $eventsMock;
         $this->service->setDi($di);
 
@@ -175,44 +173,44 @@ class ServiceSubscriptionTest extends \BBTestCase
 
     public static function searchQueryData()
     {
-        return array(
-            array(
-                array(), 'FROM subscription', array(),
-            ),
-            array(
-                array('status' => 'active'), 'AND status = :status', array(':status' => 'active'),
-            ),
-            array(
-                array('invoice_id' => '1'), 'AND invoice_id = :invoice_id', array('invoice_id' => '1'),
-            ),
-            array(
-                array('gateway_id' => '2'), 'AND gateway_id = :gateway_id', array(':gateway_id' => '2'),
-            ),
-            array(
-                array('client_id' => '3'), 'AND client_id  = :client_id', array(':client_id' => '3'),
-            ),
-            array(
-                array('currency' => 'EUR'), 'AND currency =  :currency', array(':currency' => 'EUR'),
-            ),
-            array(
-                array('date_from' => '1234567'), 'AND UNIX_TIMESTAMP(created_at) >= :date_from', array(':date_from' => '1234567'),
-            ),
-            array(
-                array('date_to' => '1234567'), 'AND UNIX_TIMESTAMP(created_at) <= :date_to', array(':date_to' => '1234567'),
-            ),
-            array(
-                array('id' => '10'), 'AND id = :id', array(':id' => '10'),
-            ),
-            array(
-                array('sid' => '10'), 'AND sid = :sid', array(':sid' => '10'),
-            ),
-        );
+        return [
+            [
+                [], 'FROM subscription', [],
+            ],
+            [
+                ['status' => 'active'], 'AND status = :status', [':status' => 'active'],
+            ],
+            [
+                ['invoice_id' => '1'], 'AND invoice_id = :invoice_id', ['invoice_id' => '1'],
+            ],
+            [
+                ['gateway_id' => '2'], 'AND gateway_id = :gateway_id', [':gateway_id' => '2'],
+            ],
+            [
+                ['client_id' => '3'], 'AND client_id  = :client_id', [':client_id' => '3'],
+            ],
+            [
+                ['currency' => 'EUR'], 'AND currency =  :currency', [':currency' => 'EUR'],
+            ],
+            [
+                ['date_from' => '1234567'], 'AND UNIX_TIMESTAMP(created_at) >= :date_from', [':date_from' => '1234567'],
+            ],
+            [
+                ['date_to' => '1234567'], 'AND UNIX_TIMESTAMP(created_at) <= :date_to', [':date_to' => '1234567'],
+            ],
+            [
+                ['id' => '10'], 'AND id = :id', [':id' => '10'],
+            ],
+            [
+                ['sid' => '10'], 'AND sid = :sid', [':sid' => '10'],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchQueryData')]
     public function testgetSearchQuery($data, $expectedSqlPart, $expectedParams)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
         $result = $this->service->getSearchQuery($data);
@@ -231,14 +229,14 @@ class ServiceSubscriptionTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(array('')));
+            ->willReturn(['']);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $invoice_id = 2;
-        $result     = $this->service->isSubscribable($invoice_id);
+        $result = $this->service->isSubscribable($invoice_id);
         $this->assertIsBool($result);
         $this->assertFalse($result);
     }
@@ -249,42 +247,42 @@ class ServiceSubscriptionTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $getAllResults = array(
-            0 => array('period' => '1W'),
-        );
+        $getAllResults = [
+            0 => ['period' => '1W'],
+        ];
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($getAllResults));
+            ->willReturn($getAllResults);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $invoice_id = 2;
-        $result     = $this->service->isSubscribable($invoice_id);
+        $result = $this->service->isSubscribable($invoice_id);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
     public function testgetSubscriptionPeriod()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)
-            ->onlyMethods(array('isSubscribable'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceSubscription::class)
+            ->onlyMethods(['isSubscribable'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('isSubscribable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $period = '1W';
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($period));
+            ->willReturn($period);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -304,11 +302,10 @@ class ServiceSubscriptionTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $this->service->unsubscribe($subscribtionModel);
     }
-
 }

--- a/tests/modules/Invoice/ServiceTaxTest.php
+++ b/tests/modules/Invoice/ServiceTaxTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
-
 
 class ServiceTaxTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Invoice\ServiceTax
+     * @var ServiceTax
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\ServiceTax();
+        $this->service = new ServiceTax();
     }
 
     public function testgetDi()
@@ -27,14 +25,14 @@ class ServiceTaxTest extends \BBTestCase
     public function testgetTaxRateForClientByCountryAndState()
     {
         $taxRateExpected = 0.21;
-        $clientModel     = new \Model_Client();
+        $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('isClientTaxable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $taxModel = new \Model_Tax();
         $taxModel->loadBean(new \DummyBean());
@@ -44,11 +42,11 @@ class ServiceTaxTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($taxModel));
+            ->willReturn($taxModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->getTaxRateForClient($clientModel);
@@ -59,14 +57,14 @@ class ServiceTaxTest extends \BBTestCase
     public function testgetTaxRateForClientByCountry()
     {
         $taxRateExpected = 0.21;
-        $clientModel     = new \Model_Client();
+        $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('isClientTaxable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $taxModel = new \Model_Tax();
         $taxModel->loadBean(new \DummyBean());
@@ -78,9 +76,9 @@ class ServiceTaxTest extends \BBTestCase
             ->method('findOne')
             ->will($this->onConsecutiveCalls(null, $taxModel));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->getTaxRateForClient($clientModel);
@@ -91,14 +89,14 @@ class ServiceTaxTest extends \BBTestCase
     public function testgetTaxRateForClient()
     {
         $taxRateExpected = 0.21;
-        $clientModel     = new \Model_Client();
+        $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('isClientTaxable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $taxModel = new \Model_Tax();
         $taxModel->loadBean(new \DummyBean());
@@ -110,9 +108,9 @@ class ServiceTaxTest extends \BBTestCase
             ->method('findOne')
             ->will($this->onConsecutiveCalls(null, null, $taxModel));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->getTaxRateForClient($clientModel);
@@ -120,7 +118,7 @@ class ServiceTaxTest extends \BBTestCase
         $this->assertEquals($taxRateExpected, $result);
     }
 
-    public function testgetTaxRateForClient_TaxWasNotFound()
+    public function testgetTaxRateForClientTaxWasNotFound()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -129,7 +127,7 @@ class ServiceTaxTest extends \BBTestCase
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('isClientTaxable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
@@ -137,18 +135,18 @@ class ServiceTaxTest extends \BBTestCase
             ->method('findOne')
             ->will($this->onConsecutiveCalls(null, null, null));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $taxRateExpected = 0;
-        $result          = $this->service->getTaxRateForClient($clientModel);
+        $result = $this->service->getTaxRateForClient($clientModel);
         $this->assertIsInt($result);
         $this->assertEquals($taxRateExpected, $result);
     }
 
-    public function testgetTaxRateForClient_ClientIsNotTaxable()
+    public function testgetTaxRateForClientClientIsNotTaxable()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -157,17 +155,17 @@ class ServiceTaxTest extends \BBTestCase
             ->getMock();
         $clientServiceMock->expects($this->atLeastOnce())
             ->method('isClientTaxable')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $taxModel = new \Model_Tax();
         $taxModel->loadBean(new \DummyBean());
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
         $this->service->setDi($di);
 
         $taxRateExpected = 0;
-        $result          = $this->service->getTaxRateForClient($clientModel);
+        $result = $this->service->getTaxRateForClient($clientModel);
         $this->assertIsInt($result);
         $this->assertEquals($taxRateExpected, $result);
     }
@@ -196,15 +194,15 @@ class ServiceTaxTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->willReturn(array($invoiceItemModel));
+            ->willReturn([$invoiceItemModel]);
 
-        $invoiceItemService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $invoiceItemService = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $invoiceItemService->expects($this->atLeastOnce())
             ->method('getTax')
             ->willReturn(21);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $invoiceItemService);
+        $di['mod_service'] = $di->protect(fn () => $invoiceItemService);
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -222,11 +220,10 @@ class ServiceTaxTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
         $this->service->setDi($di);
-
 
         $result = $this->service->delete($taxModel);
         $this->assertTrue($result);
@@ -244,22 +241,22 @@ class ServiceTaxTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($taxModel));
+            ->willReturn($taxModel);
         $newId = 2;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemService);
-        $di['db']          = $dbMock;
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
         $this->service->setDi($di);
 
-        $data   = array(
-            'name'    => 'tax',
+        $data = [
+            'name' => 'tax',
             'taxrate' => '0.18',
-        );
+        ];
         $result = $this->service->create($data);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
@@ -274,29 +271,28 @@ class ServiceTaxTest extends \BBTestCase
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
         $this->service->setDi($di);
 
-        $data   = array(
-            'name'    => 'tax',
+        $data = [
+            'name' => 'tax',
             'taxrate' => '0.18',
-        );
+        ];
         $result = $this->service->update($taxModel, $data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-
     public function testgetSearchQuery()
     {
-        $result = $this->service->getSearchQuery(array());
+        $result = $this->service->getSearchQuery([]);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
-        $this->assertEquals(array(), $result[1]);
+        $this->assertEquals([], $result[1]);
     }
 
     public function testtoApiArray()
@@ -309,7 +305,7 @@ class ServiceTaxTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
             ->with($taxModel)
-            ->willReturn(array());
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -318,5 +314,4 @@ class ServiceTaxTest extends \BBTestCase
         $result = $this->service->toApiArray($taxModel);
         $this->assertIsArray($result);
     }
-
 }

--- a/tests/modules/Invoice/ServiceTest.php
+++ b/tests/modules/Invoice/ServiceTest.php
@@ -1,22 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
-
-
-use Symfony\Component\Yaml\Tests\B;
 
 class ServiceTest extends \BBTestCase
 {
-
     /**
-     * @var \Box\Mod\Invoice\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -29,111 +24,111 @@ class ServiceTest extends \BBTestCase
 
     public static function dataForSearchQuery()
     {
-        return array(
-            array(array(), 'FROM invoice p', array()),
-            array(
-                array('order_id' => '1'),
+        return [
+            [[], 'FROM invoice p', []],
+            [
+                ['order_id' => '1'],
                 'AND pi.type = :item_type AND pi.rel_id = :order_id',
-                array(
+                [
                     'item_type' => \Model_InvoiceItem::TYPE_ORDER,
-                    'order_id'  => 1,
-                )
-            ),
-            array(
-                array('id' => 1),
+                    'order_id' => 1,
+                ],
+            ],
+            [
+                ['id' => 1],
                 'AND p.id = :id',
-                array(
+                [
                     'id' => 1,
-                )
-            ),
-            array(
-                array('nr' => 1),
+                ],
+            ],
+            [
+                ['nr' => 1],
                 'AND (p.id = :id_nr OR p.nr = :id_nr)',
-                array(
+                [
                     'id_nr' => 1,
-                )
-            ),
-            array(
-                array('approved' => true),
+                ],
+            ],
+            [
+                ['approved' => true],
                 'AND p.approved = :approved',
-                array(
+                [
                     'approved' => true,
-                )
-            ),
-            array(
-                array('status' => 'unpaid'),
+                ],
+            ],
+            [
+                ['status' => 'unpaid'],
                 'AND p.status = :status',
-                array(
+                [
                     'status' => 'unpaid',
-                )
-            ),
-            array(
-                array('currency' => 'usd'),
+                ],
+            ],
+            [
+                ['currency' => 'usd'],
                 'AND p.currency = :currency',
-                array(
+                [
                     'currency' => 'usd',
-                )
-            ),
-            array(
-                array('client_id' => 1),
+                ],
+            ],
+            [
+                ['client_id' => 1],
                 'AND p.client_id = :client_id',
-                array(
+                [
                     'client_id' => 1,
-                )
-            ),
-            array(
-                array('client' => 'John'),
+                ],
+            ],
+            [
+                ['client' => 'John'],
                 'AND (cl.first_name LIKE :client_search OR cl.last_name LIKE :client_search OR cl.id = :client OR cl.email = :client)',
-                array(
+                [
                     'client_search' => 'John%',
-                    'client'        => 'John',
-                )
-            ),
-            array(
-                array('id' => 1),
+                    'client' => 'John',
+                ],
+            ],
+            [
+                ['id' => 1],
                 'AND p.id = :id',
-                array(
+                [
                     'id' => 1,
-                )
-            ),
-            array(
-                array('created_at' => '1353715200'),
+                ],
+            ],
+            [
+                ['created_at' => '1353715200'],
                 "AND DATE_FORMAT(p.created_at, '%Y-%m-%d') = :created_at",
-                array(
+                [
                     'created_at' => '1353715200',
-                )
-            ),
-            array(
-                array('date_from' => '1353715200'),
+                ],
+            ],
+            [
+                ['date_from' => '1353715200'],
                 'AND UNIX_TIMESTAMP(p.created_at) >= :date_from',
-                array(
+                [
                     'date_from' => '1353715200',
-                )
-            ),
-            array(
-                array('date_to' => '1353715200'),
+                ],
+            ],
+            [
+                ['date_to' => '1353715200'],
                 'AND UNIX_TIMESTAMP(p.created_at) <= :date_to',
-                array(
+                [
                     'date_to' => '1353715200',
-                )
-            ),
-            array(
-                array('paid_at' => 1_353_715_200),
+                ],
+            ],
+            [
+                ['paid_at' => 1_353_715_200],
                 "AND DATE_FORMAT(p.paid_at, '%Y-%m-%d') = :paid_at",
-                array(
+                [
                     'paid_at' => 1_353_715_200,
-                )
-            ),
-            array(
-                array('search' => 'trend'),
+                ],
+            ],
+            [
+                ['search' => 'trend'],
                 'AND (p.id = :int OR p.nr LIKE :search_like OR p.id LIKE :search OR pi.title LIKE :search_like)',
-                array(
-                    'search'      => 'trend',
+                [
+                    'search' => 'trend',
                     'search_like' => '%trend%',
-                    'int'         => 0,
-                )
-            ),
-        );
+                    'int' => 0,
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('dataForSearchQuery')]
@@ -147,7 +142,7 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result[1]);
 
         $this->assertTrue(str_contains($result[0], $expectedStr), $result[0]);
-        $this->assertTrue(array_diff_key($result[1], $expectedParams) == array());
+        $this->assertTrue(array_diff_key($result[1], $expectedParams) == []);
     }
 
     public function testtoApiArray()
@@ -158,7 +153,7 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('getTax');
 
@@ -166,55 +161,55 @@ class ServiceTest extends \BBTestCase
         $systemService->expects($this->atLeastOnce())
             ->method('getCompany');
 
-        $subscriptionServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
+        $subscriptionServiceMock = $this->getMockBuilder('\\' . ServiceSubscription::class)->getMock();
         $subscriptionServiceMock->expects($this->atLeastOnce())
             ->method('isSubscribable')
-            ->will($this->returnValue(true));
-        $modelToArrayResult = array(
-            'id'                    => 1,
-            'serie'                 => 'BB',
-            'nr'                    => '0001',
-            'serie_nr'              => 'BB0001',
-            'hash'                  => 'hashedValue',
-            'gateway_id'            => '',
-            'taxname'               => '',
-            'taxrate'               => '',
-            'currency'              => '',
-            'currency_rate'         => '',
-            'status'                => '',
-            'notes'                 => '',
-            'text_1'                => '',
-            'text_2'                => '',
-            'due_at'                => '',
-            'paid_at'               => '',
-            'created_at'            => '',
-            'updated_at'            => '',
-            'buyer_first_name'      => '',
-            'buyer_last_name'       => '',
-            'buyer_company'         => '',
-            'buyer_company_vat'     => '',
-            'buyer_company_number'  => '',
-            'buyer_address'         => '',
-            'buyer_city'            => '',
-            'buyer_state'           => '',
-            'buyer_country'         => '',
-            'buyer_phone'           => '',
-            'buyer_phone_cc'        => '',
-            'buyer_email'           => '',
-            'buyer_zip'             => '',
-            'seller_company_vat'    => '',
+            ->willReturn(true);
+        $modelToArrayResult = [
+            'id' => 1,
+            'serie' => 'BB',
+            'nr' => '0001',
+            'serie_nr' => 'BB0001',
+            'hash' => 'hashedValue',
+            'gateway_id' => '',
+            'taxname' => '',
+            'taxrate' => '',
+            'currency' => '',
+            'currency_rate' => '',
+            'status' => '',
+            'notes' => '',
+            'text_1' => '',
+            'text_2' => '',
+            'due_at' => '',
+            'paid_at' => '',
+            'created_at' => '',
+            'updated_at' => '',
+            'buyer_first_name' => '',
+            'buyer_last_name' => '',
+            'buyer_company' => '',
+            'buyer_company_vat' => '',
+            'buyer_company_number' => '',
+            'buyer_address' => '',
+            'buyer_city' => '',
+            'buyer_state' => '',
+            'buyer_country' => '',
+            'buyer_phone' => '',
+            'buyer_phone_cc' => '',
+            'buyer_email' => '',
+            'buyer_zip' => '',
+            'seller_company_vat' => '',
             'seller_company_number' => '',
-        );
-        $dbMock             = $this->getMockBuilder('\Box_Database')->getMock();
+        ];
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue($modelToArrayResult));
+            ->willReturn($modelToArrayResult);
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue('1W'));
+            ->willReturn('1W');
 
         $periodMock = $this->getMockBuilder('\Box_Period')
             ->disableOriginalConstructor()
@@ -224,8 +219,8 @@ class ServiceTest extends \BBTestCase
         $periodMock->expects($this->atLeastOnce())
             ->method('getQty');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($itemInvoiceServiceMock, $systemService, $subscriptionServiceMock) {
             $service = null;
             if ($sub == 'InvoiceItem') {
@@ -240,7 +235,7 @@ class ServiceTest extends \BBTestCase
 
             return $service;
         });
-        $di['period']      = $di->protect(fn() => $periodMock);
+        $di['period'] = $di->protect(fn () => $periodMock);
 
         $this->service->setDi($di);
 
@@ -250,18 +245,18 @@ class ServiceTest extends \BBTestCase
 
     public function testonAfterAdminInvoicePaymentReceived()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('toApiArray'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['toApiArray'])
             ->getMock();
-        $arr         = array(
-            'total'  => 1,
-            'client' => array(
+        $arr = [
+            'total' => 1,
+            'client' => [
                 'id' => 0,
-            ),
-        );
+            ],
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -278,9 +273,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock) {
             if ($serviceName == 'invoice') {
                 return $serviceMock;
@@ -289,12 +284,12 @@ class ServiceTest extends \BBTestCase
                 return $emailService;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $this->service->onAfterAdminInvoicePaymentReceived($eventMock);
         $this->assertIsBool($result);
@@ -303,18 +298,18 @@ class ServiceTest extends \BBTestCase
 
     public function testonAfterAdminInvoiceReminderSent()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('toApiArray'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['toApiArray'])
             ->getMock();
-        $arr         = array(
-            'total'  => 1,
-            'client' => array(
+        $arr = [
+            'total' => 1,
+            'client' => [
                 'id' => 1,
-            ),
-        );
+            ],
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -331,9 +326,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock) {
             if ($serviceName == 'invoice') {
                 return $serviceMock;
@@ -342,14 +337,13 @@ class ServiceTest extends \BBTestCase
                 return $emailService;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $this->service->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
-
+            ->willReturn($di);
 
         $result = $this->service->onAfterAdminInvoicePaymentReceived($eventMock);
         $this->assertIsBool($result);
@@ -373,40 +367,40 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('exec');
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $this->service->onAfterAdminCronRun($eventMock);
     }
 
     public function testonEventAfterInvoiceIsDue()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('toApiArray'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['toApiArray'])
             ->getMock();
-        $arr         = array(
-            'total'  => 1,
-            'client' => array(
+        $arr = [
+            'total' => 1,
+            'client' => [
                 'id' => 1,
-            ),
-        );
+            ],
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
             ->getMock();
-        $params    = array('days_passed' => 5, 'id' => 1);
+        $params = ['days_passed' => 5, 'id' => 1];
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $emailService = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailService->expects($this->atLeastOnce())
@@ -417,9 +411,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock) {
             if ($serviceName == 'invoice') {
                 return $serviceMock;
@@ -428,19 +422,19 @@ class ServiceTest extends \BBTestCase
                 return $emailService;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $result = $serviceMock->onEventAfterInvoiceIsDue($eventMock);
     }
 
     public function testmarkAsPaid()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('countIncome'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['countIncome'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
@@ -453,7 +447,7 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('markAsPaid');
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
@@ -474,12 +468,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName, $sub = '') use ($systemService, $itemInvoiceServiceMock, $currencyService) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($systemService, $itemInvoiceServiceMock, $currencyService) {
             if ($serviceName == 'system') {
                 return $systemService;
             }
@@ -490,9 +484,9 @@ class ServiceTest extends \BBTestCase
                 return $currencyService;
             }
         });
-        $di['db']             = $dbMock;
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->markAsPaid($invoiceModel, true, true);
@@ -502,8 +496,8 @@ class ServiceTest extends \BBTestCase
 
     public function testcountIncome()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('getTotal'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getTotal'])
             ->getMock();
 
         $invoiceModel = new \Model_Invoice();
@@ -516,9 +510,9 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $currencyService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $currencyService);
 
         $serviceMock->setDi($di);
         $serviceMock->countIncome($invoiceModel);
@@ -526,25 +520,24 @@ class ServiceTest extends \BBTestCase
 
     public function testprepareInvoiceCurrencyWasNotDefined()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('setInvoiceDefaults'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['setInvoiceDefaults'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('setInvoiceDefaults');
 
-
-        $data = array(
+        $data = [
             'gateway_id' => '',
-            'text_1'     => '',
-            'text_2'     => '',
-            'items'      => array(
-                array(
-                    'id' => 1
-                )
-            ),
-            'approve'
-        );
+            'text_1' => '',
+            'text_2' => '',
+            'items' => [
+                [
+                    'id' => 1,
+                ],
+            ],
+            'approve',
+        ];
 
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -558,24 +551,24 @@ class ServiceTest extends \BBTestCase
         $currencyService = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)->getMock();
         $currencyService->expects($this->atLeastOnce())
             ->method('getDefault')
-            ->will($this->returnValue($currencyModel));
+            ->willReturn($currencyModel);
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('addNew');
 
         $newRecordId = 1;
-        $dbMock      = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newRecordId));
+            ->willReturn($newRecordId);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($currencyService, $itemInvoiceServiceMock) {
             if ($serviceName == 'Currency') {
                 return $currencyService;
@@ -584,7 +577,7 @@ class ServiceTest extends \BBTestCase
                 return $itemInvoiceServiceMock;
             }
         });
-        $di['logger']      = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->prepareInvoice($clientModel, $data);
@@ -599,58 +592,58 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
 
-        $buyer         = array(
-            'first_name'     => '',
-            'last_name'      => '',
-            'company'        => '',
-            'company_vat'    => '',
+        $buyer = [
+            'first_name' => '',
+            'last_name' => '',
+            'company' => '',
+            'company_vat' => '',
             'company_number' => '',
-            'address_1'      => '',
-            'address_2'      => '',
-            'city'           => '',
-            'state'          => '',
-            'country'        => '',
-            'phone_cc'       => '',
-            'phone'          => '',
-            'email'          => '',
-            'postcode'       => '',
-        );
+            'address_1' => '',
+            'address_2' => '',
+            'city' => '',
+            'state' => '',
+            'country' => '',
+            'phone_cc' => '',
+            'phone' => '',
+            'email' => '',
+            'postcode' => '',
+        ];
         $clientService = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($buyer));
+            ->willReturn($buyer);
 
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
-        $seller        = array(
-            'name'       => '',
+        $seller = [
+            'name' => '',
             'vat_number' => '',
-            'number'     => '',
-            'address_1'  => '',
-            'address_2'  => '',
-            'address_3'  => '',
-            'tel'        => '',
-            'email'      => '',
-        );
+            'number' => '',
+            'address_1' => '',
+            'address_2' => '',
+            'address_3' => '',
+            'tel' => '',
+            'email' => '',
+        ];
         $systemService->expects($this->atLeastOnce())
             ->method('getCompany')
-            ->will($this->returnValue($seller));
+            ->willReturn($seller);
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
-        $serviceTaxMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTax::class)->getMock();
+        $serviceTaxMock = $this->getMockBuilder('\\' . ServiceTax::class)->getMock();
         $serviceTaxMock->expects($this->atLeastOnce())
             ->method('getTaxRateForClient');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($clientService, $systemService, $serviceTaxMock) {
             if ($serviceName == 'Client') {
                 return $clientService;
@@ -670,8 +663,8 @@ class ServiceTest extends \BBTestCase
 
     public function testapproveInvoice()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('tryPayWithCredits'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['tryPayWithCredits'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
@@ -690,10 +683,10 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
 
@@ -703,19 +696,19 @@ class ServiceTest extends \BBTestCase
 
     public function testgetTotalWithTax()
     {
-        $total       = 10;
-        $tax         = 2.2;
-        $expected    = $total + $tax;
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('getTotal', 'getTax'))
+        $total = 10;
+        $tax = 2.2;
+        $expected = $total + $tax;
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getTotal', 'getTax'])
             ->getMock();
 
         $serviceMock->expects($this->once())
             ->method('getTotal')
-            ->will($this->returnValue($total));
+            ->willReturn($total);
         $serviceMock->expects($this->once())
             ->method('getTax')
-            ->will($this->returnValue($tax));
+            ->willReturn($tax);
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -736,18 +729,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
 
         $itemTotal = 10;
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('getTotal')
-            ->will($this->returnValue($itemTotal));
+            ->willReturn($itemTotal);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $itemInvoiceServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $itemInvoiceServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->getTotal($invoiceModel);
@@ -757,19 +750,19 @@ class ServiceTest extends \BBTestCase
 
     public function testrefundInvoiceWithNegativeInvoiceLogic()
     {
-        $newId       = 1;
-        $total       = 10;
-        $tax         = 2.2;
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('getTotal', 'getTax', 'countIncome', 'addNote'))
+        $newId = 1;
+        $total = 10;
+        $tax = 2.2;
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getTotal', 'getTax', 'countIncome', 'addNote'])
             ->getMock();
 
         $serviceMock->expects($this->once())
             ->method('getTotal')
-            ->will($this->returnValue($total));
+            ->willReturn($total);
         $serviceMock->expects($this->once())
             ->method('getTax')
-            ->will($this->returnValue($tax));
+            ->willReturn($tax);
         $serviceMock->expects($this->once())
             ->method('countIncome');
         $serviceMock->expects($this->exactly(3))
@@ -786,11 +779,10 @@ class ServiceTest extends \BBTestCase
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue('negative_invoice'));
+            ->willReturn('negative_invoice');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -800,13 +792,13 @@ class ServiceTest extends \BBTestCase
             ->method('store');
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemService);
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->refundInvoice($invoiceModel, 'custonNote');
@@ -816,38 +808,38 @@ class ServiceTest extends \BBTestCase
 
     public function testupdateInvoice()
     {
-        $data         = array(
-            'gateway_id'            => '',
-            'taxname'               => '',
-            'taxrate'               => '',
-            'status'                => '',
-            'notes'                 => '',
-            'text_1'                => '',
-            'text_2'                => '',
-            'due_at'                => '',
-            'paid_at'               => '',
-            'buyer_first_name'      => '',
-            'buyer_last_name'       => '',
-            'buyer_company'         => '',
-            'buyer_company_vat'     => '',
-            'buyer_company_number'  => '',
-            'buyer_address'         => '',
-            'buyer_city'            => '',
-            'buyer_state'           => '',
-            'buyer_country'         => '',
-            'buyer_phone'           => '',
-            'buyer_email'           => '',
-            'buyer_zip'             => '',
-            'seller_company'        => '',
-            'seller_address'        => '',
-            'seller_phone'          => '',
-            'seller_email'          => '',
-            'seller_company_vat'    => '',
+        $data = [
+            'gateway_id' => '',
+            'taxname' => '',
+            'taxrate' => '',
+            'status' => '',
+            'notes' => '',
+            'text_1' => '',
+            'text_2' => '',
+            'due_at' => '',
+            'paid_at' => '',
+            'buyer_first_name' => '',
+            'buyer_last_name' => '',
+            'buyer_company' => '',
+            'buyer_company_vat' => '',
+            'buyer_company_number' => '',
+            'buyer_address' => '',
+            'buyer_city' => '',
+            'buyer_state' => '',
+            'buyer_country' => '',
+            'buyer_phone' => '',
+            'buyer_email' => '',
+            'buyer_zip' => '',
+            'seller_company' => '',
+            'seller_address' => '',
+            'seller_phone' => '',
+            'seller_email' => '',
+            'seller_company_vat' => '',
             'seller_company_number' => '',
-            'approved'              => '',
-            'items'                 => array(0 => array()),
-            'new_item'              => array('title' => 'new Item'),
-        );
+            'approved' => '',
+            'items' => [0 => []],
+            'new_item' => ['title' => 'new Item'],
+        ];
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
@@ -858,7 +850,7 @@ class ServiceTest extends \BBTestCase
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('addNew');
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
@@ -869,13 +861,13 @@ class ServiceTest extends \BBTestCase
             ->method('store');
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($invoiceItemModel));
+            ->willReturn($invoiceItemModel);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn() => $itemInvoiceServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $itemInvoiceServiceMock);
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
@@ -891,17 +883,16 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('exec');
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -912,8 +903,8 @@ class ServiceTest extends \BBTestCase
 
     public function testdeleteInvoiceByAdmin()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('rmInvoice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['rmInvoice'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('rmInvoice');
@@ -925,9 +916,9 @@ class ServiceTest extends \BBTestCase
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
 
@@ -940,8 +931,8 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('rmInvoice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['rmInvoice'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('rmInvoice');
@@ -956,12 +947,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
 
@@ -973,8 +964,8 @@ class ServiceTest extends \BBTestCase
     {
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
-        $invoiceItemModel->type   = \Model_InvoiceItem::TYPE_ORDER;
-        $rel_id                   = 1;
+        $invoiceItemModel->type = \Model_InvoiceItem::TYPE_ORDER;
+        $rel_id = 1;
         $invoiceItemModel->rel_id = $rel_id;
 
         $invoiceModel = new \Model_Invoice();
@@ -987,22 +978,22 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceItemModel)));
+            ->willReturn([$invoiceItemModel]);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
 
         $this->service->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $this->expectExceptionMessage(sprintf("Invoice is related to order #%d. Please cancel order first.", $rel_id));
+        $this->expectExceptionMessage(sprintf('Invoice is related to order #%d. Please cancel order first.', $rel_id));
         $this->service->deleteInvoiceByClient($invoiceModel);
     }
 
     public function testrenewInvoice()
     {
-        $newId        = 2;
+        $newId = 2;
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
         $invoiceModel->id = $newId;
@@ -1010,25 +1001,25 @@ class ServiceTest extends \BBTestCase
         $clientOrder = new \Model_ClientOrder();
         $clientOrder->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('generateForOrder', 'approveInvoice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['generateForOrder', 'approveInvoice'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('approveInvoice');
         $serviceMock->expects($this->once())
             ->method('generateForOrder')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
         $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
-        $result = $serviceMock->renewInvoice($clientOrder, array());
+        $result = $serviceMock->renewInvoice($clientOrder, []);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
     }
@@ -1038,26 +1029,26 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('findAllUnpaid', 'tryPayWithCredits'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['findAllUnpaid', 'tryPayWithCredits'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findAllUnpaid')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('tryPayWithCredits');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
-        $result = $serviceMock->doBatchPayWithCredits(array());
+        $result = $serviceMock->doBatchPayWithCredits([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
@@ -1067,13 +1058,13 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('tryPayWithCredits'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['tryPayWithCredits'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('tryPayWithCredits');
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
@@ -1094,9 +1085,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1106,15 +1097,15 @@ class ServiceTest extends \BBTestCase
 
     public function testgenerateForOrder()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('setInvoiceDefaults'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['setInvoiceDefaults'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('setInvoiceDefaults');
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
-        $orderModel->price           = 10;
+        $orderModel->price = 10;
         $orderModel->promo_recurring = true;
 
         $clientModel = new \Model_Client();
@@ -1126,21 +1117,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $invoiceItemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)
+        $invoiceItemServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)
             ->getMock();
         $invoiceItemServiceMock->expects($this->atLeastOnce())
             ->method('generateFromOrder');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $invoiceItemServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $invoiceItemServiceMock);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->generateForOrder($orderModel);
@@ -1163,10 +1154,10 @@ class ServiceTest extends \BBTestCase
         $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getSoonExpiringActiveOrders')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
 
         $this->service->setDi($di);
         $result = $this->service->generateInvoicesForExpiringOrders();
@@ -1182,32 +1173,32 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $newId            = 4;
+        $newId = 4;
         $invoiceModel->id = $newId;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('generateForOrder', 'approveInvoice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['generateForOrder', 'approveInvoice'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('approveInvoice');
         $serviceMock->expects($this->once())
             ->method('generateForOrder')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
 
         $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getSoonExpiringActiveOrders')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($clientOrder));
+            ->willReturn($clientOrder);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
-        $di['logger']      = new \Box_Log();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
         $result = $serviceMock->generateInvoicesForExpiringOrders();
@@ -1220,23 +1211,23 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('executeTask')
             ->with($invoiceItemModel);
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('getAllNotExecutePaidItems')
-            ->willReturn(array(array()));
+            ->willReturn([[]]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($invoiceItemModel));
+            ->willReturn($invoiceItemModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $itemInvoiceServiceMock);
-        $di['logger']      = new \Box_Log();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $itemInvoiceServiceMock);
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $result = $this->service->doBatchPaidInvoiceActivation();
@@ -1249,24 +1240,24 @@ class ServiceTest extends \BBTestCase
         $invoiceItemModel = new \Model_InvoiceItem();
         $invoiceItemModel->loadBean(new \DummyBean());
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('executeTask')
             ->with($invoiceItemModel)
             ->willThrowException(new \FOSSBilling\Exception('tesitng exception..'));
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('getAllNotExecutePaidItems')
-            ->willReturn(array(array()));
+            ->willReturn([[]]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($invoiceItemModel));
+            ->willReturn($invoiceItemModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $itemInvoiceServiceMock);
-        $di['logger']      = new \Box_Log();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $itemInvoiceServiceMock);
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $result = $this->service->doBatchPaidInvoiceActivation();
@@ -1279,22 +1270,22 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('getUnpaidInvoicesLateFor', 'sendInvoiceReminder'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getUnpaidInvoicesLateFor', 'sendInvoiceReminder'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('sendInvoiceReminder');
         $serviceMock->expects($this->once())
             ->method('getUnpaidInvoicesLateFor')
-            ->will($this->returnValue(array($invoiceModel)));
+            ->willReturn([$invoiceModel]);
 
         $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->doBatchRemindersSend();
@@ -1304,7 +1295,6 @@ class ServiceTest extends \BBTestCase
 
     public function testdoBatchInvokeDueEvent()
     {
-
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue');
@@ -1314,21 +1304,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
 
         $eventManagerMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventManagerMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
-        $di['mod_service']    = $di->protect(fn() => $systemService);
-        $di['logger']         = new \Box_Log();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
-        $result = $this->service->doBatchInvokeDueEvent(array());
+        $result = $this->service->doBatchInvokeDueEvent([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
@@ -1357,10 +1347,10 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventManagerMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
@@ -1371,16 +1361,16 @@ class ServiceTest extends \BBTestCase
 
     public function testcounter()
     {
-        $sqlResult = array(
-            array('status'  => \Model_Invoice::STATUS_PAID,
-                  'counter' => 2),
-        );
-        $dbMock    = $this->getMockBuilder('\Box_Database')->getMock();
+        $sqlResult = [
+            ['status' => \Model_Invoice::STATUS_PAID,
+                  'counter' => 2],
+        ];
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($sqlResult));
+            ->willReturn($sqlResult);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1403,17 +1393,17 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $clientModel->currency = 'EUR';
-        $fundsAmount           = 2;
+        $fundsAmount = 2;
 
-        $minAmount     = 10;
-        $maxAmount     = 50;
+        $minAmount = 10;
+        $maxAmount = 50;
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
             ->will($this->onConsecutiveCalls($minAmount, $maxAmount));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
 
         $this->service->setDi($di);
 
@@ -1428,17 +1418,17 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $clientModel->currency = 'EUR';
-        $fundsAmount           = 200;
+        $fundsAmount = 200;
 
-        $minAmount     = 10;
-        $maxAmount     = 50;
+        $minAmount = 10;
+        $maxAmount = 50;
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('getParamValue')
             ->will($this->onConsecutiveCalls($minAmount, $maxAmount));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
 
         $this->service->setDi($di);
 
@@ -1456,13 +1446,13 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $clientModel->currency = 'EUR';
-        $fundsAmount           = 20;
+        $fundsAmount = 20;
 
         $minAmount = 10;
         $maxAmount = 50;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('setInvoiceDefaults'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['setInvoiceDefaults'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('setInvoiceDefaults');
@@ -1472,27 +1462,27 @@ class ServiceTest extends \BBTestCase
             ->method('getParamValue')
             ->will($this->onConsecutiveCalls($minAmount, $maxAmount, true));
 
-        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceInvoiceItem::class)->getMock();
+        $itemInvoiceServiceMock = $this->getMockBuilder('\\' . ServiceInvoiceItem::class)->getMock();
         $itemInvoiceServiceMock->expects($this->atLeastOnce())
             ->method('generateForAddFunds');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($invoiceModel));
+            ->willReturn($invoiceModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($systemService, $itemInvoiceServiceMock) {
-            if ('system' == $serviceName) {
+            if ($serviceName == 'system') {
                 return $systemService;
             }
-            if ('InvoiceItem' == $sub) {
+            if ($sub == 'InvoiceItem') {
                 return $itemInvoiceServiceMock;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
 
@@ -1502,17 +1492,17 @@ class ServiceTest extends \BBTestCase
 
     public function testprocessInvoiceInvoiceNotFound()
     {
-        $data = array(
-            'hash'       => 'hashString',
-            'gateway_id' => 2
-        );
+        $data = [
+            'hash' => 'hashString',
+            'gateway_id' => 2,
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
             ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1525,10 +1515,10 @@ class ServiceTest extends \BBTestCase
 
     public function testprocessInvoicePayGatewayNotFound()
     {
-        $data = array(
-            'hash'       => 'hashString',
-            'gateway_id' => 2
-        );
+        $data = [
+            'hash' => 'hashString',
+            'gateway_id' => 2,
+        ];
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -1541,7 +1531,7 @@ class ServiceTest extends \BBTestCase
             ->method('load')
             ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1554,10 +1544,10 @@ class ServiceTest extends \BBTestCase
 
     public function testprocessInvoicePayGatewayNotEnabled()
     {
-        $data = array(
-            'hash'       => 'hashString',
-            'gateway_id' => 2
-        );
+        $data = [
+            'hash' => 'hashString',
+            'gateway_id' => 2,
+        ];
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
@@ -1573,7 +1563,7 @@ class ServiceTest extends \BBTestCase
             ->method('load')
             ->willReturn($payGatewayModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1586,20 +1576,19 @@ class ServiceTest extends \BBTestCase
 
     public function testprocessInvoice()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)
-            ->onlyMethods(array('getPaymentInvoice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaymentInvoice'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPaymentInvoice')
             ->willReturn(new \Payment_Invoice());
-        $data = array(
-            'hash'       => 'hashString',
-            'gateway_id' => 2
-        );
+        $data = [
+            'hash' => 'hashString',
+            'gateway_id' => 2,
+        ];
 
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
-
 
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
@@ -1613,16 +1602,15 @@ class ServiceTest extends \BBTestCase
             ->method('load')
             ->willReturn($payGatewayModel);
 
-        $subcribeService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceSubscription::class)->getMock();
+        $subcribeService = $this->getMockBuilder('\\' . ServiceSubscription::class)->getMock();
         $subcribeService->expects($this->atLeastOnce())
             ->method('isSubscribable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $payGatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
+        $payGatewayService = $this->getMockBuilder('\\' . ServicePayGateway::class)->getMock();
         $payGatewayService->expects($this->atLeastOnce())
             ->method('canPerformRecurrentPayment')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $adapterMock = $this->getMockBuilder('\Payment_Adapter_Dummy')
             ->disableOriginalConstructor()
@@ -1632,14 +1620,14 @@ class ServiceTest extends \BBTestCase
             ->method('setDi');
         $adapterMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $payGatewayService->expects($this->atLeastOnce())
             ->method('getPaymentAdapter')
-            ->will($this->returnValue($adapterMock));
+            ->willReturn($adapterMock);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($payGatewayService, $subcribeService) {
             if ($sub == 'PayGateway') {
                 return $payGatewayService;
@@ -1648,8 +1636,8 @@ class ServiceTest extends \BBTestCase
                 return $subcribeService;
             }
         });
-        $di['api_admin']   = new \Api_Handler(new \Model_Admin());
-        $di['logger']      = new \Box_Log();
+        $di['api_admin'] = new \Api_Handler(new \Model_Admin());
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
         $result = $serviceMock->processInvoice($data);
@@ -1672,7 +1660,7 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1685,20 +1673,20 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $dbMock       = $this->getMockBuilder('\Box_Database')->getMock();
-        $getAllResult = array(
-            array(
-                'id'        => 1,
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $getAllResult = [
+            [
+                'id' => 1,
                 'client_id' => 1,
-                'serie'     => 'BB',
-                'nr'        => '00',
-            ),
-        );
+                'serie' => 'BB',
+                'nr' => '00',
+            ],
+        ];
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($getAllResult));
+            ->willReturn($getAllResult);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1714,9 +1702,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceModel)));
+            ->willReturn([$invoiceModel]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1724,7 +1712,6 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
         $this->assertInstanceOf('\Model_Invoice', $result[0]);
     }
-
 
     public function testgetUnpaidInvoicesLateFor()
     {
@@ -1734,9 +1721,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($invoiceModel)));
+            ->willReturn([$invoiceModel]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1750,19 +1737,19 @@ class ServiceTest extends \BBTestCase
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
 
-        $expected = array(
+        $expected = [
             'first_name' => '',
-            'last_name'  => '',
-            'company'    => '',
-            'address'    => '',
-            'city'       => '',
-            'state'      => '',
-            'country'    => '',
-            'phone'      => '',
-            'phone_cc'   => '',
-            'email'      => '',
-            'zip'        => '',
-        );
+            'last_name' => '',
+            'company' => '',
+            'address' => '',
+            'city' => '',
+            'state' => '',
+            'country' => '',
+            'phone' => '',
+            'phone_cc' => '',
+            'email' => '',
+            'zip' => '',
+        ];
 
         $result = $this->service->getBuyer($invoiceModel);
         $this->assertIsArray($result);
@@ -1777,7 +1764,7 @@ class ServiceTest extends \BBTestCase
         $modelInvoiceItem->loadBean(new \DummyBean());
         $modelInvoiceItem->type = \Model_InvoiceItem::TYPE_DEPOSIT;
 
-        $invoiceItems = array($modelInvoiceItem);
+        $invoiceItems = [$modelInvoiceItem];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -1795,7 +1782,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisInvoiceTypeDeposit_TypeIsNotDeposit()
+    public function testisInvoiceTypeDepositTypeIsNotDeposit()
     {
         $di = new \Pimple\Container();
 
@@ -1803,7 +1790,7 @@ class ServiceTest extends \BBTestCase
         $modelInvoiceItem->loadBean(new \DummyBean());
         $modelInvoiceItem->type = \Model_InvoiceItem::TYPE_ORDER;
 
-        $invoiceItems = array($modelInvoiceItem);
+        $invoiceItems = [$modelInvoiceItem];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -1821,11 +1808,11 @@ class ServiceTest extends \BBTestCase
         $this->assertFalse($result);
     }
 
-    public function testisInvoiceTypeDeposit_EmptyArray()
+    public function testisInvoiceTypeDepositEmptyArray()
     {
         $di = new \Pimple\Container();
 
-        $invoiceItems = array();
+        $invoiceItems = [];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())

--- a/tests/modules/Invoice/ServiceTransactionTest.php
+++ b/tests/modules/Invoice/ServiceTransactionTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Invoice;
-
 
 class ServiceTransactionTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Invoice\ServiceTransaction
+     * @var ServiceTransaction
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Invoice\ServiceTransaction();
+        $this->service = new ServiceTransaction();
     }
 
     public function testgetDi()
@@ -29,12 +27,12 @@ class ServiceTransactionTest extends \BBTestCase
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)
-            ->onlyMethods(array('getReceived', 'preProcessTransaction'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceTransaction::class)
+            ->onlyMethods(['getReceived', 'preProcessTransaction'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getReceived')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('preProcessTransaction');
 
@@ -44,9 +42,9 @@ class ServiceTransactionTest extends \BBTestCase
             ->method('getExistingModelById')
             ->will($this->onConsecutiveCalls($transactionModel));
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
         $result = $serviceMock->proccessReceivedATransactions();
@@ -67,25 +65,25 @@ class ServiceTransactionTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
-        $data   = array(
-            'invoice_id'   => 1,
-            'txn_id'       => 2,
-            'txn_status'   => '',
-            'gateway_id'   => 1,
-            'amount'       => '',
-            'currency'     => '',
-            'type'         => '',
-            'note'         => '',
-            'status'       => '',
+        $data = [
+            'invoice_id' => 1,
+            'txn_id' => 2,
+            'txn_status' => '',
+            'gateway_id' => 1,
+            'amount' => '',
+            'currency' => '',
+            'type' => '',
+            'note' => '',
+            'status' => '',
             'validate_ipn' => '',
-        );
+        ];
         $result = $this->service->update($transactionModel, $data);
         $this->assertTrue($result);
     }
@@ -111,71 +109,71 @@ class ServiceTransactionTest extends \BBTestCase
             ->will($this->onConsecutiveCalls($invoiceModel, $payGatewayModel));
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($transactionModel));
+            ->willReturn($transactionModel);
 
         $newId = 2;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('getClientAddress');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['events_manager'] = $eventsMock;
-        $di['request']        = $requestMock;
-        $di['logger']         = new \Box_Log();
+        $di['request'] = $requestMock;
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
-        $data   = array(
+        $data = [
             'skip_validation' => false,
-            'bb_gateway_id'   => 1,
-            'bb_invoice_id'   => 2,
-        );
+            'bb_gateway_id' => 1,
+            'bb_invoice_id' => 2,
+        ];
         $result = $this->service->create($data);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
     }
 
-    public function testcreateInvalidMissinginvoice_id()
+    public function testcreateInvalidMissinginvoiceId()
     {
         $eventsMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'skip_validation' => false,
-            'bb_gateway_id'   => 1,
-        );
+            'bb_gateway_id' => 1,
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Transaction invoice id is missing');
         $this->service->create($data);
     }
 
-    public function testcreateInvalidMissingbb_gateway_id()
+    public function testcreateInvalidMissingbbGatewayId()
     {
         $eventsMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'skip_validation' => false,
-            'bb_invoice_id'   => 2,
-        );
+            'bb_invoice_id' => 2,
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Payment gateway id is missing');
@@ -189,9 +187,9 @@ class ServiceTransactionTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $transactionModel = new \Model_Transaction();
@@ -203,36 +201,36 @@ class ServiceTransactionTest extends \BBTestCase
 
     public function testtoApiArray()
     {
-        $dbMock          = $this->getMockBuilder('\Box_Database')
+        $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($payGatewayModel));
-        $di       = new \Pimple\Container();
+            ->willReturn($payGatewayModel);
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
-        $expected         = array(
-            'id'           => null,
-            'invoice_id'   => null,
-            'txn_id'       => null,
-            'txn_status'   => null,
-            'gateway_id'   => 1,
-            'gateway'      => null,
-            'amount'       => null,
-            'currency'     => null,
-            'type'         => null,
-            'status'       => null,
-            'ip'           => null,
+        $expected = [
+            'id' => null,
+            'invoice_id' => null,
+            'txn_id' => null,
+            'txn_status' => null,
+            'gateway_id' => 1,
+            'gateway' => null,
+            'amount' => null,
+            'currency' => null,
+            'type' => null,
+            'status' => null,
+            'ip' => null,
             'validate_ipn' => null,
-            'error'        => null,
-            'error_code'   => null,
-            'note'         => null,
-            'created_at'   => null,
-            'updated_at'   => null,
-        );
+            'error' => null,
+            'error_code' => null,
+            'note' => null,
+            'created_at' => null,
+            'updated_at' => null,
+        ];
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
         $transactionModel->gateway_id = 1;
@@ -301,24 +299,24 @@ class ServiceTransactionTest extends \BBTestCase
     public function testcounter()
     {
         $queryResult = [['status' => \Model_Transaction::STATUS_RECEIVED, 'counter' => 1]];
-        $dbMock      = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($queryResult));
+            ->willReturn($queryResult);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->counter();
         $this->assertIsArray($result);
-        $expected = array(
-            'total'     => 1,
-            'received'  => 1,
-            'approved'  => 0,
-            'error'     => 0,
-            'processed' => 0
-        );
+        $expected = [
+            'total' => 1,
+            'received' => 1,
+            'approved' => 0,
+            'error' => 0,
+            'processed' => 0,
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -328,10 +326,10 @@ class ServiceTransactionTest extends \BBTestCase
         $this->assertIsArray($result);
 
         $expected = [
-            'received'  => 'Received',
-            'approved'  => 'Approved',
+            'received' => 'Received',
+            'approved' => 'Approved',
             'processed' => 'Processed',
-            'error'     => 'Error'
+            'error' => 'Error',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -341,12 +339,12 @@ class ServiceTransactionTest extends \BBTestCase
         $result = $this->service->getStatuses();
         $this->assertIsArray($result);
 
-        $expected = array(
-            'received'  => 'Received',
-            'approved'  => 'Approved/Verified',
+        $expected = [
+            'received' => 'Received',
+            'approved' => 'Approved/Verified',
             'processed' => 'Processed',
-            'error'     => 'Error'
-        );
+            'error' => 'Error',
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -355,11 +353,11 @@ class ServiceTransactionTest extends \BBTestCase
         $result = $this->service->getGatewayStatuses();
         $this->assertIsArray($result);
 
-        $expected = array(
-            'pending'  => 'Pending validation',
+        $expected = [
+            'pending' => 'Pending validation',
             'complete' => 'Complete',
-            'unknown'  => 'Unknown',
-        );
+            'unknown' => 'Unknown',
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -368,13 +366,13 @@ class ServiceTransactionTest extends \BBTestCase
         $result = $this->service->getTypes();
         $this->assertIsArray($result);
 
-        $expected = array(
-            'payment'             => 'Payment',
-            'refund'              => 'Refund',
+        $expected = [
+            'payment' => 'Payment',
+            'refund' => 'Refund',
             'subscription_create' => 'Subscription create',
             'subscription_cancel' => 'Subscription cancel',
-            'unknown'             => 'Unknown',
-        );
+            'unknown' => 'Unknown',
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -383,35 +381,34 @@ class ServiceTransactionTest extends \BBTestCase
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)
-            ->onlyMethods(array('processTransaction'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceTransaction::class)
+            ->onlyMethods(['processTransaction'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('processTransaction')
-            ->will($this->returnValue('processedOutputString'));
+            ->willReturn('processedOutputString');
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
         $serviceMock->setDi($di);
 
         $result = $serviceMock->preProcessTransaction($transactionModel);
         $this->assertIsString($result);
     }
 
-    public function testpreProcessTransaction_registerException()
+    public function testpreProcessTransactionRegisterException()
     {
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
 
         $exceptionMessage = 'Exception created with PHPUnit Test';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)
+        $serviceMock = $this->getMockBuilder('\\' . ServiceTransaction::class)
             ->addMethods(['oldProcessLogic'])
             ->onlyMethods(['processTransaction'])
             ->getMock();
@@ -423,7 +420,7 @@ class ServiceTransactionTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -434,19 +431,19 @@ class ServiceTransactionTest extends \BBTestCase
 
     public static function paymentsAdapterProvider_withprocessTransaction()
     {
-        return array(
-            array('\Payment_Adapter_PayPalEmail'),
-        );
+        return [
+            ['\Payment_Adapter_PayPalEmail'],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('paymentsAdapterProvider_withprocessTransaction')]
-    public function testprocessTransaction_supportProcessTransaction($adapter)
+    public function testprocessTransactionSupportProcessTransaction($adapter)
     {
-        $id               = 1;
+        $id = 1;
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
         $transactionModel->gateway_id = 2;
-        $transactionModel->ipn        = '{}';
+        $transactionModel->ipn = '{}';
 
         $payGatewayModel = new \Model_PayGateway();
         $payGatewayModel->loadBean(new \DummyBean());
@@ -463,15 +460,15 @@ class ServiceTransactionTest extends \BBTestCase
         $paymentAdapterMock->expects($this->atLeastOnce())
             ->method('processTransaction');
 
-        $payGatewayService = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServicePayGateway::class)->getMock();
+        $payGatewayService = $this->getMockBuilder('\\' . ServicePayGateway::class)->getMock();
         $payGatewayService->expects($this->atLeastOnce())
             ->method('getPaymentAdapter')
-            ->will($this->returnValue($paymentAdapterMock));
+            ->willReturn($paymentAdapterMock);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $payGatewayService);
-        $di['api_system']  = new \Api_Handler(new \Model_Admin());
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $payGatewayService);
+        $di['api_system'] = new \Api_Handler(new \Model_Admin());
         $this->service->setDi($di);
 
         $this->service->processTransaction($id);
@@ -479,31 +476,31 @@ class ServiceTransactionTest extends \BBTestCase
 
     public function getReceived()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)
-            ->onlyMethods(array('getSearchQuery'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceTransaction::class)
+            ->onlyMethods(['getSearchQuery'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('SqlString', array())));
+            ->willReturn(['SqlString', []]);
 
-        $assoc  = array(
-            array(
-                'id'         => 1,
+        $assoc = [
+            [
+                'id' => 1,
                 'invoice_id' => 1,
-            ),
-        );
+            ],
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($assoc));
+            ->willReturn($assoc);
 
         $transactionModel = new \Model_Transaction();
         $transactionModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -513,7 +510,7 @@ class ServiceTransactionTest extends \BBTestCase
 
     public function testdebitTransaction()
     {
-        $currency     = 'EUR';
+        $currency = 'EUR';
         $invoiceModel = new \Model_Invoice();
         $invoiceModel->loadBean(new \DummyBean());
         $invoiceModel->currency = $currency;
@@ -535,32 +532,28 @@ class ServiceTransactionTest extends \BBTestCase
             ->will($this->onConsecutiveCalls($invoiceModel, $clientModdel));
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($clientBalanceModel));
+            ->willReturn($clientBalanceModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $this->service->debitTransaction($transactionModel);
     }
 
-
     public function testcreateAndProcess()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\ServiceTransaction::class)
-            ->onlyMethods(array('create', 'processTransaction'))
+        $serviceMock = $this->getMockBuilder('\\' . ServiceTransaction::class)
+            ->onlyMethods(['create', 'processTransaction'])
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('create');
         $serviceMock->expects($this->once())
             ->method('processTransaction');
 
-        $ipn = array();
+        $ipn = [];
         $serviceMock->createAndProcess($ipn);
     }
-
-
 }
-

--- a/tests/modules/Order/Api/Api_AdminTest.php
+++ b/tests/modules/Order/Api/Api_AdminTest.php
@@ -1,21 +1,20 @@
 <?php
 
-class Api_AdminTest extends \BBTestCase
+class Api_AdminTest extends BBTestCase
 {
-
     /**
-     * @var \Box\Mod\Order\Api\Admin
+     * @var Box\Mod\Order\Api\Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Order\Api\Admin();
+        $this->api = new Box\Mod\Order\Api\Admin();
     }
 
     public function testgetDi()
     {
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
         $this->api->setDi($di);
         $getDi = $this->api->getDi();
         $this->assertEquals($di, $getDi);
@@ -24,85 +23,85 @@ class Api_AdminTest extends \BBTestCase
     public function testGet()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $apiMock->get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testGet_list()
+    public function testGetList()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getSearchQuery'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getSearchQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array('show_addons' => 0)));
+            ->willReturn(['show_addons' => 0]);
 
-        $di          = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['mod'] = $di->protect(fn() => $modMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
 
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
 
         $this->assertIsArray($result);
     }
 
     public function testCreate()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('createOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['createOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('createOrder')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->exactly(2))
             ->method('getExistingModelById')
-            ->will($this->onConsecutiveCalls(new \Model_Client(), new \Model_Product()));
+            ->will($this->onConsecutiveCalls(new Model_Client(), new Model_Product()));
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
 
-        $data   = array(
-            'client_id'  => random_int(1, 100),
-            'product_id' => random_int(1, 100)
-        );
+        $data = [
+            'client_id' => random_int(1, 100),
+            'product_id' => random_int(1, 100),
+        ];
         $result = $this->api->create($data);
 
         $this->assertIsInt($result);
@@ -111,24 +110,24 @@ class Api_AdminTest extends \BBTestCase
     public function testUpdate()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('updateOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['updateOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'client_id'  => random_int(1, 100),
-            'product_id' => random_int(1, 100)
-        );
+        $data = [
+            'client_id' => random_int(1, 100),
+            'product_id' => random_int(1, 100),
+        ];
         $result = $apiMock->update($data);
 
         $this->assertTrue($result);
@@ -137,24 +136,24 @@ class Api_AdminTest extends \BBTestCase
     public function testActivate()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('activateOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['activateOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('activateOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'client_id'  => random_int(1, 100),
-            'product_id' => random_int(1, 100)
-        );
+        $data = [
+            'client_id' => random_int(1, 100),
+            'product_id' => random_int(1, 100),
+        ];
         $result = $apiMock->activate($data);
 
         $this->assertTrue($result);
@@ -163,21 +162,21 @@ class Api_AdminTest extends \BBTestCase
     public function testRenew()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('renewOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['renewOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('renewOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->renew($data);
 
         $this->assertTrue($result);
@@ -186,18 +185,18 @@ class Api_AdminTest extends \BBTestCase
     public function testRenewPendingSetup()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_PENDING_SETUP;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder', 'activate'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder', 'activate'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
         $apiMock->expects($this->atLeastOnce())
             ->method('activate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->renew($data);
 
         $this->assertTrue($result);
@@ -206,25 +205,25 @@ class Api_AdminTest extends \BBTestCase
     public function testSuspend()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('suspendFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['suspendFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('suspendFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
 
         $apiMock->setDi($di);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->suspend($data);
 
         $this->assertTrue($result);
@@ -233,22 +232,22 @@ class Api_AdminTest extends \BBTestCase
     public function testUnsuspend()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_SUSPENDED;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('unsuspendFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['unsuspendFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('unsuspendFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->unsuspend($data);
 
         $this->assertTrue($result);
@@ -257,23 +256,23 @@ class Api_AdminTest extends \BBTestCase
     public function testUnsuspendNotSuspendedException()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_ACTIVE;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('unsuspendFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['unsuspendFromOrder'])->getMock();
         $serviceMock->expects($this->never())->method('unsuspendFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
-        $this->expectException(\FOSSBilling\Exception::class);
+        $data = [];
+        $this->expectException(FOSSBilling\Exception::class);
         $result = $apiMock->unsuspend($data);
 
         $this->assertTrue($result);
@@ -282,24 +281,24 @@ class Api_AdminTest extends \BBTestCase
     public function testCancel()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('cancelFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['cancelFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cancelFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
 
         $apiMock->setDi($di);
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->cancel($data);
 
         $this->assertTrue($result);
@@ -308,22 +307,22 @@ class Api_AdminTest extends \BBTestCase
     public function testUncancel()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_CANCELED;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('uncancelFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['uncancelFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('uncancelFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->uncancel($data);
 
         $this->assertTrue($result);
@@ -332,23 +331,23 @@ class Api_AdminTest extends \BBTestCase
     public function testUncancelNotCanceledException()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_ACTIVE;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('uncancelFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['uncancelFromOrder'])->getMock();
         $serviceMock->expects($this->never())->method('uncancelFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
-        $this->expectException(\FOSSBilling\Exception::class);
+        $data = [];
+        $this->expectException(FOSSBilling\Exception::class);
         $result = $apiMock->uncancel($data);
 
         $this->assertTrue($result);
@@ -357,21 +356,21 @@ class Api_AdminTest extends \BBTestCase
     public function testDelete()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('deleteFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['deleteFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('deleteFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $apiMock->delete($data);
 
         $this->assertTrue($result);
@@ -380,25 +379,25 @@ class Api_AdminTest extends \BBTestCase
     public function testDeleteWithAddons()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('deleteFromOrder', 'getOrderAddonsList'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['deleteFromOrder', 'getOrderAddonsList'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('deleteFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('getOrderAddonsList')
-            ->will($this->returnValue(array(new Model_ClientOrder())));
+            ->willReturn([new Model_ClientOrder()]);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'delete_addons' => true
-        );
+        $data = [
+            'delete_addons' => true,
+        ];
         $result = $apiMock->delete($data);
 
         $this->assertTrue($result);
@@ -406,14 +405,14 @@ class Api_AdminTest extends \BBTestCase
 
     public function testBatchSuspendExpired()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('batchSuspendExpired'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['batchSuspendExpired'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('batchSuspendExpired')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->api->batch_suspend_expired($data);
 
         $this->assertTrue($result);
@@ -421,65 +420,63 @@ class Api_AdminTest extends \BBTestCase
 
     public function testBatchCancelSuspended()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('batchCancelSuspended'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['batchCancelSuspended'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('batchCancelSuspended')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->api->batch_cancel_suspended($data);
 
         $this->assertTrue($result);
     }
 
-    public function testUpdate_config()
+    public function testUpdateConfig()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('updateOrderConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['updateOrderConfig'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateOrderConfig')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'config' => array()
-        );
+        $data = [
+            'config' => [],
+        ];
         $result = $apiMock->update_config($data);
 
         $this->assertTrue($result);
     }
 
-    public function testUpdate_configNotSetConfigException()
+    public function testUpdateConfigNotSetConfigException()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('updateOrderConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['updateOrderConfig'])->getMock();
         $serviceMock->expects($this->never())->method('updateOrderConfig')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array();
-        $this->expectException(\FOSSBilling\Exception::class);
+        $data = [];
+        $this->expectException(FOSSBilling\Exception::class);
         $result = $apiMock->update_config($data);
 
         $this->assertTrue($result);
@@ -488,55 +485,53 @@ class Api_AdminTest extends \BBTestCase
     public function testService()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderServiceData'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getOrderServiceData'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $admin = new Model_Admin();
-        $admin->loadBean(new \RedBeanPHP\OODBBean());
+        $admin->loadBean(new RedBeanPHP\OODBBean());
 
         $apiMock->setService($serviceMock);
         $apiMock->setIdentity($admin);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $apiMock->service($data);
 
         $this->assertIsArray($result);
     }
 
-
-
-    public function testStatus_history_get_list()
+    public function testStatusHistoryGetList()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderStatusSearchQuery'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getOrderStatusSearchQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderStatusSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
 
         $di['pager'] = $paginatorMock;
 
@@ -544,80 +539,79 @@ class Api_AdminTest extends \BBTestCase
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->status_history_get_list(array());
+        $result = $apiMock->status_history_get_list([]);
 
         $this->assertIsArray($result);
     }
 
-    public function testStatus_history_add()
+    public function testStatusHistoryAdd()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('orderStatusAdd'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['orderStatusAdd'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('orderStatusAdd')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
-
+            ->willReturn(null);
 
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $apiMock->setDi($di);
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'status' => Model_ClientOrder::STATUS_ACTIVE
-        );
+        $data = [
+            'status' => Model_ClientOrder::STATUS_ACTIVE,
+        ];
         $result = $apiMock->status_history_add($data);
 
         $this->assertTrue($result);
     }
 
-    public function testStatus_history_delete()
+    public function testStatusHistoryDelete()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('orderStatusRm'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['orderStatusRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('orderStatusRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->api->status_history_delete($data);
 
         $this->assertTrue($result);
     }
 
-    public function testGet_statuses()
+    public function testGetStatuses()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('counter'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['counter'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('counter')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -625,40 +619,40 @@ class Api_AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testGet_invoice_options()
+    public function testGetInvoiceOptions()
     {
-        $result = $this->api->get_invoice_options(array());
+        $result = $this->api->get_invoice_options([]);
         $this->assertIsArray($result);
     }
 
-    public function testGet_status_pairs()
+    public function testGetStatusPairs()
     {
-        $result = $this->api->get_status_pairs(array());
+        $result = $this->api->get_status_pairs([]);
         $this->assertIsArray($result);
     }
 
     public function testAddons()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderAddonsList', 'toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getOrderAddonsList', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderAddonsList')
-            ->will($this->returnValue(array(new Model_ClientOrder())));
+            ->willReturn([new Model_ClientOrder()]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'status' => Model_ClientOrder::STATUS_ACTIVE
-        );
+        $data = [
+            'status' => Model_ClientOrder::STATUS_ACTIVE,
+        ];
         $result = $apiMock->addons($data);
 
         $this->assertIsArray($result);
@@ -667,55 +661,53 @@ class Api_AdminTest extends \BBTestCase
 
     public function testGetOrder()
     {
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $order = new \Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order = new Model_ClientOrder();
+        $order->loadBean(new DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->api->get($data);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Admin::class)->onlyMethods(array('delete'))->getMock();
+        $activityMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Admin::class)->onlyMethods(['delete'])->getMock();
         $activityMock->expects($this->atLeastOnce())->
         method('delete')->
-        will($this->returnValue(true));
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        willReturn(true);
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
-
-
 }

--- a/tests/modules/Order/Api/Api_ClientTest.php
+++ b/tests/modules/Order/Api/Api_ClientTest.php
@@ -4,101 +4,101 @@
  * Created by PhpStorm.
  * User: giedrius
  * Date: 8/5/14
- * Time: 4:52 PM
+ * Time: 4:52 PM.
  */
 class Api_ClientTest extends PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Box\Mod\Order\Api\Client
+     * @var Box\Mod\Order\Api\Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Order\Api\Client();
+        $this->api = new Box\Mod\Order\Api\Client();
     }
 
     public function testgetDi()
     {
-        $di = new \Pimple\Container();
+        $di = new Pimple\Container();
         $this->api->setDi($di);
         $getDi = $this->api->getDi();
         $this->assertEquals($di, $getDi);
     }
 
-    public function testGet_list()
+    public function testGetList()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getSearchQuery', 'toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getSearchQuery', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $resultSet = array(
-            'list' => array(
-                0 => array('id' => 1),
-            ),
-        );
+        $resultSet = [
+            'list' => [
+                0 => ['id' => 1],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
-        $clientOrderMock = new \Model_ClientOrder();
-        $clientOrderMock->loadBean(new \DummyBean());
+        $clientOrderMock = new Model_ClientOrder();
+        $clientOrderMock->loadBean(new DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
             ->with('ClientOrder')
-            ->will($this->returnValue($clientOrderMock));
+            ->willReturn($clientOrderMock);
 
-        $di          = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['pager'] = $paginatorMock;
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
 
         $client = new Model_Client();
-        $client->loadBean(new \DummyBean());
+        $client->loadBean(new DummyBean());
         $client->id = random_int(1, 100);
 
         $this->api->setIdentity($client);
         $this->api->setService($serviceMock);
 
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
 
         $this->assertIsArray($result);
     }
 
-    public function testGet_listExpiring()
+    public function testGetListExpiring()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getSoonExpiringActiveOrdersQuery'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getSoonExpiringActiveOrdersQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSoonExpiringActiveOrdersQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
-        $di          = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['pager'] = $paginatorMock;
 
         $this->api->setDi($di);
 
         $client = new Model_Client();
-        $client->loadBean(new \DummyBean());
+        $client->loadBean(new DummyBean());
         $client->id = random_int(1, 100);
 
         $this->api->setIdentity($client);
         $this->api->setService($serviceMock);
 
-        $data   = array(
-            'expiring' => true
-        );
+        $data = [
+            'expiring' => true,
+        ];
         $result = $this->api->get_list($data);
 
         $this->assertIsArray($result);
@@ -107,23 +107,23 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
     public function testGet()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $apiMock->get($data);
 
         $this->assertIsArray($result);
@@ -131,26 +131,26 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
 
     public function testAddons()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderAddonsList', 'toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getOrderAddonsList', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderAddonsList')
-            ->will($this->returnValue(array(new Model_ClientOrder())));
+            ->willReturn([new Model_ClientOrder()]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'status' => Model_ClientOrder::STATUS_ACTIVE
-        );
+        $data = [
+            'status' => Model_ClientOrder::STATUS_ACTIVE,
+        ];
         $result = $apiMock->addons($data);
 
         $this->assertIsArray($result);
@@ -160,27 +160,27 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
     public function testService()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderServiceData'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['getOrderServiceData'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $client = new Model_Client();
-        $client->loadBean(new \DummyBean());
+        $client->loadBean(new DummyBean());
 
         $apiMock->setService($serviceMock);
         $apiMock->setIdentity($client);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $apiMock->service($data);
 
         $this->assertIsArray($result);
@@ -189,31 +189,31 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
     public function testUpgradables()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $productServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->onlyMethods(array('getUpgradablePairs'))->getMock();
+        $productServiceMock = $this->getMockBuilder('\\' . Box\Mod\Product\Service::class)->onlyMethods(['getUpgradablePairs'])->getMock();
         $productServiceMock->expects($this->atLeastOnce())
-            ->method("getUpgradablePairs")
-            ->will($this->returnValue(array()));
+            ->method('getUpgradablePairs')
+            ->willReturn([]);
 
         $product = new Model_Product();
-        $product->loadBean(new \RedBeanPHP\OODBBean());
+        $product->loadBean(new RedBeanPHP\OODBBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($product));
+            ->willReturn($product);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $productServiceMock);
+        $di = new Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $productServiceMock);
         $apiMock->setDi($di);
-        $data = array();
+        $data = [];
 
         $result = $apiMock->upgradables($data);
         $this->assertIsArray($result);
@@ -222,24 +222,24 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
     public function testDelete()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
         $order->status = Model_ClientOrder::STATUS_PENDING_SETUP;
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('deleteFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['deleteFromOrder'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('deleteFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $apiMock->delete($data);
 
         $this->assertTrue($result);
@@ -248,25 +248,25 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
     public function testDeleteNotPendingException()
     {
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Api\Client::class)->onlyMethods(array('_getOrder'))->disableOriginalConstructor()->getMock();
+        $apiMock = $this->getMockBuilder('\\' . Box\Mod\Order\Api\Client::class)->onlyMethods(['_getOrder'])->disableOriginalConstructor()->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getOrder')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('deleteFromOrder'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['deleteFromOrder'])->getMock();
         $serviceMock->expects($this->never())->method('deleteFromOrder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $result = $apiMock->delete($data);
 
         $this->assertTrue($result);
@@ -274,72 +274,72 @@ class Api_ClientTest extends PHPUnit\Framework\TestCase
 
     public function testGetOrder()
     {
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $order = new Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order->loadBean(new DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('findForClientById', 'toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['findForClientById', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('findForClientById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $order = new \Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order = new Model_ClientOrder();
+        $order->loadBean(new DummyBean());
 
         $client = new Model_Client();
-        $client->loadBean(new \DummyBean());
+        $client->loadBean(new DummyBean());
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);
         $this->api->setIdentity($client);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $this->api->get($data);
     }
 
     public function testGetOrderNotFoundException()
     {
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock = $this->getMockBuilder('\\' . FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('findForClientById', 'toApiArray'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Box\Mod\Order\Service::class)
+            ->onlyMethods(['findForClientById', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('findForClientById')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $order = new \Model_ClientOrder();
-        $order->loadBean(new \DummyBean());
+        $order = new Model_ClientOrder();
+        $order->loadBean(new DummyBean());
 
         $client = new Model_Client();
-        $client->loadBean(new \DummyBean());
+        $client->loadBean(new DummyBean());
 
-        $di              = new \Pimple\Container();
+        $di = new Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
 
         $this->api->setService($serviceMock);
         $this->api->setIdentity($client);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
-        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectException(FOSSBilling\Exception::class);
         $this->api->get($data);
     }
 }

--- a/tests/modules/Order/ServiceTest.php
+++ b/tests/modules/Order/ServiceTest.php
@@ -4,24 +4,28 @@ namespace Box\Mod\Order;
 
 class PdoMock extends \PDO
 {
-    public function __construct() { }
+    public function __construct()
+    {
+    }
 }
 
 class PdoStatmentsMock extends \PDOStatement
 {
-    public function __construct() { }
+    public function __construct()
+    {
+    }
 }
 
 class ServiceTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Order\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Order\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -34,15 +38,15 @@ class ServiceTest extends \BBTestCase
 
     public function testCounter()
     {
-        $counter = array(
-            \Model_ClientOrder::STATUS_ACTIVE => random_int(1, 100)
-        );
-        $dbMock  = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
+        $counter = [
+            \Model_ClientOrder::STATUS_ACTIVE => random_int(1, 100),
+        ];
+        $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($counter));
+            ->willReturn($counter);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -60,14 +64,14 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminOrderActivate()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -75,34 +79,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -113,23 +117,23 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->setDi($di);
 
         $serviceMock->onAfterAdminOrderActivate($eventMock);
     }
 
-    public function testOnAfterAdminOrderActivate_LogException()
+    public function testOnAfterAdminOrderActivateLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -137,34 +141,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -175,7 +179,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->setDi($di);
 
@@ -184,14 +188,14 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminOrderRenew()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -199,34 +203,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -237,21 +241,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderRenew($eventMock);
     }
 
-    public function testOnAfterAdminOrderRenew_LogException()
+    public function testOnAfterAdminOrderRenewLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -259,34 +263,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -297,21 +301,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderRenew($eventMock);
     }
 
     public function testOnAfterAdminOrderSuspend()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -319,34 +323,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -357,21 +361,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderSuspend($eventMock);
     }
 
-    public function testOnAfterAdminOrderSuspend_LogException()
+    public function testOnAfterAdminOrderSuspendLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -379,34 +383,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -418,21 +422,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderSuspend($eventMock);
     }
 
     public function testOnAfterAdminOrderUnsuspend()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -440,34 +444,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -478,21 +482,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderUnsuspend($eventMock);
     }
 
-    public function testOnAfterAdminOrderUnsuspend_LogException()
+    public function testOnAfterAdminOrderUnsuspendLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -500,34 +504,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -538,21 +542,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderUnsuspend($eventMock);
     }
 
     public function testOnAfterAdminOrderCancel()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -560,32 +564,32 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -596,21 +600,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderCancel($eventMock);
     }
 
-    public function testOnAfterAdminOrderCancel_LogException()
+    public function testOnAfterAdminOrderCancelLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -618,32 +622,32 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -654,21 +658,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderCancel($eventMock);
     }
 
     public function testOnAfterAdminOrderUncancel()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -676,34 +680,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -714,21 +718,21 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderUncancel($eventMock);
     }
 
-    public function testOnAfterAdminOrderUncancel_LogException()
+    public function testOnAfterAdminOrderUncancelLogException()
     {
-        $params = array(
-            'id' => random_int(1, 100)
-        );
+        $params = [
+            'id' => random_int(1, 100),
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getParameters')
-            ->will($this->returnValue($params));
+            ->willReturn($params);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -736,34 +740,34 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
             ->willThrowException(new \Exception('PHPUnit controlled exception'));
 
-        $orderArr = array(
-            'id'           => random_int(1, 100),
-            'client'       => array(
-                'id' => random_int(1, 100)
-            ),
-            'service_type' => 'domain'
-        );
+        $orderArr = [
+            'id' => random_int(1, 100),
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+            'service_type' => 'domain',
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderServiceData', 'toApiArray'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getOrderServiceData', 'toApiArray'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getOrderServiceData')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($orderArr));
+            ->willReturn($orderArr);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['loggedin_admin'] = $admin;
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
             if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
@@ -774,7 +778,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $serviceMock->onAfterAdminOrderUncancel($eventMock);
     }
@@ -788,20 +792,20 @@ class ServiceTest extends \BBTestCase
             ->method('findOne');
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('to_camel_case')
-            ->will($this->returnValue('ServiceCustom'));
+            ->willReturn('ServiceCustom');
 
-        $di          = new \Pimple\Container();
-        $di['db']    = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
-        $order->service_id   = random_int(1, 100);
+        $order->service_id = random_int(1, 100);
         $order->service_type = \Model_ProductTable::CUSTOM;
 
         $result = $this->service->getOrderService($order);
@@ -815,12 +819,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('getExistingModelById')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -839,12 +843,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('getExistingModelById')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
         $dbMock->expects($this->never())
             ->method('findOne')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -863,14 +867,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('from_camel_case')
-            ->will($this->returnValue('servicecustom'));
+            ->willReturn('servicecustom');
 
-        $di          = new \Pimple\Container();
-        $di['db']    = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
@@ -884,14 +888,14 @@ class ServiceTest extends \BBTestCase
 
     public function testGetConfig()
     {
-        $decoded   = array(
-            'key' => 'value'
-        );
+        $decoded = [
+            'key' => 'value',
+        ];
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('decodeJ')
-            ->will($this->returnValue($decoded));
+            ->willReturn($decoded);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
@@ -907,10 +911,10 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
 
-        return array(
-            array($order, true),
-            array(null, false),
-        );
+        return [
+            [$order, true],
+            [null, false],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('productHasOrdersProvider')]
@@ -919,9 +923,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -942,12 +946,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($orderStatus));
+            ->willReturn($orderStatus);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -967,13 +971,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array(array(), array())));
+            ->willReturn([[], []]);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getSoonExpiringActiveOrdersQuery'))->disableOriginalConstructor()->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getSoonExpiringActiveOrdersQuery'])->disableOriginalConstructor()->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSoonExpiringActiveOrdersQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -988,49 +992,48 @@ class ServiceTest extends \BBTestCase
         $orderStatus->loadBean(new \DummyBean());
 
         $systemService = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getParamValue'))->getMock();
+            ->onlyMethods(['getParamValue'])->getMock();
         $systemService->expects($this->atLeastOnce())->method('getParamValue')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
 
         $this->service->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
 
-        $data   = array(
-            'client_id' => $randId
-        );
+        $data = [
+            'client_id' => $randId,
+        ];
         $result = $this->service->getSoonExpiringActiveOrdersQuery($data);
 
-        $expectedQuery = "SELECT *
+        $expectedQuery = 'SELECT *
                 FROM client_order
                 WHERE status = :status
                 AND invoice_option = :invoice_option
                 AND period IS NOT NULL
                 AND expires_at IS NOT NULL
-                AND unpaid_invoice_id IS NULL AND client_id = :client_id HAVING DATEDIFF(expires_at, NOW()) <= :days_until_expiration ORDER BY client_id DESC";
+                AND unpaid_invoice_id IS NULL AND client_id = :client_id HAVING DATEDIFF(expires_at, NOW()) <= :days_until_expiration ORDER BY client_id DESC';
 
-        $expectedBindings = array(
-            ':client_id'             => $randId,
-            ':status'                => 'active',
-            ':invoice_option'        => 'issue-invoice',
+        $expectedBindings = [
+            ':client_id' => $randId,
+            ':status' => 'active',
+            ':invoice_option' => 'issue-invoice',
             ':days_until_expiration' => $randId,
-        );
+        ];
 
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
 
         $this->assertEquals($expectedQuery, $result[0]);
         $this->assertEquals($expectedBindings, $result[1]);
-
     }
 
     public function testgetRelatedOrderIdByType()
     {
-        $id    = 1;
+        $id = 1;
         $model = new \Model_ClientOrder();
         $model->loadBean(new \DummyBean());
         $model->id = $id;
@@ -1039,9 +1042,9 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
             ->with('ClientOrder')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1050,9 +1053,9 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($id, $result);
     }
 
-    public function testgetRelatedOrderIdByType_returnNull()
+    public function testgetRelatedOrderIdByTypeReturnNull()
     {
-        $id    = 1;
+        $id = 1;
         $model = new \Model_ClientOrder();
         $model->loadBean(new \DummyBean());
         $model->id = $id;
@@ -1061,9 +1064,9 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
             ->with('ClientOrder')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1105,15 +1108,15 @@ class ServiceTest extends \BBTestCase
     {
         $model = new \Model_ClientOrder();
         $model->loadBean(new \DummyBean());
-        $model->config   = '{}';
-        $model->price    = 10;
+        $model->config = '{}';
+        $model->price = 10;
         $model->quantity = 1;
         $model->client_id = 1;
 
         $clientService = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $supportService = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportService->expects($this->atLeastOnce())
@@ -1123,10 +1126,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder(\Box_Database::class)->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->willReturn(array());
+            ->willReturn([]);
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
@@ -1135,7 +1138,7 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
             ->willReturnCallback(function (...$args) use ($modelProduct) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'Product' => $modelProduct
                 };
 
@@ -1151,9 +1154,9 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->willReturn(array());
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($clientService, $supportService) {
             if ($serviceName == 'client') {
                 return $clientService;
@@ -1162,8 +1165,8 @@ class ServiceTest extends \BBTestCase
                 return $supportService;
             }
         });
-        $di['db']          = $dbMock;
-        $di['tools']       = $toolsMock;
+        $di['db'] = $dbMock;
+        $di['tools'] = $toolsMock;
 
         $this->service->setDi($di);
         $result = $this->service->toApiArray($model, true, new \Model_Admin());
@@ -1179,97 +1182,97 @@ class ServiceTest extends \BBTestCase
 
     public static function searchQueryData()
     {
-        return array(
-            array(array(), 'SELECT co.* from client_order co', array()),
-            array(
-                array('client_id' => 1),
+        return [
+            [[], 'SELECT co.* from client_order co', []],
+            [
+                ['client_id' => 1],
                 'co.client_id = :client_id',
-                array(':client_id' => '1',)
-            ),
-            array(
-                array('invoice_option' => 'issue-invoice'),
+                [':client_id' => '1'],
+            ],
+            [
+                ['invoice_option' => 'issue-invoice'],
                 'co.invoice_option = :invoice_option',
-                array(':invoice_option' => 'issue-invoice',)
-            ),
-            array(
-                array('id' => 1),
+                [':invoice_option' => 'issue-invoice'],
+            ],
+            [
+                ['id' => 1],
                 'co.id = :id',
-                array(':id' => '1',)
-            ),
-            array(
-                array('status' => 'pending_setup'),
+                [':id' => '1'],
+            ],
+            [
+                ['status' => 'pending_setup'],
                 'co.status = :status',
-                array(':status' => 'pending_setup',)
-            ),
-            array(
-                array('product_id' => 1),
+                [':status' => 'pending_setup'],
+            ],
+            [
+                ['product_id' => 1],
                 'co.product_id = :product_id',
-                array(':product_id' => '1',)
-            ),
-            array(
-                array('type' => 'custom'),
+                [':product_id' => '1'],
+            ],
+            [
+                ['type' => 'custom'],
                 'co.service_type = :service_type',
-                array(':service_type' => 'custom',)
-            ),
-            array(
-                array('title' => 'titleField'),
+                [':service_type' => 'custom'],
+            ],
+            [
+                ['title' => 'titleField'],
                 'co.title LIKE :title',
-                array(':title' => '%titleField%',)
-            ),
-            array(
-                array('period' => '1Y'),
+                [':title' => '%titleField%'],
+            ],
+            [
+                ['period' => '1Y'],
                 'co.period = :period',
-                array(':period' => '1Y',)
-            ),
-            array(
-                array('hide_addons' => true),
+                [':period' => '1Y'],
+            ],
+            [
+                ['hide_addons' => true],
                 'co.group_master = 1',
-                array()
-            ),
-            array(
-                array('created_at' => '2012-12-11'),
+                [],
+            ],
+            [
+                ['created_at' => '2012-12-11'],
                 "DATE_FORMAT(co.created_at, '%Y-%m-%d') = :created_at",
-                array(':created_at' => '2012-12-11',)
-            ),
-            array(
-                array('date_from' => '2012-12-11'),
+                [':created_at' => '2012-12-11'],
+            ],
+            [
+                ['date_from' => '2012-12-11'],
                 'UNIX_TIMESTAMP(co.created_at) >= :date_from',
-                array(':date_from' => strtotime('2012-12-11'),)
-            ),
-            array(
-                array('date_to' => '2012-12-11'),
+                [':date_from' => strtotime('2012-12-11')],
+            ],
+            [
+                ['date_to' => '2012-12-11'],
                 'UNIX_TIMESTAMP(co.created_at) <= :date_to',
-                array(':date_to' => strtotime('2012-12-11'),)
-            ),
-            array(
-                array('search' => 120),
+                [':date_to' => strtotime('2012-12-11')],
+            ],
+            [
+                ['search' => 120],
                 'co.id = :search',
-                array(':search' => 120,)
-            ),
-            array(
-                array('search' => 'John'),
+                [':search' => 120],
+            ],
+            [
+                ['search' => 'John'],
                 '(c.first_name LIKE :first_name OR c.last_name LIKE :last_name OR co.title LIKE :title)',
-                array(
+                [
                     ':first_name' => '%John%',
-                    ':last_name'  => '%John%',
-                    ':title'      => '%John%',
-                )
-            ),
-            array(
-                array('ids' => array(1, 2, 3)),
+                    ':last_name' => '%John%',
+                    ':title' => '%John%',
+                ],
+            ],
+            [
+                ['ids' => [1, 2, 3]],
                 'co.id IN (:ids)',
-                array(':ids' => array(1, 2, 3))
-            ),
+                [':ids' => [1, 2, 3]],
+            ],
 
-            array(
-                array('meta' => array('param' => 'value')),
+            [
+                ['meta' => ['param' => 'value']],
                 '(meta.name = :meta_name1 AND meta.value LIKE :meta_value1)',
-                array(
-                    ':meta_name1'  => 'param',
-                    ':meta_value1' => 'value%'
-                ),
-            ),
-        );
+                [
+                    ':meta_name1' => 'param',
+                    ':meta_value1' => 'value%',
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchQueryData')]
@@ -1284,10 +1287,10 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result[1]);
 
         $this->assertTrue(str_contains($result[0], $expectedStr), $result[0]);
-        $this->assertTrue(array_diff_key($result[1], $expectedParams) == array());
+        $this->assertTrue(array_diff_key($result[1], $expectedParams) == []);
     }
 
-    public function testcreateOrder_MissingOrderCurrency()
+    public function testcreateOrderMissingOrderCurrency()
     {
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -1300,7 +1303,7 @@ class ServiceTest extends \BBTestCase
             ->method('getDefault')
             ->willReturn(null);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($currencyServiceMock) {
             if ($serviceName == 'currency') {
                 return $currencyServiceMock;
@@ -1310,10 +1313,10 @@ class ServiceTest extends \BBTestCase
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Currency could not be determined for order');
-        $this->service->createOrder($modelClient, $modelProduct, array());
+        $this->service->createOrder($modelClient, $modelProduct, []);
     }
 
-    public function testcreateOrder_OutOfStock()
+    public function testcreateOrderOutOfStock()
     {
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -1341,8 +1344,8 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
             if ($serviceName == 'currency') {
                 return $currencyServiceMock;
             }
@@ -1357,10 +1360,10 @@ class ServiceTest extends \BBTestCase
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(831);
         $this->expectExceptionMessage('Product 1 is out of stock.');
-        $this->service->createOrder($modelClient, $modelProduct, array());
+        $this->service->createOrder($modelClient, $modelProduct, []);
     }
 
-    public function testcreateOrder_GroupIdMissing()
+    public function testcreateOrderGroupIdMissing()
     {
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -1368,7 +1371,7 @@ class ServiceTest extends \BBTestCase
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
-        $modelProduct->id       = 1;
+        $modelProduct->id = 1;
         $modelProduct->is_addon = 1;
 
         $currencyModel = new \Model_Currency();
@@ -1389,8 +1392,8 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
             if ($serviceName == 'currency') {
                 return $currencyServiceMock;
             }
@@ -1405,10 +1408,10 @@ class ServiceTest extends \BBTestCase
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(832);
         $this->expectExceptionMessage('Group ID parameter is missing for addon product order');
-        $this->service->createOrder($modelClient, $modelProduct, array());
+        $this->service->createOrder($modelClient, $modelProduct, []);
     }
 
-    public function testcreateOrder_ParentOrderNotFound()
+    public function testcreateOrderParentOrderNotFound()
     {
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -1436,8 +1439,8 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock) {
             if ($serviceName == 'currency') {
                 return $currencyServiceMock;
             }
@@ -1448,8 +1451,8 @@ class ServiceTest extends \BBTestCase
 
         $di['events_manager'] = $eventMock;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getMasterOrderForClient'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getMasterOrderForClient'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getMasterOrderForClient')
@@ -1458,7 +1461,7 @@ class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Parent order 1 was not found');
-        $serviceMock->createOrder($modelClient, $modelProduct, array('group_id' => 1));
+        $serviceMock->createOrder($modelClient, $modelProduct, ['group_id' => 1]);
     }
 
     public function testcreateOrder()
@@ -1469,7 +1472,7 @@ class ServiceTest extends \BBTestCase
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
-        $modelProduct->id   = 1;
+        $modelProduct->id = 1;
         $modelProduct->type = 'custom';
 
         $currencyModel = new \Model_Currency();
@@ -1509,8 +1512,8 @@ class ServiceTest extends \BBTestCase
             ->method('getCode')
             ->willReturn('1Y');
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock, $productServiceMock) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($currencyServiceMock, $cartServiceMock, $productServiceMock) {
             if ($serviceName == 'currency') {
                 return $currencyServiceMock;
             }
@@ -1522,12 +1525,12 @@ class ServiceTest extends \BBTestCase
             }
         });
         $di['events_manager'] = $eventMock;
-        $di['db']             = $dbMock;
-        $di['period']         = $di->protect(fn() => $periodMock);
-        $di['logger']         = new \Box_Log();
+        $di['db'] = $dbMock;
+        $di['period'] = $di->protect(fn () => $periodMock);
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
-        $result = $this->service->createOrder($modelClient, $modelProduct, array('period' => '1Y', 'price' => '10', 'notes' => 'test'));
+        $result = $this->service->createOrder($modelClient, $modelProduct, ['period' => '1Y', 'price' => '10', 'notes' => 'test']);
         $this->assertEquals($newId, $result);
     }
 
@@ -1545,14 +1548,14 @@ class ServiceTest extends \BBTestCase
             ->with('ClientOrder')
             ->willReturn($clientOrderModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
         $result = $this->service->getMasterOrderForClient($clientModel, 1);
         $this->assertInstanceOf('Model_ClientOrder', $result);
     }
 
-    public function testactivateOrder_ExceptionPendingOrFailedOrders()
+    public function testactivateOrderExceptionPendingOrFailedOrders()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -1566,23 +1569,23 @@ class ServiceTest extends \BBTestCase
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
-        $clientOrderModel->status       = \Model_ClientOrder::STATUS_PENDING_SETUP;
+        $clientOrderModel->status = \Model_ClientOrder::STATUS_PENDING_SETUP;
         $clientOrderModel->group_master = 1;
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('createFromOrder', 'getOrderAddonsList', 'activateOrderAddons'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['createFromOrder', 'getOrderAddonsList', 'activateOrderAddons'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createFromOrder')
-            ->willReturn(array());
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('activateOrderAddons');
 
@@ -1596,33 +1599,32 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('createFromOrder', 'getOrderAddonsList'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['createFromOrder', 'getOrderAddonsList'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('createFromOrder')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
-        $clientOrderModel->status       = \Model_ClientOrder::STATUS_PENDING_SETUP;
+        $clientOrderModel->status = \Model_ClientOrder::STATUS_PENDING_SETUP;
         $clientOrderModel->group_master = 1;
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderAddonsList')
-            ->willReturn(array($clientOrderModel));
+            ->willReturn([$clientOrderModel]);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
 
         $serviceMock->setDi($di);
         $result = $serviceMock->activateOrderAddons($clientOrderModel);
         $this->assertTrue($result);
-
     }
 
     public function testgetOrderAddonsList()
@@ -1634,9 +1636,9 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
             ->with('ClientOrder')
-            ->willReturn(array(new \Model_ClientOrder()));
+            ->willReturn([new \Model_ClientOrder()]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1656,7 +1658,7 @@ class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($productModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1678,28 +1680,27 @@ class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($clientOrderModel);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['db']             = $dbMock;
-        $di['logger']         = new \Box_Log();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
 
-        $data = array(
-            'period'         => '1Y',
-            'created_at'     => '2012-12-01',
-            'activated_at'   => '2012-12-01',
-            'expires_at'     => '2013-12-01',
+        $data = [
+            'period' => '1Y',
+            'created_at' => '2012-12-01',
+            'activated_at' => '2012-12-01',
+            'expires_at' => '2013-12-01',
             'invoice_option' => 'issue-invoice',
-            'title'          => 'Testing',
-            'price'          => 10,
-            'status'         => 'active',
-            'notes'          => 'Empty note',
-            'reason'         => 'non',
-            'meta'           => array()
+            'title' => 'Testing',
+            'price' => 10,
+            'status' => 'active',
+            'notes' => 'Empty note',
+            'reason' => 'non',
+            'meta' => [],
+        ];
 
-        );
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('updatePeriod', 'updateOrderMeta'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['updatePeriod', 'updateOrderMeta'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updatePeriod')
@@ -1718,25 +1719,25 @@ class ServiceTest extends \BBTestCase
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
         $clientOrderModel->group_master = 1;
-        $clientOrderModel->status       = \Model_ClientOrder::STATUS_PENDING_SETUP;
+        $clientOrderModel->status = \Model_ClientOrder::STATUS_PENDING_SETUP;
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
+        $di['logger'] = new \Box_Log();
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('renewFromOrder', 'getOrderAddonsList'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['renewFromOrder', 'getOrderAddonsList'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('renewFromOrder')
             ->with($clientOrderModel);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderAddonsList')
-            ->willReturn(array($clientOrderModel));
+            ->willReturn([$clientOrderModel]);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->renewOrder($clientOrderModel);
@@ -1745,8 +1746,8 @@ class ServiceTest extends \BBTestCase
 
     public function testrenewFromOrder()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('_callOnService', 'saveStatusChange'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_callOnService', 'saveStatusChange'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('_callOnService');
@@ -1765,17 +1766,16 @@ class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($clientOrderModel);
 
-        $di               = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn($name) => array());
-        $di['period']     = $di->protect(fn() => $periodMock);
-        $di['db']         = $dbMock;
-
+        $di = new \Pimple\Container();
+        $di['mod_config'] = $di->protect(fn ($name) => []);
+        $di['period'] = $di->protect(fn () => $periodMock);
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
         $serviceMock->renewFromOrder($clientOrderModel);
     }
 
-    public function testsuspendFromOrder_ExceptionNotActiveOrder()
+    public function testsuspendFromOrderExceptionNotActiveOrder()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -1785,7 +1785,7 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
 
         $this->service->setDi($di);
@@ -1809,14 +1809,13 @@ class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($clientOrderModel);
 
-
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
-        $di['logger']         = new \Box_Log();
-        $di['db']             = $dbMock;
+        $di['logger'] = new \Box_Log();
+        $di['db'] = $dbMock;
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('_callOnService', 'saveStatusChange'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_callOnService', 'saveStatusChange'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('_callOnService');
@@ -1833,32 +1832,30 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
 
-        $pdoStatment = $this->getMockBuilder('\\' . \Box\Mod\Order\PdoStatmentsMock::class)->getMock();
+        $pdoStatment = $this->getMockBuilder('\\' . PdoStatmentsMock::class)->getMock();
         $pdoStatment->expects($this->atLeastOnce())
             ->method('execute');
 
-
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Order\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatment));
+            ->willReturn($pdoStatment);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $this->service->setDi($di);
         $this->service->rmByClient($clientModel);
-
     }
 
     public function testupdatePeriod()
     {
         $period = '1Y';
-        $di     = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
         $periodMock->expects($this->atLeastOnce())
             ->method('getCode');
-        $di['period'] = $di->protect(fn() => $periodMock);
+        $di['period'] = $di->protect(fn () => $periodMock);
 
         $this->service->setDi($di);
         $clientOrder = new \Model_ClientOrder();
@@ -1867,14 +1864,14 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testupdatePeriod_isEmpty()
+    public function testupdatePeriodIsEmpty()
     {
-        $period     = '';
-        $di         = new \Pimple\Container();
+        $period = '';
+        $di = new \Pimple\Container();
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
         $periodMock->expects($this->never())
             ->method('getCode');
-        $di['period'] = $di->protect(fn() => $periodMock);
+        $di['period'] = $di->protect(fn () => $periodMock);
 
         $this->service->setDi($di);
         $clientOrder = new \Model_ClientOrder();
@@ -1883,14 +1880,14 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals(2, $result);
     }
 
-    public function testupdatePeriod_notSet()
+    public function testupdatePeriodNotSet()
     {
-        $period     = null;
-        $di         = new \Pimple\Container();
+        $period = null;
+        $di = new \Pimple\Container();
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
         $periodMock->expects($this->never())
             ->method('getCode');
-        $di['period'] = $di->protect(fn() => $periodMock);
+        $di['period'] = $di->protect(fn () => $periodMock);
 
         $this->service->setDi($di);
         $clientOrder = new \Model_ClientOrder();
@@ -1899,19 +1896,19 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals(0, $result);
     }
 
-    public function testupdateOrderMeta_isNotSet()
+    public function testupdateOrderMetaIsNotSet()
     {
-        $meta        = null;
+        $meta = null;
         $clientOrder = new \Model_ClientOrder();
         $clientOrder->loadBean(new \DummyBean());
         $result = $this->service->updateOrderMeta($clientOrder, $meta);
         $this->assertEquals(0, $result);
     }
 
-    public function testupdateOrderMeta_isEmpty()
+    public function testupdateOrderMetaIsEmpty()
     {
-        $meta = array();
-        $di   = new \Pimple\Container();
+        $meta = [];
+        $di = new \Pimple\Container();
 
         $dBMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dBMock->expects($this->atLeastOnce())
@@ -1927,10 +1924,10 @@ class ServiceTest extends \BBTestCase
 
     public function testupdateOrderMeta()
     {
-        $meta = array(
+        $meta = [
             'key' => 'value',
-        );
-        $di   = new \Pimple\Container();
+        ];
+        $di = new \Pimple\Container();
 
         $dBMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dBMock->expects($this->atLeastOnce())

--- a/tests/modules/Page/Api/AdminTest.php
+++ b/tests/modules/Page/Api/AdminTest.php
@@ -1,21 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Page\Api;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Page\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Page\Api\Admin();
+        $this->api = new Admin();
     }
-
 
     public function testgetDi()
     {
@@ -25,18 +22,16 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_pairs()
+    public function testgetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Page\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $result = $this->api->get_pairs();
         $this->assertIsArray($result);
     }
-
 }
- 

--- a/tests/modules/Page/ServiceTest.php
+++ b/tests/modules/Page/ServiceTest.php
@@ -1,25 +1,22 @@
 <?php
 
-
 namespace Box\Mod\Page;
 
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     public function testgetPairs()
     {
-        $service = new \Box\Mod\Page\Service();
+        $service = new Service();
 
         $themeService = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $themeService->expects($this->atLeastOnce())
             ->method('getCurrentClientAreaThemeCode');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $themeService);
+        $di['mod_service'] = $di->protect(fn () => $themeService);
 
         $service->setDi($di);
         $result = $service->getPairs();
         $this->assertIsArray($result);
     }
 }
- 

--- a/tests/modules/Paidsupport/ServiceTest.php
+++ b/tests/modules/Paidsupport/ServiceTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Paidsupport;
 
-
-class ServiceTest extends \BBTestCase {
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Paidsupport\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Paidsupport\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -36,19 +35,19 @@ class ServiceTest extends \BBTestCase {
             ->with($clientModel)
             ->willReturn($clientTotalAmount);
 
-        $paidSupportConfig = array(
+        $paidSupportConfig = [
             'ticket_price' => 2,
             'error_msg' => 'Insufficient funds to open ticket',
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function($serviceName, $subService) use ($clientBalanceMock){
+        $di['mod_service'] = $di->protect(function ($serviceName, $subService) use ($clientBalanceMock) {
             if ($serviceName == 'Client' && $subService == 'Balance') {
                 return $clientBalanceMock;
             }
         });
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -58,7 +57,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function test_NotenoughInBalanceToOpenTicket()
+    public function testNotenoughInBalanceToOpenTicket()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -71,19 +70,19 @@ class ServiceTest extends \BBTestCase {
             ->with($clientModel)
             ->willReturn($clientTotalAmount);
 
-        $paidSupportConfig = array(
+        $paidSupportConfig = [
             'ticket_price' => 2,
             'error_msg' => 'Insufficient funds to open ticket',
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function($serviceName, $subService) use ($clientBalanceMock){
+        $di['mod_service'] = $di->protect(function ($serviceName, $subService) use ($clientBalanceMock) {
             if ($serviceName == 'Client' && $subService == 'Balance') {
                 return $clientBalanceMock;
             }
         });
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -95,7 +94,7 @@ class ServiceTest extends \BBTestCase {
         $this->service->enoughInBalanceToOpenTicket($clientModel);
     }
 
-    public function test_enoughInBalanceToOpenTicket_TicketPriceEqualsTotalAmount()
+    public function testEnoughInBalanceToOpenTicketTicketPriceEqualsTotalAmount()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -108,19 +107,19 @@ class ServiceTest extends \BBTestCase {
             ->with($clientModel)
             ->willReturn($clientTotalAmount);
 
-        $paidSupportConfig = array(
+        $paidSupportConfig = [
             'ticket_price' => $clientTotalAmount,
             'error_msg' => 'Insufficient funds to open ticket',
-        );
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function($serviceName, $subService) use ($clientBalanceMock){
+        $di['mod_service'] = $di->protect(function ($serviceName, $subService) use ($clientBalanceMock) {
             if ($serviceName == 'Client' && $subService == 'Balance') {
                 return $clientBalanceMock;
             }
         });
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -130,7 +129,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function test_enoughInBalanceToOpenTicket_TicketPriceIsNotSet()
+    public function testEnoughInBalanceToOpenTicketTicketPriceIsNotSet()
     {
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -143,16 +142,16 @@ class ServiceTest extends \BBTestCase {
             ->with($clientModel)
             ->willReturn($clientTotalAmount);
 
-        $paidSupportConfig = array();
+        $paidSupportConfig = [];
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(function($serviceName, $subService) use ($clientBalanceMock){
+        $di['mod_service'] = $di->protect(function ($serviceName, $subService) use ($clientBalanceMock) {
             if ($serviceName == 'Client' && $subService == 'Balance') {
                 return $clientBalanceMock;
             }
         });
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -162,7 +161,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testonBeforeClientOpenTicket_PaidSupportForHelpdeskEnabled()
+    public function testonBeforeClientOpenTicketPaidSupportForHelpdeskEnabled()
     {
         $di = new \Pimple\Container();
 
@@ -176,23 +175,23 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($clientModel);
         $di['db'] = $dbMock;
 
-        $paidSupportMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)->getMock();
+        $paidSupportMock = $this->getMockBuilder('\\' . Service::class)->getMock();
         $paidSupportMock->expects($this->atLeastOnce())
             ->method('hasHelpdeskPaidSupport')
             ->willReturn(true);
         $paidSupportMock->expects($this->atLeastOnce())
             ->method('enoughInBalanceToOpenTicket')
             ->with($clientModel);
-        $di['mod_service'] = $di->protect(function ($serviceName) use($paidSupportMock){
-            if ($serviceName == 'Paidsupport'){
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($paidSupportMock) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportMock;
             }
         });
 
-        $params = array(
+        $params = [
             'client_id' => 1,
             'support_helpdesk_id' => 1,
-        );
+        ];
 
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -206,7 +205,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testonBeforeClientOpenTicket_PaidSupportForHelpdeskDisabled()
+    public function testonBeforeClientOpenTicketPaidSupportForHelpdeskDisabled()
     {
         $di = new \Pimple\Container();
 
@@ -220,23 +219,23 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($clientModel);
         $di['db'] = $dbMock;
 
-        $paidSupportMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)->getMock();
+        $paidSupportMock = $this->getMockBuilder('\\' . Service::class)->getMock();
         $paidSupportMock->expects($this->atLeastOnce())
             ->method('hasHelpdeskPaidSupport')
             ->willReturn(false);
         $paidSupportMock->expects($this->never())
             ->method('enoughInBalanceToOpenTicket')
             ->with($clientModel);
-        $di['mod_service'] = $di->protect(function ($serviceName) use($paidSupportMock){
-            if ($serviceName == 'Paidsupport'){
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($paidSupportMock) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportMock;
             }
         });
 
-        $params = array(
+        $params = [
             'client_id' => 1,
             'support_helpdesk_id' => 1,
-        );
+        ];
 
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -253,12 +252,12 @@ class ServiceTest extends \BBTestCase {
     public function testgetTicketPrice()
     {
         $di = new \Pimple\Container();
-        $paidSupportConfig = array(
+        $paidSupportConfig = [
             'ticket_price' => 1,
-        );
+        ];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -268,13 +267,13 @@ class ServiceTest extends \BBTestCase {
         $this->assertEquals($paidSupportConfig['ticket_price'], $result);
     }
 
-    public function testgetTicketPrice_NotSet()
+    public function testgetTicketPriceNotSet()
     {
         $di = new \Pimple\Container();
-        $paidSupportConfig = array();
+        $paidSupportConfig = [];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -288,34 +287,32 @@ class ServiceTest extends \BBTestCase {
     {
         $di = new \Pimple\Container();
         $errorMessage = 'Not enough funds';
-        $paidSupportConfig = array(
+        $paidSupportConfig = [
             'error_msg' => $errorMessage,
-        );
+        ];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
-
 
         $this->service->setDi($di);
         $result = $this->service->getErrorMessage();
         $this->assertEquals($errorMessage, $result);
     }
 
-    public function testgetErrorMessage_NotSet()
+    public function testgetErrorMessageNotSet()
     {
         $di = new \Pimple\Container();
         $errorMessage = 'Configure paid support module!';
-        $paidSupportConfig = array();
+        $paidSupportConfig = [];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
-
 
         $this->service->setDi($di);
         $result = $this->service->getErrorMessage();
@@ -336,7 +333,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
             ->willReturnCallback(function (...$args) use ($supportTicketModel, $clientModel) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'SupportTicket' => $supportTicketModel,
                     'Client' => $clientModel
                 };
@@ -345,7 +342,7 @@ class ServiceTest extends \BBTestCase {
             });
         $di['db'] = $dbMock;
 
-        $paidSupportMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)->getMock();
+        $paidSupportMock = $this->getMockBuilder('\\' . Service::class)->getMock();
         $paidSupportMock->expects($this->atLeastOnce())
             ->method('hasHelpdeskPaidSupport')
             ->willReturn(true);
@@ -357,19 +354,19 @@ class ServiceTest extends \BBTestCase {
         $clientBalanceMock->expects($this->atLeastOnce())
             ->method('deductFunds');
 
-        $di['mod_service'] = $di->protect(function ($serviceName, $sub ='') use($paidSupportMock, $clientBalanceMock){
-            if ($serviceName == 'Paidsupport'){
+        $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($paidSupportMock, $clientBalanceMock) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportMock;
             }
-            if ($serviceName == 'Client' && $sub == 'Balance'){
+            if ($serviceName == 'Client' && $sub == 'Balance') {
                 return $clientBalanceMock;
             }
         });
 
-        $params = array(
+        $params = [
             'id' => 1,
             'support_helpdesk_id' => 1,
-        );
+        ];
 
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -383,7 +380,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testonAfterClientOpenTicket_PaidSupportDisabledForHelpdesk()
+    public function testonAfterClientOpenTicketPaidSupportDisabledForHelpdesk()
     {
         $di = new \Pimple\Container();
 
@@ -397,7 +394,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
             ->willReturnCallback(function (...$args) use ($supportTicketModel, $clientModel) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'SupportTicket' => $supportTicketModel,
                     'Client' => $clientModel
                 };
@@ -406,7 +403,7 @@ class ServiceTest extends \BBTestCase {
             });
         $di['db'] = $dbMock;
 
-        $paidSupportMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)->getMock();
+        $paidSupportMock = $this->getMockBuilder('\\' . Service::class)->getMock();
         $paidSupportMock->expects($this->atLeastOnce())
             ->method('hasHelpdeskPaidSupport')
             ->willReturn(false);
@@ -414,16 +411,16 @@ class ServiceTest extends \BBTestCase {
             ->method('enoughInBalanceToOpenTicket')
             ->with($clientModel);
 
-        $di['mod_service'] = $di->protect(function ($serviceName, $sub ='') use($paidSupportMock){
-            if ($serviceName == 'Paidsupport'){
+        $di['mod_service'] = $di->protect(function ($serviceName, $sub = '') use ($paidSupportMock) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportMock;
             }
         });
 
-        $params = array(
+        $params = [
             'id' => 1,
             'support_helpdesk_id' => 1,
-        );
+        ];
 
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -441,15 +438,15 @@ class ServiceTest extends \BBTestCase {
     {
         $di = new \Pimple\Container();
         $helpdeskId = 2;
-        $helpdeskConfig = array(
-            $helpdeskId => 0
-        );
-        $paidSupportConfig = array(
+        $helpdeskConfig = [
+            $helpdeskId => 0,
+        ];
+        $paidSupportConfig = [
             'helpdesk' => $helpdeskConfig,
-        );
+        ];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -459,16 +456,15 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
         $this->assertEquals($helpdeskConfig, $result);
-
     }
 
-    public function testgetPaidHelpdeskConfig_IsNotSet()
+    public function testgetPaidHelpdeskConfigIsNotSet()
     {
         $di = new \Pimple\Container();
-        $paidSupportConfig = array();
+        $paidSupportConfig = [];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName== 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -479,14 +475,14 @@ class ServiceTest extends \BBTestCase {
         $this->assertEmpty($result);
     }
 
-    public function testhasHelpdeskPaidSupport_turnedOff()
+    public function testhasHelpdeskPaidSupportTurnedOff()
     {
         $helpdeskId = 1;
-        $helpdeskConfig = array(
-            $helpdeskId => 0
-        );
-        $paidSupportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)
-            ->onlyMethods(array('getPaidHelpdeskConfig'))
+        $helpdeskConfig = [
+            $helpdeskId => 0,
+        ];
+        $paidSupportServiceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaidHelpdeskConfig'])
             ->getMock();
         $paidSupportServiceMock->expects($this->atLeastOnce())
             ->method('getPaidHelpdeskConfig')
@@ -496,14 +492,14 @@ class ServiceTest extends \BBTestCase {
         $this->assertFalse($result);
     }
 
-    public function testhasHelpdeskPaidSupport_turnedOn()
+    public function testhasHelpdeskPaidSupportTurnedOn()
     {
         $helpdeskId = 1;
-        $helpdeskConfig = array(
-            $helpdeskId => 1
-        );
-        $paidSupportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)
-            ->onlyMethods(array('getPaidHelpdeskConfig'))
+        $helpdeskConfig = [
+            $helpdeskId => 1,
+        ];
+        $paidSupportServiceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaidHelpdeskConfig'])
             ->getMock();
         $paidSupportServiceMock->expects($this->atLeastOnce())
             ->method('getPaidHelpdeskConfig')
@@ -513,13 +509,13 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testhasHelpdeskPaidSupport_ConfigNotConfigured()
+    public function testhasHelpdeskPaidSupportConfigNotConfigured()
     {
         $helpdeskId = 1;
-        $helpdeskConfig = array();
+        $helpdeskConfig = [];
 
-        $paidSupportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Paidsupport\Service::class)
-            ->onlyMethods(array('getPaidHelpdeskConfig'))
+        $paidSupportServiceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaidHelpdeskConfig'])
             ->getMock();
         $paidSupportServiceMock->expects($this->atLeastOnce())
             ->method('getPaidHelpdeskConfig')
@@ -529,21 +525,21 @@ class ServiceTest extends \BBTestCase {
         $this->assertFalse($result);
     }
 
-    public function testPaidSupportAppliedForAllHelpdesks_AllHelpdesksAreNotChecked()
+    public function testPaidSupportAppliedForAllHelpdesksAllHelpdesksAreNotChecked()
     {
         $di = new \Pimple\Container();
         $helpdeskId = 2;
         $helpdeskId1 = 3;
-        $helpdeskConfig = array(
+        $helpdeskConfig = [
             $helpdeskId => 0,
-            $helpdeskId1 => 0
-        );
-        $paidSupportConfig = array(
+            $helpdeskId1 => 0,
+        ];
+        $paidSupportConfig = [
             'helpdesk' => $helpdeskConfig,
-        );
+        ];
 
-        $di['mod_config'] = $di->protect(function($serviceName) use ($paidSupportConfig){
-            if ($serviceName == 'Paidsupport'){
+        $di['mod_config'] = $di->protect(function ($serviceName) use ($paidSupportConfig) {
+            if ($serviceName == 'Paidsupport') {
                 return $paidSupportConfig;
             }
         });
@@ -574,7 +570,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testUninstall_ConfigNotFound()
+    public function testUninstallConfigNotFound()
     {
         $di = new \Pimple\Container();
 
@@ -602,8 +598,8 @@ class ServiceTest extends \BBTestCase {
             ->method('setConfig')
             ->willReturn(true);
 
-        $di['mod_service'] = $di->protect(function ($serviceName) use ($extensionServiceMock){
-            if ($serviceName == 'Extension'){
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($extensionServiceMock) {
+            if ($serviceName == 'Extension') {
                 return $extensionServiceMock;
             }
         });

--- a/tests/modules/Product/Api/AdminTest.php
+++ b/tests/modules/Product/Api/AdminTest.php
@@ -1,21 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Product\Api;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Product\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Product\Api\Admin();
+        $this->api = new Admin();
     }
-
 
     public function testgetDi()
     {
@@ -25,46 +22,44 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductSearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
-
+            ->willReturn(['sqlString', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
 
-
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testget_pairs()
+    public function testgetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->get_pairs(array());
+        $result = $this->api->get_pairs([]);
         $this->assertIsArray($result);
     }
 
     public function testget()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
@@ -72,19 +67,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
         ->method('toApiArray')
-        ->will($this->returnValue(array()));
+        ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -93,13 +88,12 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_types()
+    public function testgetTypes()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTypes')
-            ->will($this->returnValue(array()));
-
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $result = $this->api->get_types();
@@ -108,20 +102,20 @@ class AdminTest extends \BBTestCase {
 
     public function testprepareDomainProductAlreadyCreated()
     {
-        $data = array(
+        $data = [
             'title' => 'testTitle',
             'type' => 'domain',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getMainDomainProduct')
-            ->will($this->returnValue(new \Model_ProductDomain));
+            ->willReturn(new \Model_ProductDomain());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -135,27 +129,27 @@ class AdminTest extends \BBTestCase {
         $this->api->prepare($data);
     }
 
-    public function testprepare_TypeIsNotRecognized()
+    public function testprepareTypeIsNotRecognized()
     {
-        $data = array(
+        $data = [
             'title' => 'testTitle',
             'type' => 'customForTestException',
-        );
+        ];
 
-        $typeArray = array(
+        $typeArray = [
             'license' => 'License',
-            'domain' => 'Domain'
-        );
+            'domain' => 'Domain',
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTypes')
-            ->will($this->returnValue($typeArray));
+            ->willReturn($typeArray);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -171,32 +165,32 @@ class AdminTest extends \BBTestCase {
 
     public function testprepare()
     {
-        $data = array(
+        $data = [
             'title' => 'testTitle',
             'type' => 'license',
-        );
+        ];
 
-        $typeArray = array(
+        $typeArray = [
             'license' => 'License',
-            'domain' => 'Domain'
-        );
+            'domain' => 'Domain',
+        ];
 
         $newProductId = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTypes')
-            ->will($this->returnValue($typeArray));
+            ->willReturn($typeArray);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('createProduct')
-            ->will($this->returnValue($newProductId));
+            ->willReturn($newProductId);
         $di = new \Pimple\Container();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -208,26 +202,26 @@ class AdminTest extends \BBTestCase {
 
     public function testupdate()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateProduct')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -237,25 +231,25 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testupdate_priorityMissingPriorityParam()
+    public function testupdatePriorityMissingPriorityParam()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('priority params is missing');
         $this->api->update_priority($data);
     }
 
-    public function testupdate_priority()
+    public function testupdatePriority()
     {
-        $data = array(
-            'priority' => array(),
-        );
+        $data = [
+            'priority' => [],
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updatePriority')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
@@ -264,28 +258,28 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testupdate_config()
+    public function testupdateConfig()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateConfig')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -296,34 +290,33 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testaddon_get_pairs()
+    public function testaddonGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAddons')
-            ->will($this->returnValue(array()));
-
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->addon_get_pairs(array());
+        $result = $this->api->addon_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testaddon_create()
+    public function testaddonCreate()
     {
-        $data = array('title' => 'Title4test');
+        $data = ['title' => 'Title4test'];
         $newAddonId = 1;
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createAddon')
-            ->will($this->returnValue($newAddonId));
+            ->willReturn($newAddonId);
 
         $di = new \Pimple\Container();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
 
@@ -334,9 +327,9 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newAddonId, $result);
     }
 
-    public function testaddon_get()
+    public function testaddonGet()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
@@ -345,19 +338,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -367,17 +360,17 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testaddon_update()
+    public function testaddonUpdate()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Api\Admin::class)
-            ->onlyMethods(array('update'))
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['update'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
@@ -386,7 +379,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -394,7 +387,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $apiMock->setDi($di);
@@ -403,24 +396,24 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testaddon_delete()
+    public function testaddonDelete()
     {
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Api\Admin::class)
-            ->onlyMethods(array('delete'))
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['delete'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $result = $apiMock->addon_delete(array());
+        $result = $apiMock->addon_delete([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
     public function testdelete()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
@@ -428,19 +421,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteProduct')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -451,22 +444,21 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testcategory_get_pairs()
+    public function testcategoryGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductCategoryPairs')
-            ->will($this->returnValue(array()));
-
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->category_get_pairs(array());
+        $result = $this->api->category_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testcategory_update()
+    public function testcategoryUpdate()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_ProductCategory();
         $model->loadBean(new \DummyBean());
@@ -474,12 +466,12 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateCategory')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -487,7 +479,7 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -498,9 +490,9 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testcategory_get()
+    public function testcategoryGet()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_ProductCategory();
         $model->loadBean(new \DummyBean());
@@ -508,19 +500,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toProductCategoryApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -530,22 +522,22 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testcategory_create()
+    public function testcategoryCreate()
     {
-        $data = array('title' => 'test Title');
+        $data = ['title' => 'test Title'];
         $newCategoryId = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createCategory')
-            ->will($this->returnValue($newCategoryId));
+            ->willReturn($newCategoryId);
 
         $di = new \Pimple\Container();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -555,9 +547,9 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newCategoryId, $result);
     }
 
-    public function testcategory_delete()
+    public function testcategoryDelete()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_ProductCategory();
         $model->loadBean(new \DummyBean());
@@ -565,19 +557,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('removeProductCategory')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setService($serviceMock);
@@ -588,50 +580,48 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testpromo_get_list()
+    public function testpromoGetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPromoSearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
-
+            ->willReturn(['sqlString', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
 
-
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
-        $result = $this->api->promo_get_list(array());
+        $result = $this->api->promo_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testpromo_create()
+    public function testpromoCreate()
     {
-        $data = array(
+        $data = [
             'code' => 'test',
             'type' => 'addon',
             'value' => '10',
-            'products' => array(),
-            'periods' => array(),
-        );
+            'products' => [],
+            'periods' => [],
+        ];
         $newPromoId = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createPromo')
-            ->will($this->returnValue($newPromoId));
+            ->willReturn($newPromoId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -646,16 +636,16 @@ class AdminTest extends \BBTestCase {
 
     public function promo_getMissingId()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Promo id is missing');
         $this->api->promo_get($data);
     }
 
-    public function testpromo_get()
+    public function testpromoGet()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Promo();
         $model->loadBean(new \DummyBean());
@@ -663,20 +653,20 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toPromoApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
@@ -685,9 +675,9 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testpromo_update()
+    public function testpromoUpdate()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
 
         $model = new \Model_Promo();
         $model->loadBean(new \DummyBean());
@@ -695,19 +685,19 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updatePromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -717,27 +707,27 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testpromo_delete()
+    public function testpromoDelete()
     {
-        $data = array('id' => 1);
+        $data = ['id' => 1];
         $model = new \Model_Promo();
         $model->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deletePromo')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
 
@@ -747,38 +737,4 @@ class AdminTest extends \BBTestCase {
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/tests/modules/Product/Api/GuestTest.php
+++ b/tests/modules/Product/Api/GuestTest.php
@@ -1,20 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Product\Api;
 
-
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Product\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Product\Api\Guest();
+        $this->api = new Guest();
     }
-
 
     public function testgetDi()
     {
@@ -24,45 +22,43 @@ class GuestTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductSearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
-
+            ->willReturn(['sqlString', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
 
-
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testget_pairs()
+    public function testgetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->get_pairs(array());
+        $result = $this->api->get_pairs([]);
         $this->assertIsArray($result);
     }
 
     public function testgetMissingRequiredParams()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Product ID or slug is missing');
@@ -71,19 +67,19 @@ class GuestTest extends \BBTestCase {
 
     public function testgetWithSetId()
     {
-        $data = array(
-            'id' => 1
-        );
+        $data = [
+            'id' => 1,
+        ];
 
         $model = new \Model_Product();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findOneActiveById')
-            ->will($this->returnValue($model ));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 
@@ -95,19 +91,19 @@ class GuestTest extends \BBTestCase {
 
     public function testgetWithSetSlug()
     {
-        $data = array(
-            'slug' => 'product/1'
-        );
+        $data = [
+            'slug' => 'product/1',
+        ];
 
         $model = new \Model_Product();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findOneActiveBySlug')
-            ->will($this->returnValue($model ));
+            ->willReturn($model);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 
@@ -119,16 +115,16 @@ class GuestTest extends \BBTestCase {
 
     public function testgetProductNotFound()
     {
-        $data = array(
-            'slug' => 'product/1'
-        );
+        $data = [
+            'slug' => 'product/1',
+        ];
 
         $model = null;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('findOneActiveBySlug')
-            ->will($this->returnValue($model ));
+            ->willReturn($model);
         $di = new \Pimple\Container();
 
         $this->api->setDi($di);
@@ -139,140 +135,135 @@ class GuestTest extends \BBTestCase {
         $this->api->get($data);
     }
 
-    public function testcategory_get_list()
+    public function testcategoryGetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductCategorySearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
+            ->willReturn(['sqlString', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toProductCategoryApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-
-        $pager = array(
-            'list' => array(
-                0 => array('id' => 1),
-            ),
-        );
+        $pager = [
+            'list' => [
+                0 => ['id' => 1],
+            ],
+        ];
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($pager));
+            ->willReturn($pager);
 
         $modelProductCategory = new \Model_ProductCategory();
         $modelProductCategory->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($modelProductCategory));
+            ->willReturn($modelProductCategory);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['pager'] = $pagerMock;
 
-
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
-        $result = $this->api->category_get_list(array());
+        $result = $this->api->category_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testcategory_get_pairs()
+    public function testcategoryGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductCategoryPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->category_get_pairs(array());
+        $result = $this->api->category_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testget_sliderEmptyList()
+    public function testgetSliderEmptyList()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
-
-        $di = new \Pimple\Container();
-        $di['db'] = $dbMock;
-
-
-        $this->api->setDi($di);
-
-        $result = $this->api->get_slider(array());
-        $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
-    }
-
-    public function testget_slider()
-    {
-        $productModel = new \Model_Product();
-        $productModel->loadBean(new \DummyBean());
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('find')
-            ->will($this->returnValue(array($productModel)));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
 
-        $arr = array(
-            'id'    => 1,
-            'slug'          => '/',
-            'title'         => 'New Item',
-            'pricing'       => '1W',
-            'config'        => array(),
-        );
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('toApiArray')
-            ->will($this->returnValue($arr));
-
-        $this->api->setService($serviceMock);
-        $result = $this->api->get_slider(array());
+        $result = $this->api->get_slider([]);
         $this->assertIsArray($result);
+        $this->assertEquals([], $result);
     }
 
-    public function testget_sliderJsonFormat()
+    public function testgetSlider()
     {
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($productModel)));
+            ->willReturn([$productModel]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
 
-        $arr = array(
-            'id'    => 1,
-            'slug'          => '/',
-            'title'         => 'New Item',
-            'pricing'       => '1W',
-            'config'        => array(),
-
-        );
+        $arr = [
+            'id' => 1,
+            'slug' => '/',
+            'title' => 'New Item',
+            'pricing' => '1W',
+            'config' => [],
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->get_slider(array());
+        $result = $this->api->get_slider([]);
+        $this->assertIsArray($result);
+    }
+
+    public function testgetSliderJsonFormat()
+    {
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('find')
+            ->willReturn([$productModel]);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+
+        $this->api->setDi($di);
+
+        $arr = [
+            'id' => 1,
+            'slug' => '/',
+            'title' => 'New Item',
+            'pricing' => '1W',
+            'config' => [],
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('toApiArray')
+            ->willReturn($arr);
+
+        $this->api->setService($serviceMock);
+        $result = $this->api->get_slider([]);
         $this->assertIsArray($result);
 
-        $result = $this->api->get_slider(array('format' => 'json'));
+        $result = $this->api->get_slider(['format' => 'json']);
         $this->assertIsString($result);
         $this->assertIsArray(json_decode($result, 1));
     }
 }
- 

--- a/tests/modules/Product/ServiceTest.php
+++ b/tests/modules/Product/ServiceTest.php
@@ -1,21 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Product;
-
 
 class ServiceTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Product\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Product\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -25,33 +22,31 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($di, $getDi);
     }
 
-
     public function testgetPairs()
     {
-        $data = array(
-            'type'          => 'domain',
+        $data = [
+            'type' => 'domain',
             'products_only' => true,
-            'active_only'   => true
-        );
+            'active_only' => true,
+        ];
 
-        $execArray = array(
-            array(
-                'id'    => 1,
+        $execArray = [
+            [
+                'id' => 1,
                 'title' => 'title4test',
-            ),
-        );
+            ],
+        ];
 
-        $expectArray = array(
+        $expectArray = [
             '1' => 'title4test',
-        );
-
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($execArray));
+            ->willReturn($execArray);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -63,32 +58,32 @@ class ServiceTest extends \BBTestCase
 
     public function testtoApiArray()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array(
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods([
                              'getStartingFromPrice',
                              'getUpgradablePairs',
-                             'toProductPaymentApiArray',))
+                             'toProductPaymentApiArray', ])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getStartingFromPrice');
         $serviceMock->expects($this->atLeastOnce())
             ->method('getUpgradablePairs');
-        $productPaymentArray = array(
-            'type'                           => 'free',
-            \Model_ProductPayment::FREE      => array('price' => 0, 'setup' => 0),
-            \Model_ProductPayment::ONCE      => array('price' => 1, 'setup' => 10),
-            \Model_ProductPayment::RECURRENT => array(),
-        );
+        $productPaymentArray = [
+            'type' => 'free',
+            \Model_ProductPayment::FREE => ['price' => 0, 'setup' => 0],
+            \Model_ProductPayment::ONCE => ['price' => 1, 'setup' => 10],
+            \Model_ProductPayment::RECURRENT => [],
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('toProductPaymentApiArray')
-            ->will($this->returnValue($productPaymentArray));
+            ->willReturn($productPaymentArray);
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
         $model->product_category_id = 1;
-        $model->product_payment_id  = 2;
-        $model->config              = '{}';
+        $model->product_payment_id = 2;
+        $model->config = '{}';
 
         $modelProductCategory = new \Model_ProductCategory();
         $modelProductCategory->loadBean(new \DummyBean());
@@ -104,12 +99,12 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['tools']       = $toolsMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['tools'] = $toolsMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
 
         $model->setDi($di);
         $serviceMock->setDi($di);
@@ -120,29 +115,27 @@ class ServiceTest extends \BBTestCase
 
     public function testgetTypes()
     {
-        $modArray = array(
-            'servicecustomtest'
-        );
+        $modArray = [
+            'servicecustomtest',
+        ];
 
-        $expectedArray = array(
-            'custom'       => 'Custom',
-            'license'      => 'License',
+        $expectedArray = [
+            'custom' => 'Custom',
+            'license' => 'License',
             'downloadable' => 'Downloadable',
-            'hosting'      => 'Hosting',
-            'domain'       => 'Domain',
-        );
+            'hosting' => 'Hosting',
+            'domain' => 'Domain',
+        ];
 
         $expectedArray['customtest'] = 'Customtest';
-
 
         $extensionServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Extension\Service::class)->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getInstalledMods')
-            ->will($this->returnValue($modArray));
+            ->willReturn($modArray);
 
-
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $extensionServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $extensionServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->getTypes();
@@ -157,9 +150,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -170,11 +163,11 @@ class ServiceTest extends \BBTestCase
 
     public function testgetPaymentTypes()
     {
-        $expected = array(
-            'free'      => 'Free',
-            'once'      => 'One time',
+        $expected = [
+            'free' => 'Free',
+            'once' => 'One time',
             'recurrent' => 'Recurrent',
-        );
+        ];
 
         $result = $this->service->getPaymentTypes();
         $this->assertIsArray($result);
@@ -198,7 +191,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
@@ -206,43 +199,42 @@ class ServiceTest extends \BBTestCase
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newProductId));
+            ->willReturn($newProductId);
 
         $toolMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolMock->expects($this->atLeastOnce())
             ->method('slug');
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
-        $di['db']          = $dbMock;
-        $di['tools']       = $toolMock;
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
+        $di['db'] = $dbMock;
+        $di['tools'] = $toolMock;
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
         $result = $this->service->createProduct('title', 'domain');
         $this->assertIsInt($result);
         $this->assertEquals($newProductId, $result);
-
     }
 
     public function testupdateProductMissngPricingType()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getPaymentTypes'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaymentTypes'])
             ->getMock();
 
-        $typesArr = array(
-            'free'      => 'Free',
-            'once'      => 'One time',
+        $typesArr = [
+            'free' => 'Free',
+            'once' => 'One time',
             'recurrent' => 'Recurrent',
-        );
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPaymentTypes')
-            ->will($this->returnValue($typesArr));
+            ->willReturn($typesArr);
 
-        $data = array(
-            'pricing' => array(),
-        );
+        $data = [
+            'pricing' => [],
+        ];
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
@@ -257,49 +249,49 @@ class ServiceTest extends \BBTestCase
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getPaymentTypes'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPaymentTypes'])
             ->getMock();
 
-        $typesArr = array(
-            'free'      => 'Free',
-            'once'      => 'One time',
+        $typesArr = [
+            'free' => 'Free',
+            'once' => 'One time',
             'recurrent' => 'Recurrent',
-        );
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPaymentTypes')
-            ->will($this->returnValue($typesArr));
+            ->willReturn($typesArr);
 
-        $data = array(
-            'pricing'               => array(
-                'type'                           => \Model_ProductPayment::RECURRENT,
-                \Model_ProductPayment::RECURRENT => array(
-                    array(
-                        '1W' => array(
-                            'setup'   => '',
-                            'price'   => '',
+        $data = [
+            'pricing' => [
+                'type' => \Model_ProductPayment::RECURRENT,
+                \Model_ProductPayment::RECURRENT => [
+                    [
+                        '1W' => [
+                            'setup' => '',
+                            'price' => '',
                             'enabled' => true,
-                        )
-                    )
-                )
-            ),
-            'config'                => array(),
-            'product_category_id'   => 1,
-            'form_id'               => 10,
-            'icon_url'              => 'http://www.google.com',
-            'status'                => false,
-            'hidden'                => 0,
-            'slug'                  => 'product/0',
-            'setup'                 => 'test',
-            'upgrades'              => array(),
-            'addons'                => array(),
-            'title'                 => 'new Title',
-            'stock_control'         => false,
+                        ],
+                    ],
+                ],
+            ],
+            'config' => [],
+            'product_category_id' => 1,
+            'form_id' => 10,
+            'icon_url' => 'http://www.google.com',
+            'status' => false,
+            'hidden' => 0,
+            'slug' => 'product/0',
+            'setup' => 'test',
+            'upgrades' => [],
+            'addons' => [],
+            'title' => 'new Title',
+            'stock_control' => false,
             'allow_quantity_select' => false,
-            'quantity_in_stock'     => 0,
-            'description'           => 'Product description',
-            'plugin'                => 'plug in',
-        );
+            'quantity_in_stock' => 0,
+            'description' => 'Product description',
+            'plugin' => 'plug in',
+        ];
 
         $modelProductPayment = new \Model_ProductPayment();
         $modelProductPayment->loadBean(new \DummyBean());
@@ -307,22 +299,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($modelProductPayment));
+            ->willReturn($modelProductPayment);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $toolMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['tools']     = $toolMock;
-        $di['logger']    = new \Box_Log();
-
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['tools'] = $toolMock;
+        $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
 
@@ -332,12 +323,12 @@ class ServiceTest extends \BBTestCase
 
     public function testupdatePriority()
     {
-        $data = array(
-            'priority' => array(
+        $data = [
+            'priority' => [
                 1 => 10,
                 5 => 1,
-            ),
-        );
+            ],
+        ];
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
@@ -345,14 +336,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($modelProduct));
+            ->willReturn($modelProduct);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -367,24 +357,22 @@ class ServiceTest extends \BBTestCase
         $modelProduct->loadBean(new \DummyBean());
         $modelProduct->config = '{"settings":5,"max":"10"}';
 
-
-        $data = array(
-            'config'           => array(
+        $data = [
+            'config' => [
                 'settings' => 3,
-                'max'      => '',
-            ),
-            'new_config_name'  => 'newParam',
+                'max' => '',
+            ],
+            'new_config_name' => 'newParam',
             'new_config_value' => 'newValue',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -395,25 +383,24 @@ class ServiceTest extends \BBTestCase
 
     public function testgetAddons()
     {
-        $addonsRows = array(
-            array(
-                'id'    => 1,
+        $addonsRows = [
+            [
+                'id' => 1,
                 'title' => 'testTitle',
-            ),
-        );
+            ],
+        ];
 
-        $expected = array(
+        $expected = [
             1 => 'testTitle',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($addonsRows));
+            ->willReturn($addonsRows);
 
-
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -436,7 +423,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newProductId));
+            ->willReturn($newProductId);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
             ->will($this->onConsecutiveCalls($modelPayment, $modelProduct));
@@ -445,10 +432,10 @@ class ServiceTest extends \BBTestCase
         $toolMock->expects($this->atLeastOnce())
             ->method('slug');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
-        $di['tools']  = $toolMock;
+        $di['tools'] = $toolMock;
 
         $this->service->setDi($di);
 
@@ -464,10 +451,10 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('productHasOrders')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -478,23 +465,23 @@ class ServiceTest extends \BBTestCase
 
     public function testgetProductCategoryPairs()
     {
-        $execArray = array(
-            array(
-                'id'    => 1,
+        $execArray = [
+            [
+                'id' => 1,
                 'title' => 'title4test',
-            ),
-        );
+            ],
+        ];
 
-        $expectArray = array(
+        $expectArray = [
             '1' => 'title4test',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($execArray));
+            ->willReturn($execArray);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -511,10 +498,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -522,7 +509,6 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->updateCategory($model, 'title', 'decription', 'http://urltoimg.com/img.jpg');
         $this->assertIsBool($result);
         $this->assertTrue($result);
-
     }
 
     public function testcreateCategory()
@@ -539,16 +525,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newCategoryId));
+            ->willReturn($newCategoryId);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
 
@@ -569,9 +555,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($modelProduct));
+            ->willReturn($modelProduct);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -579,7 +565,6 @@ class ServiceTest extends \BBTestCase
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Can not remove product category with products');
         $this->service->removeProductCategory($modelProductCategory);
-
     }
 
     public function testremoveProductCategory()
@@ -592,13 +577,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($modelProduct));
+            ->willReturn($modelProduct);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -610,13 +595,13 @@ class ServiceTest extends \BBTestCase
 
     public function testgetPromoSearchQuery()
     {
-        $data = array(
+        $data = [
             'search' => 'keyword',
-            'id'     => 1,
+            'id' => 1,
             'status' => 'active',
-        );
+        ];
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
 
@@ -640,18 +625,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newPromoId));
+            ->willReturn($newPromoId);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
-        $di['logger']      = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
-        $result = $this->service->createPromo('code', 'percentage', 50, array(), array(), array(), array());
+        $result = $this->service->createPromo('code', 'percentage', 50, [], [], [], []);
         $this->assertIsInt($result);
         $this->assertEquals($newPromoId, $result);
     }
@@ -661,16 +646,16 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_Promo();
         $model->loadBean(new \DummyBean());
         $model->products = '{}';
-        $model->periods  = '{}';
+        $model->periods = '{}';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di          = new \Pimple\Container();
-        $di['db']    = $dbMock;
-        $di['tools'] = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['tools'] = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
 
         $this->service->setDi($di);
 
@@ -683,30 +668,29 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_Promo();
         $model->loadBean(new \DummyBean());
 
-        $data = array(
-            'code'            => 'GO',
-            'type'            => 'absolute',
-            'value'           => 10,
-            'active'          => true,
-            'freesetup'       => true,
+        $data = [
+            'code' => 'GO',
+            'type' => 'absolute',
+            'value' => 10,
+            'active' => true,
+            'freesetup' => true,
             'once_per_client' => true,
-            'recurring'       => false,
-            'maxuses'         => '1',
-            'used'            => '0',
-            'start_at'        => '2012-01-01',
-            'end_at'          => '2012-01-02',
-            'products'        => 'domain',
-            'periods'         => array(),
-        );
+            'recurring' => false,
+            'maxuses' => '1',
+            'used' => '0',
+            'start_at' => '2012-01-01',
+            'end_at' => '2012-01-02',
+            'products' => 'domain',
+            'periods' => [],
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = new \Box_Log();
-
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
         $result = $this->service->updatePromo($model, $data);
@@ -725,8 +709,8 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $this->service->setDi($di);
@@ -737,14 +721,14 @@ class ServiceTest extends \BBTestCase
 
     public function testgetProductSearchQuery()
     {
-        $data = array(
-            'search'      => 'keyword',
-            'type'        => 'domain',
-            'status'      => 'active',
+        $data = [
+            'search' => 'keyword',
+            'type' => 'domain',
+            'status' => 'active',
             'show_hidden' => true,
-        );
+        ];
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
 
@@ -761,32 +745,32 @@ class ServiceTest extends \BBTestCase
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
-        $modelProduct->type  = 'custom';
-        $categoryProductsArr = array(
-            $modelProduct
-        );
+        $modelProduct->type = 'custom';
+        $categoryProductsArr = [
+            $modelProduct,
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getCategoryProducts', 'toApiArray'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getCategoryProducts', 'toApiArray'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCategoryProducts')
-            ->will($this->returnValue($categoryProductsArr));
+            ->willReturn($categoryProductsArr);
 
-        $apiArrayResult = array(
+        $apiArrayResult = [
             'price_starting_from' => 1,
-        );
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue($apiArrayResult));
+            ->willReturn($apiArrayResult);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
@@ -794,55 +778,54 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-
-    public function testtoProductCategoryApiArray_StartingFromValue_NotZero()
+    public function testtoProductCategoryApiArrayStartingFromValueNotZero()
     {
         $model = new \Model_ProductCategory();
         $model->loadBean(new \DummyBean());
 
         $modelProduct = new \Model_Product();
         $modelProduct->loadBean(new \DummyBean());
-        $modelProduct->type  = 'custom';
-        $categoryProductsArr = array(
+        $modelProduct->type = 'custom';
+        $categoryProductsArr = [
             $modelProduct,
             $modelProduct,
             $modelProduct,
             $modelProduct,
-        );
+        ];
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getCategoryProducts', 'toApiArray'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getCategoryProducts', 'toApiArray'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCategoryProducts')
-            ->will($this->returnValue($categoryProductsArr));
+            ->willReturn($categoryProductsArr);
 
         $min = 1;
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
             ->willReturnOnConsecutiveCalls(
-                    array(
-                    'price_starting_from' => 4,
-                    ),
-                    array(
-                        'price_starting_from' => 5,
-                    ),
-                    array(
-                        'price_starting_from' => 2,
-                    ),
-                    array(
-                        'price_starting_from' => $min,
-                    )
+                [
+                'price_starting_from' => 4,
+                ],
+                [
+                    'price_starting_from' => 5,
+                ],
+                [
+                    'price_starting_from' => 2,
+                ],
+                [
+                    'price_starting_from' => $min,
+                ]
             );
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
@@ -858,15 +841,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $result = $this->service->findOneActiveById(1);
         $this->assertInstanceOf('\Model_Product', $result);
-
     }
 
     public function testfindOneActiveBySlug()
@@ -876,9 +858,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -888,11 +870,11 @@ class ServiceTest extends \BBTestCase
 
     public function testgetProductCategorySearchQuery()
     {
-        [$sql, $params] = $this->service->getProductCategorySearchQuery(array());
+        [$sql, $params] = $this->service->getProductCategorySearchQuery([]);
 
         $this->assertIsString($sql);
         $this->assertIsArray($params);
-        $this->assertEquals(array(), $params);
+        $this->assertEquals([], $params);
     }
 
     public function testgetStartingFromPriceTypeFree()
@@ -905,13 +887,12 @@ class ServiceTest extends \BBTestCase
         $productPaymentModel->loadBean(new \DummyBean());
         $productPaymentModel->type = 'free';
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($productPaymentModel));
+            ->willReturn($productPaymentModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -928,19 +909,18 @@ class ServiceTest extends \BBTestCase
 
         $result = $this->service->getStartingFromPrice($productModel);
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
-    public function testgetStartingFromPrice_DomainType()
+    public function testgetStartingFromPriceDomainType()
     {
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $productModel->type = Service::DOMAIN;
         $productModel->product_payment_id = 1;
 
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getStartingDomainPrice', 'getStartingPrice'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getStartingDomainPrice', 'getStartingPrice'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getStartingDomainPrice')
@@ -950,7 +930,6 @@ class ServiceTest extends \BBTestCase
 
         $result = $serviceMock->getStartingFromPrice($productModel);
         $this->assertNotNull($result);
-
     }
 
     public function testgetUpgradablePairs()
@@ -959,7 +938,7 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->upgrades = '{}';
 
-        $expected = array();
+        $expected = [];
 
         $result = $this->service->getUpgradablePairs($productModel);
         $this->assertIsArray($result);
@@ -968,30 +947,30 @@ class ServiceTest extends \BBTestCase
 
     public function testgetProductTitlesByIds()
     {
-        $ids = array('1', '2');
+        $ids = ['1', '2'];
 
-        $queryArr = array(
-            array(
-                'id'     => '1',
+        $queryArr = [
+            [
+                'id' => '1',
                 'titile' => 'test',
-            ),
-            array(
-                'id'     => '2',
+            ],
+            [
+                'id' => '2',
                 'titile' => 'Another',
-            ),
-        );
+            ],
+        ];
 
-        $expected = array(
+        $expected = [
             '1' => 'test',
             '2' => 'Another',
-        );
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1011,9 +990,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($productModel)));
+            ->willReturn([$productModel]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1038,20 +1017,20 @@ class ServiceTest extends \BBTestCase
 
         $minPrice = 1;
 
-        $productPaymentModel->w_enabled    = true;
-        $productPaymentModel->w_price      = 2;
-        $productPaymentModel->m_enabled    = true;
-        $productPaymentModel->m_price      = 4;
-        $productPaymentModel->q_enabled    = true;
-        $productPaymentModel->q_price      = 8;
-        $productPaymentModel->b_enabled    = true;
-        $productPaymentModel->b_price      = $minPrice;
-        $productPaymentModel->a_enabled    = true;
-        $productPaymentModel->a_price      = 10;
-        $productPaymentModel->bia_enabled  = true;
-        $productPaymentModel->bia_price    = 12;
+        $productPaymentModel->w_enabled = true;
+        $productPaymentModel->w_price = 2;
+        $productPaymentModel->m_enabled = true;
+        $productPaymentModel->m_price = 4;
+        $productPaymentModel->q_enabled = true;
+        $productPaymentModel->q_price = 8;
+        $productPaymentModel->b_enabled = true;
+        $productPaymentModel->b_price = $minPrice;
+        $productPaymentModel->a_enabled = true;
+        $productPaymentModel->a_price = 10;
+        $productPaymentModel->bia_enabled = true;
+        $productPaymentModel->bia_price = 12;
         $productPaymentModel->tria_enabled = true;
-        $productPaymentModel->tria_price   = 14;
+        $productPaymentModel->tria_price = 14;
 
         $result = $this->service->getStartingPrice($productPaymentModel);
         $this->assertIsInt($result);
@@ -1061,10 +1040,10 @@ class ServiceTest extends \BBTestCase
     public function testgetSavePath()
     {
         $filename = 'cfg.file';
-        $config   = array('path_data' => '/home');
+        $config = ['path_data' => '/home'];
         $expected = PATH_DATA . '/uploads/' . md5($filename);
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['config'] = $config;
 
         $this->service->setDi($di);
@@ -1074,14 +1053,14 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testcanUpgradeTo_returnsTrue()
+    public function testcanUpgradeToReturnsTrue()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getUpgradablePairs'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getUpgradablePairs'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getUpgradablePairs')
-            ->will($this->returnValue(array('2' => 'Hossting')));
+            ->willReturn(['2' => 'Hossting']);
 
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
@@ -1095,14 +1074,14 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testcanUpgradeTo_upgradeIsImposible()
+    public function testcanUpgradeToUpgradeIsImposible()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)
-            ->onlyMethods(array('getUpgradablePairs'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getUpgradablePairs'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getUpgradablePairs')
-            ->will($this->returnValue(array('4' => 'Domain')));
+            ->willReturn(['4' => 'Domain']);
 
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
@@ -1116,7 +1095,7 @@ class ServiceTest extends \BBTestCase
         $this->assertFalse($result);
     }
 
-    public function testcanUpgradeTo_SameProducts()
+    public function testcanUpgradeToSameProducts()
     {
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
@@ -1150,7 +1129,7 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($amount, $result);
     }
 
-    public function testgetStartingDomainPrice_noActiveTld()
+    public function testgetStartingDomainPriceNoActiveTld()
     {
         $di = new \Pimple\Container();
 
@@ -1167,6 +1146,6 @@ class ServiceTest extends \BBTestCase
         $di['db'] = $dbMock;
         $this->service->setDi($di);
         $result = $this->service->getStartingDomainPrice();
-        $this->assertEquals((double) $amount, $result);
+        $this->assertEquals((float) $amount, $result);
     }
 }

--- a/tests/modules/Profile/Api/AdminTest.php
+++ b/tests/modules/Profile/Api/AdminTest.php
@@ -24,18 +24,18 @@ class AdminTest extends \BBTestCase
         $adminApi->setIdentity($model);
         $adminApi->setService($service);
         $result = $adminApi->get();
-        $expected = array(
-            'id'    => $model->id,
-            'role'    =>  $model->role,
-            'admin_group_id'    =>  $model->admin_group_id,
-            'email'    =>  $model->email,
-            'name'    =>  $model->name,
-            'signature'    =>  $model->signature,
-            'status'    =>  $model->status,
+        $expected = [
+            'id' => $model->id,
+            'role' => $model->role,
+            'admin_group_id' => $model->admin_group_id,
+            'email' => $model->email,
+            'name' => $model->name,
+            'signature' => $model->signature,
+            'status' => $model->status,
             'api_token' => null,
-            'created_at'    =>  $model->created_at,
-            'updated_at'    =>  $model->updated_at,
-        );
+            'created_at' => $model->created_at,
+            'updated_at' => $model->updated_at,
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -63,12 +63,12 @@ class AdminTest extends \BBTestCase
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('updateAdmin')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi = new \Box\Mod\Profile\Api\Admin();
         $adminApi->setIdentity($model);
         $adminApi->setService($serviceMock);
-        $result = $adminApi->update(array('name'=>'Root'));
+        $result = $adminApi->update(['name' => 'Root']);
         $this->assertTrue($result);
     }
 
@@ -80,12 +80,12 @@ class AdminTest extends \BBTestCase
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('generateNewApiKey')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi = new \Box\Mod\Profile\Api\Admin();
         $adminApi->setIdentity($model);
         $adminApi->setService($serviceMock);
-        $result = $adminApi->generate_api_key(array());
+        $result = $adminApi->generate_api_key([]);
         $this->assertTrue($result);
     }
 
@@ -98,13 +98,12 @@ class AdminTest extends \BBTestCase
         $adminApi->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $adminApi->change_password(array());
+        $adminApi->change_password([]);
         $this->fail('password should be passed');
 
         $this->expectException(\Exception::class);
-        $adminApi->change_password(array('password'=>'new_pass'));
+        $adminApi->change_password(['password' => 'new_pass']);
         $this->fail('password confirmation should be passed');
-
     }
 
     public function testChangePassword()
@@ -121,13 +120,13 @@ class AdminTest extends \BBTestCase
             ->getMock();
         $serviceMock->expects($this->once())
             ->method('changeAdminPassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApi = new \Box\Mod\Profile\Api\Admin();
         $adminApi->setDi($di);
         $adminApi->setIdentity($model);
         $adminApi->setService($serviceMock);
-        $result = $adminApi->change_password(array('current_password'=>'oldpw','new_password'=>'84asasd221AS', 'confirm_password'=>'84asasd221AS'));
+        $result = $adminApi->change_password(['current_password' => 'oldpw', 'new_password' => '84asasd221AS', 'confirm_password' => '84asasd221AS']);
         $this->assertTrue($result);
     }
 }

--- a/tests/modules/Profile/Api/ClientTest.php
+++ b/tests/modules/Profile/Api/ClientTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Profile\Api;
 
+namespace Box\Tests\Mod\Profile\Api;
 
 class ClientTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Profile\Api\Client
      */
-    protected $clientApi = null;
+    protected $clientApi;
 
     public function setUp(): void
     {
@@ -19,10 +19,10 @@ class ClientTest extends \BBTestCase
         $clientService = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientService->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $clientService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $clientService);
         $this->clientApi->setDi($di);
         $this->clientApi->setIdentity(new \Model_Client());
 
@@ -35,54 +35,54 @@ class ClientTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('updateClient')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->clientApi->setService($service);
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data = array();
+        $data = [];
 
         $result = $this->clientApi->update($data);
         $this->assertTrue($result);
     }
 
-    public function testApi_key_get()
+    public function testApiKeyGet()
     {
-        $client            = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->api_token = '16047a3e69f5245756d73b419348f0c7';
         $this->clientApi->setIdentity($client);
 
-        $result = $this->clientApi->api_key_get(array());
+        $result = $this->clientApi->api_key_get([]);
         $this->assertEquals($result, $client->api_token);
     }
 
-    public function testApi_key_reset()
+    public function testApiKeyReset()
     {
-        $apiKey  = '16047a3e69f5245756d73b419348f0c7';
+        $apiKey = '16047a3e69f5245756d73b419348f0c7';
         $service = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('resetApiKey')
-            ->will($this->returnValue($apiKey));
+            ->willReturn($apiKey);
 
         $this->clientApi->setService($service);
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $result = $this->clientApi->api_key_reset(array());
+        $result = $this->clientApi->api_key_reset([]);
         $this->assertEquals($result, $apiKey);
     }
 
-    public function testChange_password()
+    public function testChangePassword()
     {
         $service = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('changeClientPassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -96,37 +96,37 @@ class ClientTest extends \BBTestCase
         $this->clientApi->setService($service);
         $this->clientApi->setIdentity($model);
 
-        $data   = array(
+        $data = [
             'current_password' => 'oldpw',
-            'new_password'     => '16047a3e69f5245756d73b419348f0c7',
-            'confirm_password' => '16047a3e69f5245756d73b419348f0c7'
-        );
+            'new_password' => '16047a3e69f5245756d73b419348f0c7',
+            'confirm_password' => '16047a3e69f5245756d73b419348f0c7',
+        ];
         $result = $this->clientApi->change_password($data);
         $this->assertTrue($result);
     }
 
-    public function testChange_passwordPasswordsDoNotMatchException()
+    public function testChangePasswordPasswordsDoNotMatchException()
     {
         $service = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
         $service->expects($this->never())
             ->method('changeClientPassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->clientApi->setDi($di);
         $this->clientApi->setService($service);
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data   = array(
+        $data = [
             'current_password' => '1234',
-            'new_password'     => '16047a3e69f5245756d73b419348f0c7',
-            'confirm_password' => '7c0f843914b37d6575425f96e3a74061' //passwords do not match
-        );
+            'new_password' => '16047a3e69f5245756d73b419348f0c7',
+            'confirm_password' => '7c0f843914b37d6575425f96e3a74061', // passwords do not match
+        ];
 
         $this->expectException(\Exception::class);
         $result = $this->clientApi->change_password($data);
@@ -138,7 +138,7 @@ class ClientTest extends \BBTestCase
         $service = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('logoutClient')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->clientApi->setService($service);
 
         $result = $this->clientApi->logout();

--- a/tests/modules/Profile/ServiceTest.php
+++ b/tests/modules/Profile/ServiceTest.php
@@ -9,7 +9,7 @@ class ServiceTest extends \BBTestCase
     public function testDi()
     {
         $service = new Service();
-        $di      = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $service->setDi($di);
         $getDi = $service->getDi();
         $this->assertEquals($di, $getDi);
@@ -21,7 +21,7 @@ class ServiceTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $service = new Service();
-        $result  = $service->getAdminIdentityArray($model);
+        $result = $service->getAdminIdentityArray($model);
         $this->assertIsArray($result);
     }
 
@@ -31,27 +31,27 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
+        $di['db'] = $dbMock;
 
         $model = new \Model_Admin();
         $model->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'signature' => 'new signature',
-            'email'     => 'example@gmail.com',
-            'name'      => 'Admin'
-        );
+            'email' => 'example@gmail.com',
+            'name' => 'Admin',
+        ];
 
         $service = new Service();
         $service->setDi($di);
@@ -65,19 +65,19 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['tools']          = new \FOSSBilling\Tools();
+        $di['db'] = $dbMock;
+        $di['tools'] = new \FOSSBilling\Tools();
 
         $model = new \Model_Admin();
         $model->loadBean(new \DummyBean());
@@ -92,29 +92,28 @@ class ServiceTest extends \BBTestCase
     public function testChangeAdminPassword()
     {
         $password = 'new_pass';
-        $emMock   = $this->getMockBuilder('\Box_EventManager')
+        $emMock = $this->getMockBuilder('\Box_EventManager')
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $passwordMock = $this->getMockBuilder('\Box_Password')->getMock();
         $passwordMock->expects($this->atLeastOnce())
             ->method('hashIt')
             ->with($password);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['password']       = $passwordMock;
+        $di['db'] = $dbMock;
+        $di['password'] = $passwordMock;
 
         $model = new \Model_Admin();
         $model->loadBean(new \DummyBean());
@@ -132,73 +131,72 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array(
-                                          'disable_change_email' => 0
-                                      )));
+            ->willReturn([
+                                          'disable_change_email' => 0,
+                                      ]);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientServiceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(false));
+        method('emailAlreadyRegistered')->willReturn(false);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn($name) => $clientServiceMock);
-        $di['mod']            = $di->protect(fn() => $modMock);
-        $di['tools']          = $toolsMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $clientServiceMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
+        $di['tools'] = $toolsMock;
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
-        $data            = array(
-            'email'          => 'email@example.com',
-            'first_name'     => 'string',
-            'last_name'      => 'string',
-            'gender'         => 'string',
-            'birthday'       => '1981-01-01',
-            'company'        => 'string',
-            'company_vat'    => 'string',
+        $data = [
+            'email' => 'email@example.com',
+            'first_name' => 'string',
+            'last_name' => 'string',
+            'gender' => 'string',
+            'birthday' => '1981-01-01',
+            'company' => 'string',
+            'company_vat' => 'string',
             'company_number' => 'string',
-            'type'           => 'string',
-            'address_1'      => 'string',
-            'address_2'      => 'string',
-            'phone_cc'       => random_int(10, 300),
-            'phone'          => random_int(10000, 90000),
-            'country'        => 'string',
-            'postcode'       => 'string',
-            'city'           => 'string',
-            'state'          => 'string',
-            'document_type'  => 'string',
-            'document_nr'    => random_int(100000, 900000),
-            'lang'           => 'string',
-            'notes'          => 'string',
-            'custom_1'       => 'string',
-            'custom_2'       => 'string',
-            'custom_3'       => 'string',
-            'custom_4'       => 'string',
-            'custom_5'       => 'string',
-            'custom_6'       => 'string',
-            'custom_7'       => 'string',
-            'custom_8'       => 'string',
-            'custom_9'       => 'string',
-            'custom_10'      => 'string',
-        );
-
+            'type' => 'string',
+            'address_1' => 'string',
+            'address_2' => 'string',
+            'phone_cc' => random_int(10, 300),
+            'phone' => random_int(10000, 90000),
+            'country' => 'string',
+            'postcode' => 'string',
+            'city' => 'string',
+            'state' => 'string',
+            'document_type' => 'string',
+            'document_nr' => random_int(100000, 900000),
+            'lang' => 'string',
+            'notes' => 'string',
+            'custom_1' => 'string',
+            'custom_2' => 'string',
+            'custom_3' => 'string',
+            'custom_4' => 'string',
+            'custom_5' => 'string',
+            'custom_6' => 'string',
+            'custom_7' => 'string',
+            'custom_8' => 'string',
+            'custom_9' => 'string',
+            'custom_10' => 'string',
+        ];
 
         $service = new Service();
         $service->setDi($di);
@@ -212,39 +210,38 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array(
-                                          'disable_change_email' => 1
-                                      )));
+            ->willReturn([
+                                          'disable_change_email' => 1,
+                                      ]);
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientServiceMock->expects($this->never())->
-        method('emailAlreadyRegistered')->will($this->returnValue(false));
+        method('emailAlreadyRegistered')->willReturn(false);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn($name) => $clientServiceMock);
-        $di['mod']            = $di->protect(fn() => $modMock);
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $clientServiceMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
-        $data            = array(
+        $data = [
             'email' => 'email@example.com',
-        );
-
+        ];
 
         $service = new Service();
         $service->setDi($di);
@@ -259,43 +256,42 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array(
-                                          'disable_change_email' => 0
-                                      )));
+            ->willReturn([
+                                          'disable_change_email' => 0,
+                                      ]);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientServiceMock->expects($this->atLeastOnce())->
-        method('emailAlreadyRegistered')->will($this->returnValue(true));
+        method('emailAlreadyRegistered')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn($name) => $clientServiceMock);
-        $di['mod']            = $di->protect(fn() => $modMock);
-        $di['tools']          = $toolsMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $clientServiceMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
+        $di['tools'] = $toolsMock;
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
-        $data            = array(
+        $data = [
             'email' => 'email@example.com',
-        );
-
+        ];
 
         $service = new Service();
         $service->setDi($di);
@@ -306,18 +302,17 @@ class ServiceTest extends \BBTestCase
 
     public function testResetApiKey()
     {
-
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = new \Box_Log();
-        $di['db']     = $dbMock;
-        $di['tools']  = new \FOSSBilling\Tools();
-        $model        = new \Model_Client();
+        $di['db'] = $dbMock;
+        $di['tools'] = new \FOSSBilling\Tools();
+        $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
 
         $service = new Service();
@@ -333,13 +328,13 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $password = 'new password';
 
@@ -348,12 +343,11 @@ class ServiceTest extends \BBTestCase
             ->method('hashIt')
             ->with($password);
 
-
-        $di                   = new \Pimple\Container();
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['password']       = $passwordMock;
+        $di['db'] = $dbMock;
+        $di['password'] = $passwordMock;
 
         $model = new \Model_Client();
         $model->loadBean(new \DummyBean());
@@ -371,10 +365,10 @@ class ServiceTest extends \BBTestCase
             ->getMock();
 
         $sessionMock->expects($this->atLeastOnce())
-            ->method("destroy");
+            ->method('destroy');
 
-        $di            = new \Pimple\Container();
-        $di['logger']  = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['logger'] = new \Box_Log();
         $di['session'] = $sessionMock;
 
         $model = new \Model_Client();

--- a/tests/modules/Servicecustom/Api/Api_AdminTest.php
+++ b/tests/modules/Servicecustom/Api/Api_AdminTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Servicecustom\Api;
 
+namespace Box\Tests\Mod\Servicecustom\Api;
 
 class Api_AdminTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Servicecustom\Api\Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
@@ -16,17 +16,17 @@ class Api_AdminTest extends \BBTestCase
 
     public function testUpdate()
     {
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('updateConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['updateConfig'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateConfig')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $data = array(
+        $data = [
             'order_id' => random_int(1, 100),
-            'config'   => array(
-                'param1' => 'value1'
-            )
-        );
+            'config' => [
+                'param1' => 'value1',
+            ],
+        ];
 
         $this->api->setService($serviceMock);
 
@@ -35,16 +35,16 @@ class Api_AdminTest extends \BBTestCase
 
     public function testUpdateOrderIdNotSetException()
     {
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('updateConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['updateConfig'])->getMock();
         $serviceMock->expects($this->never())
             ->method('updateConfig')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $data = array(
-            'config' => array(
-                'param1' => 'value1'
-            )
-        );
+        $data = [
+            'config' => [
+                'param1' => 'value1',
+            ],
+        ];
 
         $this->api->setService($serviceMock);
         $this->expectException(\Exception::class);
@@ -55,14 +55,14 @@ class Api_AdminTest extends \BBTestCase
 
     public function testUpdateConfigNotSet()
     {
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('updateConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['updateConfig'])->getMock();
         $serviceMock->expects($this->never())
             ->method('updateConfig')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $data = array(
+        $data = [
             'order_id' => random_int(1, 100),
-        );
+        ];
 
         $this->api->setService($serviceMock);
 
@@ -72,15 +72,15 @@ class Api_AdminTest extends \BBTestCase
 
     public function testUpdateConfigIsNotArray()
     {
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('updateConfig'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['updateConfig'])->getMock();
         $serviceMock->expects($this->never())
             ->method('updateConfig')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $data = array(
+        $data = [
             'order_id' => random_int(1, 100),
-            'config'   => 'NotArray'
-        );
+            'config' => 'NotArray',
+        ];
 
         $this->api->setService($serviceMock);
 
@@ -93,16 +93,16 @@ class Api_AdminTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->atLeastOnce())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array(
-            0 => array(
-                'order_id' => random_int(1, 100)
-            ),
-        );
+        $arguments = [
+            0 => [
+                'order_id' => random_int(1, 100),
+            ],
+        ];
 
         $this->api->setService($serviceMock);
 
@@ -114,12 +114,12 @@ class Api_AdminTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->never())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->never())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array();
+        $arguments = [];
 
         $this->api->setService($serviceMock);
         $this->expectException(\Exception::class);
@@ -131,14 +131,14 @@ class Api_AdminTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->never())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->never())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array(
-            0 => array(),
-        );
+        $arguments = [
+            0 => [],
+        ];
 
         $this->api->setService($serviceMock);
         $this->expectException(\Exception::class);

--- a/tests/modules/Servicecustom/Api/Api_ClientTest.php
+++ b/tests/modules/Servicecustom/Api/Api_ClientTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Servicecustom\Api;
 
+namespace Box\Tests\Mod\Servicecustom\Api;
 
 class Api_ClientTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Servicecustom\Api\Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
@@ -19,16 +19,16 @@ class Api_ClientTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->atLeastOnce())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array(
-            0 => array(
-                'order_id' => random_int(1, 100)
-            ),
-        );
+        $arguments = [
+            0 => [
+                'order_id' => random_int(1, 100),
+            ],
+        ];
 
         $this->api->setService($serviceMock);
 
@@ -40,12 +40,12 @@ class Api_ClientTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->never())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->never())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array();
+        $arguments = [];
 
         $this->api->setService($serviceMock);
         $this->expectException(\Exception::class);
@@ -57,18 +57,17 @@ class Api_ClientTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
         $serviceMock->expects($this->never())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
         $serviceMock->expects($this->never())
             ->method('customCall')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $arguments = array(
-            0 => array(),
-        );
+        $arguments = [
+            0 => [],
+        ];
 
         $this->api->setService($serviceMock);
         $this->expectException(\Exception::class);
         $this->api->__call('delete', $arguments);
     }
 }
- 

--- a/tests/modules/Servicecustom/ServiceTest.php
+++ b/tests/modules/Servicecustom/ServiceTest.php
@@ -1,14 +1,13 @@
 <?php
-namespace Box\Tests\Mod\Servicecustom;
 
-use \RedBeanPHP\SimpleModel;
+namespace Box\Tests\Mod\Servicecustom;
 
 class ServiceTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Servicecustom\Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
@@ -25,106 +24,105 @@ class ServiceTest extends \BBTestCase
 
     public function testValidateCustomForm()
     {
-
-        $form = array(
-            'fields' => array(
-                0 => array(
-                    'required'      => 1,
-                    'readonly'      => 1,
-                    'name'          => 'field_name',
+        $form = [
+            'fields' => [
+                0 => [
+                    'required' => 1,
+                    'readonly' => 1,
+                    'name' => 'field_name',
                     'default_value' => 'FieldName',
-                    'label'         => 'label',
-                ),
-            ),
-        );
+                    'label' => 'label',
+                ],
+            ],
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getForm')
-            ->will($this->returnValue($form));
+            ->willReturn($form);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $this->service->setDi($di);
 
-        $product = array(
-            'form_id' => random_int(1, 100)
-        );
-        $data    = array(
-            'label'      => 'label',
-            'field_name' => 'FieldName'
-        );
-        $result  = $this->service->validateCustomForm($data, $product);
+        $product = [
+            'form_id' => random_int(1, 100),
+        ];
+        $data = [
+            'label' => 'label',
+            'field_name' => 'FieldName',
+        ];
+        $result = $this->service->validateCustomForm($data, $product);
         $this->assertNull($result);
     }
 
     public function testValidateCustomFormFieldNameNotSetException()
     {
-        $form = array(
-            'fields' => array(
-                0 => array(
-                    'required'      => 1,
-                    'readonly'      => 1,
-                    'name'          => 'field_name',
+        $form = [
+            'fields' => [
+                0 => [
+                    'required' => 1,
+                    'readonly' => 1,
+                    'name' => 'field_name',
                     'default_value' => 'default',
-                    'label'         => 'label'
-                )
-            )
-        );
+                    'label' => 'label',
+                ],
+            ],
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getForm')
-            ->will($this->returnValue($form));
+            ->willReturn($form);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $this->service->setDi($di);
 
-        $product = array(
-            'form_id' => random_int(1, 100)
-        );
-        $data    = array();
+        $product = [
+            'form_id' => random_int(1, 100),
+        ];
+        $data = [];
         $this->expectException(\Exception::class);
-        $result  = $this->service->validateCustomForm($data, $product);
+        $result = $this->service->validateCustomForm($data, $product);
         $this->assertNull($result);
     }
 
     public function testValidateCustomFormReadonlyFieldChangeException()
     {
-        $form = array(
-            'fields' => array(
-                0 => array(
-                    'required'      => 1,
-                    'readonly'      => 1,
-                    'name'          => 'field_name',
+        $form = [
+            'fields' => [
+                0 => [
+                    'required' => 1,
+                    'readonly' => 1,
+                    'name' => 'field_name',
                     'default_value' => 'default',
-                    'label'         => 'label'
-                )
-            )
-        );
+                    'label' => 'label',
+                ],
+            ],
+        ];
 
         $service = $this->getMockBuilder('\\' . \Box\Mod\Formbuilder\Service::class)->getMock();
         $service->expects($this->atLeastOnce())
             ->method('getForm')
-            ->will($this->returnValue($form));
+            ->willReturn($form);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $service);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $service);
 
         $this->service->setDi($di);
 
-        $product = array(
-            'form_id' => random_int(1, 100)
-        );
-        $data    = array(
-            'field_name' => 'field_name'
-        );
+        $product = [
+            'form_id' => random_int(1, 100),
+        ];
+        $data = [
+            'field_name' => 'field_name',
+        ];
 
         $this->expectException(\Exception::class);
-        $result  = $this->service->validateCustomForm($data, $product);
+        $result = $this->service->validateCustomForm($data, $product);
         $this->assertNull($result);
     }
 
@@ -133,28 +131,28 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->product_id = random_int(1, 100);
-        $order->client_id  = random_int(1, 100);
-        $order->config     = 'config';
+        $order->client_id = random_int(1, 100);
+        $order->config = 'config';
 
         $product = new \Model_Product();
         $product->loadBean(new \DummyBean());
-        $product->plugin        = 'plugin';
+        $product->plugin = 'plugin';
         $product->plugin_config = 'plugin_config';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($product));
+            ->willReturn($product);
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -167,19 +165,19 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_activate($order);
@@ -191,15 +189,15 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
         $this->expectException(\Exception::class);
         $this->service->action_activate($order);
@@ -210,25 +208,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_renew($order);
@@ -239,17 +237,17 @@ class ServiceTest extends \BBTestCase
     {
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
-        $order->id        = random_int(1, 100);
+        $order->id = random_int(1, 100);
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
         $this->expectException(\Exception::class);
         $result = $this->service->action_renew($order);
@@ -261,25 +259,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_suspend($order);
@@ -291,25 +289,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_unsuspend($order);
@@ -321,25 +319,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_cancel($order);
@@ -351,25 +349,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
         $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_uncancel($order);
@@ -381,25 +379,25 @@ class ServiceTest extends \BBTestCase
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $order->config    = 'config';
+        $order->config = 'config';
 
         $serviceCustomModel = new \Model_ServiceCustom();
-        $serviceCustomModel->loadBean(new \DummyBean());;
+        $serviceCustomModel->loadBean(new \DummyBean());
         $serviceCustomModel->plugin = '';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceCustomModel));
+            ->willReturn($serviceCustomModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $serviceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $serviceMock);
         $this->service->setDi($di);
 
         $result = $this->service->action_delete($order);
@@ -408,25 +406,24 @@ class ServiceTest extends \BBTestCase
 
     public function testGetConfig()
     {
-        $decoded   = array(
+        $decoded = [
             'J' => 5,
-            0   => 'N'
-        );
+            0 => 'N',
+        ];
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue($decoded));
+            ->willReturn($decoded);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
         $model = new \Model_ServiceCustom();
-        $model->loadBean(new \DummyBean());;
+        $model->loadBean(new \DummyBean());
         $model->config = json_encode($decoded);
 
         $result = $this->service->getConfig($model);
-
 
         $this->assertEquals($result, $decoded);
     }
@@ -436,19 +433,18 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue(array('config_param' => 'config_value')));
+            ->willReturn(['config_param' => 'config_value']);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
-
         $model = new \Model_ServiceCustom();
         $model->loadBean(new \DummyBean());
-        $model->id         = random_int(1, 100);
-        $model->client_id  = random_int(1, 100);
-        $model->plugin     = 'plugin';
-        $model->config     = 'config_json';
+        $model->id = random_int(1, 100);
+        $model->client_id = random_int(1, 100);
+        $model->plugin = 'plugin';
+        $model->config = 'config_json';
         $model->updated_at = date('Y-m-d H:i:s');
         $model->created_at = date('Y-m-d H:i:s');
 
@@ -472,16 +468,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceCustom()));
+            ->willReturn(new \Model_ServiceCustom());
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->service->setDi($di);
 
         $result = $this->service->getServiceCustomByOrderId(random_int(1, 100));
@@ -494,16 +490,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->service->setDi($di);
         $this->expectException(\Exception::class);
         $this->service->getServiceCustomByOrderId(random_int(1, 100));
@@ -512,26 +508,25 @@ class ServiceTest extends \BBTestCase
     public function testUpdateConfig()
     {
         $model = new \Model_ServiceCustom();
-        $model->loadBean(new \DummyBean());;
+        $model->loadBean(new \DummyBean());
         $model->id = random_int(1, 100);
 
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('getServiceCustomByOrderId'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['getServiceCustomByOrderId'])->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
-
-        $config = array('param1' => 'value1');
+        $config = ['param1' => 'value1'];
         $result = $serviceMock->updateConfig(random_int(1, 100), $config);
         $this->assertNull($result);
     }
@@ -542,21 +537,20 @@ class ServiceTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
         $model->id = random_int(1, 100);
 
-        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(array('getServiceCustomByOrderId'))->getMock();
+        $serviceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->onlyMethods(['getServiceCustomByOrderId'])->getMock();
         $serviceMock->expects($this->never())
             ->method('getServiceCustomByOrderId')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
-
 
         $config = '';
         $this->expectException(\Exception::class);

--- a/tests/modules/Servicedomain/Api/Api_AdminTest.php
+++ b/tests/modules/Servicedomain/Api/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Box\Tests\Mod\Servicedomain\Api;
 
 class Api_AdminTest extends \BBTestCase
@@ -6,7 +7,7 @@ class Api_AdminTest extends \BBTestCase
     /**
      * @var \Box\Mod\Servicedomain\Api\Admin
      */
-    protected $adminApi = null;
+    protected $adminApi;
 
     public function setup(): void
     {
@@ -19,133 +20,133 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('updateDomain'))->getMock();
+            ->onlyMethods(['updateDomain'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testUpdate_nameservers()
+    public function testUpdateNameservers()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('updateNameservers'))->getMock();
+            ->onlyMethods(['updateNameservers'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateNameservers')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->update_nameservers($data);
 
         $this->assertTrue($result);
     }
 
-    public function testUpdate_contacts()
+    public function testUpdateContacts()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('updateContacts'))->getMock();
+            ->onlyMethods(['updateContacts'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateContacts')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->update_contacts($data);
 
         $this->assertTrue($result);
     }
 
-    public function testEnable_privacy_protection()
+    public function testEnablePrivacyProtection()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('enablePrivacyProtection'))->getMock();
+            ->onlyMethods(['enablePrivacyProtection'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('enablePrivacyProtection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->enable_privacy_protection($data);
 
         $this->assertTrue($result);
     }
 
-    public function testDisable_privacy_protection()
+    public function testDisablePrivacyProtection()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('disablePrivacyProtection'))->getMock();
+            ->onlyMethods(['disablePrivacyProtection'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('disablePrivacyProtection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->disable_privacy_protection($data);
 
         $this->assertTrue($result);
     }
 
-    public function testGet_transfer_code()
+    public function testGetTransferCode()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('getTransferCode'))->getMock();
+            ->onlyMethods(['getTransferCode'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getTransferCode')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->get_transfer_code($data);
 
         $this->assertTrue($result);
@@ -157,18 +158,18 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('lock'))->getMock();
+            ->onlyMethods(['lock'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->lock($data);
 
         $this->assertTrue($result);
@@ -180,60 +181,60 @@ class Api_AdminTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $adminApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Admin::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $adminApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('unlock'))->getMock();
+            ->onlyMethods(['unlock'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('unlock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $adminApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $adminApiMock->unlock($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTld_get_list()
+    public function testTldGetList()
     {
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldGetSearchQuery'))->getMock();
+            ->onlyMethods(['tldGetSearchQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldGetSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->tld_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTld_get()
+    public function testTldGet()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('tldToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -241,26 +242,26 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
         $result = $this->adminApi->tld_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTld_getTldNotFoundException()
+    public function testTldGetTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('tldToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -268,14 +269,14 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
         $this->expectException(\FOSSBilling\Exception::class);
         $this->adminApi->tld_get($data);
     }
 
-    public function testTld_delete()
+    public function testTldDelete()
     {
         $tldMock = new \Model_Tld();
         $tldMock->loadBean(new \DummyBean());
@@ -283,19 +284,19 @@ class Api_AdminTest extends \BBTestCase
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue($tldMock));
+            ->willReturn($tldMock);
         $serviceMock->expects($this->atLeastOnce())->method('tldRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->once())->method('find')
             ->with($this->equalTo('ServiceDomain'), $this->equalTo('tld = :tld'), $this->equalTo([':tld' => $tldMock->tld]))
-            ->will($this->returnValue([])); // No domains found
+            ->willReturn([]); // No domains found
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -304,29 +305,26 @@ class Api_AdminTest extends \BBTestCase
         $this->adminApi->setDi($di);
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
         $result = $this->adminApi->tld_delete($data);
 
         $this->assertTrue($result);
     }
 
-
-
-
-    public function testTld_deleteTldNotFoundException()
+    public function testTldDeleteTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('tldRm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -334,26 +332,26 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->adminApi->tld_delete($data);
     }
 
-    public function testTld_create()
+    public function testTldCreate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldAlreadyRegistered')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->atLeastOnce())->method('tldCreate')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -361,29 +359,28 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array(
-            'tld'                => '.com',
-            'tld_registrar_id'   => random_int(1, 100),
+        $data = [
+            'tld' => '.com',
+            'tld_registrar_id' => random_int(1, 100),
             'price_registration' => random_int(1, 100),
-            'price_renew'        => random_int(1, 100),
-            'price_transfer'     => random_int(1, 100),
-
-        );
+            'price_renew' => random_int(1, 100),
+            'price_transfer' => random_int(1, 100),
+        ];
 
         $result = $this->adminApi->tld_create($data);
         $this->assertIsInt($result);
     }
 
-    public function testTld_createAlreadyRegisteredException()
+    public function testTldCreateAlreadyRegisteredException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldAlreadyRegistered')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -391,91 +388,87 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->tld_create($data);
         $this->assertIsInt($result);
     }
 
-
-    public function testTld_update()
+    public function testTldUpdate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('tldUpdate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
-
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
         $result = $this->adminApi->tld_update($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTld_updateTldNotFoundException()
+    public function testTldUpdateTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('tldUpdate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
-
         $this->adminApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->adminApi->tld_update($data);
     }
 
-    public function testRegistrar_get_list()
+    public function testRegistrarGetList()
     {
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetSearchQuery'))->getMock();
+            ->onlyMethods(['registrarGetSearchQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetSearchQuery')
-            ->will($this->returnValue(array('query', array())));
-
+            ->willReturn(['query', []]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
         $di['db'] = $dbMock;
 
@@ -483,54 +476,54 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->registrar_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testRegistrar_get_pairs()
+    public function testRegistrarGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->registrar_get_pairs(array());
+        $result = $this->adminApi->registrar_get_pairs([]);
 
         $this->assertIsArray($result);
     }
 
-    public function testRegistrar_get_available()
+    public function testRegistrarGetAvailable()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetAvailable')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->registrar_get_available(array());
+        $result = $this->adminApi->registrar_get_available([]);
 
         $this->assertIsArray($result);
     }
 
-    public function testRegistrar_install()
+    public function testRegistrarInstall()
     {
-        $registrars = array(
-            'ResellerClub', 'Custom'
-        );
+        $registrars = [
+            'ResellerClub', 'Custom',
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetAvailable')
-            ->will($this->returnValue($registrars));
+            ->willReturn($registrars);
         $serviceMock->expects($this->atLeastOnce())->method('registrarCreate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -538,39 +531,39 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'code' => 'ResellerClub'
-        );
+        $data = [
+            'code' => 'ResellerClub',
+        ];
         $result = $this->adminApi->registrar_install($data);
 
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_installRegistrarNotAvailableException()
+    public function testRegistrarInstallRegistrarNotAvailableException()
     {
-        $registrars = array(
-            'Custom'
-        );
+        $registrars = [
+            'Custom',
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetAvailable')
-            ->will($this->returnValue($registrars));
+            ->willReturn($registrars);
         $serviceMock->expects($this->never())->method('registrarCreate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'code' => 'ResellerClub'
-        );
+        $data = [
+            'code' => 'ResellerClub',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->registrar_install($data);
@@ -578,7 +571,7 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_deleteIdNotSetException()
+    public function testRegistrarDeleteIdNotSetException()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -586,13 +579,13 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('load')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('registrarRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -603,7 +596,7 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->registrar_delete($data);
@@ -611,7 +604,7 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_copy()
+    public function testRegistrarCopy()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -619,32 +612,32 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarCopy')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->registrar_copy($data);
 
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_copyIdNotSetException()
+    public function testRegistrarCopyIdNotSetException()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -652,13 +645,13 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('load')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('registrarCopy')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -669,7 +662,7 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->registrar_copy($data);
@@ -677,7 +670,7 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_get()
+    public function testRegistrarGet()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -685,32 +678,32 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->registrar_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testRegistrar_getIdNotSetException()
+    public function testRegistrarGetIdNotSetException()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -718,13 +711,13 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('load')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('registrarToApiArray')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -735,7 +728,7 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->registrar_get($data);
@@ -743,20 +736,20 @@ class Api_AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testBatch_sync_expiration_dates()
+    public function testBatchSyncExpirationDates()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('batchSyncExpirationDates')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->batch_sync_expiration_dates(array());
+        $result = $this->adminApi->batch_sync_expiration_dates([]);
 
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_update()
+    public function testRegistrarUpdate()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -764,32 +757,32 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->registrar_update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testRegistrar_updateIdNotSetException()
+    public function testRegistrarUpdateIdNotSetException()
     {
         $registrar = new \Model_TldRegistrar();
         $registrar->loadBean(new \DummyBean());
@@ -797,13 +790,13 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('load')
-            ->will($this->returnValue($registrar));
+            ->willReturn($registrar);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('registrarUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -814,7 +807,7 @@ class Api_AdminTest extends \BBTestCase
 
         $this->adminApi->setService($serviceMock);
 
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->registrar_update($data);
@@ -826,33 +819,33 @@ class Api_AdminTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adminApi->setService($serviceMock);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDomain()));
+            ->willReturn(new \Model_ServiceDomain());
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
-        $data   = array(
-            'order_id' => random_int(1, 100)
-        );
+        $data = [
+            'order_id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->update($data);
 
         $this->assertTrue($result);
@@ -862,23 +855,23 @@ class Api_AdminTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('updateDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adminApi->setService($serviceMock);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('load')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $orderService->expects($this->never())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDomain()));
+            ->willReturn(new \Model_ServiceDomain());
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
@@ -886,7 +879,7 @@ class Api_AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
-        $data   = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->update($data);
@@ -898,23 +891,23 @@ class Api_AdminTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('updateDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adminApi->setService($serviceMock);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
@@ -922,15 +915,13 @@ class Api_AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
-        $data   = array(
-            'order_id' => random_int(1, 100)
-        );
+        $data = [
+            'order_id' => random_int(1, 100),
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->adminApi->update($data);
 
         $this->assertTrue($result);
     }
-
-
 }

--- a/tests/modules/Servicedomain/Api/Api_ClientTest.php
+++ b/tests/modules/Servicedomain/Api/Api_ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Box\Tests\Mod\Servicedomain\Api;
 
 class Api_ClientTest extends \BBTestCase
@@ -6,27 +7,27 @@ class Api_ClientTest extends \BBTestCase
     /**
      * @var \Box\Mod\Servicedomain\Api\Client
      */
-    protected $clientApi = null;
+    protected $clientApi;
 
     public function setup(): void
     {
         $this->clientApi = new \Box\Mod\Servicedomain\Api\Client();
     }
 
-    public function testUpdate_nameservers()
+    public function testUpdateNameservers()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('updateNameservers'))->getMock();
+            ->onlyMethods(['updateNameservers'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateNameservers')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
@@ -38,99 +39,99 @@ class Api_ClientTest extends \BBTestCase
         $di['events_manager'] = $eventMock;
         $clientApiMock->setDi($di);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->update_nameservers($data);
 
         $this->assertTrue($result);
     }
 
-    public function testUpdate_contacts()
+    public function testUpdateContacts()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('updateContacts'))->getMock();
+            ->onlyMethods(['updateContacts'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('updateContacts')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->update_contacts($data);
 
         $this->assertTrue($result);
     }
 
-    public function testEnable_privacy_protection()
+    public function testEnablePrivacyProtection()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('enablePrivacyProtection'))->getMock();
+            ->onlyMethods(['enablePrivacyProtection'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('enablePrivacyProtection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->enable_privacy_protection($data);
 
         $this->assertTrue($result);
     }
 
-    public function testDisable_privacy_protection()
+    public function testDisablePrivacyProtection()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('disablePrivacyProtection'))->getMock();
+            ->onlyMethods(['disablePrivacyProtection'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('disablePrivacyProtection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->disable_privacy_protection($data);
 
         $this->assertTrue($result);
     }
 
-    public function testGet_transfer_code()
+    public function testGetTransferCode()
     {
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('getTransferCode'))->getMock();
+            ->onlyMethods(['getTransferCode'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getTransferCode')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->get_transfer_code($data);
 
         $this->assertTrue($result);
@@ -142,18 +143,18 @@ class Api_ClientTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('lock'))->getMock();
+            ->onlyMethods(['lock'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->lock($data);
 
         $this->assertTrue($result);
@@ -165,49 +166,48 @@ class Api_ClientTest extends \BBTestCase
         $model->loadBean(new \DummyBean());
 
         $clientApiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Api\Client::class)
-            ->onlyMethods(array('_getService'))->getMock();
+            ->onlyMethods(['_getService'])->getMock();
         $clientApiMock->expects($this->atLeastOnce())->method('_getService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('unlock'))->getMock();
+            ->onlyMethods(['unlock'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('unlock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $clientApiMock->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $clientApiMock->unlock($data);
 
         $this->assertTrue($result);
     }
 
-
     public function testGetService()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->clientApi->setService($serviceMock);
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService', 'findForClientById'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService', 'findForClientById'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('findForClientById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDomain()));
+            ->willReturn(new \Model_ServiceDomain());
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->clientApi->setDi($di);
 
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data   = array(
-            'order_id' => random_int(1, 100)
-        );
+        $data = [
+            'order_id' => random_int(1, 100),
+        ];
         $result = $this->clientApi->lock($data);
 
         $this->assertTrue($result);
@@ -217,25 +217,25 @@ class Api_ClientTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->clientApi->setService($serviceMock);
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService', 'findForClientById'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService', 'findForClientById'])->getMock();
         $orderService->expects($this->never())
             ->method('findForClientById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
         $orderService->expects($this->never())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDomain()));
+            ->willReturn(new \Model_ServiceDomain());
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->clientApi->setDi($di);
 
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data   = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->clientApi->lock($data);
@@ -247,27 +247,27 @@ class Api_ClientTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->clientApi->setService($serviceMock);
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService', 'findForClientById'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService', 'findForClientById'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('findForClientById')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $orderService->expects($this->never())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDomain()));
+            ->willReturn(new \Model_ServiceDomain());
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->clientApi->setDi($di);
 
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data   = array(
-            'order_id' => random_int(1, 100)
-        );
+        $data = [
+            'order_id' => random_int(1, 100),
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->clientApi->lock($data);
@@ -279,32 +279,31 @@ class Api_ClientTest extends \BBTestCase
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->never())->method('lock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->clientApi->setService($serviceMock);
 
-        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(array('getOrderService', 'findForClientById'))->getMock();
+        $orderService = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->onlyMethods(['getOrderService', 'findForClientById'])->getMock();
         $orderService->expects($this->atLeastOnce())
             ->method('findForClientById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
         $orderService->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderService);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderService);
         $this->clientApi->setDi($di);
 
         $this->clientApi->setIdentity(new \Model_Client());
 
-        $data   = array(
-            'order_id' => random_int(1, 100)
-        );
+        $data = [
+            'order_id' => random_int(1, 100),
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->clientApi->lock($data);
 
         $this->assertTrue($result);
     }
-
 }

--- a/tests/modules/Servicedomain/Api/Api_GuestTest.php
+++ b/tests/modules/Servicedomain/Api/Api_GuestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Box\Tests\Mod\Servicedomain\Api;
 
 class Api_GuestTest extends \BBTestCase
@@ -6,7 +7,7 @@ class Api_GuestTest extends \BBTestCase
     /**
      * @var \Box\Mod\Servicedomain\Api\Guest
      */
-    protected $guestApi = null;
+    protected $guestApi;
 
     public function setup(): void
     {
@@ -16,24 +17,23 @@ class Api_GuestTest extends \BBTestCase
     public function testTlds()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldToApiArray'))->getMock();
+            ->onlyMethods(['tldToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->guestApi->setService($serviceMock);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_Tld())));
+            ->willReturn([new \Model_Tld()]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-
 
         $this->guestApi->setDi($di);
 
-        $result = $this->guestApi->tlds(array());
+        $result = $this->guestApi->tlds([]);
         $this->assertIsArray($result);
         $this->assertIsArray($result[0]);
     }
@@ -41,25 +41,25 @@ class Api_GuestTest extends \BBTestCase
     public function testPricing()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'tldToApiArray'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'tldToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('tldToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
 
         $result = $this->guestApi->pricing($data);
         $this->assertIsArray($result);
@@ -68,25 +68,25 @@ class Api_GuestTest extends \BBTestCase
     public function testPricingTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'tldToApiArray'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'tldToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('tldToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
-            'tld' => '.com'
-        );
+        $data = [
+            'tld' => '.com',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->guestApi->pricing($data);
@@ -96,26 +96,26 @@ class Api_GuestTest extends \BBTestCase
     public function testCheck()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'isDomainAvailable'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'isDomainAvailable'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('isDomainAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->guestApi->setService($serviceMock);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $result = $this->guestApi->check($data);
         $this->assertTrue($result);
@@ -125,19 +125,19 @@ class Api_GuestTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->guestApi->check($data);
@@ -146,29 +146,29 @@ class Api_GuestTest extends \BBTestCase
     public function testCheckTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'isDomainAvailable'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'isDomainAvailable'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('isDomainAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->guestApi->setService($serviceMock);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->guestApi->check($data);
@@ -177,47 +177,47 @@ class Api_GuestTest extends \BBTestCase
     public function testCheckDomainNotAvailableException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'isDomainAvailable'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'isDomainAvailable'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('isDomainAvailable')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->guestApi->setService($serviceMock);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->guestApi->check($data);
     }
 
-    public function testCan_be_transferred()
+    public function testCanBeTransferred()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'canBeTransferred'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('canBeTransferred')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -225,70 +225,68 @@ class Api_GuestTest extends \BBTestCase
 
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $result = $this->guestApi->can_be_transferred($data);
         $this->assertTrue($result);
     }
 
-    public function testCan_be_transferredTldNotFoundException()
+    public function testCanBeTransferredTldNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'canBeTransferred'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->never())->method('canBeTransferred')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->guestApi->can_be_transferred($data);
     }
 
-    public function testCan_be_transferredCanNotBeTransferredException()
+    public function testCanBeTransferredCanNotBeTransferredException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'canBeTransferred'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue(new \Model_Tld()));
+            ->willReturn(new \Model_Tld());
         $serviceMock->expects($this->atLeastOnce())->method('canBeTransferred')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->guestApi->setDi($di);
         $this->guestApi->setService($serviceMock);
 
-        $data = array(
+        $data = [
             'tld' => '.com',
-            'sld' => 'example'
-        );
+            'sld' => 'example',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->guestApi->can_be_transferred($data);
     }
-
-
 }

--- a/tests/modules/Servicedomain/ServiceTest.php
+++ b/tests/modules/Servicedomain/ServiceTest.php
@@ -2,13 +2,12 @@
 
 namespace Box\Tests\Mod\Servicedomain;
 
-
 class ServiceTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Servicedomain\Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
@@ -25,28 +24,28 @@ class ServiceTest extends \BBTestCase
 
     public static function getCartProductTitleProvider()
     {
-        return array(
-            array(
-                array(
-                    'action'       => 'register',
+        return [
+            [
+                [
+                    'action' => 'register',
                     'register_tld' => '.com',
-                    'register_sld' => 'example'
-                ),
-                "Domain example.com registration"
-            ),
-            array(
-                array(
-                    'action'       => 'transfer',
+                    'register_sld' => 'example',
+                ],
+                'Domain example.com registration',
+            ],
+            [
+                [
+                    'action' => 'transfer',
                     'transfer_tld' => '.com',
-                    'transfer_sld' => 'example'
-                ),
-                "Domain example.com transfer"
-            ),
-            array(
-                array(),
-                "Example.com Registration"
-            )
-        );
+                    'transfer_sld' => 'example',
+                ],
+                'Domain example.com transfer',
+            ],
+            [
+                [],
+                'Example.com Registration',
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getCartProductTitleProvider')]
@@ -54,7 +53,7 @@ class ServiceTest extends \BBTestCase
     {
         $product = new \Model_CartProduct();
         $product->loadBean(new \DummyBean());
-        $product->title = "Example.com Registration";
+        $product->title = 'Example.com Registration';
 
         $result = $this->service->getCartProductTitle($product, $data);
 
@@ -65,39 +64,39 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
-                array(
-                    'action'        => 'owndomain',
+        return [
+            [
+                [
+                    'action' => 'owndomain',
                     'owndomain_sld' => 'example',
-                    'owndomain_tld' => '.com'
-                ),
+                    'owndomain_tld' => '.com',
+                ],
                 $self->never(),
                 $self->never(),
-                $self->never()
-            ),
-            array(
-                array(
-                    'action'       => 'transfer',
+                $self->never(),
+            ],
+            [
+                [
+                    'action' => 'transfer',
                     'transfer_sld' => 'example',
-                    'transfer_tld' => '.com'
-                ),
+                    'transfer_tld' => '.com',
+                ],
                 $self->atLeastOnce(),
-                $self->atLeastOnce(),
-                $self->never()
-            ),
-            array(
-                array(
-                    'action'         => 'register',
-                    'register_sld'   => 'example',
-                    'register_tld'   => '.com',
-                    'register_years' => '2'
-                ),
                 $self->atLeastOnce(),
                 $self->never(),
-                $self->atLeastOnce()
-            )
-        );
+            ],
+            [
+                [
+                    'action' => 'register',
+                    'register_sld' => 'example',
+                    'register_tld' => '.com',
+                    'register_years' => '2',
+                ],
+                $self->atLeastOnce(),
+                $self->never(),
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDataProvider')]
@@ -105,24 +104,24 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $tld = new \Model_Tld();
         $tld->loadBean(new \DummyBean());
-        $tld->tld       = '.com';
+        $tld->tld = '.com';
         $tld->min_years = 2;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'canBeTransferred', 'isDomainAvailable'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred', 'isDomainAvailable'])->getMock();
 
         $serviceMock->expects($finOneByTldCalled)->method('tldFindOneByTld')
-            ->will($this->returnValue($tld));
+            ->willReturn($tld);
         $serviceMock->expects($canBeTransferredCalled)->method('canBeTransferred')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($isDomainAvailableCalled)->method('isDomainAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $serviceMock->setDi($di);
 
@@ -132,13 +131,13 @@ class ServiceTest extends \BBTestCase
 
     public static function validateOrderDataExceptionsProvider()
     {
-        return array(
-            array(
-                array(
-                    'action' => 'NonExistingAction'
-                ),
-            )
-        );
+        return [
+            [
+                [
+                    'action' => 'NonExistingAction',
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDataExceptionsProvider')]
@@ -146,7 +145,7 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
 
@@ -159,26 +158,25 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
-                array( //"owndomain_sld" is missing
-                    'action'        => 'owndomain',
-                    'owndomain_tld' => '.com'
-                ),
+        return [
+            [
+                [ // "owndomain_sld" is missing
+                    'action' => 'owndomain',
+                    'owndomain_tld' => '.com',
+                ],
                 $self->never(),
                 true,
-
-            ),
-            array(
-                array(
-                    'action'        => 'owndomain',
+            ],
+            [
+                [
+                    'action' => 'owndomain',
                     'owndomain_sld' => 'example',
-                    'owndomain_tld' => '.com'
-                ),
+                    'owndomain_tld' => '.com',
+                ],
                 $self->atLeastOnce(),
-                false ////"isSldValid" returns false
-            ),
-        );
+                false, // //"isSldValid" returns false
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDateOwndomainExceptionsProvider')]
@@ -186,12 +184,11 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($isSldValidCalled)->method('isSldValid')
-            ->will($this->returnValue($isSldValidReturn));
+            ->willReturn($isSldValidReturn);
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
 
@@ -199,7 +196,6 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->validateOrderData($data);
         $this->assertNull($result);
     }
-
 
     public static function validateOrderDateTransferExceptionsProvider()
     {
@@ -209,46 +205,46 @@ class ServiceTest extends \BBTestCase
         $tldModel->loadBean(new \DummyBean());
         $tldModel->tld = '.com';
 
-        return array(
-            array(
-                array(
-                    'action'       => 'transfer',
+        return [
+            [
+                [
+                    'action' => 'transfer',
                     'transfer_sld' => 'example',
                     'transfer_tld' => '.com',
-                ),
-                array( //isSldValidArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => true
-                ),
-                array( //tldFindOneByTldArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => null
-                ),
-                array( //canBeTransferred
-                    'called'  => $self->never(),
-                    'returns' => true
-                )
-            ),
-            array(
-                array(
-                    'action'       => 'transfer',
+                ],
+                [ // isSldValidArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => true,
+                ],
+                [ // tldFindOneByTldArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => null,
+                ],
+                [ // canBeTransferred
+                    'called' => $self->never(),
+                    'returns' => true,
+                ],
+            ],
+            [
+                [
+                    'action' => 'transfer',
                     'transfer_sld' => 'example',
                     'transfer_tld' => '.com',
-                ),
-                array( //isSldValidArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => true
-                ),
-                array( //tldFindOneByTldArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => $tldModel
-                ),
-                array( //canBeTransferred
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => false
-                )
-            )
-        );
+                ],
+                [ // isSldValidArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => true,
+                ],
+                [ // tldFindOneByTldArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => $tldModel,
+                ],
+                [ // canBeTransferred
+                    'called' => $self->atLeastOnce(),
+                    'returns' => false,
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDateTransferExceptionsProvider')]
@@ -256,18 +252,18 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($isSldValidArr['called'])->method('isSldValid')
-            ->will($this->returnValue($isSldValidArr['returns']));
+            ->willReturn($isSldValidArr['returns']);
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'canBeTransferred'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred'])->getMock();
         $serviceMock->expects($tldFindOneByTldArr['called'])->method('tldFindOneByTld')
-            ->will($this->returnValue($tldFindOneByTldArr['returns']));
+            ->willReturn($tldFindOneByTldArr['returns']);
         $serviceMock->expects($canBeTransferred['called'])->method('canBeTransferred')
-            ->will($this->returnValue($canBeTransferred['returns']));
+            ->willReturn($canBeTransferred['returns']);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $serviceMock->setDi($di);
 
@@ -282,71 +278,71 @@ class ServiceTest extends \BBTestCase
 
         $tldModel = new \Model_Tld();
         $tldModel->loadBean(new \DummyBean());
-        $tldModel->tld       = '.com';
+        $tldModel->tld = '.com';
         $tldModel->min_years = 2;
 
-        return array(
-            array(
-                array(
-                    'action'         => 'register',
-                    'register_sld'   => 'example',
+        return [
+            [
+                [
+                    'action' => 'register',
+                    'register_sld' => 'example',
                     'register_years' => 2,
-                    'register_tld'   => '.com',
-                ),
-                array( //isSldValidArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => true
-                ),
-                array( //tldFindOneByTldArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => null
-                ),
-                array( //isDomainAvailable
-                    'called'  => $self->never(),
-                    'returns' => true
-                )
-            ),
-            array(
-                array(
-                    'action'         => 'register',
-                    'register_sld'   => 'example',
-                    'register_years' => $tldModel->min_years - 1, //less years than required
-                    'register_tld'   => '.com',
-                ),
-                array( //isSldValidArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => true
-                ),
-                array( //tldFindOneByTldArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => $tldModel
-                ),
-                array( //isDomainAvailable
-                    'called'  => $self->never(),
-                    'returns' => true
-                )
-            ),
-            array(
-                array(
-                    'action'         => 'register',
-                    'register_sld'   => 'example',
-                    'register_tld'   => '.com',
+                    'register_tld' => '.com',
+                ],
+                [ // isSldValidArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => true,
+                ],
+                [ // tldFindOneByTldArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => null,
+                ],
+                [ // isDomainAvailable
+                    'called' => $self->never(),
+                    'returns' => true,
+                ],
+            ],
+            [
+                [
+                    'action' => 'register',
+                    'register_sld' => 'example',
+                    'register_years' => $tldModel->min_years - 1, // less years than required
+                    'register_tld' => '.com',
+                ],
+                [ // isSldValidArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => true,
+                ],
+                [ // tldFindOneByTldArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => $tldModel,
+                ],
+                [ // isDomainAvailable
+                    'called' => $self->never(),
+                    'returns' => true,
+                ],
+            ],
+            [
+                [
+                    'action' => 'register',
+                    'register_sld' => 'example',
+                    'register_tld' => '.com',
                     'register_years' => 2,
-                ),
-                array( //isSldValidArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => true
-                ),
-                array( //tldFindOneByTldArr
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => $tldModel
-                ),
-                array( //isDomainAvailable
-                    'called'  => $self->atLeastOnce(),
-                    'returns' => false
-                )
-            )
-        );
+                ],
+                [ // isSldValidArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => true,
+                ],
+                [ // tldFindOneByTldArr
+                    'called' => $self->atLeastOnce(),
+                    'returns' => $tldModel,
+                ],
+                [ // isDomainAvailable
+                    'called' => $self->atLeastOnce(),
+                    'returns' => false,
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDateRegisterExceptionsProvider')]
@@ -354,18 +350,18 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($isSldValidArr['called'])->method('isSldValid')
-            ->will($this->returnValue($isSldValidArr['returns']));
+            ->willReturn($isSldValidArr['returns']);
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'isDomainAvailable'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'isDomainAvailable'])->getMock();
         $serviceMock->expects($tldFindOneByTldArr['called'])->method('tldFindOneByTld')
-            ->will($this->returnValue($tldFindOneByTldArr['returns']));
+            ->willReturn($tldFindOneByTldArr['returns']);
         $serviceMock->expects($canBeTransferred['called'])->method('isDomainAvailable')
-            ->will($this->returnValue($canBeTransferred['returns']));
+            ->willReturn($canBeTransferred['returns']);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $serviceMock->setDi($di);
 
@@ -380,50 +376,50 @@ class ServiceTest extends \BBTestCase
         $tldModel->loadBean(new \DummyBean());
         $tldModel->tld_registrar_id = random_int(1, 100);
 
-        $data = array(
-            'action'         => 'register',
-            'register_sld'   => 'example',
-            'register_tld'   => '.com',
+        $data = [
+            'action' => 'register',
+            'register_sld' => 'example',
+            'register_tld' => '.com',
             'register_years' => 2,
-        );
+        ];
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getConfig'))->getMock();
+            ->onlyMethods(['getConfig'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getConfig')
-            ->will($this->returnValue($data));
+            ->willReturn($data);
 
-        $nameservers       = array(
+        $nameservers = [
             'nameserver_1' => 'ns1.example.com',
             'nameserver_2' => 'ns2.example.com',
             'nameserver_3' => 'ns3.example.com',
             'nameserver_4' => 'ns4.example.com',
-        );
+        ];
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getNameservers'))->getMock();
+            ->onlyMethods(['getNameservers'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())->method('getNameservers')
-            ->will($this->returnValue($nameservers));
+            ->willReturn($nameservers);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('tldFindOneByTld', 'validateOrderData'))->getMock();
+            ->onlyMethods(['tldFindOneByTld', 'validateOrderData'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('tldFindOneByTld')
-            ->will($this->returnValue($tldModel));
+            ->willReturn($tldModel);
         $serviceMock->expects($this->atLeastOnce())->method('validateOrderData')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->first_name = 'first_name';
-        $client->last_name  = 'last_name';
-        $client->email      = 'email';
-        $client->company    = 'company';
-        $client->address_1  = 'address_1';
-        $client->address_2  = 'address_2';
-        $client->country    = 'country';
-        $client->city       = 'city';
-        $client->state      = 'state';
-        $client->postcode   = 'postcode';
-        $client->phone_cc   = 'phone_cc';
-        $client->phone      = 'phone';
+        $client->last_name = 'last_name';
+        $client->email = 'email';
+        $client->company = 'company';
+        $client->address_1 = 'address_1';
+        $client->address_2 = 'address_2';
+        $client->country = 'country';
+        $client->city = 'city';
+        $client->state = 'state';
+        $client->postcode = 'postcode';
+        $client->phone_cc = 'phone_cc';
+        $client->phone = 'phone';
 
         $serviceDomainModel = new \Model_ServiceDomain();
         $serviceDomainModel->loadBean(new \DummyBean());
@@ -431,12 +427,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($client));
+            ->willReturn($client);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($serviceDomainModel));
+            ->willReturn($serviceDomainModel);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($orderServiceMock, $systemServiceMock) {
             if ($name == 'order') {
                 return $orderServiceMock;
@@ -444,10 +440,9 @@ class ServiceTest extends \BBTestCase
                 return $systemServiceMock;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
-
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
@@ -463,29 +458,29 @@ class ServiceTest extends \BBTestCase
         $tldModel->loadBean(new \DummyBean());
         $tldModel->tld_registrar_id = random_int(1, 100);
 
-        $data = array(
-            'action'         => 'register',
-            'register_sld'   => 'example',
-            'register_tld'   => '.com',
+        $data = [
+            'action' => 'register',
+            'register_sld' => 'example',
+            'register_tld' => '.com',
             'register_years' => 2,
-        );
+        ];
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getConfig'))->getMock();
+            ->onlyMethods(['getConfig'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getConfig')
-            ->will($this->returnValue($data));
+            ->willReturn($data);
 
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getNameservers'))->getMock();
+            ->onlyMethods(['getNameservers'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())->method('getNameservers')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('validateOrderData'))->getMock();
+            ->onlyMethods(['validateOrderData'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('validateOrderData')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($orderServiceMock, $systemServiceMock) {
             if ($name == 'order') {
                 return $orderServiceMock;
@@ -506,18 +501,18 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
+        return [
+            [
                 'register',
                 $self->atLeastOnce(),
-                $self->never()
-            ),
-            array(
+                $self->never(),
+            ],
+            [
                 'transfer',
                 $self->never(),
-                $self->atLeastOnce()
-            )
-        );
+                $self->atLeastOnce(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('actionActivateProvider')]
@@ -530,53 +525,53 @@ class ServiceTest extends \BBTestCase
         $domainModel = new \Model_ServiceDomain();
         $domainModel->loadBean(new \DummyBean());
         $domainModel->tld_registrar_id = random_int(1, 100);
-        $domainModel->action           = $action;
+        $domainModel->action = $action;
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue($domainModel));
+            ->willReturn($domainModel);
 
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($registerDomainCalled)->method('registerDomain')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $registrarAdapterMock->expects($transferDomainCalled)->method('transferDomain')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD', 'syncWhois'))->getMock();
+            ->onlyMethods(['_getD', 'syncWhois'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
         $serviceMock->expects($this->atLeastOnce())->method('syncWhois')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
+        $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $result           = $serviceMock->action_activate($order);
+        $result = $serviceMock->action_activate($order);
         $this->assertInstanceOf('Model_ServiceDomain', $result);
     }
 
     public function testActionActivateServiceNotFoundException()
     {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
         $this->service->setDi($di);
 
         $order = new \Model_ClientOrder();
@@ -596,47 +591,46 @@ class ServiceTest extends \BBTestCase
         $domainModel = new \Model_ServiceDomain();
         $domainModel->loadBean(new \DummyBean());
         $domainModel->tld_registrar_id = random_int(1, 100);
-        $domainModel->action           = 'register';
+        $domainModel->action = 'register';
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue($domainModel));
+            ->willReturn($domainModel);
 
         $registrarDomainMock = $this->getMockBuilder('Registrar_Domain')->disableOriginalConstructor()
             ->getMock();
         $registrarDomainMock->expects($this->atLeastOnce())->method('getContactRegistrar')
-            ->will($this->returnValue(new \Registrar_Domain_Contact()));
+            ->willReturn(new \Registrar_Domain_Contact());
         $registrarDomainMock->expects($this->atLeastOnce())->method('getLocked')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('renewDomain')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $registrarAdapterMock->expects($this->atLeastOnce())->method('getDomainDetails')
-            ->will($this->returnValue($registrarDomainMock));
-
+            ->willReturn($registrarDomainMock);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
         $serviceMock->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $result           = $serviceMock->action_renew($order);
+        $result = $serviceMock->action_renew($order);
 
         $this->assertTrue($result);
     }
@@ -644,21 +638,21 @@ class ServiceTest extends \BBTestCase
     public function testActionRenewServiceNotFoundException()
     {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
         $this->service->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
-        $order->id        = random_int(1, 100);
+        $order->id = random_int(1, 100);
         $order->client_id = random_int(1, 100);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result           = $this->service->action_renew($order);
+        $result = $this->service->action_renew($order);
 
         $this->assertTrue($result);
     }
@@ -688,32 +682,31 @@ class ServiceTest extends \BBTestCase
         $domainModel = new \Model_ServiceDomain();
         $domainModel->loadBean(new \DummyBean());
         $domainModel->tld_registrar_id = random_int(1, 100);
-        $domainModel->action           = 'register';
+        $domainModel->action = 'register';
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue($domainModel));
+            ->willReturn($domainModel);
 
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('deleteDomain')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
-
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
         $serviceMock->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $result           = $serviceMock->action_cancel($order);
+        $result = $serviceMock->action_cancel($order);
 
         $this->assertTrue($result);
     }
@@ -721,21 +714,21 @@ class ServiceTest extends \BBTestCase
     public function testActionCancelServiceNotFoundException()
     {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
         $this->service->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
-        $order->id        = random_int(1, 100);
+        $order->id = random_int(1, 100);
         $order->client_id = random_int(1, 100);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result           = $this->service->action_cancel($order);
+        $result = $this->service->action_cancel($order);
 
         $this->assertTrue($result);
     }
@@ -743,14 +736,14 @@ class ServiceTest extends \BBTestCase
     public function testActionUncancel()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('action_activate'))->getMock();
+            ->onlyMethods(['action_activate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('action_activate')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->client_id = random_int(1, 100);
-        $result           = $serviceMock->action_uncancel($order);
+        $result = $serviceMock->action_uncancel($order);
 
         $this->assertTrue($result);
     }
@@ -764,38 +757,37 @@ class ServiceTest extends \BBTestCase
         $domainModel = new \Model_ServiceDomain();
         $domainModel->loadBean(new \DummyBean());
         $domainModel->tld_registrar_id = random_int(1, 100);
-        $domainModel->action           = 'register';
+        $domainModel->action = 'register';
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)
-            ->onlyMethods(array('getOrderService'))->getMock();
+            ->onlyMethods(['getOrderService'])->getMock();
         $orderServiceMock->expects($this->atLeastOnce())->method('getOrderService')
-            ->will($this->returnValue($domainModel));
+            ->willReturn($domainModel);
 
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('deleteDomain')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
-
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $orderServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $orderServiceMock);
+        $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
         $order = new \Model_ClientOrder();
         $order->loadBean(new \DummyBean());
         $order->status = \Model_ClientOrder::STATUS_ACTIVE;
-        $result        = $serviceMock->action_delete($order);
+        $result = $serviceMock->action_delete($order);
 
         $this->assertNull($result);
     }
@@ -805,30 +797,29 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('modifyNs')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
-
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
-        $data = array(
+        $data = [
             'ns1' => 'ns1.example.com',
             'ns2' => 'ns2.example.com',
             'ns3' => 'ns3.example.com',
             'ns4' => 'ns4.example.com',
-        );
+        ];
 
         $serviceDomainModel = new \Model_ServiceDomain();
         $serviceDomainModel->loadBean(new \DummyBean());
@@ -839,14 +830,14 @@ class ServiceTest extends \BBTestCase
 
     public static function updateNameserversExceptionProvider()
     {
-        return array(
-            array(
-                array('ns2' => 'ns2.example.com') //ns1 is missing
-            ),
-            array(
-                array('ns1' => 'ns1.example.com') //ns2 is missing
-            ),
-        );
+        return [
+            [
+                ['ns2' => 'ns2.example.com'], // ns1 is missing
+            ],
+            [
+                ['ns1' => 'ns1.example.com'], // ns2 is missing
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('updateNameserversExceptionProvider')]
@@ -864,45 +855,43 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('modifyContact')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
-
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['validator'] = $validatorMock;
         $serviceMock->setDi($di);
 
-
-        $data               = array(
-            'contact' => array(
+        $data = [
+            'contact' => [
                 'first_name' => 'first_name',
-                'last_name'  => 'last_name',
-                'email'      => 'email',
-                'company'    => 'company',
-                'address1'   => 'address1',
-                'address2'   => 'address2',
-                'country'    => 'country',
-                'city'       => 'city',
-                'state'      => 'state',
-                'postcode'   => 'postcode',
-                'phone_cc'   => 'phone_cc',
-                'phone'      => 'phone',
-            )
-        );
+                'last_name' => 'last_name',
+                'email' => 'email',
+                'company' => 'company',
+                'address1' => 'address1',
+                'address2' => 'address2',
+                'country' => 'country',
+                'city' => 'city',
+                'state' => 'state',
+                'postcode' => 'postcode',
+                'phone_cc' => 'phone_cc',
+                'phone' => 'phone',
+            ],
+        ];
         $serviceDomainModel = new \Model_ServiceDomain();
         $serviceDomainModel->loadBean(new \DummyBean());
         $result = $serviceMock->updateContacts($serviceDomainModel, $data);
@@ -917,12 +906,12 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('getEpp')
-            ->will($this->returnValue($epp));
+            ->willReturn($epp);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $serviceDomainModel = new \Model_ServiceDomain();
         $serviceDomainModel->loadBean(new \DummyBean());
@@ -937,20 +926,20 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('lock')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -961,26 +950,25 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
     public function testUnlock()
     {
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('unlock')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -996,20 +984,20 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('enablePrivacyProtection')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -1025,20 +1013,20 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('disablePrivacyProtection')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('_getD'))->getMock();
+            ->onlyMethods(['_getD'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('_getD')
-            ->will($this->returnValue(array(new \Registrar_Domain(), $registrarAdapterMock)));
+            ->willReturn([new \Registrar_Domain(), $registrarAdapterMock]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -1054,12 +1042,12 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('isDomaincanBeTransferred')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetRegistrarAdapter'))->getMock();
+            ->onlyMethods(['registrarGetRegistrarAdapter'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetRegistrarAdapter')
-            ->will($this->returnValue($registrarAdapterMock));
+            ->willReturn($registrarAdapterMock);
 
         $tldRegistrar = new \Model_TldRegistrar();
         $tldRegistrar->loadBean(new \DummyBean());
@@ -1068,16 +1056,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($tldRegistrar));
+            ->willReturn($tldRegistrar);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
         $tld = new \Model_Tld();
         $tld->loadBean(new \DummyBean());
-        $tld->allow_transfer   = true;
-        $tld->tld              = '.com';
+        $tld->allow_transfer = true;
+        $tld->tld = '.com';
         $tld->tld_registrar_id = random_int(1, 100);
 
         $result = $serviceMock->canBeTransferred($tld, 'example');
@@ -1106,12 +1094,12 @@ class ServiceTest extends \BBTestCase
         $registrarAdapterMock = $this->getMockBuilder('Registrar_Adapter_Custom')->disableOriginalConstructor()
             ->getMock();
         $registrarAdapterMock->expects($this->atLeastOnce())->method('isDomainAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetRegistrarAdapter'))->getMock();
+            ->onlyMethods(['registrarGetRegistrarAdapter'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetRegistrarAdapter')
-            ->will($this->returnValue($registrarAdapterMock));
+            ->willReturn($registrarAdapterMock);
 
         $tldRegistrar = new \Model_TldRegistrar();
         $tldRegistrar->loadBean(new \DummyBean());
@@ -1120,21 +1108,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($tldRegistrar));
+            ->willReturn($tldRegistrar);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
         $serviceMock->setDi($di);
 
         $tld = new \Model_Tld();
         $tld->loadBean(new \DummyBean());
-        $tld->allow_register   = true;
-        $tld->tld              = '.com';
+        $tld->allow_register = true;
+        $tld->tld = '.com';
         $tld->tld_registrar_id = random_int(1, 100);
 
         $result = $serviceMock->isDomainAvailable($tld, 'example');
@@ -1154,9 +1142,9 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
 
@@ -1170,9 +1158,9 @@ class ServiceTest extends \BBTestCase
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
 
@@ -1200,16 +1188,16 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_Admin();
         $model->loadBean(new \DummyBean());
 
-        return array(
-            array(
+        return [
+            [
                 $model,
-                $self->atLeastOnce()
-            ),
-            array(
+                $self->atLeastOnce(),
+            ],
+            [
                 null,
-                $self->never()
-            )
-        );
+                $self->never(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('toApiArrayProvider')]
@@ -1218,32 +1206,32 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
 
-        $model->sld           = 'sld';
-        $model->tld           = 'tld';
-        $model->ns1           = 'ns1.example.com';
-        $model->ns2           = 'ns2.example.com';
-        $model->ns3           = 'ns3.example.com';
-        $model->ns4           = 'ns4.example.com';
-        $model->period        = 'period';
-        $model->privacy       = 'privacy';
-        $model->locked        = 'locked';
+        $model->sld = 'sld';
+        $model->tld = 'tld';
+        $model->ns1 = 'ns1.example.com';
+        $model->ns2 = 'ns2.example.com';
+        $model->ns3 = 'ns3.example.com';
+        $model->ns4 = 'ns4.example.com';
+        $model->period = 'period';
+        $model->privacy = 'privacy';
+        $model->locked = 'locked';
         $model->registered_at = date('Y-m-d H:i:s');
-        $model->expires_at    = date('Y-m-d H:i:s');
+        $model->expires_at = date('Y-m-d H:i:s');
 
         $model->contact_first_name = 'first_name';
-        $model->contact_last_name  = 'last_name';
-        $model->contact_email      = 'email';
-        $model->contact_company    = 'company';
-        $model->contact_address1   = 'address1';
-        $model->contact_address2   = 'address2';
-        $model->contact_country    = 'country';
-        $model->contact_city       = 'city';
-        $model->contact_state      = 'state';
-        $model->contact_postcode   = 'postcode';
-        $model->contact_phone_cc   = 'phone_cc';
-        $model->contact_phone      = 'phone';
-        $model->transfer_code      = 'EPPCODE';
-        $model->tld_registrar_id   = random_int(1, 100);
+        $model->contact_last_name = 'last_name';
+        $model->contact_email = 'email';
+        $model->contact_company = 'company';
+        $model->contact_address1 = 'address1';
+        $model->contact_address2 = 'address2';
+        $model->contact_country = 'country';
+        $model->contact_city = 'city';
+        $model->contact_state = 'state';
+        $model->contact_postcode = 'postcode';
+        $model->contact_phone_cc = 'phone_cc';
+        $model->contact_phone = 'phone';
+        $model->transfer_code = 'EPPCODE';
+        $model->tld_registrar_id = random_int(1, 100);
 
         $tldRegistrar = new \Model_TldRegistrar();
         $tldRegistrar->loadBean(new \DummyBean());
@@ -1252,9 +1240,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($dbLoadCalled)
             ->method('load')
-            ->will($this->returnValue($tldRegistrar));
+            ->willReturn($tldRegistrar);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1328,12 +1316,12 @@ class ServiceTest extends \BBTestCase
 
     public function testOnBeforeAdminCronRun()
     {
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('batchSyncExpirationDates')
             ->willReturn(true);
-        $di['mod_service'] = $di->protect(fn($serviceName) => $serviceMock);
+        $di['mod_service'] = $di->protect(fn ($serviceName) => $serviceMock);
 
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -1348,35 +1336,33 @@ class ServiceTest extends \BBTestCase
     public function testBatchSyncExpirationDates()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('syncExpirationDate'))->getMock();
+            ->onlyMethods(['syncExpirationDate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('syncExpirationDate')
-            ->will($this->returnValue(null));
-
+            ->willReturn(null);
 
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getParamValue', 'setParamValue'))->getMock();
+            ->onlyMethods(['getParamValue', 'setParamValue'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())->method('getParamValue')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $systemServiceMock->expects($this->atLeastOnce())->method('setParamValue')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $domains = array(
+        $domains = [
             'domain1.com',
             'domain2.com',
             'domain3.com',
             'domain4.com',
-        );
-        $dbMock  = $this->getMockBuilder('\Box_Database')->getMock();
+        ];
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue($domains));
+            ->willReturn($domains);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $systemServiceMock);
-        $di['db']          = $dbMock;
-        $di['logger']      = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $systemServiceMock);
+        $di['db'] = $dbMock;
+        $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
-
 
         $result = $serviceMock->batchSyncExpirationDates();
 
@@ -1386,22 +1372,21 @@ class ServiceTest extends \BBTestCase
     public function testBatchSyncExpirationDatesReturnsFalse()
     {
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getParamValue', 'setParamValue'))->getMock();
+            ->onlyMethods(['getParamValue', 'setParamValue'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())->method('getParamValue')
-            ->will($this->returnValue(date('Y-m-d H:i:s')));
+            ->willReturn(date('Y-m-d H:i:s'));
         $systemServiceMock->expects($this->never())->method('setParamValue')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn($name) => $systemServiceMock);
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $systemServiceMock);
+        $di['db'] = $dbMock;
         $this->service->setDi($di);
-
 
         $result = $this->service->batchSyncExpirationDates();
 
@@ -1410,50 +1395,49 @@ class ServiceTest extends \BBTestCase
 
     public static function tldGetSearchQueryProvider()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 'SELECT * FROM tld ORDER BY id ASC',
-                array()
-            ),
-            array(
-                array(
-                    'hide_inactive' => true
-                ),
+                [],
+            ],
+            [
+                [
+                    'hide_inactive' => true,
+                ],
                 'SELECT * FROM tld WHERE active = 1 ORDER BY id ASC',
-                array()
-            ),
-            array(
-                array(
-                    'allow_register' => true
-                ),
-                'SELECT * FROM tld WHERE allow_register = 1 ORDER BY id ASC',
-                array()
-            ),
-            array(
-                array(
-                    'allow_transfer' => true
-                ),
-                'SELECT * FROM tld WHERE allow_transfer = 1 ORDER BY id ASC',
-                array()
-            ),
-            array(
-                array(
-                    'hide_inactive'  => true,
+                [],
+            ],
+            [
+                [
                     'allow_register' => true,
-                    'allow_transfer' => true
-                ),
+                ],
+                'SELECT * FROM tld WHERE allow_register = 1 ORDER BY id ASC',
+                [],
+            ],
+            [
+                [
+                    'allow_transfer' => true,
+                ],
+                'SELECT * FROM tld WHERE allow_transfer = 1 ORDER BY id ASC',
+                [],
+            ],
+            [
+                [
+                    'hide_inactive' => true,
+                    'allow_register' => true,
+                    'allow_transfer' => true,
+                ],
                 'SELECT * FROM tld WHERE active = 1 AND allow_register = 1 AND allow_transfer = 1 ORDER BY id ASC',
-                array()
-            ),
-
-        );
+                [],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('tldGetSearchQueryProvider')]
     public function testTldGetSearchQuery($data, $expectedQuery, $expectedBindings)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
         [$query, $bindings] = $this->service->tldGetSearchQuery($data);
@@ -1462,7 +1446,6 @@ class ServiceTest extends \BBTestCase
 
         $this->assertIsArray($bindings);
         $this->assertEquals($bindings, $expectedBindings);
-
     }
 
     public function testTldFindAllActive()
@@ -1470,9 +1453,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1488,9 +1471,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($tldModel));
+            ->willReturn($tldModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1501,15 +1484,15 @@ class ServiceTest extends \BBTestCase
 
     public function testTldGetPairs()
     {
-        $returns = array(
-            0 => '.com'
-        );
-        $dbMock  = $this->getMockBuilder('\Box_Database')->getMock();
+        $returns = [
+            0 => '.com',
+        ];
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($returns));
+            ->willReturn($returns);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1526,9 +1509,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($tldModel));
+            ->willReturn($tldModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1542,9 +1525,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1558,10 +1541,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1583,24 +1566,23 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($tldRegistrar));
+            ->willReturn($tldRegistrar);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $model = new \Model_Tld();
         $model->loadBean(new \DummyBean());
-        $model->tld                = '.com';
+        $model->tld = '.com';
         $model->price_registration = random_int(1, 100);
-        $model->price_renew        = random_int(1, 100);
-        $model->price_transfer     = random_int(1, 100);
-        $model->active             = 1;
-        $model->allow_register     = 1;
-        $model->allow_transfer     = 1;
-        $model->min_years          = 2;
-        $model->tld_registrar_id   = random_int(1, 100);
-
+        $model->price_renew = random_int(1, 100);
+        $model->price_transfer = random_int(1, 100);
+        $model->active = 1;
+        $model->allow_register = 1;
+        $model->allow_transfer = 1;
+        $model->min_years = 2;
+        $model->tld_registrar_id = random_int(1, 100);
 
         $result = $this->service->tldToApiArray($model);
         $this->assertIsArray($result);
@@ -1633,7 +1615,6 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($registrar['title'], $tldRegistrar->name);
     }
 
-
     public function testTldFindOneByTld()
     {
         $tldModel = new \Model_Tld();
@@ -1641,9 +1622,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($tldModel));
+            ->willReturn($tldModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1654,25 +1635,25 @@ class ServiceTest extends \BBTestCase
 
     public function testRegistrarGetSearchQuery()
     {
-        [$query, $bindings] = $this->service->registrarGetSearchQuery(array());
+        [$query, $bindings] = $this->service->registrarGetSearchQuery([]);
 
         $this->assertEquals('SELECT * FROM tld_registrar ORDER BY name ASC', $query);
         $this->assertIsArray($bindings);
-        $this->assertEquals(array(), $bindings);
+        $this->assertEquals([], $bindings);
     }
 
     public function testRegistrarGetAvailable()
     {
-        $registrars = array(
-            'Resellerclub' => 'Reseller Club'
-        );
+        $registrars = [
+            'Resellerclub' => 'Reseller Club',
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($registrars));
+            ->willReturn($registrars);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1682,18 +1663,18 @@ class ServiceTest extends \BBTestCase
 
     public function testRegistrarGetPairs()
     {
-        $registrars = array(
+        $registrars = [
             1 => 'Resellerclub',
             2 => 'Email',
-            3 => 'Custom'
-        );
+            3 => 'Custom',
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($registrars));
+            ->willReturn($registrars);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1701,7 +1682,6 @@ class ServiceTest extends \BBTestCase
 
         $this->assertIsArray($result);
         $this->assertEquals(count($result), 3);
-
     }
 
     public function testRegistrarGetActiveRegistrar()
@@ -1712,30 +1692,29 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($tldRegistrarModel));
+            ->willReturn($tldRegistrarModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->registrarGetActiveRegistrar();
 
         $this->assertInstanceOf('Model_TldRegistrar', $result);
-
     }
 
     public function testRegistrarGetConfiguration()
     {
-        $config = array(
-            'config_param' => 'config_value'
-        );
+        $config = [
+            'config_param' => 'config_value',
+        ];
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
@@ -1783,10 +1762,10 @@ class ServiceTest extends \BBTestCase
     public function testRegistrarGetRegistrarAdapter()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetConfiguration'))->getMock();
+            ->onlyMethods(['registrarGetConfiguration'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetConfiguration')
-            ->will($this->returnValue(array()));
-        $di           = new \Pimple\Container();
+            ->willReturn([]);
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder(\Box_Log::class)->getMock();
         $serviceMock->setDi($di);
         $model = new \Model_TldRegistrar();
@@ -1801,9 +1780,9 @@ class ServiceTest extends \BBTestCase
     public function testRegistrarGetRegistrarAdapterNotFoundException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetConfiguration'))->getMock();
+            ->onlyMethods(['registrarGetConfiguration'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetConfiguration')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
@@ -1819,19 +1798,19 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
-        $model->id   = random_int(1, 100);
+        $model->id = random_int(1, 100);
         $model->name = 'ResellerClub';
 
         $result = $this->service->registrarRm($model);
@@ -1846,12 +1825,12 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($serviceDomainModel)));
+            ->willReturn([$serviceDomainModel]);
         $dbMock->expects($this->never())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1861,28 +1840,26 @@ class ServiceTest extends \BBTestCase
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->service->registrarRm($model);
-
     }
 
     public function testRegistrarToApiArray()
     {
-        $config = array(
+        $config = [
             'label' => 'Label',
-            'form'  => random_int(1, 100)
-        );
+            'form' => random_int(1, 100),
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(array('registrarGetRegistrarAdapterConfig', 'registrarGetConfiguration'))->getMock();
+            ->onlyMethods(['registrarGetRegistrarAdapterConfig', 'registrarGetConfiguration'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetRegistrarAdapterConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
         $serviceMock->expects($this->atLeastOnce())->method('registrarGetConfiguration')
-            ->will($this->returnValue(array('param1' => 'value1')));
-
+            ->willReturn(['param1' => 'value1']);
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
-        $model->id        = random_int(1, 100);
-        $model->name      = 'ResellerClub';
+        $model->id = random_int(1, 100);
+        $model->name = 'ResellerClub';
         $model->test_mode = true;
 
         $serviceMock->registrarToApiArray($model);
@@ -1890,17 +1867,17 @@ class ServiceTest extends \BBTestCase
 
     public function testTldCreate()
     {
-        $data                       = array();
-        $data['tld']                = '.com';
-        $data['tld_registrar_id']   = random_int(1, 100);
+        $data = [];
+        $data['tld'] = '.com';
+        $data['tld_registrar_id'] = random_int(1, 100);
         $data['price_registration'] = random_int(1, 10);
-        $data['price_renew']        = random_int(1, 10);
-        $data['price_transfer']     = random_int(1, 10);
-        $data['min_years']          = random_int(1, 5);
-        $data['allow_register']     = 1;
-        $data['allow_transfer']     = 1;
-        $data['updated_at']         = date('Y-m-d H:i:s');
-        $data['created_at']         = date('Y-m-d H:i:s');
+        $data['price_renew'] = random_int(1, 10);
+        $data['price_transfer'] = random_int(1, 10);
+        $data['min_years'] = random_int(1, 5);
+        $data['allow_register'] = 1;
+        $data['allow_transfer'] = 1;
+        $data['updated_at'] = date('Y-m-d H:i:s');
+        $data['created_at'] = date('Y-m-d H:i:s');
 
         $randId = random_int(1, 100);
 
@@ -1910,13 +1887,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($tldModel));
+            ->willReturn($tldModel);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1924,34 +1901,33 @@ class ServiceTest extends \BBTestCase
 
         $this->assertIsInt($result);
         $this->assertEquals($result, $randId);
-
     }
 
     public function testTldUpdate()
     {
-        $data                       = array();
-        $data['tld']                = '.com';
-        $data['tld_registrar_id']   = random_int(1, 100);
+        $data = [];
+        $data['tld'] = '.com';
+        $data['tld_registrar_id'] = random_int(1, 100);
         $data['price_registration'] = random_int(1, 10);
-        $data['price_renew']        = random_int(1, 10);
-        $data['price_transfer']     = random_int(1, 10);
-        $data['min_years']          = random_int(1, 5);
-        $data['allow_register']     = true;
-        $data['allow_transfer']     = true;
-        $data['active']             = true;
-        $data['updated_at']         = date('Y-m-d H:i:s');
-        $data['created_at']         = date('Y-m-d H:i:s');
+        $data['price_renew'] = random_int(1, 10);
+        $data['price_transfer'] = random_int(1, 10);
+        $data['min_years'] = random_int(1, 5);
+        $data['allow_register'] = true;
+        $data['allow_transfer'] = true;
+        $data['active'] = true;
+        $data['updated_at'] = date('Y-m-d H:i:s');
+        $data['created_at'] = date('Y-m-d H:i:s');
 
         $randId = random_int(1, 100);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
@@ -1962,7 +1938,6 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->tldUpdate($model, $data);
 
         $this->assertTrue($result);
-
     }
 
     public function testRegistrarCreate()
@@ -1970,16 +1945,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1990,29 +1965,28 @@ class ServiceTest extends \BBTestCase
 
     public function testRegistrarCopy()
     {
-        $newId  = random_int(1, 100);
+        $newId = random_int(1, 100);
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
-        $model->name      = 'ResellerClub';
+        $model->name = 'ResellerClub';
         $model->registrar = 'ResellerClub';
         $model->test_mode = 1;
-
 
         $result = $this->service->registrarCopy($model);
 
@@ -2025,21 +1999,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
-        $data = array(
-            'title'     => 'ResellerClub',
+        $data = [
+            'title' => 'ResellerClub',
             'test_mode' => 1,
-            'config'    => array(
-                'param1' => 'value1'
-            )
-        );
+            'config' => [
+                'param1' => 'value1',
+            ],
+        ];
 
         $model = new \Model_TldRegistrar();
         $model->loadBean(new \DummyBean());
@@ -2055,24 +2029,24 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
-        $data = array(
-            'ns1'           => 'ns1.example.com',
-            'ns2'           => 'ns2.example.com',
-            'ns3'           => 'ns3.example.com',
-            'ns4'           => 'ns4.example.com',
-            'period'        => random_int(1, 10),
-            'privacy'       => 1,
-            'locked'        => 1,
-            'transfer_code' => 'EPPCODE'
-        );
+        $data = [
+            'ns1' => 'ns1.example.com',
+            'ns2' => 'ns2.example.com',
+            'ns3' => 'ns3.example.com',
+            'ns4' => 'ns4.example.com',
+            'period' => random_int(1, 10),
+            'privacy' => 1,
+            'locked' => 1,
+            'transfer_code' => 'EPPCODE',
+        ];
 
         $model = new \Model_ServiceDomain();
         $model->loadBean(new \DummyBean());
@@ -2082,5 +2056,4 @@ class ServiceTest extends \BBTestCase
 
         $this->assertTrue($result);
     }
-
 }

--- a/tests/modules/Servicedownloadable/Api/AdminTest.php
+++ b/tests/modules/Servicedownloadable/Api/AdminTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicedownloadable\Api;
-
 
 class AdminTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Servicedownloadable\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Servicedownloadable\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -27,20 +25,20 @@ class AdminTest extends \BBTestCase
     public function testuploadFileNotUploaded()
     {
         $data['id'] = 1;
-        $model      = new \Model_Product();
+        $model = new \Model_Product();
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -52,24 +50,24 @@ class AdminTest extends \BBTestCase
     public function testupload()
     {
         $data['id'] = 1;
-        $model      = new \Model_Product();
+        $model = new \Model_Product();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedownloadable\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('uploadProductFile')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $_FILES['file_data'] = 'exits';
@@ -84,12 +82,12 @@ class AdminTest extends \BBTestCase
     public function testupdateOrderNotActivated()
     {
         $data['order_id'] = 1;
-        $model            = new \Model_ClientOrder();
+        $model = new \Model_ClientOrder();
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
@@ -97,12 +95,12 @@ class AdminTest extends \BBTestCase
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-        $di['validator']   = $validatorMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
+        $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
@@ -113,33 +111,33 @@ class AdminTest extends \BBTestCase
     public function testupdate()
     {
         $data['order_id'] = 1;
-        $model            = new \Model_ClientOrder();
+        $model = new \Model_ClientOrder();
 
         $modelDownloadableModel = new \Model_ServiceDownloadable();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedownloadable\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateProductFile')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($modelDownloadableModel));
+            ->willReturn($modelDownloadableModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-        $di['validator']   = $validatorMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
+        $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);

--- a/tests/modules/Servicedownloadable/Api/ClientTest.php
+++ b/tests/modules/Servicedownloadable/Api/ClientTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicedownloadable\Api;
 
-
-class ClientTest extends \BBTestCase {
+class ClientTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicedownloadable\Api\Client
+     * @var Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Servicedownloadable\Api\Client();
+        $this->api = new Client();
     }
 
     public function testgetDi()
@@ -23,20 +22,20 @@ class ClientTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testsend_fileMissingOrderId()
+    public function testsendFileMissingOrderId()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Order id is required');
         $this->api->send_file($data);
     }
 
-    public function testsend_fileOrderNotFound()
+    public function testsendFileOrderNotFound()
     {
-        $data = array(
-            'order_id' => 1
-        );
+        $data = [
+            'order_id' => 1,
+        ];
 
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -56,11 +55,11 @@ class ClientTest extends \BBTestCase {
         $this->api->send_file($data);
     }
 
-    public function testsend_fileOrderNotActivated()
+    public function testsendFileOrderNotActivated()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -72,11 +71,11 @@ class ClientTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
         $this->api->setIdentity($modelClient);
@@ -86,11 +85,11 @@ class ClientTest extends \BBTestCase {
         $this->api->send_file($data);
     }
 
-    public function testsend_file()
+    public function testsendFile()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $modelClient = new \Model_Client();
         $modelClient->loadBean(new \DummyBean());
@@ -98,25 +97,25 @@ class ClientTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedownloadable\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('sendFile')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDownloadable()));
+            ->willReturn(new \Model_ServiceDownloadable());
 
         $mockOrder = new \Model_ClientOrder();
-        $mockOrder->loadBean(New \DummyBean());
-        $mockOrder->status = "active";
+        $mockOrder->loadBean(new \DummyBean());
+        $mockOrder->status = 'active';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($mockOrder));
+            ->willReturn($mockOrder);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
         $this->api->setIdentity($modelClient);
@@ -125,7 +124,5 @@ class ClientTest extends \BBTestCase {
         $result = $this->api->send_file($data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
-
     }
 }
- 

--- a/tests/modules/Servicedownloadable/ServiceTest.php
+++ b/tests/modules/Servicedownloadable/ServiceTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicedownloadable;
-
 
 class ServiceTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Servicedownloadable\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Servicedownloadable\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -30,16 +28,16 @@ class ServiceTest extends \BBTestCase
         $productModel->loadBean(new \DummyBean());
         $productModel->config = '{"filename" : "temp/asdcxTest.txt"}';
 
-        $data = array();
+        $data = [];
 
         $expected = array_merge(json_decode($productModel->config, 1), $data);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->service->setDi($di);
         $result = $this->service->attachOrderConfig($productModel, $data);
@@ -47,7 +45,7 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testaction_create()
+    public function testactionCreate()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -59,18 +57,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->service->setDi($di);
@@ -78,22 +76,22 @@ class ServiceTest extends \BBTestCase
         $this->assertInstanceOf('\Model_ServiceDownloadable', $result);
     }
 
-    public function testaction_delete()
+    public function testactionDelete()
     {
-        $clientOrderModel = new \Model_ClientOrder();;
+        $clientOrderModel = new \Model_ClientOrder();
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceDownloadable()));
+            ->willReturn(new \Model_ServiceDownloadable());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->service->action_delete($clientOrderModel);
@@ -108,7 +106,7 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -121,24 +119,24 @@ class ServiceTest extends \BBTestCase
         $model = new \Model_ServiceDownloadable();
         $model->loadBean(new \DummyBean());
 
-        $model->filename  = 'config.cfg';
+        $model->filename = 'config.cfg';
         $model->downloads = 1;
 
         $filePath = 'path/to/location' . md5($model->filename);
 
-        $expected = array(
-            'path'      => $filePath,
-            'filename'  => $model->filename,
+        $expected = [
+            'path' => $filePath,
+            'filename' => $model->filename,
             'downloads' => 1,
-        );
+        ];
 
         $productServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $productServiceMock->expects($this->atLeastOnce())
             ->method('getSavePath')
-            ->will($this->returnValue($filePath));
+            ->willReturn($filePath);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $productServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $productServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->toApiArray($model, null, new \Model_Admin());
@@ -148,42 +146,41 @@ class ServiceTest extends \BBTestCase
 
     public function testuploadProductFileErrorUploadingFile()
     {
-        $productModel = new  \Model_Product();
+        $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $successfullyUploadedFileCount = 0;
-        $requestMock                   = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('hasFiles')
-            ->will($this->returnValue($successfullyUploadedFileCount));
-        $di            = new \Pimple\Container();
+            ->willReturn($successfullyUploadedFileCount);
+        $di = new \Pimple\Container();
         $di['request'] = $requestMock;
         $this->service->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Error uploading file');
         $this->service->uploadProductFile($productModel);
-
     }
 
     public function testuploadProductFile()
     {
-        $productModel = new  \Model_Product();
+        $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $successfullyUploadedFileCount = 1;
 
-        $file     = array(
-            'name'     => 'test',
+        $file = [
+            'name' => 'test',
             'tmp_name' => '12345',
-        );
+        ];
         $fileMock = new \FOSSBilling\RequestFile($file);
 
         $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('hasFiles')
-            ->will($this->returnValue($successfullyUploadedFileCount));
+            ->willReturn($successfullyUploadedFileCount);
         $requestMock->expects($this->atLeastOnce())
             ->method('getUploadedFiles')
-            ->will($this->returnValue(array($fileMock)));
+            ->willReturn([$fileMock]);
 
         $productServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $productServiceMock->expects($this->atLeastOnce())
@@ -195,11 +192,11 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $productServiceMock);
-        $di['db']          = $dbMock;
-        $di['logger']      = new \Box_Log();
-        $di['request']     = $requestMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $productServiceMock);
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+        $di['request'] = $requestMock;
         $this->service->setDi($di);
 
         $result = $this->service->uploadProductFile($productModel);
@@ -217,19 +214,19 @@ class ServiceTest extends \BBTestCase
 
         $successfullyUploadedFileCount = 1;
 
-        $file     = array(
-            'name'     => 'test',
+        $file = [
+            'name' => 'test',
             'tmp_name' => '12345',
-        );
+        ];
         $fileMock = new \FOSSBilling\RequestFile($file);
 
         $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('hasFiles')
-            ->will($this->returnValue($successfullyUploadedFileCount));
+            ->willReturn($successfullyUploadedFileCount);
         $requestMock->expects($this->atLeastOnce())
             ->method('getUploadedFiles')
-            ->will($this->returnValue(array($fileMock)));
+            ->willReturn([$fileMock]);
 
         $productServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $productServiceMock->expects($this->atLeastOnce())
@@ -239,11 +236,11 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $productServiceMock);
-        $di['db']          = $dbMock;
-        $di['logger']      = new \Box_Log();
-        $di['request']     = $requestMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $productServiceMock);
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+        $di['request'] = $requestMock;
 
         $this->service->setDi($di);
         $result = $this->service->updateProductFile($serviceDownloadableModel, $orderModel);
@@ -260,11 +257,11 @@ class ServiceTest extends \BBTestCase
         $serviceDownloadableModel->loadBean(new \DummyBean());
 
         $successfullyUploadedFileCount = 0;
-        $requestMock                   = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $requestMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $requestMock->expects($this->atLeastOnce())
             ->method('hasFiles')
-            ->will($this->returnValue($successfullyUploadedFileCount));
-        $di            = new \Pimple\Container();
+            ->willReturn($successfullyUploadedFileCount);
+        $di = new \Pimple\Container();
         $di['request'] = $requestMock;
         $this->service->setDi($di);
 
@@ -277,7 +274,7 @@ class ServiceTest extends \BBTestCase
     {
         $serviceDownloadableModel = new \Model_ServiceDownloadable();
         $serviceDownloadableModel->loadBean(new \DummyBean());
-        $serviceDownloadableModel->filename  = 'config.cfg';
+        $serviceDownloadableModel->filename = 'config.cfg';
         $serviceDownloadableModel->downloads = 1;
 
         $filePath = 'path/to/location' . md5($serviceDownloadableModel->filename);
@@ -285,11 +282,11 @@ class ServiceTest extends \BBTestCase
         $productServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Product\Service::class)->getMock();
         $productServiceMock->expects($this->atLeastOnce())
             ->method('getSavePath')
-            ->will($this->returnValue($filePath));
+            ->willReturn($filePath);
 
-        $di                = new \Pimple\Container();
-        $di['tools']       = $toolsMock;
-        $di['mod_service'] = $di->protect(fn() => $productServiceMock);
+        $di = new \Pimple\Container();
+        $di['tools'] = $toolsMock;
+        $di['mod_service'] = $di->protect(fn () => $productServiceMock);
 
         $this->service->setDi($di);
 
@@ -298,6 +295,4 @@ class ServiceTest extends \BBTestCase
         $this->expectExceptionMessage('File can not be downloaded at the moment. Please contact support');
         $this->service->sendFile($serviceDownloadableModel);
     }
-
-
 }

--- a/tests/modules/Servicehosting/Api/AdminTest.php
+++ b/tests/modules/Servicehosting/Api/AdminTest.php
@@ -1,20 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicehosting\Api;
-
 
 class AdminTest extends \BBTestCase
 {
-
     /**
-     * @var \Box\Mod\Servicehosting\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Servicehosting\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -25,32 +22,32 @@ class AdminTest extends \BBTestCase
         $this->assertEquals($di, $getDi);
     }
 
-    public function testchange_plan()
+    public function testchangePlan()
     {
-        $data = array(
+        $data = [
             'plan_id' => 1,
-        );
+        ];
 
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountPlan')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingHp));
+            ->willReturn(new \Model_ServiceHostingHp());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $apiMock->setDi($di);
@@ -61,229 +58,228 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testchange_planMissingPlanId()
+    public function testchangePlanMissingPlanId()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('plan_id is missing');
         $this->api->change_plan($data);
     }
 
-    public function testchange_username()
+    public function testchangeUsername()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountUsername')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_username(array());
+        $result = $apiMock->change_username([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testchange_ip()
+    public function testchangeIp()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountIp')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_ip(array());
+        $result = $apiMock->change_ip([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testchange_domain()
+    public function testchangeDomain()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_domain(array());
+        $result = $apiMock->change_domain([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testchange_password()
+    public function testchangePassword()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountPassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_password(array());
+        $result = $apiMock->change_password([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
     public function testsync()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('sync')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->sync(array());
+        $result = $apiMock->sync([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
     public function testupdate()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock               = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->update(array());
+        $result = $apiMock->update([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testmanager_get_pairs()
+    public function testmanagerGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerManagers')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->manager_get_pairs(array());
+        $result = $this->api->manager_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testserver_get_pairs()
+    public function testserverGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->server_get_pairs(array());
+        $result = $this->api->server_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testserver_get_list()
+    public function testserverGetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServersSearchQuery')
-            ->will($this->returnValue(array('SQLstring', array())));
+            ->willReturn(['SQLstring', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pagerMock;
-        $di['db']        = $dbMock;
-
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
+        $di['db'] = $dbMock;
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
 
-        $result = $this->api->server_get_list(array());
+        $result = $this->api->server_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testserver_create()
+    public function testserverCreate()
     {
-        $data = array(
-            'name'    => 'test',
-            'ip'      => '1.1.1.1',
+        $data = [
+            'name' => 'test',
+            'ip' => '1.1.1.1',
             'manager' => 'ServerManagerCode',
-        );
+        ];
 
         $newServerId = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createServer')
-            ->will($this->returnValue($newServerId));
+            ->willReturn($newServerId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
 
@@ -294,27 +290,27 @@ class AdminTest extends \BBTestCase
         $this->assertEquals($newServerId, $result);
     }
 
-    public function testserver_get()
+    public function testserverGet()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toHostingServerApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingServer));
+            ->willReturn(new \Model_ServiceHostingServer());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -332,20 +328,20 @@ class AdminTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteServer')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingServer));
+            ->willReturn(new \Model_ServiceHostingServer());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -360,20 +356,20 @@ class AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingServer));
+            ->willReturn(new \Model_ServiceHostingServer());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         // Mock the 'find' method to return a non-empty array, simulating the server being used by service hostings
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(['dummy_data']));
+            ->willReturn(['dummy_data']);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -385,27 +381,26 @@ class AdminTest extends \BBTestCase
         $this->api->server_delete($data);
     }
 
-
-    public function testserver_update()
+    public function testserverUpdate()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateServer')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingServer));
+            ->willReturn(new \Model_ServiceHostingServer());
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -416,26 +411,26 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testserver_test_connection()
+    public function testserverTestConnection()
     {
         $data['id'] = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('testConnection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ServiceHostingServer));
+            ->willReturn(new \Model_ServiceHostingServer());
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -446,66 +441,64 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testhp_get_pairs()
+    public function testhpGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getHpPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->hp_get_pairs(array());
+        $result = $this->api->hp_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testhp_get_list()
+    public function testhpGetList()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getHpSearchQuery')
-            ->will($this->returnValue(array('SQLstring', array())));
+            ->willReturn(['SQLstring', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
-
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pagerMock;
-
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
 
-        $result = $this->api->hp_get_list(array());
+        $result = $this->api->hp_get_list([]);
         $this->assertIsArray($result);
     }
 
-    public function testhp_delete()
+    public function testhpDelete()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $model = new \Model_ServiceHostingHp();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteHp')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -520,36 +513,35 @@ class AdminTest extends \BBTestCase
             $this->assertTrue($result);
         } catch (\FOSSBilling\Exception $e) {
             // If the function throws an exception, the test should fail
-            $this->fail("Exception thrown: " . $e->getMessage());
+            $this->fail('Exception thrown: ' . $e->getMessage());
         }
     }
 
-
-    public function testhp_get()
+    public function testhpGet()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $model = new \Model_ServiceHostingHp();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toHostingHpApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -559,31 +551,31 @@ class AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testhp_update()
+    public function testhpUpdate()
     {
-        $data = array(
+        $data = [
             'id' => 1,
-        );
+        ];
 
         $model = new \Model_ServiceHostingHp();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateHp')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
@@ -594,26 +586,25 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-
-    public function testhp_create()
+    public function testhpCreate()
     {
-        $data = array(
+        $data = [
             'name' => 'test',
-        );
+        ];
 
         $newHpId = 2;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createHp')
-            ->will($this->returnValue($newHpId));
+            ->willReturn($newHpId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->api->setDi($di);
 
@@ -624,33 +615,32 @@ class AdminTest extends \BBTestCase
         $this->assertEquals($newHpId, $result);
     }
 
-    public function test_getService()
+    public function testGetService()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $clientOrderModel = new \Model_ClientOrder();
-        $dbMock           = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($clientOrderModel));
+            ->willReturn($clientOrderModel);
 
-
-        $model            = new \Model_ServiceHosting();
+        $model = new \Model_ServiceHosting();
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-        $di['db']          = $dbMock;
-        $di['validator']   = $validatorMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
+        $di['db'] = $dbMock;
+        $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
 
@@ -660,34 +650,33 @@ class AdminTest extends \BBTestCase
         $this->assertInstanceOf('\Model_ServiceHosting', $result[1]);
     }
 
-    public function test_getServiceOrderNotActivated()
+    public function testGetServiceOrderNotActivated()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $clientOrderModel = new \Model_ClientOrder();
-        $dbMock           = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($clientOrderModel));
+            ->willReturn($clientOrderModel);
 
-
-        $model            = null;
+        $model = null;
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-        $di['db']          = $dbMock;
-        $di['validator']   = $validatorMock;
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
+        $di['db'] = $dbMock;
+        $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
 

--- a/tests/modules/Servicehosting/Api/ClientTest.php
+++ b/tests/modules/Servicehosting/Api/ClientTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicehosting\Api;
 
-
-class ClientTest extends \BBTestCase {
+class ClientTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicehosting\Api\Client
+     * @var Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Servicehosting\Api\Client();
+        $this->api = new Client();
     }
 
     public function testgetDi()
@@ -23,108 +22,107 @@ class ClientTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testchange_username()
+    public function testchangeUsername()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Client::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Client::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountUsername')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_username(array());
+        $result = $apiMock->change_username([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testchange_domain()
+    public function testchangeDomain()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Client::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Client::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountDomain')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_domain(array());
+        $result = $apiMock->change_domain([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testchange_password()
+    public function testchangePassword()
     {
-        $getServiceReturnValue = array(new \Model_ClientOrder(), new \Model_ServiceHosting);
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Api\Client::class)
-            ->onlyMethods(array('_getService'))
+        $getServiceReturnValue = [new \Model_ClientOrder(), new \Model_ServiceHosting()];
+        $apiMock = $this->getMockBuilder('\\' . Client::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
 
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue($getServiceReturnValue));
+            ->willReturn($getServiceReturnValue);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changeAccountPassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
 
-        $result = $apiMock->change_password(array());
+        $result = $apiMock->change_password([]);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testhp_get_pairs()
+    public function testhpGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getHpPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->hp_get_pairs(array());
+        $result = $this->api->hp_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function test_getService()
+    public function testGetService()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $clientOrderModel = new \Model_ClientOrder();
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientOrderModel));
-
+            ->willReturn($clientOrderModel);
 
         $model = new \Model_ServiceHosting();
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
@@ -139,27 +137,26 @@ class ClientTest extends \BBTestCase {
         $this->assertInstanceOf('\Model_ServiceHosting', $result[1]);
     }
 
-    public function test_getServiceOrderNotActivated()
+    public function testGetServiceOrderNotActivated()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $clientOrderModel = new \Model_ClientOrder();
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientOrderModel));
-
+            ->willReturn($clientOrderModel);
 
         $model = null;
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
@@ -174,17 +171,17 @@ class ClientTest extends \BBTestCase {
         $this->api->_getService($data);
     }
 
-    public function test_getServiceOrderNotFound()
+    public function testGetServiceOrderNotFound()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
         $clientOrderModel = null;
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($clientOrderModel));
+            ->willReturn($clientOrderModel);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -199,12 +196,11 @@ class ClientTest extends \BBTestCase {
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Order not found');
         $this->api->_getService($data);
-
     }
 
-    public function test_getServiceMissingOrderId()
+    public function testGetServiceMissingOrderId()
     {
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Order id is required');

--- a/tests/modules/Servicehosting/Api/GuestTest.php
+++ b/tests/modules/Servicehosting/Api/GuestTest.php
@@ -1,29 +1,28 @@
 <?php
+
 namespace Box\Mod\Servicehosting\Api;
 
 class GuestTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Servicehosting\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Servicehosting\Api\Guest();
+        $this->api = new Guest();
     }
 
-    public function testfree_tlds()
+    public function testfreeTlds()
     {
         $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di['validator'] = $validatorMock;
-
-
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
@@ -31,7 +30,7 @@ class GuestTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di['db'] = $dbMock;
 
@@ -39,32 +38,30 @@ class GuestTest extends \BBTestCase
         $serviceMock->expects($this->atLeastOnce())
             ->method('getFreeTlds')
             ->with($model)
-            ->willReturn(array());
+            ->willReturn([]);
         $this->api->setService($serviceMock);
         $this->api->setDi($di);
 
-        $result = $this->api->free_tlds(array('product_id' => 1));
+        $result = $this->api->free_tlds(['product_id' => 1]);
         $this->assertIsArray($result);
     }
 
-    public function testfree_tlds_ProductTypeIsNotHosting()
+    public function testfreeTldsProductTypeIsNotHosting()
     {
         $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di['validator'] = $validatorMock;
-
-
 
         $model = new \Model_Product();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di['db'] = $dbMock;
 
@@ -75,6 +72,6 @@ class GuestTest extends \BBTestCase
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Product type is invalid');
-        $this->api->free_tlds(array('product_id' => 1));
+        $this->api->free_tlds(['product_id' => 1]);
     }
 }

--- a/tests/modules/Servicehosting/ServiceTest.php
+++ b/tests/modules/Servicehosting/ServiceTest.php
@@ -1,20 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Servicehosting;
 
-
-class ServiceTest extends \BBTestCase {
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicehosting\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Servicehosting\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -26,45 +24,45 @@ class ServiceTest extends \BBTestCase {
 
     public static function validateOrdertDataProvider()
     {
-        return array(
-            array('server_id', 'Hosting product is not configured completely. Configure server for hosting product.', 701),
-            array('hosting_plan_id', 'Hosting product is not configured completely. Configure hosting plan for hosting product.', 702),
-            array('sld', 'Domain name is invalid.', 703),
-            array('tld', 'Domain extension is invalid.', 704),
-        );
+        return [
+            ['server_id', 'Hosting product is not configured completely. Configure server for hosting product.', 701],
+            ['hosting_plan_id', 'Hosting product is not configured completely. Configure hosting plan for hosting product.', 702],
+            ['sld', 'Domain name is invalid.', 703],
+            ['tld', 'Domain extension is invalid.', 704],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('validateOrdertDataProvider')]
     public function testvalidateOrderData($field, $exceptionMessage, $excCode)
     {
-        $data = array(
+        $data = [
             'server_id' => 1,
             'hosting_plan_id' => 2,
             'sld' => 'great',
-            'tld' => 'com'
-        );
+            'tld' => 'com',
+        ];
 
-        unset ($data [ $field ]);
+        unset($data[$field]);
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage($exceptionMessage);
         $this->service->validateOrderData($data);
     }
 
-    public function testaction_create()
+    public function testactionCreate()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
-        $confArr = array(
+        $confArr = [
             'server_id' => 1,
             'hosting_plan_id' => 2,
             'sld' => 'great',
-            'tld' => 'com'
-        );
+            'tld' => 'com',
+        ];
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue($confArr));
+            ->willReturn($confArr);
 
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
@@ -79,74 +77,72 @@ class ServiceTest extends \BBTestCase {
         $servhostingModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($servhostingModel));
+            ->willReturn($servhostingModel);
 
         $newserviceHostingId = 4;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newserviceHostingId));
+            ->willReturn($newserviceHostingId);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->service->action_create($orderModel);
     }
 
-    public function testaction_activate()
+    public function testactionActivate()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
 
-        $confArr = array(
+        $confArr = [
             'server_id' => 1,
             'hosting_plan_id' => 2,
             'sld' => 'great',
             'tld' => 'com',
             'username' => 'username',
-            'password' => 'password'
-        );
+            'password' => 'password',
+        ];
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue($confArr));
+            ->willReturn($confArr);
 
         $servhostingModel = new \Model_ServiceHosting();
         $servhostingModel->loadBean(new \DummyBean());
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($servhostingModel));
-
+            ->willReturn($servhostingModel);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('generatePassword')
-            ->will($this->returnValue('generatePassword'));
+            ->willReturn('generatePassword');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('createAccount');
 
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['tools'] = $toolsMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $serviceMock->setDi($di);
         $orderModel->config = $confArr;
@@ -156,7 +152,7 @@ class ServiceTest extends \BBTestCase {
         $this->assertNotEmpty($result['password']);
     }
 
-    public function testaction_renew()
+    public function testactionRenew()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -167,23 +163,22 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->action_renew($orderModel);
         $this->assertTrue($result);
     }
 
-    public function testaction_renewOrderWithoutActiveService()
+    public function testactionRenewOrderWithoutActiveService()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -194,16 +189,15 @@ class ServiceTest extends \BBTestCase {
             ->method('getOrderService');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage(sprintf('Order %d has no active service', $orderModel->id));
         $this->service->action_renew($orderModel);
-
     }
 
-    public function testaction_suspend()
+    public function testactionSuspend()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -214,34 +208,33 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('suspendAccount');
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->action_suspend($orderModel);
         $this->assertTrue($result);
     }
 
-    public function testaction_suspendOrderWithoutActiveService()
+    public function testactionSuspendOrderWithoutActiveService()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -252,16 +245,15 @@ class ServiceTest extends \BBTestCase {
             ->method('getOrderService');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage(sprintf('Order %d has no active service', $orderModel->id));
         $this->service->action_suspend($orderModel);
-
     }
 
-    public function testaction_unsuspend()
+    public function testactionUnsuspend()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -272,34 +264,33 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('unsuspendAccount');
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->action_unsuspend($orderModel);
         $this->assertTrue($result);
     }
 
-    public function testaction_unsuspendOrderWithoutActiveService()
+    public function testactionUnsuspendOrderWithoutActiveService()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -310,16 +301,15 @@ class ServiceTest extends \BBTestCase {
             ->method('getOrderService');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage(sprintf('Order %d has no active service', $orderModel->id));
         $this->service->action_unsuspend($orderModel);
-
     }
 
-    public function testaction_cancel()
+    public function testactionCancel()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -330,7 +320,7 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -338,25 +328,25 @@ class ServiceTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('cancelAccount');
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->action_cancel($orderModel);
         $this->assertTrue($result);
     }
 
-    public function testaction_cancelOrderWithoutActiveService()
+    public function testactionCancelOrderWithoutActiveService()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -367,7 +357,7 @@ class ServiceTest extends \BBTestCase {
             ->method('getOrderService');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
@@ -375,26 +365,26 @@ class ServiceTest extends \BBTestCase {
         $this->service->action_cancel($orderModel);
     }
 
-    public function testaction_uncancel()
+    public function testactionUncancel()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
-        $confArr = array(
+        $confArr = [
             'server_id' => 1,
             'hosting_plan_id' => 2,
             'sld' => 'great',
-            'tld' => 'com'
-        );
+            'tld' => 'com',
+        ];
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue($confArr));
+            ->willReturn($confArr);
 
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
@@ -409,37 +399,34 @@ class ServiceTest extends \BBTestCase {
         $servhostingModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($servhostingModel));
+            ->willReturn($servhostingModel);
 
         $newserviceHostingId = 4;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newserviceHostingId));
+            ->willReturn($newserviceHostingId);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
-
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('createAccount');
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
-
+            ->willReturn($AMresultArray);
 
         $serviceMock->setDi($di);
         $serviceMock->action_uncancel($orderModel);
     }
 
-    public function testaction_delete()
+    public function testactionDelete()
     {
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -451,7 +438,7 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -459,10 +446,10 @@ class ServiceTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('action_cancel'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['action_cancel'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('action_cancel');
@@ -480,7 +467,7 @@ class ServiceTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
 
         $modelHp = new \Model_ServiceHostingHp();
-        $modelHp->loadBean(new \DummyBean());;
+        $modelHp->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -490,19 +477,19 @@ class ServiceTest extends \BBTestCase {
         $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM', 'getServerPackage'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM', 'getServerPackage'])
             ->getMock();
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('changeAccountPackage');
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerPackage')
-            ->will($this->returnValue(new \Server_Package()));
+            ->willReturn(new \Server_Package());
 
         $serviceMock->setDi($di);
         $result = $serviceMock->changeAccountPlan($orderModel, $model, $modelHp);
@@ -511,9 +498,9 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountUsername()
     {
-        $data = array(
+        $data = [
             'username' => 'u123456',
-        );
+        ];
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -521,18 +508,18 @@ class ServiceTest extends \BBTestCase {
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('changeAccountUsername');
 
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -555,7 +542,7 @@ class ServiceTest extends \BBTestCase {
 
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
-        $data = array();
+        $data = [];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Account username is missing or is invalid');
@@ -564,9 +551,9 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountIp()
     {
-        $data = array(
-            'ip' => '1.1.1.1'
-        );
+        $data = [
+            'ip' => '1.1.1.1',
+        ];
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -574,18 +561,18 @@ class ServiceTest extends \BBTestCase {
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('changeAccountIp');
 
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -603,7 +590,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountIpMissingIp()
     {
-        $data = array();
+        $data = [];
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
 
@@ -617,10 +604,10 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountDomain()
     {
-        $data = array(
+        $data = [
             'tld' => 'com',
             'sld' => 'testingSld',
-        );
+        ];
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -628,18 +615,18 @@ class ServiceTest extends \BBTestCase {
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('changeAccountDomain');
 
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -657,7 +644,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountDomainMissingParams()
     {
-        $data = array();
+        $data = [];
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
 
@@ -671,10 +658,10 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountPassword()
     {
-        $data = array(
+        $data = [
             'password' => 'topsecret',
             'password_confirm' => 'topsecret',
-        );
+        ];
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -682,18 +669,18 @@ class ServiceTest extends \BBTestCase {
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('changeAccountPassword');
 
-        $AMresultArray = array($serverManagerMock, new \Server_Account());
+        $AMresultArray = [$serverManagerMock, new \Server_Account()];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -711,7 +698,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testchangeAccountPasswordMissingParams()
     {
-        $data = array();
+        $data = [];
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
 
@@ -725,10 +712,10 @@ class ServiceTest extends \BBTestCase {
 
     public function testsync()
     {
-        $data = array(
+        $data = [
             'password' => 'topsecret',
             'password_confirm' => 'topsecret',
-        );
+        ];
 
         $orderModel = new \Model_ClientOrder();
         $orderModel->loadBean(new \DummyBean());
@@ -736,8 +723,8 @@ class ServiceTest extends \BBTestCase {
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('_getAM'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['_getAM'])
             ->getMock();
 
         $accountObj = new \Server_Account();
@@ -751,12 +738,12 @@ class ServiceTest extends \BBTestCase {
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('synchronizeAccount')
-            ->will($this->returnValue($accountObj2));
+            ->willReturn($accountObj2);
 
-        $AMresultArray = array($serverManagerMock, $accountObj);
+        $AMresultArray = [$serverManagerMock, $accountObj];
         $serviceMock->expects($this->atLeastOnce())
             ->method('_getAM')
-            ->will($this->returnValue($AMresultArray));
+            ->willReturn($AMresultArray);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -783,7 +770,6 @@ class ServiceTest extends \BBTestCase {
         $hostingHp = new \Model_ServiceHostingHp();
         $hostingHp->loadBean(new \DummyBean());
 
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
@@ -797,8 +783,8 @@ class ServiceTest extends \BBTestCase {
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-        $di['server_manager'] = $di->protect(fn($manager, $config) => $serverManagerCustomMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
+        $di['server_manager'] = $di->protect(fn ($manager, $config) => $serverManagerCustomMock);
 
         $this->service->setDi($di);
 
@@ -808,10 +794,10 @@ class ServiceTest extends \BBTestCase {
 
     public function testupdate()
     {
-        $data = array(
+        $data = [
             'username' => 'testUser',
             'ip' => '1.1.1.1',
-        );
+        ];
         $model = new \Model_ServiceHosting();
         $model->loadBean(new \DummyBean());
 
@@ -838,9 +824,9 @@ class ServiceTest extends \BBTestCase {
     {
         $manager = 'Custom';
 
-        $expected = array(
-            'label' => "Custom Server Manager"
-        );
+        $expected = [
+            'label' => 'Custom Server Manager',
+        ];
 
         $result = $this->service->getServerManagerConfig($manager);
         $this->assertIsArray($result);
@@ -849,25 +835,25 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetServerPairs()
     {
-        $expected = array(
+        $expected = [
             '1' => 'name',
             '2' => 'ding',
-        );
+        ];
 
-        $queryResult = array(
-            array(
+        $queryResult = [
+            [
                 'id' => 1,
-                'name' => 'name'
-            ),array(
+                'name' => 'name',
+            ], [
                 'id' => 2,
-                'name' => 'ding'
-            ),
-        );
+                'name' => 'ding',
+            ],
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($queryResult));
+            ->willReturn($queryResult);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -880,27 +866,26 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetServerSearchQuery()
     {
-        $result = $this->service->getServersSearchQuery(array());
+        $result = $this->service->getServersSearchQuery([]);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
-        $this->assertEquals(array(), $result[1]);
+        $this->assertEquals([], $result[1]);
     }
 
     public function testcreateServer()
     {
-
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
 
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($hostingServerModel));
+            ->willReturn($hostingServerModel);
 
         $newId = 1;
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -911,7 +896,7 @@ class ServiceTest extends \BBTestCase {
         $name = 'newSuperFastServer';
         $ip = '1.1.1.1';
         $manager = 'Custom';
-        $data = array();
+        $data = [];
         $result = $this->service->createServer($name, $ip, $manager, $data);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
@@ -937,7 +922,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testupdateServer()
     {
-        $data = array(
+        $data = [
             'name' => 'newName',
             'ip' => '1.1.1.1',
             'hostname' => 'unknownStar',
@@ -953,7 +938,7 @@ class ServiceTest extends \BBTestCase {
             'accesshash' => 'secret',
             'port' => '23',
             'secure' => 0,
-        );
+        ];
 
         $hostingServerModel = new \Model_ServiceHostingServer();
         $hostingServerModel->loadBean(new \DummyBean());
@@ -965,7 +950,6 @@ class ServiceTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
-
 
         $this->service->setDi($di);
 
@@ -982,7 +966,7 @@ class ServiceTest extends \BBTestCase {
         $serverManagerCustom = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
 
         $di = new \Pimple\Container();
-        $di['server_manager'] = $di->protect(fn($manager, $config) => $serverManagerCustom);
+        $di['server_manager'] = $di->protect(fn ($manager, $config) => $serverManagerCustom);
         $this->service->setDi($di);
 
         $result = $this->service->getServerManager($hostingServerModel);
@@ -1007,7 +991,7 @@ class ServiceTest extends \BBTestCase {
         $hostingServerModel->manager = 'Custom';
 
         $di = new \Pimple\Container();
-        $di['server_manager'] = $di->protect(fn($manager, $config) => null);
+        $di['server_manager'] = $di->protect(fn ($manager, $config) => null);
         $this->service->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
@@ -1020,43 +1004,43 @@ class ServiceTest extends \BBTestCase {
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('testConnection')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('getServerManager'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getServerManager'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerManager')
-            ->will($this->returnValue($serverManagerMock));
+            ->willReturn($serverManagerMock);
 
         $hostingServerModel = new \Model_ServiceHostingServer();
-        $result = $serviceMock->testConnection($hostingServerModel );
+        $result = $serviceMock->testConnection($hostingServerModel);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
     public function testgetHpPairs()
     {
-        $expected = array(
+        $expected = [
             '1' => 'free',
             '2' => 'paid',
-        );
+        ];
 
-        $queryResult = array(
-            array(
+        $queryResult = [
+            [
                 'id' => 1,
-                'name' => 'free'
-            ),array(
+                'name' => 'free',
+            ], [
                 'id' => 2,
-                'name' => 'paid'
-            ),
-        );
+                'name' => 'paid',
+            ],
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($queryResult));
+            ->willReturn($queryResult);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -1069,10 +1053,10 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetHpSearchQuery()
     {
-        $result = $this->service->getServersSearchQuery(array());
+        $result = $this->service->getServersSearchQuery([]);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
-        $this->assertEquals(array(), $result[1]);
+        $this->assertEquals([], $result[1]);
     }
 
     public function testdeleteHp()
@@ -1104,7 +1088,7 @@ class ServiceTest extends \BBTestCase {
 
     public function testUpdateHp()
     {
-        $data = array(
+        $data = [
             'name' => 'firstPlan',
             'bandwidth' => '100000',
             'quota' => '1000',
@@ -1114,7 +1098,7 @@ class ServiceTest extends \BBTestCase {
             'max_pop' => '1',
             'max_sub' => '2',
             'max_park' => '1',
-        );
+        ];
 
         $model = new \Model_ServiceHostingHp();
         $model->loadBean(new \DummyBean());
@@ -1129,7 +1113,6 @@ class ServiceTest extends \BBTestCase {
 
         $this->service->setDi($di);
 
-
         $result = $this->service->updateHp($model, $data);
         $this->assertTrue($result);
     }
@@ -1142,9 +1125,9 @@ class ServiceTest extends \BBTestCase {
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
-            ->method('dispense')->will($this->returnValue($model));
+            ->method('dispense')->willReturn($model);
         $dbMock->expects($this->atLeastOnce())
-            ->method('store')->will($this->returnValue($newId));
+            ->method('store')->willReturn($newId);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -1152,7 +1135,7 @@ class ServiceTest extends \BBTestCase {
 
         $this->service->setDi($di);
 
-        $result = $this->service->createHp('Free Plan', array());
+        $result = $this->service->createHp('Free Plan', []);
         $this->assertIsInt($result);
         $this->assertEquals($newId, $result);
     }
@@ -1177,26 +1160,24 @@ class ServiceTest extends \BBTestCase {
         $hostingServerModel->loadBean(new \DummyBean());
         $hostingServerModel->manager = 'Custom';
 
-
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
 
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('getServerManager'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getServerManager'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerManager')
-            ->will($this->returnValue($serverManagerMock));
-
+            ->willReturn($serverManagerMock);
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getLogger')
-            ->will($this->returnValue(new \Box_Log()));
+            ->willReturn(new \Box_Log());
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $serviceMock->setDi($di);
         $result = $serviceMock->getServerManagerWithLog($hostingServerModel, $clientOrderModel);
@@ -1212,17 +1193,17 @@ class ServiceTest extends \BBTestCase {
         $serverManagerMock = $this->getMockBuilder('\Server_Manager_Custom')->disableOriginalConstructor()->getMock();
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('getLoginUrl')
-            ->will($this->returnValue('/login'));
+            ->willReturn('/login');
         $serverManagerMock->expects($this->atLeastOnce())
             ->method('getResellerLoginUrl')
-            ->will($this->returnValue('/admin/login'));
+            ->willReturn('/admin/login');
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('getServerManager'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getServerManager'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerManager')
-            ->will($this->returnValue($serverManagerMock));
+            ->willReturn($serverManagerMock);
 
         $result = $serviceMock->getMangerUrls($hostingServerModel);
         $this->assertIsArray($result);
@@ -1236,8 +1217,8 @@ class ServiceTest extends \BBTestCase {
         $hostingServerModel->loadBean(new \DummyBean());
         $hostingServerModel->manager = 'Custom';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)
-            ->onlyMethods(array('getServerManager'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getServerManager'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getServerManager')
@@ -1249,9 +1230,9 @@ class ServiceTest extends \BBTestCase {
         $this->assertFalse($result[1]);
     }
 
-    public function testgetFreeTlds_FreeTldsAreNotSet()
+    public function testgetFreeTldsFreeTldsAreNotSet()
     {
-        $config  = array();
+        $config = [];
         $di = new \Pimple\Container();
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
@@ -1259,14 +1240,12 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($config);
         $di['tools'] = $toolsMock;
 
-
-
-        $tldArray = array('tld' => '.com');
+        $tldArray = ['tld' => '.com'];
         $serviceDomainServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)->getMock();
         $serviceDomainServiceMock->expects($this->atLeastOnce())
             ->method('tldToApiArray')
             ->willReturn($tldArray);
-        $di['mod_service'] = $di->protect(fn() => $serviceDomainServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $serviceDomainServiceMock);
 
         $tldModel = new \Model_Tld();
         $tldModel->loadBean(new \DummyBean());
@@ -1274,7 +1253,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->willReturn(array($tldModel));
+            ->willReturn([$tldModel]);
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -1282,22 +1261,19 @@ class ServiceTest extends \BBTestCase {
         $model->loadBean(new \DummyBean());
         $result = $this->service->getFreeTlds($model);
         $this->assertIsArray($result);
-
     }
 
     public function testgetFreeTlds()
     {
-        $config  = array(
-            'free_tlds' => array('.com'),
-        );
+        $config = [
+            'free_tlds' => ['.com'],
+        ];
         $di = new \Pimple\Container();
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('decodeJ')
             ->willReturn($config);
         $di['tools'] = $toolsMock;
-
-
 
         $this->service->setDi($di);
         $model = new \Model_Product();
@@ -1306,7 +1282,4 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
     }
-
-
-
 }

--- a/tests/modules/Servicelicense/Api/AdminTest.php
+++ b/tests/modules/Servicelicense/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicelicense\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicelicense\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Servicelicense\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,47 +22,47 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testplugin_get_pairs()
+    public function testpluginGetPairs()
     {
         $licensePluginArray[]['filename'] = 'plugin1';
         $licensePluginArray[]['filename'] = 'plugin2';
         $licensePluginArray[]['filename'] = 'plugin3';
 
-        $expected = array(
+        $expected = [
             'plugin1' => 'plugin1',
             'plugin2' => 'plugin2',
             'plugin3' => 'plugin3',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getLicensePlugins')
-            ->will($this->returnValue($licensePluginArray));
+            ->willReturn($licensePluginArray);
 
         $this->api->setService($serviceMock);
 
-        $result = $this->api->plugin_get_pairs(array());
+        $result = $this->api->plugin_get_pairs([]);
         $this->assertIsArray($result);
         $this->assertEquals($expected, $result);
     }
 
     public function testupdate()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue(new \Model_ServiceLicense()));
+            ->willReturn(new \Model_ServiceLicense());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
         $result = $apiMock->update($data);
@@ -74,21 +73,21 @@ class AdminTest extends \BBTestCase {
 
     public function testreset()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue(new \Model_ServiceLicense()));
+            ->willReturn(new \Model_ServiceLicense());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('reset')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
         $result = $apiMock->reset($data);
@@ -97,19 +96,19 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function test_getService()
+    public function testGetService()
     {
         $data['order_id'] = 1;
 
-        $orderServiceMock= $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
+        $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceLicense()));
+            ->willReturn(new \Model_ServiceLicense());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -118,7 +117,7 @@ class AdminTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
 
@@ -126,19 +125,19 @@ class AdminTest extends \BBTestCase {
         $this->assertInstanceOf('\Model_ServiceLicense', $result);
     }
 
-    public function test_getServiceOrderNotActivated()
+    public function testGetServiceOrderNotActivated()
     {
         $data['order_id'] = 1;
 
-        $orderServiceMock= $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
+        $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -147,7 +146,7 @@ class AdminTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
 
@@ -155,7 +154,4 @@ class AdminTest extends \BBTestCase {
         $this->expectExceptionMessage('Order is not activated');
         $this->api->_getService($data);
     }
-
-
-
 }

--- a/tests/modules/Servicelicense/Api/ClientTest.php
+++ b/tests/modules/Servicelicense/Api/ClientTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicelicense\Api;
 
-
-class ClientTest extends \BBTestCase {
+class ClientTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicelicense\Api\Client
+     * @var Client
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Servicelicense\Api\Client();
+        $this->api = new Client();
     }
 
     public function testgetDi()
@@ -25,21 +24,21 @@ class ClientTest extends \BBTestCase {
 
     public function testreset()
     {
-        $data = array(
+        $data = [
             'order_id' => 1,
-        );
+        ];
 
-        $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Api\Admin::class)
-            ->onlyMethods(array('_getService'))
+        $apiMock = $this->getMockBuilder('\\' . Admin::class)
+            ->onlyMethods(['_getService'])
             ->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('_getService')
-            ->will($this->returnValue(new \Model_ServiceLicense()));
+            ->willReturn(new \Model_ServiceLicense());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('reset')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $apiMock->setService($serviceMock);
         $result = $apiMock->reset($data);
@@ -48,20 +47,20 @@ class ClientTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function test_getService()
+    public function testGetService()
     {
         $data['order_id'] = 1;
 
-        $orderServiceMock= $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
+        $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(new \Model_ServiceLicense()));
+            ->willReturn(new \Model_ServiceLicense());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
             ->with('ClientOrder')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -70,7 +69,7 @@ class ClientTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
 
@@ -82,20 +81,20 @@ class ClientTest extends \BBTestCase {
         $this->assertInstanceOf('\Model_ServiceLicense', $result);
     }
 
-    public function test_getServiceOrderNotActivated()
+    public function testGetServiceOrderNotActivated()
     {
         $data['order_id'] = 1;
 
-        $orderServiceMock= $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
+        $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
             ->with('ClientOrder')
-            ->will($this->returnValue(new \Model_ClientOrder()));
+            ->willReturn(new \Model_ClientOrder());
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -104,7 +103,7 @@ class ClientTest extends \BBTestCase {
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->api->setDi($di);
 

--- a/tests/modules/Servicelicense/Api/GuestTest.php
+++ b/tests/modules/Servicelicense/Api/GuestTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicelicense\Api;
 
-
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Servicelicense\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Servicelicense\Api\Guest();
+        $this->api = new Guest();
     }
 
     public function testgetDi()
@@ -25,22 +24,22 @@ class GuestTest extends \BBTestCase {
 
     public function testcheckLicenseDetails()
     {
-        $data = array(
+        $data = [
             'license' => 'license1234',
             'host' => 'fossbilling.org',
             'version' => 1,
-        );
+        ];
 
-        $licenseResult =  array(
+        $licenseResult = [
             'licensed_to' => 'fossbilling.org',
             'created_at' => '2011-12-31',
             'expires_at' => '2020-01+01',
             'valid' => true,
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('checkLicenseDetails')
-            ->will($this->returnValue($licenseResult));
+            ->willReturn($licenseResult);
 
         $this->api->setService($serviceMock);
         $result = $this->api->check($data);
@@ -48,4 +47,3 @@ class GuestTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 }
- 

--- a/tests/modules/Servicelicense/ServiceTest.php
+++ b/tests/modules/Servicelicense/ServiceTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Servicelicense;
-
 
 class ServiceTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Servicelicense\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\Servicelicense\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -29,11 +27,11 @@ class ServiceTest extends \BBTestCase
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $productModel->config = '{}';
-        $data                 = array();
+        $data = [];
 
         $result = $this->service->attachOrderConfig($productModel, $data);
         $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
     public function testattachOrderConfig()
@@ -41,8 +39,8 @@ class ServiceTest extends \BBTestCase
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
         $productModel->config = '["hello", "world"]';
-        $data                 = array('testing' => 'phase');
-        $expected             = array_merge(json_decode($productModel->config, 1), $data);
+        $data = ['testing' => 'phase'];
+        $expected = array_merge(json_decode($productModel->config, 1), $data);
 
         $result = $this->service->attachOrderConfig($productModel, $data);
         $this->assertIsArray($result);
@@ -55,7 +53,7 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testaction_create()
+    public function testactionCreate()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -66,16 +64,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -83,7 +81,7 @@ class ServiceTest extends \BBTestCase
         $this->assertInstanceOf('\Model_ServiceLicense', $result);
     }
 
-    public function testaction_activate()
+    public function testactionActivate()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -95,19 +93,18 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
-
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -115,7 +112,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testaction_activateLicenseCollision()
+    public function testactionActivateLicenseCollision()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -127,10 +124,10 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array('iterations' =>3)));
+            ->willReturn(['iterations' => 3]);
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
@@ -139,9 +136,9 @@ class ServiceTest extends \BBTestCase
             ->method('findOne')
             ->will($this->onConsecutiveCalls($serviceLicenseModel, $serviceLicenseModel, null));
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -149,7 +146,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testaction_activateLicenseCollisionMaxIterationsException()
+    public function testactionActivateLicenseCollisionMaxIterationsException()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -161,21 +158,21 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->never())
             ->method('store');
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -184,7 +181,7 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testaction_activatePluginNotFound()
+    public function testactionActivatePluginNotFound()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -196,13 +193,13 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -211,7 +208,7 @@ class ServiceTest extends \BBTestCase
         $this->service->action_activate($clientOrderModel);
     }
 
-    public function testaction_activateOrderActivationException()
+    public function testactionActivateOrderActivationException()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -219,13 +216,13 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -234,7 +231,7 @@ class ServiceTest extends \BBTestCase
         $this->service->action_activate($clientOrderModel);
     }
 
-    public function testaction_delete()
+    public function testactionDelete()
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
@@ -245,15 +242,15 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getOrderService')
-            ->will($this->returnValue($serviceLicenseModel));
+            ->willReturn($serviceLicenseModel);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $this->service->action_delete($clientOrderModel);
@@ -272,9 +269,9 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = new \Box_Log();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
         $di['events_manager'] = $eventMock;
 
         $this->service->setDi($di);
@@ -291,14 +288,13 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
 
-
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getServiceOrder')
-            ->will($this->returnValue($clientOrderModel));
+            ->willReturn($clientOrderModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->isLicenseActive($serviceLicenseModel);
@@ -313,10 +309,10 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getServiceOrder')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
         $result = $this->service->isLicenseActive($serviceLicenseModel);
@@ -328,13 +324,13 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->ips = '{}';
-        $value                    = '1.1.1.1';
+        $value = '1.1.1.1';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -343,18 +339,18 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidIp_test2()
+    public function testisValidIpTest2()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->ips = '["2.2.2.2"]';
-        $value                    = '1.1.1.1';
+        $value = '1.1.1.1';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -363,13 +359,13 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidIp_test3()
+    public function testisValidIpTest3()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
-        $serviceLicenseModel->ips         = '["2.2.2.2"]';
+        $serviceLicenseModel->ips = '["2.2.2.2"]';
         $serviceLicenseModel->validate_ip = '3.3.3.3';
-        $value                            = '1.1.1.1';
+        $value = '1.1.1.1';
 
         $result = $this->service->isValidIp($serviceLicenseModel, $value);
         $this->assertFalse($result);
@@ -380,13 +376,13 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->versions = '{}';
-        $value                         = '1.0';
+        $value = '1.0';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -395,18 +391,18 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidVersion_test2()
+    public function testisValidVersionTest2()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->versions = '["2.0"]';
-        $value                         = '1.0';
+        $value = '1.0';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -415,13 +411,13 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidVersion_test3()
+    public function testisValidVersionTest3()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
-        $serviceLicenseModel->versions         = '["2.0"]';
+        $serviceLicenseModel->versions = '["2.0"]';
         $serviceLicenseModel->validate_version = '3.3.3.3';
-        $value                                 = '1.0';
+        $value = '1.0';
 
         $result = $this->service->isValidVersion($serviceLicenseModel, $value);
         $this->assertFalse($result);
@@ -432,13 +428,13 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->paths = '{}';
-        $value                      = '/var';
+        $value = '/var';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -447,18 +443,18 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidPath_test2()
+    public function testisValidPathTest2()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->paths = '["/"]';
-        $value                      = '/var';
+        $value = '/var';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -467,13 +463,13 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidPath_test3()
+    public function testisValidPathTest3()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
-        $serviceLicenseModel->paths         = '["/"]';
+        $serviceLicenseModel->paths = '["/"]';
         $serviceLicenseModel->validate_path = '/user';
-        $value                              = '/var';
+        $value = '/var';
 
         $result = $this->service->isValidPath($serviceLicenseModel, $value);
         $this->assertFalse($result);
@@ -484,13 +480,13 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->hosts = '{}';
-        $value                      = 'site.com';
+        $value = 'site.com';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -499,18 +495,18 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidHost_test2()
+    public function testisValidHostTest2()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
         $serviceLicenseModel->hosts = '["fossbilling.org"]';
-        $value                      = 'site.com';
+        $value = 'site.com';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -519,13 +515,13 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testisValidHost_test3()
+    public function testisValidHostTest3()
     {
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
-        $serviceLicenseModel->hosts         = '["fossbilling.org"]';
+        $serviceLicenseModel->hosts = '["fossbilling.org"]';
         $serviceLicenseModel->validate_host = 'example.com';
-        $value                              = 'site.com';
+        $value = 'site.com';
 
         $result = $this->service->isValidHost($serviceLicenseModel, $value);
         $this->assertFalse($result);
@@ -546,7 +542,7 @@ class ServiceTest extends \BBTestCase
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
         $clientModel->first_name = 'John';
-        $clientModel->last_name  = 'Smith';
+        $clientModel->last_name = 'Smith';
 
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
@@ -556,9 +552,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($clientModel));
+            ->willReturn($clientModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -570,7 +566,7 @@ class ServiceTest extends \BBTestCase
 
     public function testgetExpirationDate()
     {
-        $expected         = '2004-02-12 15:19:21';
+        $expected = '2004-02-12 15:19:21';
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
         $clientOrderModel->expires_at = $expected;
@@ -581,10 +577,10 @@ class ServiceTest extends \BBTestCase
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('getServiceOrder')
-            ->will($this->returnValue($clientOrderModel));
+            ->willReturn($clientOrderModel);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
@@ -598,19 +594,19 @@ class ServiceTest extends \BBTestCase
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
 
-        $expected = array(
-            'license_key'      => '',
-            'validate_ip'      => '',
-            'validate_host'    => '',
+        $expected = [
+            'license_key' => '',
+            'validate_ip' => '',
+            'validate_host' => '',
             'validate_version' => '',
-            'validate_path'    => '',
-            'ips'              => '',
-            'hosts'            => '',
-            'paths'            => '',
-            'versions'         => '',
-            'pinged_at'        => '',
-            'plugin'           => '',
-        );
+            'validate_path' => '',
+            'ips' => '',
+            'hosts' => '',
+            'paths' => '',
+            'versions' => '',
+            'pinged_at' => '',
+            'plugin' => '',
+        ];
 
         $result = $this->service->toApiArray($serviceLicenseModel, false, new \Model_Admin());
         $this->assertIsArray($result);
@@ -619,16 +615,16 @@ class ServiceTest extends \BBTestCase
 
     public function testupdate()
     {
-        $data                = array(
-            'license_key'      => '123456Licence',
-            'validate_ip'      => '1.1.1.1',
-            'validate_host'    => 'fossbilling.org',
+        $data = [
+            'license_key' => '123456Licence',
+            'validate_ip' => '1.1.1.1',
+            'validate_host' => 'fossbilling.org',
             'validate_version' => '1.0',
-            'validate_path'    => '/usr',
-            'ips'              => '2.2.2.2\n',
-            'pinged_at'        => '',
-            'plugin'           => 'Simple',
-        );
+            'validate_path' => '/usr',
+            'ips' => '2.2.2.2\n',
+            'pinged_at' => '',
+            'plugin' => 'Simple',
+        ];
         $serviceLicenseModel = new \Model_ServiceLicense();
         $serviceLicenseModel->loadBean(new \DummyBean());
 
@@ -636,9 +632,8 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
 
         $this->service->setDi($di);
         $result = $this->service->update($serviceLicenseModel, $data);
@@ -653,21 +648,21 @@ class ServiceTest extends \BBTestCase
         $loggerMock->expects($this->atLeastOnce())
             ->method('setChannel');
 
-        $data = array(
+        $data = [
             'format' => 2,
-        );
+        ];
 
-        $licenseServerMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Server::class)
+        $licenseServerMock = $this->getMockBuilder('\\' . Server::class)
             ->disableOriginalConstructor()
             ->getMock();
         $licenseServerMock->expects($this->atLeastOnce())
             ->method('process')
-            ->willReturn(array());
+            ->willReturn([]);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = $loggerMock;
+        $di = new \Pimple\Container();
+        $di['logger'] = $loggerMock;
         $di['license_server'] = $licenseServerMock;
-        $di['config']         = array('debug_and_monitoring' => ['debug' => false]);
+        $di['config'] = ['debug_and_monitoring' => ['debug' => false]];
         $this->service->setDi($di);
 
         $result = $this->service->checkLicenseDetails($data);
@@ -684,19 +679,19 @@ class ServiceTest extends \BBTestCase
         $loggerMock->expects($this->atLeastOnce())
             ->method('setChannel');
 
-        $data = array();
+        $data = [];
 
-        $licenseServerMock = $this->getMockBuilder('\\' . \Box\Mod\Servicelicense\Server::class)
+        $licenseServerMock = $this->getMockBuilder('\\' . Server::class)
             ->disableOriginalConstructor()
             ->getMock();
         $licenseServerMock->expects($this->atLeastOnce())
             ->method('process')
-            ->willReturn(array());
+            ->willReturn([]);
 
-        $di                   = new \Pimple\Container();
-        $di['logger']         = $loggerMock;
+        $di = new \Pimple\Container();
+        $di['logger'] = $loggerMock;
         $di['license_server'] = $licenseServerMock;
-        $di['config']         = array('debug_and_monitoring' => ['debug' => false]);
+        $di['config'] = ['debug_and_monitoring' => ['debug' => false]];
         $this->service->setDi($di);
 
         $result = $this->service->checkLicenseDetails($data);

--- a/tests/modules/Spamchecker/Api/GuestTest.php
+++ b/tests/modules/Spamchecker/Api/GuestTest.php
@@ -2,17 +2,16 @@
 
 namespace Box\Mod\Spamchecker\Api;
 
-
 class GuestTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\Spamchecker\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api = new \Box\Mod\Spamchecker\Api\Guest();
+        $this->api = new Guest();
     }
 
     public function testgetDi()
@@ -25,66 +24,62 @@ class GuestTest extends \BBTestCase
 
     public static function datarecaptchaConfig()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'captcha_recaptcha_publickey' => 1234,
                     'captcha_enabled' => true,
-                ),
-                array(
+                ],
+                [
                     'publickey' => 1234,
                     'enabled' => true,
-                    'version' => null
-                ),
-            ),
-            array(
-                array(
-
+                    'version' => null,
+                ],
+            ],
+            [
+                [
                     'captcha_enabled' => true,
-                ),
-                array(
+                ],
+                [
                     'publickey' => null,
                     'enabled' => true,
-                    'version' => null
-                ),
-            ),
-            array(
-                array(
+                    'version' => null,
+                ],
+            ],
+            [
+                [
                     'captcha_recaptcha_publickey' => 1234,
                     'captcha_enabled' => false,
-                    'captcha_version' => 2
-                ),
-                array(
+                    'captcha_version' => 2,
+                ],
+                [
                     'publickey' => 1234,
                     'enabled' => false,
-                    'version' => 2
-                ),
-            ),
-            array(
-                array(
+                    'version' => 2,
+                ],
+            ],
+            [
+                [
                     'captcha_enabled' => false,
-                ),
-                array(
+                ],
+                [
                     'publickey' => null,
                     'enabled' => false,
-                    'version' => null
-                ),
-            ),
-        );
+                    'version' => null,
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('datarecaptchaConfig')]
     public function testrecaptcha($config, $expected)
     {
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(fn() => $config);
-
+        $di['mod_config'] = $di->protect(fn () => $config);
 
         $this->api->setDi($di);
-        $result = $this->api->recaptcha(array());
+        $result = $this->api->recaptcha([]);
 
         $this->assertEquals($expected, $result);
-
-
     }
 }

--- a/tests/modules/Spamchecker/ServiceTest.php
+++ b/tests/modules/Spamchecker/ServiceTest.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Spamchecker;
 
-
-class ServiceTest extends \BBTestCase {
-
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Spamchecker\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Spamchecker\Service();
+        $this->service = new Service();
     }
 
     public function testgetDi()
@@ -26,14 +24,14 @@ class ServiceTest extends \BBTestCase {
 
     public function testonBeforeClientSignUp()
     {
-        $spamCheckerService = $this->getMockBuilder('\\' . \Box\Mod\Spamchecker\Service::class)->getMock();
+        $spamCheckerService = $this->getMockBuilder('\\' . Service::class)->getMock();
         $spamCheckerService->expects($this->atLeastOnce())
             ->method('isBlockedIp');
         $spamCheckerService->expects($this->atLeastOnce())
             ->method('isSpam');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $spamCheckerService);
+        $di['mod_service'] = $di->protect(fn () => $spamCheckerService);
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()
             ->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -45,14 +43,14 @@ class ServiceTest extends \BBTestCase {
 
     public function testonBeforeGuestPublicTicketOpen()
     {
-        $spamCheckerService = $this->getMockBuilder('\\' . \Box\Mod\Spamchecker\Service::class)->getMock();
+        $spamCheckerService = $this->getMockBuilder('\\' . Service::class)->getMock();
         $spamCheckerService->expects($this->atLeastOnce())
             ->method('isBlockedIp');
         $spamCheckerService->expects($this->atLeastOnce())
             ->method('isSpam');
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $spamCheckerService);
+        $di['mod_service'] = $di->protect(fn () => $spamCheckerService);
         $boxEventMock = $this->getMockBuilder('\Box_Event')->disableOriginalConstructor()
             ->getMock();
         $boxEventMock->expects($this->atLeastOnce())
@@ -62,14 +60,13 @@ class ServiceTest extends \BBTestCase {
         $this->service->onBeforeGuestPublicTicketOpen($boxEventMock);
     }
 
-    public function testisBlockedIp_IpBlocked()
+    public function testisBlockedIpIpBlocked()
     {
         $clientIp = '1.1.1.1';
-        $modConfig = array(
+        $modConfig = [
             'block_ips' => true,
-            'blocked_ips' => '1.1.1.1'.PHP_EOL.'2.2.2.2',
-        );
-
+            'blocked_ips' => '1.1.1.1' . PHP_EOL . '2.2.2.2',
+        ];
 
         $reqMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $reqMock->expects($this->atLeastOnce())
@@ -77,8 +74,8 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($clientIp);
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function($modName) use ($modConfig ){
-            if ($modName == 'Spamchecker'){
+        $di['mod_config'] = $di->protect(function ($modName) use ($modConfig) {
+            if ($modName == 'Spamchecker') {
                 return $modConfig;
             }
         });
@@ -91,18 +88,17 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $this->expectExceptionMessage(sprintf("Your IP address (%s) is blocked. Please contact our support to lift your block.", $clientIp));
+        $this->expectExceptionMessage(sprintf('Your IP address (%s) is blocked. Please contact our support to lift your block.', $clientIp));
         $this->service->isBlockedIp($boxEventMock);
     }
 
-    public function testisBlockedIp_IpNotBlocked()
+    public function testisBlockedIpIpNotBlocked()
     {
         $clientIp = '214.1.4.99';
-        $modConfig = array(
+        $modConfig = [
             'block_ips' => true,
-            'blocked_ips' => '1.1.1.1'.PHP_EOL.'2.2.2.2',
-        );
-
+            'blocked_ips' => '1.1.1.1' . PHP_EOL . '2.2.2.2',
+        ];
 
         $reqMock = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $reqMock->expects($this->atLeastOnce())
@@ -110,8 +106,8 @@ class ServiceTest extends \BBTestCase {
             ->willReturn($clientIp);
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function($modName) use ($modConfig ){
-            if ($modName == 'Spamchecker'){
+        $di['mod_config'] = $di->protect(function ($modName) use ($modConfig) {
+            if ($modName == 'Spamchecker') {
                 return $modConfig;
             }
         });
@@ -126,16 +122,15 @@ class ServiceTest extends \BBTestCase {
         $this->service->isBlockedIp($boxEventMock);
     }
 
-    public function testisBlockedIp_BlockIpsNotEnabled()
+    public function testisBlockedIpBlockIpsNotEnabled()
     {
-        $modConfig = array(
+        $modConfig = [
             'block_ips' => false,
-        );
-
+        ];
 
         $di = new \Pimple\Container();
-        $di['mod_config'] = $di->protect(function($modName) use ($modConfig ){
-            if ($modName == 'Spamchecker'){
+        $di['mod_config'] = $di->protect(function ($modName) use ($modConfig) {
+            if ($modName == 'Spamchecker') {
                 return $modConfig;
             }
         });
@@ -151,16 +146,16 @@ class ServiceTest extends \BBTestCase {
 
     public function dataProviderSpamResponses()
     {
-        return array(
-            array(
-                '{"success" : "true", "username" : {"appears" : "true" }}', 'Your username is blacklisted in the Stop Forum Spam database'
-            ),
-            array(
-                '{"success" : "true", "email" : {"appears" : "true" }}', 'Your e-mail is blacklisted in the Stop Forum Spam database'
-            ),
-            array(
-                '{"success" : "true", "ip" : {"appears" : "true" }}', 'Your IP address is blacklisted in the Stop Forum Spam database'
-            ),
-        );
+        return [
+            [
+                '{"success" : "true", "username" : {"appears" : "true" }}', 'Your username is blacklisted in the Stop Forum Spam database',
+            ],
+            [
+                '{"success" : "true", "email" : {"appears" : "true" }}', 'Your e-mail is blacklisted in the Stop Forum Spam database',
+            ],
+            [
+                '{"success" : "true", "ip" : {"appears" : "true" }}', 'Your IP address is blacklisted in the Stop Forum Spam database',
+            ],
+        ];
     }
 }

--- a/tests/modules/Staff/Api/AdminTest.php
+++ b/tests/modules/Staff/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Staff\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Staff\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Staff\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,37 +22,36 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
+            ->willReturn(['sqlString', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toModel_AdminApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $resultSet = array(
-            'list' => array('id' => 1),
-        );
+        $resultSet = [
+            'list' => ['id' => 1],
+        ];
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
         $di['db'] = $dbMock;
-
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -69,7 +67,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toModel_AdminApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -77,7 +75,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -97,7 +95,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('update')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -105,7 +103,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -126,7 +124,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -134,7 +132,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -148,14 +146,13 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-
-    public function testchange_password()
+    public function testchangePassword()
     {
-        $data = array(
+        $data = [
             'id' => '1',
             'password' => 'test!23A',
             'password_confirm' => 'test!23A',
-        );
+        ];
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -166,12 +163,12 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('changePassword')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -184,13 +181,13 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue(true);
     }
 
-    public function testchange_passwordPasswordDonotMatch()
+    public function testchangePasswordPasswordDonotMatch()
     {
-        $data = array(
+        $data = [
             'id' => '1',
             'password' => 'test!23A',
             'password_confirm' => 'test',
-        );
+        ];
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -207,19 +204,19 @@ class AdminTest extends \BBTestCase {
 
     public function testcreate()
     {
-        $data = array(
+        $data = [
             'admin_group_id' => '1',
             'password' => 'test!23A',
             'email' => 'okey@example.com',
             'name' => 'OkeyTest',
-        );
+        ];
 
         $newStaffId = 1;
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('create')
-            ->will($this->returnValue($newStaffId));
+            ->willReturn($newStaffId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -240,7 +237,7 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newStaffId, $result);
     }
 
-    public function testpermissions_get()
+    public function testpermissionsGet()
     {
         $data['id'] = 1;
 
@@ -250,7 +247,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -258,7 +255,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($staffModel));
+            ->willReturn($staffModel);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -271,18 +268,17 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testpermissions_update()
+    public function testpermissionsUpdate()
     {
-        $data = array(
+        $data = [
             'id' => '1',
             'permissions' => 'default',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('setPermissions')
-            ->will($this->returnValue(true));
-
+            ->willReturn(true);
 
         $staffModel = new \Model_Admin();
         $staffModel->loadBean(new \DummyBean());
@@ -293,7 +289,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($staffModel));
+            ->willReturn($staffModel);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -308,35 +304,34 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testgroup_get_pairs()
+    public function testgroupGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdminGroupPair')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
-        $result = $this->api->group_get_pairs(array());
+        $result = $this->api->group_get_pairs([]);
         $this->assertIsArray($result);
     }
 
-    public function testgroup_get_list()
+    public function testgroupGetList()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getAdminGroupSearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
+            ->willReturn(['sqlString', []]);
 
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
-
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -345,7 +340,7 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testgroup_create()
+    public function testgroupCreate()
     {
         $data['name'] = 'Prime Group';
         $newGroupId = 1;
@@ -353,7 +348,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createGroup')
-            ->will($this->returnValue($newGroupId));
+            ->willReturn($newGroupId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -370,15 +365,14 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($newGroupId, $result);
     }
 
-    public function testgroup_get()
+    public function testgroupGet()
     {
         $data['id'] = '1';
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toAdminGroupApiArray')
-            ->will($this->returnValue(array()));
-
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -386,7 +380,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_AdminGroup()));
+            ->willReturn(new \Model_AdminGroup());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -400,14 +394,14 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testgroup_delete()
+    public function testgroupDelete()
     {
         $data['id'] = '1';
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -415,7 +409,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_AdminGroup()));
+            ->willReturn(new \Model_AdminGroup());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -430,14 +424,14 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testgroup_update()
+    public function testgroupUpdate()
     {
         $data['id'] = '1';
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateGroup')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -445,7 +439,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_AdminGroup()));
+            ->willReturn(new \Model_AdminGroup());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -460,37 +454,36 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testlogin_history_get_list()
+    public function testloginHistoryGetList()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getActivityAdminHistorySearchQuery')
-            ->will($this->returnValue(array('sqlString', array())));
+            ->willReturn(['sqlString', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toActivityAdminHistoryApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $resultSet = array(
-            'list' => array('id' => 1),
-        );
+        $resultSet = [
+            'list' => ['id' => 1],
+        ];
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
         $model = new \Model_ActivityAdminHistory();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
         $di['db'] = $dbMock;
-
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
@@ -499,14 +492,14 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testlogin_history_get()
+    public function testloginHistoryGet()
     {
         $data['id'] = '1';
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('toActivityAdminHistoryApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -514,7 +507,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ActivityAdminHistory()));
+            ->willReturn(new \Model_ActivityAdminHistory());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -528,14 +521,14 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testlogin_history_delete()
+    public function testloginHistoryDelete()
     {
         $data['id'] = '1';
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('deleteLoginHistory')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -543,7 +536,7 @@ class AdminTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_ActivityAdminHistory()));
+            ->willReturn(new \Model_ActivityAdminHistory());
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -558,21 +551,21 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Api\Admin::class)->onlyMethods(array('login_history_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('login_history_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . Admin::class)->onlyMethods(['login_history_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('login_history_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_logs(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_logs(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 }

--- a/tests/modules/Staff/Api/GuestTest.php
+++ b/tests/modules/Staff/Api/GuestTest.php
@@ -7,11 +7,11 @@ class GuestTest extends \BBTestCase
     /**
      * @var \Box\Mod\Staff\Api\Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Staff\Api\Guest();
+        $this->api = new \Box\Mod\Staff\Api\Guest();
     }
 
     public function testgetDi()
@@ -27,7 +27,7 @@ class GuestTest extends \BBTestCase
         $adminId = 1;
 
         $apiMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Api\Guest::class)
-            ->onlyMethods(array('login'))
+            ->onlyMethods(['login'])
             ->getMock();
         $apiMock->expects($this->atLeastOnce())
             ->method('login');
@@ -35,7 +35,7 @@ class GuestTest extends \BBTestCase
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('createAdmin')
-            ->will($this->returnValue($adminId));
+            ->willReturn($adminId);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -44,7 +44,7 @@ class GuestTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -57,30 +57,30 @@ class GuestTest extends \BBTestCase
         $apiMock->setDi($di);
         $apiMock->setService($serviceMock);
 
-        $data = array(
+        $data = [
             'email' => 'example@fossbilling.org',
             'password' => 'EasyToGuess',
-        );
+        ];
         $result = $apiMock->create($data);
         $this->assertTrue($result);
     }
 
-    public function testCreate_Exception()
+    public function testCreateException()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(array(array())));
+            ->willReturn([[]]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->api->setDi($di);
 
-        $data = array(
+        $data = [
             'email' => 'example@fossbilling.org',
             'password' => 'EasyToGuess',
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionCode(55);
@@ -100,7 +100,7 @@ class GuestTest extends \BBTestCase
 
         $guestApi->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $guestApi->login(array());
+        $guestApi->login([]);
     }
 
     /**
@@ -115,7 +115,7 @@ class GuestTest extends \BBTestCase
 
         $guestApi->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
-        $guestApi->login(array('email'=>'email@domain.com'));
+        $guestApi->login(['email' => 'email@domain.com']);
     }
 
     public function testSuccessfulLogin()
@@ -125,13 +125,13 @@ class GuestTest extends \BBTestCase
             ->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('login')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -153,7 +153,7 @@ class GuestTest extends \BBTestCase
         $guestApi->setMod($modMock);
         $guestApi->setService($serviceMock);
         $guestApi->setDi($di);
-        $result = $guestApi->login(array('email'=>'email@domain.com', 'password'=>'pass'));
+        $result = $guestApi->login(['email' => 'email@domain.com', 'password' => 'pass']);
         $this->assertIsArray($result);
     }
 
@@ -162,13 +162,13 @@ class GuestTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')
             ->disableOriginalConstructor()
             ->getMock();
-        $configArr = array(
-            'allowed_ips' => '1.1.1.1'.PHP_EOL.'2.2.2.2',
+        $configArr = [
+            'allowed_ips' => '1.1.1.1' . PHP_EOL . '2.2.2.2',
             'check_ip' => true,
-        );
+        ];
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue($configArr));
+            ->willReturn($configArr);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -191,10 +191,10 @@ class GuestTest extends \BBTestCase
         $this->expectExceptionCode(403);
         $this->expectExceptionMessage(sprintf('You are not allowed to login to admin area from %s address', $ip));
 
-        $data = array(
-            'email'    => 'email@domain.com',
+        $data = [
+            'email' => 'email@domain.com',
             'password' => 'pass',
-        );
+        ];
         $guestApi->login($data);
     }
 }

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -18,39 +18,37 @@ class PdoStatementMock extends \PDOStatement
 
 class ServiceTest extends \BBTestCase
 {
-
     public function testLogin()
     {
-        $email    = 'email@domain.com';
+        $email = 'email@domain.com';
         $password = 'pass';
-        $ip       = '127.0.0.1';
+        $ip = '127.0.0.1';
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
-        $admin->id    = 1;
+        $admin->id = 1;
         $admin->email = $email;
-        $admin->name  = 'Admin';
-        $admin->role  = 'admin';
-
+        $admin->name = 'Admin';
+        $admin->role = 'admin';
 
         $emMock = $this->getMockBuilder('\Box_EventManager')
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($admin));
+            ->willReturn($admin);
 
         $sessionMock = $this->getMockBuilder('\\' . \FOSSBilling\Session::class)
             ->disableOriginalConstructor()
             ->getMock();
         $sessionMock->expects($this->atLeastOnce())
             ->method('set')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authMock->expects($this->atLeastOnce())
@@ -58,51 +56,51 @@ class ServiceTest extends \BBTestCase
             ->with($admin, $password)
             ->willReturn($admin);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
-        $di['session']        = $sessionMock;
-        $di['logger']         = new \Box_Log();
-        $di['auth']           = $authMock;
+        $di['db'] = $dbMock;
+        $di['session'] = $sessionMock;
+        $di['logger'] = new \Box_Log();
+        $di['auth'] = $authMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->login($email, $password, $ip);
 
-        $expected = array(
-            'id'    => 1,
+        $expected = [
+            'id' => 1,
             'email' => $email,
-            'name'  => 'Admin',
-            'role'  => 'admin',
-        );
+            'name' => 'Admin',
+            'role' => 'admin',
+        ];
 
         $this->assertEquals($expected, $result);
     }
 
-    public function testLogin_Exception()
+    public function testLoginException()
     {
-        $email    = 'email@domain.com';
+        $email = 'email@domain.com';
         $password = 'pass';
-        $ip       = '127.0.0.1';
+        $ip = '127.0.0.1';
 
         $emMock = $this->getMockBuilder('\Box_EventManager')
             ->getMock();
         $emMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $emMock;
-        $di['db']             = $dbMock;
+        $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $this->expectException(\FOSSBilling\Exception::class);
@@ -119,12 +117,12 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue($countResult));
+            ->willReturn($countResult);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getAdminsCount();
@@ -138,7 +136,7 @@ class ServiceTest extends \BBTestCase
         $member->loadBean(new \DummyBean());
         $member->role = 'admin';
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
         $result = $service->hasPermission($member, 'example');
         $this->assertTrue($result);
@@ -150,20 +148,20 @@ class ServiceTest extends \BBTestCase
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
-            ->onlyMethods(array('getPermissions'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPermissions'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions');
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(['getSpecificModulePermissions'])->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $extensionServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $extensionServiceMock);
 
         $serviceMock->setDi($di);
 
@@ -177,21 +175,21 @@ class ServiceTest extends \BBTestCase
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
-            ->onlyMethods(array('getPermissions'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPermissions'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions')
-            ->will($this->returnValue(array('cart' => array(), 'client' => array())));
+            ->willReturn(['cart' => [], 'client' => []]);
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(['getSpecificModulePermissions'])->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $extensionServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $extensionServiceMock);
 
         $serviceMock->setDi($di);
 
@@ -205,21 +203,21 @@ class ServiceTest extends \BBTestCase
         $member->loadBean(new \DummyBean());
         $member->role = 'staff';
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
-            ->onlyMethods(array('getPermissions'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPermissions'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPermissions')
-            ->will($this->returnValue(array('example' => array(), 'client' => array())));
+            ->willReturn(['example' => [], 'client' => []]);
 
-        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(array('getSpecificModulePermissions'))->getMock();
+        $extensionServiceMock = $this->getMockBuilder('\Box\Mod\Extension\Service')->onlyMethods(['getSpecificModulePermissions'])->getMock();
         $extensionServiceMock->expects($this->atLeastOnce())
             ->method('getSpecificModulePermissions')
             ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $extensionServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $extensionServiceMock);
 
         $serviceMock->setDi($di);
 
@@ -236,10 +234,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -248,9 +246,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -262,12 +260,12 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientReplyTicket($eventMock);
     }
 
-    public function testonAfterClientReplyTicket_Exception()
+    public function testonAfterClientReplyTicketException()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -276,10 +274,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -289,9 +287,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -303,7 +301,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientReplyTicket($eventMock);
     }
@@ -317,10 +315,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -329,9 +327,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -343,12 +341,12 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientCloseTicket($eventMock);
     }
 
-    public function testonAfterClientCloseTicket_Exception()
+    public function testonAfterClientCloseTicketException()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -357,10 +355,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -370,9 +368,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -384,7 +382,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientCloseTicket($eventMock);
     }
@@ -398,10 +396,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getPublicTicketById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -410,9 +408,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -424,12 +422,12 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterGuestPublicTicketOpen($eventMock);
     }
 
-    public function testonAfterGuestPublicTicketOpen_Exception()
+    public function testonAfterGuestPublicTicketOpenException()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -438,10 +436,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getPublicTicketById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -451,9 +449,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -465,7 +463,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterGuestPublicTicketOpen($eventMock);
     }
@@ -479,10 +477,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getPublicTicketById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -491,9 +489,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -505,12 +503,12 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterGuestPublicTicketReply($eventMock);
     }
 
-    public function testonAfterGuestPublicTicketReply_Exception()
+    public function testonAfterGuestPublicTicketReplyException()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -519,10 +517,10 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getPublicTicketById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -532,9 +530,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
                 return $supportServiceMock;
@@ -546,7 +544,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterGuestPublicTicketReply($eventMock);
     }
@@ -560,7 +558,7 @@ class ServiceTest extends \BBTestCase
         $clientMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientMock->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -569,9 +567,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($clientMock, $emailServiceMock) {
             if ($name == 'client') {
                 return $clientMock;
@@ -583,12 +581,12 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientSignUp($eventMock);
     }
 
-    public function testonAfterClientSignUp_Exception()
+    public function testonAfterClientSignUpException()
     {
         $eventMock = $this->getMockBuilder('\Box_Event')
             ->disableOriginalConstructor()
@@ -597,7 +595,7 @@ class ServiceTest extends \BBTestCase
         $clientMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)->getMock();
         $clientMock->expects($this->atLeastOnce())
             ->method('get')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -607,9 +605,9 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($clientMock, $emailServiceMock) {
             if ($name == 'client') {
                 return $clientMock;
@@ -621,7 +619,7 @@ class ServiceTest extends \BBTestCase
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterClientSignUp($eventMock);
     }
@@ -635,7 +633,7 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
         $emailServiceMock->expects($this->atLeastOnce())
@@ -648,11 +646,11 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'Support') {
                 return $supportServiceMock;
@@ -661,16 +659,16 @@ class ServiceTest extends \BBTestCase
                 return $emailServiceMock;
             }
         });
-        $di['db']          = $dbMock;
+        $di['db'] = $dbMock;
 
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
         $service->setDi($di);
         $service->onAfterGuestPublicTicketClose($eventMock);
     }
 
-    public function testonAfterClientOpenTicket_mod_staff_ticket_open()
+    public function testonAfterClientOpenTicketModStaffTicketOpen()
     {
         $di = new \Pimple\Container();
 
@@ -680,25 +678,24 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue($ticketModel));
+            ->willReturn($ticketModel);
 
-        $supportTicketArray = array();
+        $supportTicketArray = [];
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
             ->willReturn($supportTicketArray);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
 
-        $emailConfig = array(
+        $emailConfig = [
             'to_staff' => true,
             'code' => 'mod_staff_ticket_open',
             'ticket' => $supportTicketArray,
-        );
+        ];
         $emailServiceMock->expects($this->once())
             ->method('sendTemplate')
             ->with($emailConfig)
             ->willReturn(true);
-
 
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
@@ -726,11 +723,11 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->onAfterClientOpenTicket($eventMock);
     }
 
-    public function testonAfterClientOpenTicket_mod_support_helpdesk_ticket_open()
+    public function testonAfterClientOpenTicketModSupportHelpdeskTicketOpen()
     {
         $di = new \Pimple\Container();
 
@@ -740,9 +737,9 @@ class ServiceTest extends \BBTestCase
         $supportServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('getTicketById')
-            ->will($this->returnValue($ticketModel));
+            ->willReturn($ticketModel);
 
-        $supportTicketArray = array();
+        $supportTicketArray = [];
         $supportServiceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
             ->willReturn($supportTicketArray);
@@ -752,16 +749,15 @@ class ServiceTest extends \BBTestCase
         $helpdeskModel->email = 'helpdesk@support.com';
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)->getMock();
-        $emailConfig = array(
+        $emailConfig = [
             'to' => $helpdeskModel->email,
             'code' => 'mod_support_helpdesk_ticket_open',
             'ticket' => $supportTicketArray,
-        );
+        ];
         $emailServiceMock->expects($this->once())
             ->method('sendTemplate')
             ->with($emailConfig)
             ->willReturn(true);
-
 
         $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
             if ($name == 'support') {
@@ -789,7 +785,7 @@ class ServiceTest extends \BBTestCase
         $eventMock->expects($this->atLeastOnce())
             ->method('getparameters');
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->onAfterClientOpenTicket($eventMock);
     }
 
@@ -798,58 +794,57 @@ class ServiceTest extends \BBTestCase
         $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
         $pagerMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
-        $di['pager']     = $pagerMock;
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
 
-
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
-        $result = $service->getList(array());
+        $result = $service->getList([]);
         $this->assertIsArray($result);
     }
 
     public static function searchFilters()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 'SELECT * FROM admin',
-                array()
-            ),
-            array(
-                array('search' => 'keyword'),
+                [],
+            ],
+            [
+                ['search' => 'keyword'],
                 '(name LIKE :name OR email LIKE :email )',
-                array(':name' => '%keyword%', ':email' => '%keyword%')
-            ),
-            array(
-                array('status' => 'active'),
+                [':name' => '%keyword%', ':email' => '%keyword%'],
+            ],
+            [
+                ['status' => 'active'],
                 'status = :status',
-                array(':status' => 'active')
-            ),
-            array(
-                array('no_cron' => 'true'),
+                [':status' => 'active'],
+            ],
+            [
+                ['no_cron' => 'true'],
                 'role != :role',
-                array(':role' => \Model_Admin::ROLE_CRON)
-            ),
-        );
+                [':role' => \Model_Admin::ROLE_CRON],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('searchFilters')]
     public function testgetSearchQuery($data, $expectedStr, $expectedParams)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
-        $service         = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
         $result = $service->getSearchQuery($data);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
 
         $this->assertTrue(str_contains($result[0], $expectedStr), $result[0]);
-        $this->assertTrue(array_diff_key($result[1], $expectedParams) == array());
+        $this->assertTrue(array_diff_key($result[1], $expectedParams) == []);
     }
 
     public function testgetCronAdminAlreadyExists()
@@ -857,15 +852,15 @@ class ServiceTest extends \BBTestCase
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getCronAdmin();
@@ -878,14 +873,14 @@ class ServiceTest extends \BBTestCase
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
@@ -894,12 +889,12 @@ class ServiceTest extends \BBTestCase
         $passwordMock->expects($this->atLeastOnce())
             ->method('hashIt');
 
-        $di             = new \Pimple\Container();
-        $di['db']       = $dbMock;
-        $di['tools']    = new \FOSSBilling\Tools();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['tools'] = new \FOSSBilling\Tools();
         $di['password'] = $passwordMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getCronAdmin();
@@ -907,7 +902,7 @@ class ServiceTest extends \BBTestCase
         $this->assertInstanceOf('\Model_Admin', $result);
     }
 
-    public function testtoModel_AdminApiArray()
+    public function testtoModelAdminApiArray()
     {
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
@@ -915,30 +910,30 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel = new \Model_Admin();
         $adminGroupModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($adminGroupModel));
+            ->willReturn($adminGroupModel);
 
         $expected =
-            array(
-                'id'             => '',
-                'role'           => '',
+            [
+                'id' => '',
+                'role' => '',
                 'admin_group_id' => '',
-                'email'          => '',
-                'name'           => '',
-                'status'         => '',
-                'signature'      => '',
-                'created_at'     => '',
-                'updated_at'     => '',
-                'protected'      => '',
-                'group'          => array('id' => '', 'name' => ''),
-            );
+                'email' => '',
+                'name' => '',
+                'status' => '',
+                'signature' => '',
+                'created_at' => '',
+                'updated_at' => '',
+                'protected' => '',
+                'group' => ['id' => '', 'name' => ''],
+            ];
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
         $result = $service->toModel_AdminApiArray($adminModel);
 
@@ -949,13 +944,13 @@ class ServiceTest extends \BBTestCase
 
     public function testupdate()
     {
-        $data = array(
-            'email'          => 'test@example.com',
+        $data = [
+            'email' => 'test@example.com',
             'admin_group_id' => '1',
-            'name'           => 'testJohn',
-            'status'         => 'active',
-            'signature'      => '1345',
-        );
+            'name' => 'testJohn',
+            'status' => 'active',
+            'signature' => '1345',
+        ];
 
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
@@ -966,20 +961,20 @@ class ServiceTest extends \BBTestCase
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = $logMock;
-        $di['db']             = $dbMock;
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
 
@@ -998,20 +993,20 @@ class ServiceTest extends \BBTestCase
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = $logMock;
-        $di['db']             = $dbMock;
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
 
@@ -1025,7 +1020,7 @@ class ServiceTest extends \BBTestCase
         $adminModel->loadBean(new \DummyBean());
         $adminModel->protected = 1;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('This administrator account is protected and can not be removed');
@@ -1035,7 +1030,7 @@ class ServiceTest extends \BBTestCase
     public function testchangePassword()
     {
         $plainTextPassword = 'password';
-        $adminModel        = new \Model_Admin();
+        $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
 
         $eventsMock = $this->getMockBuilder('\Box_EventManager')->getMock();
@@ -1044,7 +1039,7 @@ class ServiceTest extends \BBTestCase
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
@@ -1056,17 +1051,17 @@ class ServiceTest extends \BBTestCase
         $profileService = $this->getMockBuilder('\\' . \Box\Mod\Profile\Service::class)->getMock();
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = $logMock;
-        $di['db']             = $dbMock;
-        $di['password']       = $passwordMock;
-        $di['mod_service'] = $di->protect(fn() => $profileService);
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
+        $di['password'] = $passwordMock;
+        $di['mod_service'] = $di->protect(fn () => $profileService);
 
         $serviceMock->setDi($di);
 
@@ -1076,13 +1071,13 @@ class ServiceTest extends \BBTestCase
 
     public function testcreate()
     {
-        $data = array(
-            'email'          => 'test@example.com',
+        $data = [
+            'email' => 'test@example.com',
             'admin_group_id' => '1',
-            'name'           => 'testJohn',
-            'status'         => 'active',
-            'password'       => '1345',
-        );
+            'name' => 'testJohn',
+            'status' => 'active',
+            'password' => '1345',
+        ];
 
         $newId = 1;
 
@@ -1097,13 +1092,13 @@ class ServiceTest extends \BBTestCase
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
@@ -1113,18 +1108,18 @@ class ServiceTest extends \BBTestCase
             ->with($data['password']);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = $logMock;
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn() => $systemServiceMock);
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
 
-        $di['password']       = $passwordMock;
+        $di['password'] = $passwordMock;
 
         $serviceMock->setDi($di);
 
@@ -1133,15 +1128,15 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($newId, $result);
     }
 
-    public function testcreate_Exception()
+    public function testcreateException()
     {
-        $data = array(
-            'email'          => 'test@example.com',
+        $data = [
+            'email' => 'test@example.com',
             'admin_group_id' => '1',
-            'name'           => 'testJohn',
-            'status'         => 'active',
-            'password'       => '1345',
-        );
+            'name' => 'testJohn',
+            'status' => 'active',
+            'password' => '1345',
+        ];
 
         $newId = 1;
 
@@ -1156,10 +1151,10 @@ class ServiceTest extends \BBTestCase
         $eventsMock->expects($this->atLeastOnce())
             ->method('fire');
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
             ->willThrowException(new \RedBeanPHP\RedException());
@@ -1172,18 +1167,18 @@ class ServiceTest extends \BBTestCase
             ->with($data['password']);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['events_manager'] = $eventsMock;
-        $di['logger']         = $logMock;
-        $di['db']             = $dbMock;
-        $di['mod_service']    = $di->protect(fn() => $systemServiceMock);
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
 
-        $di['password']       = $passwordMock;
+        $di['password'] = $passwordMock;
 
         $serviceMock->setDi($di);
 
@@ -1195,26 +1190,26 @@ class ServiceTest extends \BBTestCase
 
     public function testcreateAdmin()
     {
-        $data = array(
-            'email'          => 'test@example.com',
+        $data = [
+            'email' => 'test@example.com',
             'admin_group_id' => '1',
-            'name'           => 'testJohn',
-            'status'         => 'active',
-            'password'       => '1345',
-        );
+            'name' => 'testJohn',
+            'status' => 'active',
+            'password' => '1345',
+        ];
 
         $newId = 1;
 
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newId));
+            ->willReturn($newId);
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
@@ -1225,17 +1220,17 @@ class ServiceTest extends \BBTestCase
             ->method('hashIt')
             ->with($data['password']);
 
-        $di                = new \Pimple\Container();
-        $di['logger']      = $logMock;
-        $di['db']          = $dbMock;
+        $di = new \Pimple\Container();
+        $di['logger'] = $logMock;
+        $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(function ($serviceName) use ($systemService) {
-            if ('system' == $serviceName) {
+            if ($serviceName == 'system') {
                 return $systemService;
             }
         });
-        $di['password']    = $passwordMock;
+        $di['password'] = $passwordMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->createAdmin($data);
@@ -1245,31 +1240,31 @@ class ServiceTest extends \BBTestCase
 
     public function testgetAdminGroupPair()
     {
-        $rows = array(
-            array(
-                'id'   => '1',
+        $rows = [
+            [
+                'id' => '1',
                 'name' => 'First Jogh',
-            ),
-            array(
-                'id'   => '2',
+            ],
+            [
+                'id' => '2',
                 'name' => 'Another Smith',
-            ),
-        );
+            ],
+        ];
 
-        $expected = array(
+        $expected = [
             1 => 'First Jogh',
             2 => 'Another Smith',
-        );
+        ];
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($rows));
+            ->willReturn($rows);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->getAdminGroupPair();
@@ -1280,9 +1275,9 @@ class ServiceTest extends \BBTestCase
 
     public function testgetAdminGroupSearchQuery()
     {
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $result = $service->getAdminGroupSearchQuery(array());
+        $result = $service->getAdminGroupSearchQuery([]);
 
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
@@ -1298,24 +1293,24 @@ class ServiceTest extends \BBTestCase
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('checkLimits');
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($adminGroupModel));
+            ->willReturn($adminGroupModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($newGroupId));
+            ->willReturn($newGroupId);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['logger']      = new \Box_Log();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
 
         $serviceMock->setDi($di);
 
@@ -1330,14 +1325,14 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel->loadBean(new \DummyBean());
 
         $expected =
-            array(
-                'id'         => '',
-                'name'       => '',
+            [
+                'id' => '',
+                'name' => '',
                 'created_at' => '',
                 'updated_at' => '',
-            );
+            ];
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
         $result = $service->toAdminGroupApiArray($adminGroupModel);
 
@@ -1350,21 +1345,21 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel = new \Model_AdminGroup();
         $adminGroupModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
@@ -1381,7 +1376,7 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel->id = 1;
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
@@ -1396,18 +1391,18 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel = new \Model_AdminGroup();
         $adminGroupModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
@@ -1422,23 +1417,23 @@ class ServiceTest extends \BBTestCase
         $adminGroupModel = new \Model_AdminGroup();
         $adminGroupModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = new \Box_Log();
 
         $serviceMock->setDi($di);
 
-        $data   = array('name' => 'OhExampleName');
+        $data = ['name' => 'OhExampleName'];
         $result = $serviceMock->updateGroup($adminGroupModel, $data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
@@ -1446,38 +1441,38 @@ class ServiceTest extends \BBTestCase
 
     public static function ActivityAdminHistorySearchFilters()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 'SELECT m.*, a.email, a.name',
-                array()
-            ),
-            array(
-                array('search' => 'keyword'),
+                [],
+            ],
+            [
+                ['search' => 'keyword'],
                 'a.name LIKE :name OR a.id LIKE :id OR a.email LIKE :email',
-                array('name' => '%keyword%', 'id' => '%keyword%', 'email' => '%keyword%')
-            ),
-            array(
-                array('admin_id' => '2'),
+                ['name' => '%keyword%', 'id' => '%keyword%', 'email' => '%keyword%'],
+            ],
+            [
+                ['admin_id' => '2'],
                 'm.admin_id = :admin_id',
-                array('admin_id' => '2')
-            ),
-        );
+                ['admin_id' => '2'],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('ActivityAdminHistorySearchFilters')]
     public function testgetActivityAdminHistorySearchQuery($data, $expectedStr, $expectedParams)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
-        $service         = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
         $result = $service->getActivityAdminHistorySearchQuery($data);
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
 
         $this->assertTrue(str_contains($result[0], $expectedStr), $result[0]);
-        $this->assertTrue(array_diff_key($result[1], $expectedParams) == array());
+        $this->assertTrue(array_diff_key($result[1], $expectedParams) == []);
     }
 
     public function testtoActivityAdminHistoryApiArray()
@@ -1486,31 +1481,30 @@ class ServiceTest extends \BBTestCase
         $adminHistoryModel->loadBean(new \DummyBean());
         $adminHistoryModel->admin_id = 2;
 
-        $expected = array(
-            'id'         => '',
-            'ip'         => '',
+        $expected = [
+            'id' => '',
+            'ip' => '',
             'created_at' => '',
-            'staff'      => array(
-                'id'    => $adminHistoryModel->admin_id,
-                'name'  => '',
+            'staff' => [
+                'id' => $adminHistoryModel->admin_id,
+                'name' => '',
                 'email' => '',
-
-            ),
-        );
+            ],
+        ];
 
         $adminModel = new \Model_Admin();
         $adminModel->loadBean(new \DummyBean());
         $adminModel->id = 2;
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($adminModel));
+            ->willReturn($adminModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
         $result = $service->toActivityAdminHistoryApiArray($adminHistoryModel);
 
@@ -1524,14 +1518,14 @@ class ServiceTest extends \BBTestCase
         $adminHistoryModel = new \Model_ActivityAdminHistory();
         $adminHistoryModel->loadBean(new \DummyBean());
 
-        $dbMock = $this->getMockBuilder(('\Box_Database'))->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash');
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->deleteLoginHistory($adminHistoryModel);
@@ -1540,91 +1534,90 @@ class ServiceTest extends \BBTestCase
 
     public function testsetPermissions()
     {
-        $pdoStatementMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoStatementMock::class)
+        $pdoStatementMock = $this->getMockBuilder('\\' . PdoStatementMock::class)
             ->getMock();
         $pdoStatementMock->expects($this->atLeastOnce())
             ->method('execute');
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatementMock));
+            ->willReturn($pdoStatementMock);
 
         $serviceMock = $this->getMockBuilder('\Box\Mod\Staff\Service')
-            ->onlyMethods(array('hasPermission'))->getMock();
+            ->onlyMethods(['hasPermission'])->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('hasPermission')->willReturn(true);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $serviceMock->setDi($di);
 
         $member_id = 1;
-        $result    = $serviceMock->setPermissions($member_id, array());
+        $result = $serviceMock->setPermissions($member_id, []);
         $this->assertTrue($result);
     }
 
-    public function testgetPermissions_PermAreEmpty()
+    public function testgetPermissionsPermAreEmpty()
     {
-        $pdoStatementMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoStatementMock::class)
+        $pdoStatementMock = $this->getMockBuilder('\\' . PdoStatementMock::class)
             ->getMock();
         $pdoStatementMock->expects($this->atLeastOnce())
             ->method('execute');
         $pdoStatementMock->expects($this->atLeastOnce())
             ->method('fetchColumn')
-            ->will($this->returnValue('{}'));
+            ->willReturn('{}');
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatementMock));
+            ->willReturn($pdoStatementMock);
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $service->setDi($di);
 
         $member_id = 1;
-        $result    = $service->getPermissions($member_id);
+        $result = $service->getPermissions($member_id);
         $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
     public function testgetPermissions()
     {
-        $pdoStatementMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoStatementMock::class)
+        $pdoStatementMock = $this->getMockBuilder('\\' . PdoStatementMock::class)
             ->getMock();
         $pdoStatementMock->expects($this->atLeastOnce())
             ->method('execute');
         $queryResult = '{"id" : "1"}';
         $pdoStatementMock->expects($this->atLeastOnce())
             ->method('fetchColumn')
-            ->will($this->returnValue($queryResult));
+            ->willReturn($queryResult);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatementMock));
+            ->willReturn($pdoStatementMock);
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $service->setDi($di);
 
         $member_id = 1;
-        $expected  = json_decode($queryResult, 1);
-        $result    = $service->getPermissions($member_id);
+        $expected = json_decode($queryResult, 1);
+        $result = $service->getPermissions($member_id);
         $this->assertIsArray($result);
         $this->assertEquals($expected, $result);
     }
 
-
-    public function testauthorizeAdmin_DidntFoundEmail()
+    public function testauthorizeAdminDidntFoundEmail()
     {
-        $email    = 'example@fossbilling.vm';
+        $email = 'example@fossbilling.vm';
         $password = '123456';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
@@ -1633,10 +1626,10 @@ class ServiceTest extends \BBTestCase
             ->with('Admin', 'email = ? AND status = ?')
             ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->authorizeAdmin($email, $password);
@@ -1645,7 +1638,7 @@ class ServiceTest extends \BBTestCase
 
     public function testauthorizeAdmin()
     {
-        $email    = 'example@fossbilling.vm';
+        $email = 'example@fossbilling.vm';
         $password = '123456';
 
         $model = new \Model_Admin();
@@ -1663,11 +1656,11 @@ class ServiceTest extends \BBTestCase
             ->with($model, $password)
             ->willReturn($model);
 
-        $di         = new \Pimple\Container();
-        $di['db']   = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['auth'] = $authMock;
 
-        $service = new \Box\Mod\Staff\Service();
+        $service = new Service();
         $service->setDi($di);
 
         $result = $service->authorizeAdmin($email, $password);

--- a/tests/modules/Staff/ServiceTest.php
+++ b/tests/modules/Staff/ServiceTest.php
@@ -47,8 +47,7 @@ class ServiceTest extends \BBTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $sessionMock->expects($this->atLeastOnce())
-            ->method('set')
-            ->willReturn(null);
+            ->method('set');
 
         $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authMock->expects($this->atLeastOnce())

--- a/tests/modules/Stats/Api/AdminTest.php
+++ b/tests/modules/Stats/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Stats\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Stats\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Stats\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,12 +22,12 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_summary()
+    public function testgetSummary()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSummary')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -36,12 +35,12 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_summary_income()
+    public function testgetSummaryIncome()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSummaryIncome')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -49,172 +48,171 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testget_orders_statuses()
+    public function testgetOrdersStatuses()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getOrdersStatuses')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_orders_statuses($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_product_summary()
+    public function testgetProductSummary()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductSummary')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_product_summary($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_product_sales()
+    public function testgetProductSales()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getProductSales')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_product_sales($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_income_vs_refunds()
+    public function testgetIncomeVsRefunds()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('incomeAndRefundStats')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_income_vs_refunds($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_refunds()
+    public function testgetRefunds()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getRefunds')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_refunds($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_income()
+    public function testgetIncome()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getIncome')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_income($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_orders()
+    public function testgetOrders()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTableStats')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_orders($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_clients()
+    public function testgetClients()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTableStats')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_clients($data);
         $this->assertIsArray($result);
     }
 
-    public function testclient_countries()
+    public function testclientCountries()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getClientCountries')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->client_countries($data);
         $this->assertIsArray($result);
     }
 
-    public function testsales_countries()
+    public function testsalesCountries()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getSalesByCountry')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->sales_countries($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_invoices()
+    public function testgetInvoices()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTableStats')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_invoices($data);
         $this->assertIsArray($result);
     }
 
-    public function testget_tickets()
+    public function testgetTickets()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTableStats')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
-        $data = array();
+        $data = [];
         $result = $this->api->get_tickets($data);
         $this->assertIsArray($result);
     }
 }
- 

--- a/tests/modules/Stats/ServiceTest.php
+++ b/tests/modules/Stats/ServiceTest.php
@@ -1,28 +1,31 @@
 <?php
 
-
 namespace Box\Mod\Stats;
 
 class PdoMock extends \PDO
 {
-    public function __construct (){}
+    public function __construct()
+    {
+    }
 }
 class PdoStatmentsMock extends \PDOStatement
 {
-    public function __construct (){}
+    public function __construct()
+    {
+    }
 }
 
-class ServiceTest extends \BBTestCase {
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Stats\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Stats\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -37,25 +40,25 @@ class ServiceTest extends \BBTestCase {
         $orderServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Order\Service::class)->getMock();
         $orderServiceMock->expects($this->atLeastOnce())
             ->method('counter')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $orderServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $orderServiceMock);
 
         $this->service->setDi($di);
 
-        $result = $this->service->getOrdersStatuses(array());
+        $result = $this->service->getOrdersStatuses([]);
         $this->assertIsArray($result);
     }
 
     public function testgetProductSummary()
     {
-        $data = array();
+        $data = [];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -67,45 +70,45 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetSummary()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
-        $expected = array(
-            'clients_total'       => null,
-            'clients_today'       => null,
-            'clients_yesterday'   => null,
-            'clients_this_month'  => null,
-            'clients_last_month'  => null,
+        $expected = [
+            'clients_total' => null,
+            'clients_today' => null,
+            'clients_yesterday' => null,
+            'clients_this_month' => null,
+            'clients_last_month' => null,
 
-            'orders_total'        => null,
-            'orders_today'        => null,
-            'orders_yesterday'    => null,
-            'orders_this_month'   => null,
-            'orders_last_month'   => null,
+            'orders_total' => null,
+            'orders_today' => null,
+            'orders_yesterday' => null,
+            'orders_this_month' => null,
+            'orders_last_month' => null,
 
-            'invoices_total'      => null,
-            'invoices_today'      => null,
-            'invoices_yesterday'  => null,
+            'invoices_total' => null,
+            'invoices_today' => null,
+            'invoices_yesterday' => null,
             'invoices_this_month' => null,
             'invoices_last_month' => null,
 
-            'tickets_total'       => null,
-            'tickets_today'       => null,
-            'tickets_yesterday'   => null,
-            'tickets_this_month'  => null,
-            'tickets_last_month'  => null,
-        );
+            'tickets_total' => null,
+            'tickets_today' => null,
+            'tickets_yesterday' => null,
+            'tickets_this_month' => null,
+            'tickets_last_month' => null,
+        ];
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchColumn');
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $this->service->setDi($di);
 
@@ -116,29 +119,29 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetSummaryIncome()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchColumn');
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $this->service->setDi($di);
 
-        $expected = array(
-            'total'      => null,
-            'today'      => null,
-            'yesterday'  => null,
+        $expected = [
+            'total' => null,
+            'today' => null,
+            'yesterday' => null,
             'this_month' => null,
             'last_month' => null,
-        );
+        ];
 
         $result = $this->service->getSummaryIncome();
         $this->assertIsArray($result);
@@ -147,201 +150,200 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetProductSales()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
-        $res = array(
+        $res = [
             'testProduct' => 1,
-        );
+        ];
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue($res));
+            ->willReturn($res);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'date_from' => 'yesterday',
             'date_to' => 'now',
-        );
+        ];
         $result = $this->service->getProductSales($data);
         $this->assertIsArray($result);
     }
 
     public function testincomeAndRefundStats()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
-        $res = array(
-            array(
+        $res = [
+            [
                 'refund' => 0,
-                'income' => 0
-            )
-        );
+                'income' => 0,
+            ],
+        ];
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue($res));
+            ->willReturn($res);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
         $this->service->setDi($di);
 
-        $result = $this->service->incomeAndRefundStats(array());
+        $result = $this->service->incomeAndRefundStats([]);
         $this->assertIsArray($result);
         $this->assertEquals($res[0], $result);
     }
 
     public function testgetRefunds()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'date_from' => 'yesterday',
             'date_to' => 'now',
-        );
+        ];
         $result = $this->service->getRefunds($data);
         $this->assertIsArray($result);
     }
 
     public function testgetIncome()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'date_from' => 'yesterday',
             'date_to' => 'now',
-        );
+        ];
         $result = $this->service->getIncome($data);
         $this->assertIsArray($result);
     }
 
     public function testgetClientCountries()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
 
-        $result = $this->service->getClientCountries(array());
+        $result = $this->service->getClientCountries([]);
         $this->assertIsArray($result);
     }
 
     public function testgetSalesByCountry()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
 
-        $result = $this->service->getSalesByCountry(array());
+        $result = $this->service->getSalesByCountry([]);
         $this->assertIsArray($result);
     }
 
     public function testgetTableStats()
     {
-        $pdoStatmentMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoStatmentsMock::class)
+        $pdoStatmentMock = $this->getMockBuilder('\\' . PdoStatmentsMock::class)
             ->getMock();
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('execute');
 
         $pdoStatmentMock->expects($this->atLeastOnce())
             ->method('fetchAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $pdoMock = $this->getMockBuilder('\\' . \Box\Mod\Stats\PdoMock::class)->getMock();
+        $pdoMock = $this->getMockBuilder('\\' . PdoMock::class)->getMock();
         $pdoMock->expects($this->atLeastOnce())
             ->method('prepare')
-            ->will($this->returnValue($pdoStatmentMock));
+            ->willReturn($pdoStatmentMock);
 
-        $di        = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pdo'] = $pdoMock;
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'date_from' => 'yesterday',
             'date_to' => 'now',
-        );
+        ];
         $result = $this->service->getTableStats('TableName', $data);
         $this->assertIsArray($result);
     }
 }
- 

--- a/tests/modules/Support/Api/Api_AdminTest.php
+++ b/tests/modules/Support/Api/Api_AdminTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Box\Tests\Mod\Support\Api;
 
 class Api_AdminTest extends \BBTestCase
@@ -6,222 +7,222 @@ class Api_AdminTest extends \BBTestCase
     /**
      * @var \Box\Mod\Support\Api\Admin
      */
-    protected $adminApi = null;
+    protected $adminApi;
 
     public function setup(): void
     {
         $this->adminApi = new \Box\Mod\Support\Api\Admin();
     }
 
-    public function testTicket_get_list()
+    public function testTicketGetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array('id' => 1),
-            ),
-        );
+        $simpleResultArr = [
+            'list' => [
+                ['id' => 1],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getSearchQuery', 'toApiArray'))->getMock();
+            ->onlyMethods(['getSearchQuery', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_SupportTicket();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['db']    = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->ticket_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTicket_get()
+    public function testTicketGet()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+            ->onlyMethods(['toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->ticket_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTicket_update()
+    public function testTicketUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketUpdate'))->getMock();
+            ->onlyMethods(['ticketUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->adminApi->ticket_update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_message_update()
+    public function testTicketMessageUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicketMessage()));
+            ->willReturn(new \Model_SupportTicketMessage());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketMessageUpdate'))->getMock();
+            ->onlyMethods(['ticketMessageUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketMessageUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id'      => random_int(1, 100),
-            'content' => 'Content'
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'content' => 'Content',
+        ];
         $result = $this->adminApi->ticket_message_update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_delete()
+    public function testTicketDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('rm'))->getMock();
+            ->onlyMethods(['rm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('rm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->ticket_delete($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_reply()
+    public function testTicketReply()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketReply'))->getMock();
+            ->onlyMethods(['ticketReply'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketReply')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'id'      => random_int(1, 100),
-            'content' => 'Content'
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'content' => 'Content',
+        ];
         $result = $this->adminApi->ticket_reply($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_close()
+    public function testTicketClose()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
@@ -229,34 +230,34 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('closeTicket'))->getMock();
+            ->onlyMethods(['closeTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('closeTicket')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->ticket_close($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_closeAlreadyClosed()
+    public function testTicketCloseAlreadyClosed()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
@@ -265,34 +266,34 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('closeTicket'))->getMock();
+            ->onlyMethods(['closeTicket'])->getMock();
         $serviceMock->expects($this->never())->method('closeTicket')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->ticket_close($data);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_create()
+    public function testTicketCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $clientModel = new \Model_Client();
         $clientModel->loadBean(new \DummyBean());
@@ -305,39 +306,39 @@ class Api_AdminTest extends \BBTestCase
             ->method('getExistingModelById')
             ->will($this->onConsecutiveCalls($clientModel, $supportHelpdeskModel));
 
-        $randID      = random_int(1, 100);
+        $randID = random_int(1, 100);
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketCreateForAdmin')
-            ->will($this->returnValue($randID));
+            ->willReturn($randID);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
-            'client_id'           => random_int(1, 100),
-            'content'             => 'Content',
-            'subject'             => 'Subject',
+        $data = [
+            'client_id' => random_int(1, 100),
+            'content' => 'Content',
+            'subject' => 'Subject',
             'support_helpdesk_id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->ticket_create($data);
 
         $this->assertIsInt($result);
         $this->assertEquals($randID, $result);
     }
 
-    public function testBatch_ticket_auto_close()
+    public function testBatchTicketAutoClose()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getExpired', 'autoClose'))->getMock();
+            ->onlyMethods(['getExpired', 'autoClose'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getExpired')
-            ->will($this->returnValue(array(array('id' => 1), array('id' => 2))));
+            ->willReturn([['id' => 1], ['id' => 2]]);
         $serviceMock->expects($this->atLeastOnce())->method('autoClose')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
@@ -346,615 +347,614 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
 
         $this->adminApi->setService($serviceMock);
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->adminApi->setDi($di);
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->batch_ticket_auto_close(array());
+        $result = $this->adminApi->batch_ticket_auto_close([]);
 
         $this->assertTrue($result);
     }
 
-    public function testBatch_ticket_auto_closeNotClosed()
+    public function testBatchTicketAutoCloseNotClosed()
     {
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
         $ticket->id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getExpired', 'autoClose'))->getMock();
+            ->onlyMethods(['getExpired', 'autoClose'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getExpired')
-            ->will($this->returnValue(array(array('id' => 1), array('id' => 2))));
+            ->willReturn([['id' => 1], ['id' => 2]]);
         $serviceMock->expects($this->atLeastOnce())->method('autoClose')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($ticket));
-
+            ->willReturn($ticket);
 
         $this->adminApi->setService($serviceMock);
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
-        $result = $this->adminApi->batch_ticket_auto_close(array());
+        $result = $this->adminApi->batch_ticket_auto_close([]);
 
         $this->assertTrue($result);
     }
 
-    public function testBatch_public_ticket_auto_close()
+    public function testBatchPublicTicketAutoClose()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicGetExpired', 'publicAutoClose'))->getMock();
+            ->onlyMethods(['publicGetExpired', 'publicAutoClose'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicGetExpired')
-            ->will($this->returnValue(array(new \Model_SupportPTicket(), new \Model_SupportPTicket())));
+            ->willReturn([new \Model_SupportPTicket(), new \Model_SupportPTicket()]);
         $serviceMock->expects($this->atLeastOnce())->method('publicAutoClose')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->batch_public_ticket_auto_close(array());
+        $result = $this->adminApi->batch_public_ticket_auto_close([]);
 
         $this->assertTrue($result);
     }
 
-    public function testBatch_public_ticket_auto_closeNotClosed()
+    public function testBatchPublicTicketAutoCloseNotClosed()
     {
         $ticket = new \Model_SupportPTicket();
         $ticket->loadBean(new \DummyBean());
         $ticket->id = random_int(1, 100);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicGetExpired', 'publicAutoClose'))->getMock();
+            ->onlyMethods(['publicGetExpired', 'publicAutoClose'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicGetExpired')
-            ->will($this->returnValue(array($ticket, $ticket)));
+            ->willReturn([$ticket, $ticket]);
         $serviceMock->expects($this->atLeastOnce())->method('publicAutoClose')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->adminApi->setService($serviceMock);
-        $di           = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->adminApi->setDi($di);
-        $result = $this->adminApi->batch_public_ticket_auto_close(array());
+        $result = $this->adminApi->batch_public_ticket_auto_close([]);
 
         $this->assertTrue($result);
     }
 
-    public function testTicket_get_statuses()
+    public function testTicketGetStatuses()
     {
-        $statuses    = array(
+        $statuses = [
             \Model_SupportPTicket::OPENED => 'Open',
             \Model_SupportPTicket::ONHOLD => 'On hold',
             \Model_SupportPTicket::CLOSED => 'Closed',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getStatuses', 'counter'))->getMock();
+            ->onlyMethods(['getStatuses', 'counter'])->getMock();
         $serviceMock->expects($this->never())->method('getStatuses')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
         $serviceMock->expects($this->atLeastOnce())->method('counter')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->ticket_get_statuses(array());
+        $result = $this->adminApi->ticket_get_statuses([]);
 
         $this->assertEquals($result, $statuses);
     }
 
-    public function testTicket_get_statusesTitlesSet()
+    public function testTicketGetStatusesTitlesSet()
     {
-        $statuses    = array(
+        $statuses = [
             \Model_SupportPTicket::OPENED => 'Open',
             \Model_SupportPTicket::ONHOLD => 'On hold',
             \Model_SupportPTicket::CLOSED => 'Closed',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getStatuses', 'counter'))->getMock();
+            ->onlyMethods(['getStatuses', 'counter'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getStatuses')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
         $serviceMock->expects($this->never())->method('counter')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'titles' => true
-        );
+        $data = [
+            'titles' => true,
+        ];
         $result = $this->adminApi->ticket_get_statuses($data);
 
         $this->assertEquals($result, $statuses);
     }
 
-    public function testPublic_ticket_get_list()
+    public function testPublicTicketGetList()
     {
-        $resultSet = array(
-            'list' => array(
-                0 => array('id' => 1),
-            )
-        );
+        $resultSet = [
+            'list' => [
+                0 => ['id' => 1],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicGetSearchQuery', 'publicToApiArray'))->getMock();
+            ->onlyMethods(['publicGetSearchQuery', 'publicToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicGetSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
         $model = new \Model_SupportPTicket();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_DAtabase')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['db']    = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->public_ticket_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testPublic_ticket_create()
+    public function testPublicTicketCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $randID      = random_int(1, 100);
+        $randID = random_int(1, 100);
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicTicketCreate'))->getMock();
+            ->onlyMethods(['publicTicketCreate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicTicketCreate')
-            ->will($this->returnValue($randID));
+            ->willReturn($randID);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
-            'name'    => 'Name',
-            'email'   => 'email@example.com',
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
             'subject' => 'Subject',
-            'message' => 'Message'
-        );
+            'message' => 'Message',
+        ];
         $result = $this->adminApi->public_ticket_create($data);
 
         $this->assertIsInt($result);
         $this->assertEquals($randID, $result);
     }
 
-    public function testPublic_ticket_get()
+    public function testPublicTicketGet()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
-        $randID      = random_int(1, 100);
+        $randID = random_int(1, 100);
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicToApiArray'))->getMock();
+            ->onlyMethods(['publicToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->public_ticket_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testPublic_ticket_delete()
+    public function testPublicTicketDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicRm'))->getMock();
+            ->onlyMethods(['publicRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->public_ticket_delete($data);
 
         $this->assertTrue($result);
     }
 
-    public function testPublic_ticket_close()
+    public function testPublicTicketClose()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicCloseTicket'))->getMock();
+            ->onlyMethods(['publicCloseTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicCloseTicket')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->public_ticket_close($data);
 
         $this->assertTrue($result);
     }
 
-    public function testPublic_ticket_update()
+    public function testPublicTicketUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicTicketUpdate'))->getMock();
+            ->onlyMethods(['publicTicketUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicTicketUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->public_ticket_update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testPublic_ticket_reply()
+    public function testPublicTicketReply()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicTicketReply'))->getMock();
+            ->onlyMethods(['publicTicketReply'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicTicketReply')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
-            'id'      => random_int(1, 100),
-            'content' => 'Content'
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'content' => 'Content',
+        ];
         $result = $this->adminApi->public_ticket_reply($data);
 
         $this->assertTrue($result);
     }
 
-    public function testPublic_ticket_get_statuses()
+    public function testPublicTicketGetStatuses()
     {
-        $statuses    = array(
+        $statuses = [
             \Model_SupportPTicket::OPENED => 'Open',
             \Model_SupportPTicket::ONHOLD => 'On hold',
             \Model_SupportPTicket::CLOSED => 'Closed',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicGetStatuses', 'publicCounter'))->getMock();
+            ->onlyMethods(['publicGetStatuses', 'publicCounter'])->getMock();
         $serviceMock->expects($this->never())->method('publicGetStatuses')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
         $serviceMock->expects($this->atLeastOnce())->method('publicCounter')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
 
         $this->adminApi->setService($serviceMock);
 
-        $result = $this->adminApi->public_ticket_get_statuses(array());
+        $result = $this->adminApi->public_ticket_get_statuses([]);
 
         $this->assertEquals($result, $statuses);
     }
 
-    public function testPublic_ticket_get_statusesTitlesSet()
+    public function testPublicTicketGetStatusesTitlesSet()
     {
-        $statuses    = array(
+        $statuses = [
             \Model_SupportPTicket::OPENED => 'Open',
             \Model_SupportPTicket::ONHOLD => 'On hold',
             \Model_SupportPTicket::CLOSED => 'Closed',
-        );
+        ];
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicGetStatuses', 'publicCounter'))->getMock();
+            ->onlyMethods(['publicGetStatuses', 'publicCounter'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicGetStatuses')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
         $serviceMock->expects($this->never())->method('publicCounter')
-            ->will($this->returnValue($statuses));
+            ->willReturn($statuses);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
-            'titles' => true
-        );
+        $data = [
+            'titles' => true,
+        ];
         $result = $this->adminApi->public_ticket_get_statuses($data);
 
         $this->assertEquals($result, $statuses);
     }
 
-    public function testHelpdeks_get_list()
+    public function testHelpdeksGetList()
     {
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskGetSearchQuery'))->getMock();
+            ->onlyMethods(['helpdeskGetSearchQuery'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskGetSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->helpdesk_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testHelpdeks_get_pairs()
+    public function testHelpdeksGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskGetPairs'))->getMock();
+            ->onlyMethods(['helpdeskGetPairs'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskGetPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->helpdesk_get_pairs($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testHelpdesk_get()
+    public function testHelpdeskGet()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportHelpdesk()));
+            ->willReturn(new \Model_SupportHelpdesk());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskToApiArray'))->getMock();
+            ->onlyMethods(['helpdeskToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskToApiArray')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->helpdesk_get($data);
 
         $this->assertTrue($result);
     }
 
-    public function testHelpdesk_update()
+    public function testHelpdeskUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportHelpdesk()));
+            ->willReturn(new \Model_SupportHelpdesk());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskUpdate'))->getMock();
+            ->onlyMethods(['helpdeskUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskUpdate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->helpdesk_update($data);
 
         $this->assertTrue($result);
     }
 
-    public function testHelpdesk_create()
+    public function testHelpdeskCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskCreate'))->getMock();
+            ->onlyMethods(['helpdeskCreate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskCreate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->helpdesk_create($data);
 
         $this->assertTrue($result);
     }
 
-    public function testHelpdesk_delete()
+    public function testHelpdeskDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportHelpdesk()));
+            ->willReturn(new \Model_SupportHelpdesk());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskRm'))->getMock();
+            ->onlyMethods(['helpdeskRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => 'General',
-        );
+        ];
         $result = $this->adminApi->helpdesk_delete($data);
 
         $this->assertTrue($result);
     }
 
-    public function testCanned_get_list()
+    public function testCannedGetList()
     {
-        $resultSet = array(
-            'list' => array(
-                0 => array('id' => 1),
-            )
-        );
+        $resultSet = [
+            'list' => [
+                0 => ['id' => 1],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedGetSearchQuery', 'cannedToApiArray'))->getMock();
+            ->onlyMethods(['cannedGetSearchQuery', 'cannedToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedGetSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())->method('cannedToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_SupportPr();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_DAtabase')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['db']    = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->canned_get_list($data);
 
         $this->assertIsArray($result);
@@ -965,97 +965,97 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array(1 => 'Title')));
+            ->willReturn([1 => 'Title']);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
-        $data   = array();
+        $data = [];
         $result = $this->adminApi->canned_pairs();
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_get()
+    public function testCannedGet()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPr()));
+            ->willReturn(new \Model_SupportPr());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedToApiArray'))->getMock();
+            ->onlyMethods(['cannedToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->canned_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_delete()
+    public function testCannedDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPr()));
+            ->willReturn(new \Model_SupportPr());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedRm'))->getMock();
+            ->onlyMethods(['cannedRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedRm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->canned_delete($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_create()
+    public function testCannedCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedCreate'))->getMock();
+            ->onlyMethods(['cannedCreate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedCreate')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
 
         $this->adminApi->setDi($di);
@@ -1063,110 +1063,109 @@ class Api_AdminTest extends \BBTestCase
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
-            'title'       => 'Title',
+        $data = [
+            'title' => 'Title',
             'category_id' => 'Title',
-            'content'     => 'Content'
-        );
+            'content' => 'Content',
+        ];
         $result = $this->adminApi->canned_create($data);
 
         $this->assertIsInt($result);
     }
 
-    public function testCanned_update()
+    public function testCannedUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedUpdate'))->getMock();
+            ->onlyMethods(['cannedUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedUpdate')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPr()));
+            ->willReturn(new \Model_SupportPr());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => 'Title',
-        );
+        ];
         $result = $this->adminApi->canned_update($data);
 
         $this->assertIsInt($result);
     }
 
-
-    public function testCanned_category_pairs()
+    public function testCannedCategoryPairs()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array(1 => 'Category 1')));
+            ->willReturn([1 => 'Category 1']);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => 'Title',
-        );
+        ];
         $result = $this->adminApi->canned_category_pairs($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_category_get()
+    public function testCannedCategoryGet()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPrCategory()));
+            ->willReturn(new \Model_SupportPrCategory());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedCategoryToApiArray'))->getMock();
+            ->onlyMethods(['cannedCategoryToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->canned_category_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_category_update()
+    public function testCannedCategoryUpdate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $supportCategory = new \Model_SupportPrCategory();
         $supportCategory->loadBean(new \DummyBean());
@@ -1174,36 +1173,36 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($supportCategory));
+            ->willReturn($supportCategory);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedCategoryUpdate'))->getMock();
+            ->onlyMethods(['cannedCategoryUpdate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedCategoryUpdate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->canned_category_update($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_category_delete()
+    public function testCannedCategoryDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $supportCategory = new \Model_SupportPrCategory();
         $supportCategory->loadBean(new \DummyBean());
@@ -1211,304 +1210,303 @@ class Api_AdminTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($supportCategory));
+            ->willReturn($supportCategory);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedCategoryRm'))->getMock();
+            ->onlyMethods(['cannedCategoryRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedCategoryRm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->canned_category_delete($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_category_create()
+    public function testCannedCategoryCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('cannedCategoryCreate'))->getMock();
+            ->onlyMethods(['cannedCategoryCreate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('cannedCategoryCreate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'title' => 'Title',
-        );
+        ];
         $result = $this->adminApi->canned_category_create($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_note_create()
+    public function testCannedNoteCreate()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('noteCreate'))->getMock();
+            ->onlyMethods(['noteCreate'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('noteCreate')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'ticket_id' => random_int(1, 100),
-            'note'      => 'Note',
-        );
+            'note' => 'Note',
+        ];
         $result = $this->adminApi->note_create($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testCanned_note_delete()
+    public function testCannedNoteDelete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('noteRm'))->getMock();
+            ->onlyMethods(['noteRm'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('noteRm')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicketNote()));
+            ->willReturn(new \Model_SupportTicketNote());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
         $this->adminApi->setIdentity(new \Model_Admin());
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->note_delete($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTask_complete()
+    public function testTaskComplete()
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketTaskComplete'))->getMock();
+            ->onlyMethods(['ticketTaskComplete'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketTaskComplete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']     = $dbMock;
+        $di['db'] = $dbMock;
         $this->adminApi->setDi($di);
 
         $this->adminApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
         $result = $this->adminApi->task_complete($data);
 
         $this->assertTrue($result);
     }
 
-    public function testBatch_delete()
+    public function testBatchDelete()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Api\Admin::class)->onlyMethods(array('ticket_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('ticket_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Api\Admin::class)->onlyMethods(['ticket_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('ticket_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
-    public function testBatch_delete_public()
+    public function testBatchDeletePublic()
     {
-        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Api\Admin::class)->onlyMethods(array('public_ticket_delete'))->getMock();
-        $activityMock->expects($this->atLeastOnce())->method('public_ticket_delete')->will($this->returnValue(true));
+        $activityMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Api\Admin::class)->onlyMethods(['public_ticket_delete'])->getMock();
+        $activityMock->expects($this->atLeastOnce())->method('public_ticket_delete')->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $activityMock->setDi($di);
 
-        $result = $activityMock->batch_delete_public(array('ids' => array(1, 2, 3)));
-        $this->assertEquals(true, $result);
+        $result = $activityMock->batch_delete_public(['ids' => [1, 2, 3]]);
+        $this->assertTrue($result);
     }
 
     /*
     * Knowledge Base Tests.
     */
 
-    public function testKb_article_get_list()
+    public function testKbArticleGetList()
     {
         $di = new \Pimple\Container();
 
         $adminApi = new \Box\Mod\Support\Api\Admin();
         $adminApi->setDi($di);
 
-        $data = array(
+        $data = [
             'status' => 'status',
             'search' => 'search',
-            'cat'    => 'category'
-        );
+            'cat' => 'category',
+        ];
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbSearchArticles'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbSearchArticles'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbSearchArticles')
-            ->will($this->returnValue(array('list' => array())));
+            ->willReturn(['list' => []]);
 
         $adminApi->setService($kbService);
 
         $result = $adminApi->kb_article_get_list($data);
         $this->assertIsArray($result);
-
     }
 
-    public function testKb_article_get()
+    public function testKbArticleGet()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $data = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
 
-        $admin     = new \Model_Admin();
+        $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
 
         $admin->id = 5;
 
-        $di                   = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['loggedin_admin'] = $admin;
-        $di['db']             = $db;
+        $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbToApiArray'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbToApiArray'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
         $result = $adminApi->kb_article_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_article_getNotFoundException()
+    public function testKbArticleGetNotFoundException()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $data = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
         $this->expectException(\FOSSBilling\Exception::class);
         $adminApi->kb_article_get($data);
     }
 
-    public function testKb_article_create()
+    public function testKbArticleCreate()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $data = array(
+        $data = [
             'kb_article_category_id' => random_int(1, 100),
-            'title'                  => 'Title',
-        );
+            'title' => 'Title',
+        ];
 
         $id = random_int(1, 100);
 
         $di = new \Pimple\Container();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCreateArticle'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCreateArticle'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCreateArticle')
-            ->will($this->returnValue($id));
+            ->willReturn($id);
         $adminApi->setService($kbService);
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -1517,30 +1515,30 @@ class Api_AdminTest extends \BBTestCase
         $this->assertEquals($result, $id);
     }
 
-    public function testKb_article_update()
+    public function testKbArticleUpdate()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $data = array(
-            "id"                     => random_int(1, 100),
-            "kb_article_category_id" => random_int(1, 100),
-            "title"                  => "Title",
-            "slug"                   => "article-slug",
-            "status"                 => "active",
-            "content"                => "Content",
-            "views"                  => random_int(1, 100),
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'kb_article_category_id' => random_int(1, 100),
+            'title' => 'Title',
+            'slug' => 'article-slug',
+            'status' => 'active',
+            'content' => 'Content',
+            'views' => random_int(1, 100),
+        ];
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbUpdateArticle'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbUpdateArticle'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbUpdateArticle')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $di = new \Pimple\Container();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
@@ -1551,144 +1549,144 @@ class Api_AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testKb_article_delete()
+    public function testKbArticleDelete()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $data = array(
-            "id" => random_int(1, 100),
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbRm'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbRm'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $adminApi->setService($kbService);
 
         $result = $adminApi->kb_article_delete($data);
         $this->assertTrue($result);
     }
 
-    public function testKb_article_deleteNotFoundException()
+    public function testKbArticleDeleteNotFoundException()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbRm'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbRm'])->getMock();
         $kbService->expects($this->never())
             ->method('kbRm')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $adminApi->setService($kbService);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_article_delete(array('id' => random_int(1, 100)));
+        $result = $adminApi->kb_article_delete(['id' => random_int(1, 100)]);
         $this->assertTrue($result);
     }
 
-    public function testKb_category_get_list()
+    public function testKbCategoryGetList()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $willReturn = array(
-            "pages"    => 5,
-            "page"     => 2,
-            "per_page" => 2,
-            "total"    => 10,
-            "list"     => array(),
-        );
+        $willReturn = [
+            'pages' => 5,
+            'page' => 2,
+            'per_page' => 2,
+            'total' => 10,
+            'list' => [],
+        ];
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $pager;
 
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryGetSearchQuery'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryGetSearchQuery'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryGetSearchQuery')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $adminApi->setService($kbService);
 
-        $result = $adminApi->kb_category_get_list(array());
+        $result = $adminApi->kb_category_get_list([]);
         $this->assertIsArray($result);
         $this->assertEquals($result, $willReturn);
     }
 
-    public function testKb_category_get()
+    public function testKbCategoryGet()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryToApiArray'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryToApiArray'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $adminApi->kb_category_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_getIdNotSetException()
+    public function testKbCategoryGetIdNotSetException()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->never())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1697,71 +1695,71 @@ class Api_AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryToApiArray'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryToApiArray'])->getMock();
         $kbService->expects($this->never())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_category_get(array());
+        $result = $adminApi->kb_category_get([]);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_getNotFoundException()
+    public function testKbCategoryGetNotFoundException()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $di['db'] = $db;
         $adminApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryToApiArray'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryToApiArray'])->getMock();
         $kbService->expects($this->never())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_category_get($data);;
+        $result = $adminApi->kb_category_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_create()
+    public function testKbCategoryCreate()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCreateCategory'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCreateCategory'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCreateCategory')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
-        $data = array(
-            'title'       => 'Title',
+        $data = [
+            'title' => 'Title',
             'description' => 'Description',
-        );
+        ];
 
         $di = new \Pimple\Container();
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
@@ -1769,159 +1767,59 @@ class Api_AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_update()
+    public function testKbCategoryUpdate()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbUpdateCategory'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbUpdateCategory'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbUpdateCategory')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
 
         $adminApi->setDi($di);
 
-        $data = array(
-            'id'          => random_int(1, 100),
-            'title'       => 'Title',
-            'slug'        => 'category-slug',
-            'description' => 'Description',
-        );
-
-        $result = $adminApi->kb_category_update($data);
-        $this->assertIsArray($result);
-    }
-
-    public function testKb_category_updateIdNotSet()
-    {
-        $adminApi = new \Box\Mod\Support\Api\Admin();
-
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbUpdateCategory'))->getMock();
-        $kbService->expects($this->never())
-            ->method('kbUpdateCategory')
-            ->will($this->returnValue(array()));
-        $adminApi->setService($kbService);
-
-        $db = $this->getMockBuilder('Box_Database')->getMock();
-        $db->expects($this->never())
-            ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
-
-        $di       = new \Pimple\Container();
-        $di['db'] = $db;
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
-            ->method('checkRequiredParamsForArray')
-            ->willThrowException(new \FOSSBilling\Exception('Category ID not passed'));
-        $di['validator'] = $validatorMock;
-        $adminApi->setDi($di);
-
-        $data = array();
-
-        $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_category_update($data);
-        $this->assertIsArray($result);
-    }
-
-    public function testKb_category_updateNotFound()
-    {
-        $adminApi = new \Box\Mod\Support\Api\Admin();
-
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbUpdateCategory'))->getMock();
-        $kbService->expects($this->never())
-            ->method('kbUpdateCategory')
-            ->will($this->returnValue(array()));
-        $adminApi->setService($kbService);
-
-        $db = $this->getMockBuilder('Box_Database')->getMock();
-        $db->expects($this->atLeastOnce())
-            ->method('findOne')
-            ->will($this->returnValue(false));
-
-        $di       = new \Pimple\Container();
-        $di['db'] = $db;
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
-            ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
-        $di['validator'] = $validatorMock;
-        $adminApi->setDi($di);
-
-
-        $data = array(
-            'id'          => random_int(1, 100),
-            'title'       => 'Title',
-            'slug'        => 'category-slug',
-            'description' => 'Description',
-        );
-
-        $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_category_update($data);
-        $this->assertIsArray($result);
-    }
-
-    public function testKb_category_delete()
-    {
-        $adminApi = new \Box\Mod\Support\Api\Admin();
-
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryRm'))->getMock();
-        $kbService->expects($this->atLeastOnce())
-            ->method('kbCategoryRm')
-            ->will($this->returnValue(array()));
-        $adminApi->setService($kbService);
-
-
-        $db = $this->getMockBuilder('Box_Database')->getMock();
-        $db->expects($this->atLeastOnce())
-            ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
-
-        $di       = new \Pimple\Container();
-        $di['db'] = $db;
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
-        $validatorMock->expects($this->atLeastOnce())
-            ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
-        $di['validator'] = $validatorMock;
-        $adminApi->setDi($di);
-
-        $data   = array(
+        $data = [
             'id' => random_int(1, 100),
-        );
-        $result = $adminApi->kb_category_delete($data);
+            'title' => 'Title',
+            'slug' => 'category-slug',
+            'description' => 'Description',
+        ];
+
+        $result = $adminApi->kb_category_update($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_deleteIdNotSet()
+    public function testKbCategoryUpdateIdNotSet()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryRm'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbUpdateCategory'])->getMock();
         $kbService->expects($this->never())
-            ->method('kbCategoryRm')
-            ->will($this->returnValue(array()));
+            ->method('kbUpdateCategory')
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->never())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
@@ -1930,57 +1828,154 @@ class Api_AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $data   = array();
+        $data = [];
+
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $adminApi->kb_category_delete($data);
+        $result = $adminApi->kb_category_update($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_deleteNotFound()
+    public function testKbCategoryUpdateNotFound()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryRm'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbUpdateCategory'])->getMock();
         $kbService->expects($this->never())
-            ->method('kbCategoryRm')
-            ->will($this->returnValue(array()));
+            ->method('kbUpdateCategory')
+            ->willReturn([]);
         $adminApi->setService($kbService);
-
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $di['validator'] = $validatorMock;
         $adminApi->setDi($di);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+            'title' => 'Title',
+            'slug' => 'category-slug',
+            'description' => 'Description',
+        ];
+
+        $this->expectException(\FOSSBilling\Exception::class);
+        $result = $adminApi->kb_category_update($data);
+        $this->assertIsArray($result);
+    }
+
+    public function testKbCategoryDelete()
+    {
+        $adminApi = new \Box\Mod\Support\Api\Admin();
+
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryRm'])->getMock();
+        $kbService->expects($this->atLeastOnce())
+            ->method('kbCategoryRm')
+            ->willReturn([]);
+        $adminApi->setService($kbService);
+
+        $db = $this->getMockBuilder('Box_Database')->getMock();
+        $db->expects($this->atLeastOnce())
+            ->method('findOne')
+            ->willReturn(new \Model_SupportKbArticleCategory());
+
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->willReturn(null);
+        $di['validator'] = $validatorMock;
+        $adminApi->setDi($di);
+
+        $data = [
+            'id' => random_int(1, 100),
+        ];
+        $result = $adminApi->kb_category_delete($data);
+        $this->assertIsArray($result);
+    }
+
+    public function testKbCategoryDeleteIdNotSet()
+    {
+        $adminApi = new \Box\Mod\Support\Api\Admin();
+
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryRm'])->getMock();
+        $kbService->expects($this->never())
+            ->method('kbCategoryRm')
+            ->willReturn([]);
+        $adminApi->setService($kbService);
+
+        $db = $this->getMockBuilder('Box_Database')->getMock();
+        $db->expects($this->never())
+            ->method('findOne')
+            ->willReturn(new \Model_SupportKbArticleCategory());
+
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->willThrowException(new \FOSSBilling\Exception('Category ID not passed'));
+        $di['validator'] = $validatorMock;
+        $adminApi->setDi($di);
+
+        $data = [];
+        $this->expectException(\FOSSBilling\Exception::class);
+        $result = $adminApi->kb_category_delete($data);
+        $this->assertIsArray($result);
+    }
+
+    public function testKbCategoryDeleteNotFound()
+    {
+        $adminApi = new \Box\Mod\Support\Api\Admin();
+
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryRm'])->getMock();
+        $kbService->expects($this->never())
+            ->method('kbCategoryRm')
+            ->willReturn([]);
+        $adminApi->setService($kbService);
+
+        $db = $this->getMockBuilder('Box_Database')->getMock();
+        $db->expects($this->atLeastOnce())
+            ->method('findOne')
+            ->willReturn(false);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->willReturn(null);
+        $di['validator'] = $validatorMock;
+        $adminApi->setDi($di);
+
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $adminApi->kb_category_delete($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_get_pairs()
+    public function testKbCategoryGetPairs()
     {
         $adminApi = new \Box\Mod\Support\Api\Admin();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryGetPairs'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryGetPairs'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryGetPairs')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $adminApi->setService($kbService);
 
-        $result = $adminApi->kb_category_get_pairs(array());
+        $result = $adminApi->kb_category_get_pairs([]);
         $this->assertIsArray($result);
     }
 }

--- a/tests/modules/Support/Api/Api_ClientTest.php
+++ b/tests/modules/Support/Api/Api_ClientTest.php
@@ -7,43 +7,43 @@ class Api_ClientTest extends \BBTestCase
     /**
      * @var \Box\Mod\Support\Api\Client
      */
-    protected $clientApi = null;
+    protected $clientApi;
 
     public function setup(): void
     {
         $this->clientApi = new \Box\Mod\Support\Api\Client();
     }
 
-    public function testTicket_get_list()
+    public function testTicketGetList()
     {
-        $simpleResultArr = array(
-            'list' => array(
-                array('id' => 1),
-            ),
-        );
+        $simpleResultArr = [
+            'list' => [
+                ['id' => 1],
+            ],
+        ];
         $paginatorMock = $this->getMockBuilder('\Box_Pagination')->disableOriginalConstructor()->getMock();
         $paginatorMock->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($simpleResultArr));
+            ->willReturn($simpleResultArr);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getSearchQuery', 'toApiArray'))->getMock();
+            ->onlyMethods(['getSearchQuery', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('getSearchQuery')
-            ->will($this->returnValue(array('query', array())));
+            ->willReturn(['query', []]);
         $serviceMock->expects($this->atLeastOnce())
             ->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $model = new \Model_SupportTicket();
         $model->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $paginatorMock;
-        $di['db']    = $dbMock;
+        $di['db'] = $dbMock;
 
         $this->clientApi->setDi($di);
 
@@ -54,27 +54,27 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array();
+        $data = [];
         $result = $this->clientApi->ticket_get_list($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTicket_get()
+    public function testTicketGet()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('findOneByClient', 'toApiArray'))->getMock();
+            ->onlyMethods(['findOneByClient', 'toApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('findOneByClient')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->clientApi->setDi($di);
 
@@ -85,20 +85,20 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $this->clientApi->ticket_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testHelpdesk_get_pairs()
+    public function testHelpdeskGetPairs()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('helpdeskGetPairs'))->getMock();
+            ->onlyMethods(['helpdeskGetPairs'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskGetPairs')
-            ->will($this->returnValue(array(0 => 'General')));
+            ->willReturn([0 => 'General']);
 
         $this->clientApi->setService($serviceMock);
 
@@ -107,26 +107,26 @@ class Api_ClientTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testTicket_create()
+    public function testTicketCreate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketCreateForClient'))->getMock();
+            ->onlyMethods(['ticketCreateForClient'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketCreateForClient')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportHelpdesk()));
+            ->willReturn(new \Model_SupportHelpdesk());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->clientApi->setDi($di);
 
         $client = new \Model_Client();
@@ -136,38 +136,38 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
-            'content'             => 'Content',
-            'subject'             => 'Subject',
+        $data = [
+            'content' => 'Content',
+            'subject' => 'Subject',
             'support_helpdesk_id' => random_int(1, 100),
-        );
+        ];
         $result = $this->clientApi->ticket_create($data);
 
         $this->assertIsInt($result);
     }
 
-    public function testTicket_reply()
+    public function testTicketReply()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('canBeReopened', 'ticketReply'))->getMock();
+            ->onlyMethods(['canBeReopened', 'ticketReply'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('canBeReopened')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $serviceMock->expects($this->atLeastOnce())->method('ticketReply')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->clientApi->setDi($di);
 
         $client = new \Model_Client();
@@ -177,38 +177,38 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
+        $data = [
             'content' => 'Content',
-            'id'      => random_int(1, 100),
-        );
+            'id' => random_int(1, 100),
+        ];
         $result = $this->clientApi->ticket_reply($data);
 
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testTicket_replyCanNotBeReopenedException()
+    public function testTicketReplyCanNotBeReopenedException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('canBeReopened', 'ticketReply'))->getMock();
+            ->onlyMethods(['canBeReopened', 'ticketReply'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('canBeReopened')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $serviceMock->expects($this->never())->method('ticketReply')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $di['db']        = $dbMock;
+        $di['db'] = $dbMock;
         $this->clientApi->setDi($di);
 
         $client = new \Model_Client();
@@ -218,31 +218,31 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
+        $data = [
             'content' => 'Content',
-            'id'      => random_int(1, 100),
-        );
+            'id' => random_int(1, 100),
+        ];
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->clientApi->ticket_reply($data);
 
         $this->assertIsInt($result);
     }
 
-    public function testTicket_close()
+    public function testTicketClose()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('findOneByClient', 'closeTicket'))->getMock();
+            ->onlyMethods(['findOneByClient', 'closeTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('findOneByClient')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
         $serviceMock->expects($this->atLeastOnce())->method('closeTicket')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
         $this->clientApi->setDi($di);
 
@@ -253,10 +253,10 @@ class Api_ClientTest extends \BBTestCase
         $this->clientApi->setService($serviceMock);
         $this->clientApi->setIdentity($client);
 
-        $data   = array(
+        $data = [
             'content' => 'Content',
-            'id'      => random_int(1, 100),
-        );
+            'id' => random_int(1, 100),
+        ];
         $result = $this->clientApi->ticket_close($data);
 
         $this->assertIsInt($result);

--- a/tests/modules/Support/Api/Api_GuestTest.php
+++ b/tests/modules/Support/Api/Api_GuestTest.php
@@ -7,69 +7,67 @@ class Api_GuestTest extends \BBTestCase
     /**
      * @var \Box\Mod\Support\Api\Guest
      */
-    protected $guestApi = null;
+    protected $guestApi;
 
     public function setup(): void
     {
         $this->guestApi = new \Box\Mod\Support\Api\Guest();
     }
 
-    public function testTicket_create()
+    public function testTicketCreate()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketCreateForGuest'))->getMock();
+            ->onlyMethods(['ticketCreateForGuest'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketCreateForGuest')
-            ->will($this->returnValue(sha1(uniqid())));
+            ->willReturn(sha1(uniqid()));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $this->guestApi ->setDi($di);
+        $this->guestApi->setDi($di);
 
-        $this->guestApi ->setService($serviceMock);
+        $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'name'    => 'Name',
-            'email'   => 'email@wxample.com',
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@wxample.com',
             'subject' => 'Subject',
             'message' => 'Message',
-        );
+        ];
         $result = $this->guestApi->ticket_create($data);
 
         $this->assertIsString($result);
         $this->assertEquals(strlen($result), 40);
     }
 
-    public function testTicket_createMessageTooShortException()
+    public function testTicketCreateMessageTooShortException()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketCreateForGuest'))->getMock();
+            ->onlyMethods(['ticketCreateForGuest'])->getMock();
         $serviceMock->expects($this->never())->method('ticketCreateForGuest')
-            ->will($this->returnValue(sha1(uniqid())));
+            ->willReturn(sha1(uniqid()));
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $this->guestApi ->setDi($di);
+        $this->guestApi->setDi($di);
 
-        $this->guestApi ->setService($serviceMock);
+        $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'name'    => 'Name',
-            'email'   => 'email@wxample.com',
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@wxample.com',
             'subject' => 'Subject',
             'message' => '',
-        );
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $this->guestApi->ticket_create($data);
@@ -78,89 +76,86 @@ class Api_GuestTest extends \BBTestCase
         $this->assertEquals(strlen($result), 40);
     }
 
-    public function testTicket_get()
+    public function testTicketGet()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicFindOneByHash', 'publicToApiArray'))->getMock();
+            ->onlyMethods(['publicFindOneByHash', 'publicToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicFindOneByHash')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $this->guestApi ->setDi($di);
+        $this->guestApi->setDi($di);
 
-        $this->guestApi ->setService($serviceMock);
+        $this->guestApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'hash' => sha1(uniqid()),
-        );
+        ];
         $result = $this->guestApi->ticket_get($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTicket_close()
+    public function testTicketClose()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicFindOneByHash', 'publicCloseTicket'))->getMock();
+            ->onlyMethods(['publicFindOneByHash', 'publicCloseTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicFindOneByHash')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $serviceMock->expects($this->atLeastOnce())->method('publicCloseTicket')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $this->guestApi ->setDi($di);
+        $this->guestApi->setDi($di);
 
-        $this->guestApi ->setService($serviceMock);
+        $this->guestApi->setService($serviceMock);
 
-        $data   = array(
+        $data = [
             'hash' => sha1(uniqid()),
-        );
+        ];
         $result = $this->guestApi->ticket_close($data);
 
         $this->assertIsArray($result);
     }
 
-    public function testTicket_reply()
+    public function testTicketReply()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicFindOneByHash', 'publicTicketReplyForGuest'))->getMock();
+            ->onlyMethods(['publicFindOneByHash', 'publicTicketReplyForGuest'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicFindOneByHash')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
         $serviceMock->expects($this->atLeastOnce())->method('publicTicketReplyForGuest')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
-        $this->guestApi ->setDi($di);
+        $this->guestApi->setDi($di);
 
-        $this->guestApi ->setService($serviceMock);
+        $this->guestApi->setService($serviceMock);
 
-        $data   = array(
-            'hash'    => sha1(uniqid()),
-            'message' => 'Message'
-        );
+        $data = [
+            'hash' => sha1(uniqid()),
+            'message' => 'Message',
+        ];
         $result = $this->guestApi->ticket_reply($data);
 
         $this->assertIsArray($result);
@@ -170,22 +165,22 @@ class Api_GuestTest extends \BBTestCase
     * Knowledge Base Tests.
     */
 
-    public function testKb_article_get_list()
+    public function testKbArticleGetList()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $willReturn = array(
-            "pages"    => 5,
-            "page"     => 2,
-            "per_page" => 2,
-            "total"    => 10,
-            "list"     => array(),
-        );
+        $willReturn = [
+            'pages' => 5,
+            'page' => 2,
+            'per_page' => 2,
+            'total' => 10,
+            'list' => [],
+        ];
 
-        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbSearchArticles'))->getMock();
+        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbSearchArticles'])->getMock();
         $supportService->expects($this->atLeastOnce())
             ->method('kbSearchArticles')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
         $guestApi->setService($supportService);
 
         $pagerMock = $this->getMockBuilder('Box_Pagination')->getMock();
@@ -196,12 +191,12 @@ class Api_GuestTest extends \BBTestCase
         $di['pager'] = $pagerMock;
 
         $guestApi->setDi($di);
-        $result = $guestApi->kb_article_get_list(array());
+        $result = $guestApi->kb_article_get_list([]);
         $this->assertIsArray($result);
         $this->assertEquals($result, $willReturn);
     }
 
-    public function testKb_article_getWithId()
+    public function testKbArticleGetWithId()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
@@ -209,29 +204,29 @@ class Api_GuestTest extends \BBTestCase
 
         $guestApi->setDi($di);
 
-        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'))->getMock();
+        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'])->getMock();
         $supportService->expects($this->atLeastOnce())
             ->method('kbFindActiveArticleById')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->never())
             ->method('kbFindActiveArticleBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->atLeastOnce())
             ->method('kbHitView')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->atLeastOnce())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($supportService);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
         $result = $guestApi->kb_article_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_article_getWithSlug()
+    public function testKbArticleGetWithSlug()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
@@ -239,74 +234,74 @@ class Api_GuestTest extends \BBTestCase
 
         $guestApi->setDi($di);
 
-        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'))->getMock();
+        $supportService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'])->getMock();
         $supportService->expects($this->never())
             ->method('kbFindActiveArticleById')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->atLeastOnce())
             ->method('kbFindActiveArticleBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->atLeastOnce())
             ->method('kbHitView')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $supportService->expects($this->atLeastOnce())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($supportService);
 
-        $data   = array(
-            'slug' => 'article-slug'
-        );
+        $data = [
+            'slug' => 'article-slug',
+        ];
         $result = $guestApi->kb_article_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_article_getIdAndSlugNotSetException()
+    public function testKbArticleGetIdAndSlugNotSetException()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'])->getMock();
         $kbService->expects($this->never())
             ->method('kbFindActiveArticleById')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbFindActiveArticleBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbHitView')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $guestApi->kb_article_get(array());
+        $result = $guestApi->kb_article_get([]);
         $this->assertIsArray($result);
     }
 
-    public function testKb_Article_getNotFoundById()
+    public function testKbArticleGetNotFoundById()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbFindActiveArticleById')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $kbService->expects($this->never())
             ->method('kbFindActiveArticleBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbHitView')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $di = new \Pimple\Container();
 
@@ -316,110 +311,110 @@ class Api_GuestTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_article_getNotFoundBySlug()
+    public function testKbArticleGetNotFoundBySlug()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindActiveArticleById', 'kbHitView', 'kbToApiArray', 'kbFindActiveArticleBySlug'])->getMock();
         $kbService->expects($this->never())
             ->method('kbFindActiveArticleById')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->atLeastOnce())
             ->method('kbFindActiveArticleBySlug')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $kbService->expects($this->never())
             ->method('kbHitView')
-            ->will($this->returnValue(new \Model_SupportKbArticle()));
+            ->willReturn(new \Model_SupportKbArticle());
         $kbService->expects($this->never())
             ->method('kbToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
         $di = new \Pimple\Container();
 
         $guestApi->setDi($di);
 
-        $data = array(
-            'slug' => 'article-slug'
-        );
+        $data = [
+            'slug' => 'article-slug',
+        ];
 
         $this->expectException(\FOSSBilling\Exception::class);
         $result = $guestApi->kb_article_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_get_list()
+    public function testKbCategoryGetList()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $willReturn = array(
-            "pages"    => 5,
-            "page"     => 2,
-            "per_page" => 2,
-            "total"    => 10,
-            "list"     => array(),
-        );
+        $willReturn = [
+            'pages' => 5,
+            'page' => 2,
+            'per_page' => 2,
+            'total' => 10,
+            'list' => [],
+        ];
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getAdvancedResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-        $di          = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['pager'] = $pager;
 
         $guestApi->setDi($di);
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryGetSearchQuery'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryGetSearchQuery'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryGetSearchQuery')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $guestApi->setService($kbService);
 
-        $result = $guestApi->kb_category_get_list(array());
+        $result = $guestApi->kb_category_get_list([]);
         $this->assertIsArray($result);
         $this->assertEquals($result, $willReturn);
     }
 
-    public function testKb_category_get_pairs()
+    public function testKbCategoryGetPairs()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $expected = array(
-            1 => "First Category",
-            2 => "Second Category"
-        );
+        $expected = [
+            1 => 'First Category',
+            2 => 'Second Category',
+        ];
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbCategoryGetPairs'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbCategoryGetPairs'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryGetPairs')
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
         $guestApi->setService($kbService);
 
-        $result = $guestApi->kb_category_get_pairs(array());
+        $result = $guestApi->kb_category_get_pairs([]);
         $this->assertIsArray($result);
         $this->assertEquals($result, $expected);
     }
 
-    public function testKb_category_getWithId()
+    public function testKbCategoryGetWithId()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbFindCategoryById')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->never())
             ->method('kbFindCategoryBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
-        $data   = array(
-            'id' => random_int(1, 100)
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $di = new \Pimple\Container();
 
@@ -428,102 +423,73 @@ class Api_GuestTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_getWithSlug()
+    public function testKbCategoryGetWithSlug()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'])->getMock();
         $kbService->expects($this->never())
             ->method('kbFindCategoryById')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->atLeastOnce())
             ->method('kbFindCategoryBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->atLeastOnce())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
         $di = new \Pimple\Container();
 
         $guestApi->setDi($di);
 
-        $data   = array(
-            'slug' => 'category-slug'
-        );
+        $data = [
+            'slug' => 'category-slug',
+        ];
         $result = $guestApi->kb_category_get($data);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_getIdAndSlugNotSetException()
+    public function testKbCategoryGetIdAndSlugNotSetException()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'])->getMock();
         $kbService->expects($this->never())
             ->method('kbFindCategoryById')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->never())
             ->method('kbFindCategoryBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->never())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
         $this->expectException(\FOSSBilling\Exception::class);
-        $result = $guestApi->kb_category_get(array());
+        $result = $guestApi->kb_category_get([]);
         $this->assertIsArray($result);
     }
 
-    public function testKb_category_getNotFoundById()
+    public function testKbCategoryGetNotFoundById()
     {
         $guestApi = new \Box\Mod\Support\Api\Guest();
 
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'))->getMock();
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'])->getMock();
         $kbService->expects($this->atLeastOnce())
             ->method('kbFindCategoryById')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $kbService->expects($this->never())
             ->method('kbFindCategoryBySlug')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
+            ->willReturn(new \Model_SupportKbArticleCategory());
         $kbService->expects($this->never())
             ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $guestApi->setService($kbService);
 
-        $data = array(
-            'id' => random_int(1, 100)
-        );
-
-        $di = new \Pimple\Container();
-
-        $guestApi->setDi($di);
-
-        $this->expectException(\FOSSBilling\Exception::class);
-        $result = $guestApi->kb_category_get($data);
-        $this->assertIsArray($result);
-    }
-
-    public function testKb_category_getNotFoundBySlug()
-    {
-        $guestApi = new \Box\Mod\Support\Api\Guest();
-
-        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(array('kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'))->getMock();
-        $kbService->expects($this->never())
-            ->method('kbFindCategoryById')
-            ->will($this->returnValue(new \Model_SupportKbArticleCategory()));
-        $kbService->expects($this->atLeastOnce())
-            ->method('kbFindCategoryBySlug')
-            ->will($this->returnValue(null));
-        $kbService->expects($this->never())
-            ->method('kbCategoryToApiArray')
-            ->will($this->returnValue(array()));
-        $guestApi->setService($kbService);
-
-        $data = array(
-            'slug' => 'article-slug'
-        );
+        $data = [
+            'id' => random_int(1, 100),
+        ];
 
         $di = new \Pimple\Container();
 
@@ -534,4 +500,32 @@ class Api_GuestTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
+    public function testKbCategoryGetNotFoundBySlug()
+    {
+        $guestApi = new \Box\Mod\Support\Api\Guest();
+
+        $kbService = $this->getMockBuilder(\Box\Mod\Support\Service::class)->onlyMethods(['kbFindCategoryById', 'kbHitView', 'kbCategoryToApiArray', 'kbFindCategoryBySlug'])->getMock();
+        $kbService->expects($this->never())
+            ->method('kbFindCategoryById')
+            ->willReturn(new \Model_SupportKbArticleCategory());
+        $kbService->expects($this->atLeastOnce())
+            ->method('kbFindCategoryBySlug')
+            ->willReturn(null);
+        $kbService->expects($this->never())
+            ->method('kbCategoryToApiArray')
+            ->willReturn([]);
+        $guestApi->setService($kbService);
+
+        $data = [
+            'slug' => 'article-slug',
+        ];
+
+        $di = new \Pimple\Container();
+
+        $guestApi->setDi($di);
+
+        $this->expectException(\FOSSBilling\Exception::class);
+        $result = $guestApi->kb_category_get($data);
+        $this->assertIsArray($result);
+    }
 }

--- a/tests/modules/Support/ServiceTest.php
+++ b/tests/modules/Support/ServiceTest.php
@@ -2,14 +2,12 @@
 
 namespace Box\Tests\Mod\Support;
 
-use \RedBeanPHP\OODBBean;
-
 class ServiceTest extends \BBTestCase
 {
     /**
      * @var \Box\Mod\Support\Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
@@ -26,31 +24,31 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterClientOpenTicket()
     {
-        $toApiArrayReturn   = array(
-            'client' => array(
-                'id' => random_int(1, 100)
-            )
-        );
-        $serviceMock        = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getTicketById', 'toApiArray'))->getMock();
+        $toApiArrayReturn = [
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getTicketById', 'toApiArray'])->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getTicketById')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                    = new \Pimple\Container();
-        $di['mod_service']     = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -61,7 +59,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterClientOpenTicket($eventMock);
         $this->assertNull($result);
@@ -69,31 +67,31 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminOpenTicket()
     {
-        $toApiArrayReturn   = array(
-            'client' => array(
-                'id' => random_int(1, 100)
-            )
-        );
-        $serviceMock        = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getTicketById', 'toApiArray'))->getMock();
+        $toApiArrayReturn = [
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getTicketById', 'toApiArray'])->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getTicketById')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -104,7 +102,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminOpenTicket($eventMock);
         $this->assertNull($result);
@@ -112,31 +110,31 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminCloseTicket()
     {
-        $toApiArrayReturn   = array(
-            'client' => array(
-                'id' => random_int(1, 100)
-            )
-        );
-        $serviceMock        = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getTicketById', 'toApiArray'))->getMock();
+        $toApiArrayReturn = [
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getTicketById', 'toApiArray'])->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getTicketById')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -147,7 +145,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminCloseTicket($eventMock);
         $this->assertNull($result);
@@ -155,31 +153,31 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminReplyTicket()
     {
-        $toApiArrayReturn   = array(
-            'client' => array(
-                'id' => random_int(1, 100)
-            )
-        );
-        $serviceMock        = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getTicketById', 'toApiArray'))->getMock();
+        $toApiArrayReturn = [
+            'client' => [
+                'id' => random_int(1, 100),
+            ],
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getTicketById', 'toApiArray'])->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getTicketById')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -190,7 +188,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminReplyTicket($eventMock);
         $this->assertNull($result);
@@ -198,30 +196,30 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterGuestPublicTicketOpen()
     {
-        $toApiArrayReturn    = array(
+        $toApiArrayReturn = [
             'author_email' => 'email@example.com',
-            'author_name'  => 'Name',
-        );
-        $serviceMock         = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getPublicTicketById', 'publicToApiArray'))->getMock();
+            'author_name' => 'Name',
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getPublicTicketById', 'publicToApiArray'])->getMock();
         $supportPTicketModel = new \Model_SupportPTicket();
         $supportPTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getPublicTicketById')
-            ->will($this->returnValue($supportPTicketModel));
+            ->willReturn($supportPTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -231,7 +229,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterGuestPublicTicketOpen($eventMock);
         $this->assertNull($result);
@@ -239,30 +237,30 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminPublicTicketOpen()
     {
-        $toApiArrayReturn    = array(
+        $toApiArrayReturn = [
             'author_email' => 'email@example.com',
-            'author_name'  => 'Name',
-        );
-        $serviceMock         = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getPublicTicketById', 'publicToApiArray'))->getMock();
+            'author_name' => 'Name',
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getPublicTicketById', 'publicToApiArray'])->getMock();
         $supportPTicketModel = new \Model_SupportPTicket();
         $supportPTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getPublicTicketById')
-            ->will($this->returnValue($supportPTicketModel));
+            ->willReturn($supportPTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -273,7 +271,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminPublicTicketOpen($eventMock);
         $this->assertNull($result);
@@ -281,30 +279,30 @@ class ServiceTest extends \BBTestCase
 
     public function testOnAfterAdminPublicTicketReply()
     {
-        $toApiArrayReturn    = array(
+        $toApiArrayReturn = [
             'author_email' => 'email@example.com',
-            'author_name'  => 'Name',
-        );
-        $serviceMock         = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getPublicTicketById', 'publicToApiArray'))->getMock();
+            'author_name' => 'Name',
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getPublicTicketById', 'publicToApiArray'])->getMock();
         $supportPTicketModel = new \Model_SupportPTicket();
         $supportPTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getPublicTicketById')
-            ->will($this->returnValue($supportPTicketModel));
+            ->willReturn($supportPTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -315,39 +313,38 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminPublicTicketReply($eventMock);
         $this->assertNull($result);
     }
 
-
     public function testOnAfterAdminPublicTicketClose()
     {
-        $toApiArrayReturn    = array(
+        $toApiArrayReturn = [
             'author_email' => 'email@example.com',
-            'author_name'  => 'Name',
-        );
-        $serviceMock         = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('getPublicTicketById', 'publicToApiArray'))->getMock();
+            'author_name' => 'Name',
+        ];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['getPublicTicketById', 'publicToApiArray'])->getMock();
         $supportPTicketModel = new \Model_SupportPTicket();
         $supportPTicketModel->loadBean(new \DummyBean());
         $serviceMock->expects($this->atLeastOnce())->method('getPublicTicketById')
-            ->will($this->returnValue($supportPTicketModel));
+            ->willReturn($supportPTicketModel);
         $serviceMock->expects($this->atLeastOnce())->method('publicToApiArray')
-            ->will($this->returnValue($toApiArrayReturn));
+            ->willReturn($toApiArrayReturn);
 
         $emailServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->onlyMethods(array('sendTemplate'))->getMock();
+            ->onlyMethods(['sendTemplate'])->getMock();
         $emailServiceMock->expects($this->atLeastOnce())->method('sendTemplate')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                   = new \Pimple\Container();
-        $di['mod_service']    = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
-            if ('email' == $serviceName) {
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+            if ($serviceName == 'email') {
                 return $emailServiceMock;
             }
-            if ('support' == $serviceName) {
+            if ($serviceName == 'support') {
                 return $serviceMock;
             }
         });
@@ -358,7 +355,7 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('getDi')
-            ->will($this->returnValue($di));
+            ->willReturn($di);
 
         $result = $serviceMock->onAfterAdminPublicTicketClose($eventMock);
         $this->assertNull($result);
@@ -369,9 +366,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportTicket()));
+            ->willReturn(new \Model_SupportTicket());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -381,14 +378,14 @@ class ServiceTest extends \BBTestCase
 
     public function testGetPublicTicketById()
     {
-        $dbMock             = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -404,14 +401,14 @@ class ServiceTest extends \BBTestCase
 
     public function testFindOneByClient()
     {
-        $dbMock             = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -428,9 +425,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -445,48 +442,48 @@ class ServiceTest extends \BBTestCase
 
     public static function getSearchQueryProvider()
     {
-        return array(
-            array(
-                array(
-                    'search'              => 'query',
-                    'id'                  => random_int(1, 100),
-                    'status'              => 'open',
-                    'client_id'           => random_int(1, 100),
-                    'client'              => 'Client name',
-                    'order_id'            => random_int(1, 100),
-                    'subject'             => 'subject',
-                    'content'             => 'Content',
+        return [
+            [
+                [
+                    'search' => 'query',
+                    'id' => random_int(1, 100),
+                    'status' => 'open',
+                    'client_id' => random_int(1, 100),
+                    'client' => 'Client name',
+                    'order_id' => random_int(1, 100),
+                    'subject' => 'subject',
+                    'content' => 'Content',
                     'support_helpdesk_id' => random_int(1, 100),
-                    'created_at'          => date('Y-m-d H:i:s'),
-                    'date_from'           => date('Y-m-d H:i:s'),
-                    'date_to'             => date('Y-m-d H:i:s'),
-                    'priority'            => random_int(1, 100),
-                )
-            ),
-            array(
-                array(
-                    'search'              => random_int(1, 100),
-                    'id'                  => random_int(1, 100),
-                    'status'              => 'open',
-                    'client_id'           => random_int(1, 100),
-                    'client'              => 'Client name',
-                    'order_id'            => random_int(1, 100),
-                    'subject'             => 'subject',
-                    'content'             => 'Content',
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'date_from' => date('Y-m-d H:i:s'),
+                    'date_to' => date('Y-m-d H:i:s'),
+                    'priority' => random_int(1, 100),
+                ],
+            ],
+            [
+                [
+                    'search' => random_int(1, 100),
+                    'id' => random_int(1, 100),
+                    'status' => 'open',
+                    'client_id' => random_int(1, 100),
+                    'client' => 'Client name',
+                    'order_id' => random_int(1, 100),
+                    'subject' => 'subject',
+                    'content' => 'Content',
                     'support_helpdesk_id' => random_int(1, 100),
-                    'created_at'          => date('Y-m-d H:i:s'),
-                    'date_from'           => date('Y-m-d H:i:s'),
-                    'date_to'             => date('Y-m-d H:i:s'),
-                    'priority'            => random_int(1, 100),
-                )
-            )
-        );
+                    'created_at' => date('Y-m-d H:i:s'),
+                    'date_from' => date('Y-m-d H:i:s'),
+                    'date_to' => date('Y-m-d H:i:s'),
+                    'priority' => random_int(1, 100),
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getSearchQueryProvider')]
     public function testGetSearchQuery($data)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
         [$query, $bindings] = $this->service->getSearchQuery($data);
@@ -496,17 +493,17 @@ class ServiceTest extends \BBTestCase
 
     public function testCounter()
     {
-        $arr    = array(
+        $arr = [
             \Model_SupportTicket::OPENED => random_int(1, 100),
             \Model_SupportTicket::ONHOLD => random_int(1, 100),
             \Model_SupportTicket::CLOSED => random_int(1, 100),
-        );
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -524,9 +521,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($ticket, $ticket)));
+            ->willReturn([$ticket, $ticket]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -542,9 +539,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array(array('id' => 1))));
+            ->willReturn([['id' => 1]]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -558,9 +555,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -573,9 +570,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -588,14 +585,14 @@ class ServiceTest extends \BBTestCase
 
     public function testCheckIfTaskAlreadyExistsTrue()
     {
-        $dbMock             = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
+        $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $supportTicketModel = new \Model_SupportTicket();
         $supportTicketModel->loadBean(new \DummyBean());
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($supportTicketModel));
+            ->willReturn($supportTicketModel);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -611,9 +608,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -626,10 +623,10 @@ class ServiceTest extends \BBTestCase
 
     public static function closeTicketProvider()
     {
-        return array(
-            array(new \Model_Admin()),
-            array(new \Model_Client())
-        );
+        return [
+            [new \Model_Admin()],
+            [new \Model_Client()],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('closeTicketProvider')]
@@ -638,14 +635,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['events_manager'] = $eventMock;
         $this->service->setDi($di);
 
@@ -661,10 +658,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -682,10 +679,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->never())
             ->method('getExistingModelById')
-            ->will($this->returnValue($helpdesk));
+            ->willReturn($helpdesk);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -701,15 +698,15 @@ class ServiceTest extends \BBTestCase
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
         $helpdesk->support_helpdesk_id = random_int(1, 100);
-        $helpdesk->can_reopen          = true;
+        $helpdesk->can_reopen = true;
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($helpdesk));
+            ->willReturn($helpdesk);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -730,19 +727,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($model)));
+            ->willReturn([$model]);
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
-
 
         $result = $this->service->rmByClient($client);
         $this->assertNull($result);
@@ -754,7 +750,7 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->exactly(2))
             ->method('find')
             ->willReturnCallback(function (...$args) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'SupportTicketNote' => new \Model_SupportTicketNote(),
                     'SupportTicketMessage' => new \Model_SupportTicketMessage()
                 };
@@ -764,10 +760,10 @@ class ServiceTest extends \BBTestCase
 
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -788,11 +784,11 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($supportTicketMessageModel));
+            ->willReturn($supportTicketMessageModel);
         $dbMock->expects($this->atleastOnce())
             ->method('load')
             ->willReturnCallback(function (...$args) use ($helpdesk) {
-                $value = match($args[0]) {
+                $value = match ($args[0]) {
                     'SupportHelpdesk' => $helpdesk,
                     'Client' => new \Model_Client()
                 };
@@ -802,26 +798,26 @@ class ServiceTest extends \BBTestCase
 
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_SupportTicketNote())));
+            ->willReturn([new \Model_SupportTicketNote()]);
 
-        $ticketMessages = array(new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage());
-        $serviceMock    = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('messageGetRepliesCount', 'messageToApiArray', 'helpdeskToApiArray', 'messageGetTicketMessages', 'noteToApiArray', 'getClientApiArrayForTicket'))->getMock();
+        $ticketMessages = [new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage()];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['messageGetRepliesCount', 'messageToApiArray', 'helpdeskToApiArray', 'messageGetTicketMessages', 'noteToApiArray', 'getClientApiArrayForTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('messageGetRepliesCount')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $serviceMock->expects($this->atLeastOnce())->method('messageToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('messageGetTicketMessages')
-            ->will($this->returnValue($ticketMessages));
+            ->willReturn($ticketMessages);
         $serviceMock->expects($this->atLeastOnce())->method('noteToApiArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->atLeastOnce())->method('getClientApiArrayForTicket')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -842,7 +838,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportTicketMessage()));
+            ->willReturn(new \Model_SupportTicketMessage());
         $dbMock->expects($this->atleastOnce())
             ->method('load')
             ->willReturnCallback(function (...$args) {
@@ -858,32 +854,32 @@ class ServiceTest extends \BBTestCase
 
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_SupportTicketNote())));
+            ->willReturn([new \Model_SupportTicketNote()]);
 
-        $ticketMessages = array(new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage());
-        $serviceMock    = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('messageGetRepliesCount', 'messageToApiArray', 'helpdeskToApiArray', 'messageGetTicketMessages', 'noteToApiArray', 'getClientApiArrayForTicket'))->getMock();
+        $ticketMessages = [new \Model_SupportTicketMessage(), new \Model_SupportTicketMessage()];
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
+            ->onlyMethods(['messageGetRepliesCount', 'messageToApiArray', 'helpdeskToApiArray', 'messageGetTicketMessages', 'noteToApiArray', 'getClientApiArrayForTicket'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('messageGetRepliesCount')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
         $serviceMock->expects($this->atLeastOnce())->method('messageToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('helpdeskToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('messageGetTicketMessages')
-            ->will($this->returnValue($ticketMessages));
+            ->willReturn($ticketMessages);
         $serviceMock->expects($this->atLeastOnce())->method('noteToApiArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $serviceMock->expects($this->atLeastOnce())->method('getClientApiArrayForTicket')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
-        $ticket->rel_id   = random_int(1, 100);
+        $ticket->rel_id = random_int(1, 100);
         $ticket->rel_type = 'Type';
 
         $result = $serviceMock->toApiArray($ticket, true, new \Model_Admin());
@@ -900,17 +896,17 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(new \Model_Client()));
+            ->willReturn(new \Model_Client());
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+            ->onlyMethods(['toApiArray'])->getMock();
         $clientServiceMock->expects($this->atLeastOnce())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['logger']      = $this->getMockBuilder('Box_Log')->getMock();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportTicket();
@@ -926,17 +922,17 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $clientServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Client\Service::class)
-            ->onlyMethods(array('toApiArray'))->getMock();
+            ->onlyMethods(['toApiArray'])->getMock();
         $clientServiceMock->expects($this->never())->method('toApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $dbMock;
-        $di['logger']      = $this->getMockBuilder('Box_Log')->getMock();
-        $di['mod_service'] = $di->protect(fn() => $clientServiceMock);
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['mod_service'] = $di->protect(fn () => $clientServiceMock);
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportTicket();
@@ -956,9 +952,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($admin));
+            ->willReturn($admin);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -973,10 +969,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -992,14 +988,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('noteGetAuthorDetails'))->getMock();
+            ->onlyMethods(['noteGetAuthorDetails'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('noteGetAuthorDetails')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1015,20 +1011,20 @@ class ServiceTest extends \BBTestCase
 
     public function testHelpdeskGetSearchQuery()
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
 
-        $data = array(
-            'search' => 'SearchQuery'
-        );
+        $data = [
+            'search' => 'SearchQuery',
+        ];
         [$query, $bindings] = $this->service->helpdeskGetSearchQuery($data);
 
-        $expectedBindings = array(
-            ':name'      => '%SearchQuery%',
-            ':email'     => '%SearchQuery%',
+        $expectedBindings = [
+            ':name' => '%SearchQuery%',
+            ':email' => '%SearchQuery%',
             ':signature' => '%SearchQuery%',
-        );
+        ];
 
         $this->assertIsString($query);
         $this->assertIsArray($bindings);
@@ -1041,10 +1037,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array(0 => 'General')));
+            ->willReturn([0 => 'General']);
 
-
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1062,21 +1057,21 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
         $helpdesk->id = random_int(1, 100);
-        $result       = $this->service->helpdeskRm($helpdesk);
+        $result = $this->service->helpdeskRm($helpdesk);
         $this->assertTrue($result);
     }
 
@@ -1085,14 +1080,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_SupportTicket())));
+            ->willReturn([new \Model_SupportTicket()]);
 
         $dbMock->expects($this->never())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1100,7 +1095,7 @@ class ServiceTest extends \BBTestCase
         $helpdesk->loadBean(new \DummyBean());
         $helpdesk->id = random_int(1, 100);
         $this->expectException(\FOSSBilling\Exception::class);
-        $result       = $this->service->helpdeskRm($helpdesk);
+        $result = $this->service->helpdeskRm($helpdesk);
         $this->assertTrue($result);
     }
 
@@ -1109,16 +1104,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
         $helpdesk->id = random_int(1, 100);
-        $result       = $this->service->helpdeskToApiArray($helpdesk);
+        $result = $this->service->helpdeskToApiArray($helpdesk);
         $this->assertIsArray($result);
     }
 
@@ -1127,9 +1122,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_SupportTicketMessage())));
+            ->willReturn([new \Model_SupportTicketMessage()]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1146,9 +1141,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1169,9 +1164,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($admin));
+            ->willReturn($admin);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1194,9 +1189,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($client));
+            ->willReturn($client);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1215,14 +1210,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('messageGetAuthorDetails'))->getMock();
+            ->onlyMethods(['messageGetAuthorDetails'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('messageGetAuthorDetails')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -1240,23 +1235,23 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'support_helpdesk_id' => random_int(1, 100),
-            'status'              => \Model_SupportTicket::OPENED,
-            'subject'             => 'Subject',
-            'priority'            => random_int(1, 100),
-        );
+            'status' => \Model_SupportTicket::OPENED,
+            'subject' => 'Subject',
+            'priority' => random_int(1, 100),
+        ];
 
         $result = $this->service->ticketUpdate($ticket, $data);
         $this->assertTrue($result);
@@ -1267,22 +1262,22 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $message = new \Model_SupportTicketMessage();
         $message->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'support_helpdesk_id' => random_int(1, 100),
-            'status'              => \Model_SupportTicket::OPENED,
-            'subject'             => 'Subject',
-            'priority'            => random_int(1, 100),
-        );
+            'status' => \Model_SupportTicket::OPENED,
+            'subject' => 'Subject',
+            'priority' => random_int(1, 100),
+        ];
 
         $result = $this->service->ticketMessageUpdate($message, $data);
         $this->assertTrue($result);
@@ -1298,10 +1293,10 @@ class ServiceTest extends \BBTestCase
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
 
-        return array(
-            array($admin),
-            array($client)
-        );
+        return [
+            [$admin],
+            [$client],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('ticketReplyProvider')]
@@ -1314,24 +1309,23 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
-
 
         $result = $this->service->ticketReply($ticket, $identity, 'Content');
         $this->assertIsInt($result);
@@ -1347,18 +1341,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
 
         $this->service->setDi($di);
@@ -1374,10 +1368,10 @@ class ServiceTest extends \BBTestCase
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
 
-        $data = array(
+        $data = [
             'subject' => 'Subject',
-            'content' => 'Content'
-        );
+            'content' => 'Content',
+        ];
 
         $result = $this->service->ticketCreateForAdmin($client, $helpdesk, $data, $admin);
         $this->assertIsInt($result);
@@ -1393,37 +1387,37 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
             ->method('fire')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
-        $di['tools']          = $toolsMock;
+        $di['tools'] = $toolsMock;
 
         $this->service->setDi($di);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
 
-        $data = array(
-            'name'    => 'Name',
-            'email'   => 'email@example.com',
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
             'subject' => 'Subject',
-            'message' => 'message'
-        );
+            'message' => 'message',
+        ];
 
         $result = $this->service->ticketCreateForGuest($data);
         $this->assertIsString($result);
@@ -1441,62 +1435,62 @@ class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
             ->with('SupportTicket')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue(new \Model_SupportPr()));
+            ->willReturn(new \Model_SupportPr());
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $config         = array(
-            'autorespond_enable'     => 1,
-            'autorespond_message_id' => random_int(1, 100)
-        );
+        $config = [
+            'autorespond_enable' => 1,
+            'autorespond_message_id' => random_int(1, 100),
+        ];
         $supportModMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()
-            ->onlyMethods(array('getConfig'))->getMock();
+            ->onlyMethods(['getConfig'])->getMock();
         $supportModMock->expects($this->atLeastOnce())->method('getConfig')
-            ->will($this->returnValue($config));
+            ->willReturn($config);
 
         $staffServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)
-            ->onlyMethods(array('getCronAdmin'))->getMock();
+            ->onlyMethods(['getCronAdmin'])->getMock();
         $staffServiceMock->expects($this->atLeastOnce())->method('getCronAdmin')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('ticketReply', 'messageCreateForTicket', 'cannedToApiArray'))->getMock();
+            ->onlyMethods(['ticketReply', 'messageCreateForTicket', 'cannedToApiArray'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('ticketReply')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
         $serviceMock->expects($this->atLeastOnce())->method('messageCreateForTicket')
-            ->will($this->returnValue(new \Model_Admin()));
+            ->willReturn(new \Model_Admin());
         $serviceMock->expects($this->atLeastOnce())->method('cannedToApiArray')
-            ->will($this->returnValue(array('content' => 'Content')));
+            ->willReturn(['content' => 'Content']);
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
-        $di['mod']            = $di->protect(fn() => $supportModMock);
-        $di['mod_service']    = $di->protect(fn() => $staffServiceMock);
+        $di['mod'] = $di->protect(fn () => $supportModMock);
+        $di['mod_service'] = $di->protect(fn () => $staffServiceMock);
 
         $serviceMock->setDi($di);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
 
-        $guest     = new \Model_Guest();
+        $guest = new \Model_Guest();
         $guest->id = random_int(1, 100);
 
-        $data = array(
-            'name'    => 'Name',
-            'email'   => 'email@example.com',
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
             'subject' => 'Subject',
-            'content' => 'content'
-        );
+            'content' => 'content',
+        ];
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
@@ -1516,22 +1510,22 @@ class ServiceTest extends \BBTestCase
         $message->loadBean(new \DummyBean());
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('checkIfTaskAlreadyExists'))->getMock();
+            ->onlyMethods(['checkIfTaskAlreadyExists'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('checkIfTaskAlreadyExists')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
 
-        $guest     = new \Model_Guest();
+        $guest = new \Model_Guest();
         $guest->id = random_int(1, 100);
 
-        $data = array(
-            'rel_id'        => random_int(1, 100),
-            'rel_type'      => 'Type',
-            'rel_task'      => 'Task',
+        $data = [
+            'rel_id' => random_int(1, 100),
+            'rel_type' => 'Type',
+            'rel_task' => 'Task',
             'rel_new_value' => 'New value',
-        );
+        ];
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
@@ -1540,7 +1534,7 @@ class ServiceTest extends \BBTestCase
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
 
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $serviceMock->setDi($di);
 
@@ -1558,33 +1552,33 @@ class ServiceTest extends \BBTestCase
         $client->loadBean(new \DummyBean());
         $client->id = random_int(1, 100);
 
-        return array(
-            array(
-                $admin
-            ),
-            array(
-                $client
-            ),
-        );
+        return [
+            [
+                $admin,
+            ],
+            [
+                $client,
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('messageCreateForTicketProvider')]
     public function testMessageCreateForTicket($identity)
     {
-        $randId               = random_int(1, 100);
+        $randId = random_int(1, 100);
         $supportTicketMessage = new \Model_SupportTicketMessage();
         $supportTicketMessage->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($supportTicketMessage));
+            ->willReturn($supportTicketMessage);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di            = new \Pimple\Container();
-        $di['db']      = $dbMock;
-        $di['logger']  = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $this->service->setDi($di);
 
@@ -1598,20 +1592,20 @@ class ServiceTest extends \BBTestCase
 
     public function testMessageCreateForTicketIdentityException()
     {
-        $randId               = random_int(1, 100);
+        $randId = random_int(1, 100);
         $supportTicketMessage = new \Model_SupportTicketMessage();
         $supportTicketMessage->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($supportTicketMessage));
+            ->willReturn($supportTicketMessage);
         $dbMock->expects($this->never())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di            = new \Pimple\Container();
-        $di['db']      = $dbMock;
-        $di['logger']  = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['request'] = $this->getMockBuilder('B\FOSSBilling\Request')->getMock();
         $this->service->setDi($di);
 
@@ -1635,9 +1629,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(new \Model_SupportPTicket()));
+            ->willReturn(new \Model_SupportPTicket());
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1654,9 +1648,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1671,38 +1665,37 @@ class ServiceTest extends \BBTestCase
 
     public static function publicGetSearchQueryProvider()
     {
-        return array(
-            array(
-                array(
-                    'search'  => 'Query',
-                    'id'      => random_int(1, 100),
-                    'status'  => \Model_SupportPTicket::OPENED,
-                    'name'    => 'Name',
-                    'email'   => 'email@example.com',
+        return [
+            [
+                [
+                    'search' => 'Query',
+                    'id' => random_int(1, 100),
+                    'status' => \Model_SupportPTicket::OPENED,
+                    'name' => 'Name',
+                    'email' => 'email@example.com',
                     'subject' => 'Subject',
                     'content' => 'Content',
-                )
-            ),
-            array(
-                array(
-                    'search'  => random_int(1, 100),
-                    'search'  => random_int(1, 100),
-                    'id'      => random_int(1, 100),
-                    'status'  => \Model_SupportPTicket::OPENED,
-                    'name'    => 'Name',
-                    'email'   => 'email@example.com',
+                ],
+            ],
+            [
+                [
+                    'search' => random_int(1, 100),
+                    'search' => random_int(1, 100),
+                    'id' => random_int(1, 100),
+                    'status' => \Model_SupportPTicket::OPENED,
+                    'name' => 'Name',
+                    'email' => 'email@example.com',
                     'subject' => 'Subject',
                     'content' => 'Content',
-                )
-            ),
-        );
+                ],
+            ],
+        ];
     }
-
 
     #[\PHPUnit\Framework\Attributes\DataProvider('publicGetSearchQueryProvider')]
     public function testPublicGetSearchQuery($data)
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
 
@@ -1713,17 +1706,17 @@ class ServiceTest extends \BBTestCase
 
     public function testPublicCounter()
     {
-        $arr    = array(
+        $arr = [
             \Model_SupportPTicket::OPENED => random_int(1, 100),
             \Model_SupportPTicket::ONHOLD => random_int(1, 100),
             \Model_SupportPTicket::CLOSED => random_int(1, 100),
-        );
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue($arr));
+            ->willReturn($arr);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1739,9 +1732,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($ticket, $ticket)));
+            ->willReturn([$ticket, $ticket]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1755,9 +1748,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1771,9 +1764,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array($ticket, $ticket)));
+            ->willReturn([$ticket, $ticket]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1784,10 +1777,10 @@ class ServiceTest extends \BBTestCase
 
     public static function publicCloseTicketProvider()
     {
-        return array(
-            array(new \Model_Admin()),
-            array(new \Model_Guest())
-        );
+        return [
+            [new \Model_Admin()],
+            [new \Model_Guest()],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('publicCloseTicketProvider')]
@@ -1796,14 +1789,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $di['events_manager'] = $eventMock;
         $this->service->setDi($di);
 
@@ -1819,10 +1812,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1838,13 +1831,13 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array(new \Model_SupportPTicketMessage())));
+            ->willReturn([new \Model_SupportPTicketMessage()]);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -1859,43 +1852,43 @@ class ServiceTest extends \BBTestCase
     {
         $self = new ServiceTest('ServiceTest');
 
-        return array(
-            array(
+        return [
+            [
                 new \Model_SupportPTicketMessage(),
-                $self->atLeastOnce()
-            ),
-            array(
+                $self->atLeastOnce(),
+            ],
+            [
                 null,
-                $self->never()
-            )
-        );
+                $self->never(),
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('publicToApiArrayProvider')]
     public function testPublicToApiArray($findOne, $publicMessageGetAuthorDetailsCalled)
     {
-        $ticketMessages = array(new \Model_SupportPTicketMessage(), new \Model_SupportPTicketMessage());
+        $ticketMessages = [new \Model_SupportPTicketMessage(), new \Model_SupportPTicketMessage()];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->any())
             ->method('findOne')
-            ->will($this->returnValue($findOne));
+            ->willReturn($findOne);
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $dbMock->expects($this->any())
             ->method('find')
-            ->will($this->returnValue($ticketMessages));
+            ->willReturn($ticketMessages);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicMessageToApiArray', 'publicMessageGetAuthorDetails'))->getMock();
+            ->onlyMethods(['publicMessageToApiArray', 'publicMessageGetAuthorDetails'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicMessageToApiArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $serviceMock->expects($this->atLeastOnce())->method('publicMessageGetAuthorDetails')
-            ->will($this->returnValue(array('name' => 'Name', 'email' => 'email#example.com')));
+            ->willReturn(['name' => 'Name', 'email' => 'email#example.com']);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $serviceMock->setDi($di);
 
@@ -1919,10 +1912,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($admin));
+            ->willReturn($admin);
 
-
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1940,15 +1932,15 @@ class ServiceTest extends \BBTestCase
     {
         $ticket = new \Model_SupportPTicket();
         $ticket->loadBean(new \DummyBean());
-        $ticket->author_name  = "Name";
-        $ticket->author_email = "Email@example.com";
+        $ticket->author_name = 'Name';
+        $ticket->author_email = 'Email@example.com';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -1967,14 +1959,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Support\Service::class)
-            ->onlyMethods(array('publicMessageGetAuthorDetails'))->getMock();
+            ->onlyMethods(['publicMessageGetAuthorDetails'])->getMock();
         $serviceMock->expects($this->atLeastOnce())->method('publicMessageGetAuthorDetails')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $serviceMock->setDi($di);
 
@@ -1996,10 +1988,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
@@ -2007,25 +1999,25 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
-        $di['tools']          = $toolsMock;
+        $di['tools'] = $toolsMock;
         $this->service->setDi($di);
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
         $admin->id = random_int(1, 100);
 
-        $data = array(
-            'email'   => 'email@example.com',
-            'name'    => 'Name',
+        $data = [
+            'email' => 'email@example.com',
+            'name' => 'Name',
             'message' => 'Message',
             'request' => 'Request',
             'subject' => 'Subject',
-        );
+        ];
 
         $result = $this->service->publicTicketCreate($data, $admin);
         $this->assertIsInt($result);
@@ -2037,23 +2029,23 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportPTicket();
         $ticket->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'support_helpdesk_id' => random_int(1, 100),
-            'status'              => \Model_SupportTicket::OPENED,
-            'subject'             => 'Subject',
-            'priority'            => random_int(1, 100),
-        );
+            'status' => \Model_SupportTicket::OPENED,
+            'subject' => 'Subject',
+            'priority' => random_int(1, 100),
+        ];
 
         $result = $this->service->publicTicketUpdate($ticket, $data);
         $this->assertTrue($result);
@@ -2068,18 +2060,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
         $this->service->setDi($di);
 
@@ -2103,18 +2095,18 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($message));
+            ->willReturn($message);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())->method('fire');
 
-        $di                   = new \Pimple\Container();
-        $di['db']             = $dbMock;
-        $di['logger']         = $this->getMockBuilder('Box_Log')->getMock();
-        $di['request']        = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['request'] = $this->getMockBuilder('\\' . \FOSSBilling\Request::class)->getMock();
         $di['events_manager'] = $eventMock;
         $this->service->setDi($di);
 
@@ -2135,24 +2127,24 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
         $helpdesk = new \Model_SupportHelpdesk();
         $helpdesk->loadBean(new \DummyBean());
 
-        $data = array(
-            'name'        => 'Name',
-            'email'       => 'email@example.com',
-            'can_reopen'  => 1,
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
+            'can_reopen' => 1,
             'close_after' => random_int(1, 100),
-            'signature'   => 'Signature',
-        );
+            'signature' => 'Signature',
+        ];
 
         $result = $this->service->helpdeskUpdate($helpdesk, $data);
         $this->assertTrue($result);
@@ -2160,33 +2152,33 @@ class ServiceTest extends \BBTestCase
 
     public function testHelpdeskCreate()
     {
-        $randId        = random_int(1, 100);
+        $randId = random_int(1, 100);
         $helpDeskModel = new \Model_SupportHelpdesk();
         $helpDeskModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($helpDeskModel));
+            ->willReturn($helpDeskModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportHelpdesk();
         $ticket->loadBean(new \DummyBean());
 
-        $data = array(
-            'name'        => 'Name',
-            'email'       => 'email@example.com',
-            'can_reopen'  => 1,
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
+            'can_reopen' => 1,
             'close_after' => random_int(1, 100),
-            'signature'   => 'Signature',
-        );
+            'signature' => 'Signature',
+        ];
 
         $result = $this->service->helpdeskCreate($data);
         $this->assertIsInt($result);
@@ -2195,13 +2187,13 @@ class ServiceTest extends \BBTestCase
 
     public function testCannedGetSearchQuery()
     {
-        $di              = new \Pimple\Container();
+        $di = new \Pimple\Container();
 
         $this->service->setDi($di);
 
-        $data = array(
+        $data = [
             'search' => 'query',
-        );
+        ];
 
         [$query, $bindings] = $this->service->cannedGetSearchQuery($data);
         $this->assertIsString($query);
@@ -2210,29 +2202,28 @@ class ServiceTest extends \BBTestCase
 
     public function testCannedGetGroupedPairs()
     {
-        $pairs = array(
-            0 => array(
-                'id'      => 1,
+        $pairs = [
+            0 => [
+                'id' => 1,
                 'r_title' => 'R  Title',
                 'c_title' => 'General',
-            )
-        );
+            ],
+        ];
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($pairs));
+            ->willReturn($pairs);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
-        $expected = array(
-            'General' =>
-            array(
+        $expected = [
+            'General' => [
                 1 => 'R  Title',
-            ),
-        );
+            ],
+        ];
 
         $result = $this->service->cannedGetGroupedPairs();
         $this->assertIsArray($result);
@@ -2244,10 +2235,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -2262,21 +2253,20 @@ class ServiceTest extends \BBTestCase
     {
         $category = new \Model_SupportPrCategory();
         $category->loadBean(new \DummyBean());
-        $category->id    = random_int(1, 100);
+        $category->id = random_int(1, 100);
         $category->title = 'General';
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue($category));
+            ->willReturn($category);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
-
 
         $canned = new \Model_SupportPr();
         $canned->loadBean(new \DummyBean());
@@ -2294,15 +2284,14 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
-
 
         $canned = new \Model_SupportPr();
         $canned->loadBean(new \DummyBean());
@@ -2310,7 +2299,7 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->cannedToApiArray($canned);
         $this->assertIsArray($result);
         $this->assertArrayHasKey('category', $result);
-        $this->assertEquals($result['category'], array());
+        $this->assertEquals($result['category'], []);
     }
 
     public function testCannedCategoryGetPairs()
@@ -2318,10 +2307,9 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array(0 => 'General')));
+            ->willReturn([0 => 'General']);
 
-
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
@@ -2339,10 +2327,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -2358,10 +2346,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('toArray')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -2374,38 +2362,38 @@ class ServiceTest extends \BBTestCase
 
     public function testCannedCreate()
     {
-        $randId        = random_int(1, 100);
+        $randId = random_int(1, 100);
         $helpDeskModel = new \Model_SupportHelpdesk();
         $helpDeskModel->loadBean(new \DummyBean());
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($helpDeskModel));
+            ->willReturn($helpDeskModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
         $settingsServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Email\Service::class)
-            ->addMethods(array('checkLimits'))->getMock();
+            ->addMethods(['checkLimits'])->getMock();
         $settingsServiceMock->expects($this->atLeastOnce())->method('checkLimits')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $settingsServiceMock);
-        $di['db']          = $dbMock;
-        $di['logger']      = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn () => $settingsServiceMock);
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
         $ticket = new \Model_SupportHelpdesk();
         $ticket->loadBean(new \DummyBean());
 
-        $data = array(
-            'name'        => 'Name',
-            'email'       => 'email@example.com',
-            'can_reopen'  => 1,
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
+            'can_reopen' => 1,
             'close_after' => random_int(1, 100),
-            'signature'   => 'Signature',
-        );
+            'signature' => 'Signature',
+        ];
 
         $result = $this->service->cannedCreate($data, random_int(1, 100), 'Content');
         $this->assertIsInt($result);
@@ -2417,22 +2405,22 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(random_int(1, 100)));
+            ->willReturn(random_int(1, 100));
 
-        $di              = new \Pimple\Container();
-        $di['db']        = $dbMock;
-        $di['logger']    = $this->getMockBuilder('Box_Log')->getMock();
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->service->setDi($di);
 
         $model = new \Model_SupportPr();
         $model->loadBean(new \DummyBean());
 
-        $data = array(
+        $data = [
             'category_id' => random_int(1, 100),
-            'title'       => 'email@example.com',
-            'content'     => 1,
-        );
+            'title' => 'email@example.com',
+            'content' => 1,
+        ];
 
         $result = $this->service->cannedUpdate($model, $data);
         $this->assertTrue($result);
@@ -2440,30 +2428,30 @@ class ServiceTest extends \BBTestCase
 
     public function testCannedCategoryCreate()
     {
-        $randId                 = random_int(1, 100);
+        $randId = random_int(1, 100);
         $supportPrCategoryModel = new \Model_SupportPrCategory();
         $supportPrCategoryModel->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($supportPrCategoryModel));
+            ->willReturn($supportPrCategoryModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
-        $data = array(
-            'name'        => 'Name',
-            'email'       => 'email@example.com',
-            'can_reopen'  => 1,
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
+            'can_reopen' => 1,
             'close_after' => random_int(1, 100),
-            'signature'   => 'Signature',
-        );
+            'signature' => 'Signature',
+        ];
 
         $result = $this->service->cannedCategoryCreate($data);
         $this->assertIsInt($result);
@@ -2476,10 +2464,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -2492,30 +2480,30 @@ class ServiceTest extends \BBTestCase
 
     public function testNoteCreate()
     {
-        $randId                 = random_int(1, 100);
+        $randId = random_int(1, 100);
         $supportPrCategoryModel = new \Model_SupportPrCategory();
         $supportPrCategoryModel->loadBean(new \DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($supportPrCategoryModel));
+            ->willReturn($supportPrCategoryModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
-        $data = array(
-            'name'        => 'Name',
-            'email'       => 'email@example.com',
-            'can_reopen'  => 1,
+        $data = [
+            'name' => 'Name',
+            'email' => 'email@example.com',
+            'can_reopen' => 1,
             'close_after' => random_int(1, 100),
-            'signature'   => 'Signature',
-        );
+            'signature' => 'Signature',
+        ];
 
         $admin = new \Model_Admin();
         $admin->loadBean(new \DummyBean());
@@ -2534,10 +2522,10 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $dbMock;
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $this->service->setDi($di);
 
@@ -2550,22 +2538,21 @@ class ServiceTest extends \BBTestCase
 
     public static function canClientSubmitNewTicketProvider()
     {
-
         $ticket = new \Model_SupportTicket();
         $ticket->loadBean(new \DummyBean());
-        $ticket->client_id  = 5;
+        $ticket->client_id = 5;
         $ticket->created_at = date('Y-m-d H:i:s');
 
         $ticket2 = new \Model_SupportTicket();
         $ticket2->loadBean(new \DummyBean());
-        $ticket2->client_id  = 5;
-        $ticket2->created_at = date('Y-m-d H:i:s', strtotime("-2 days"));;
+        $ticket2->client_id = 5;
+        $ticket2->created_at = date('Y-m-d H:i:s', strtotime('-2 days'));
 
-        return array(
-            array($ticket, 24, false), //Ticket is created today, exception should be thrown
-            array(null, 24, true), //No previously created tickets found, can submit a ticket
-            array($ticket2, 24, true) //Last ticket submitted 2 days ago, can submit a ticket
-        );
+        return [
+            [$ticket, 24, false], // Ticket is created today, exception should be thrown
+            [null, 24, true], // No previously created tickets found, can submit a ticket
+            [$ticket2, 24, true], // Last ticket submitted 2 days ago, can submit a ticket
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('canClientSubmitNewTicketProvider')]
@@ -2577,16 +2564,16 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($ticket));
+            ->willReturn($ticket);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $this->service->setDi($di);
         $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
         $client->id = 5;
 
-        $config = array('wait_hours' => $hours);
+        $config = ['wait_hours' => $hours];
 
         $result = $this->service->canClientSubmitNewTicket($client, $config);
         $this->assertTrue($result);
@@ -2596,29 +2583,28 @@ class ServiceTest extends \BBTestCase
     * Knowledge Base Tests.
     */
 
-    public function testKb_searchArticles()
+    public function testKbSearchArticles()
     {
         $service = new \Box\Mod\Support\Service();
 
-        $willReturn = array(
-            "pages"    => 5,
-            "page"     => 2,
-            "per_page" => 2,
-            "total"    => 10,
-            "list"     => array(),
-        );
+        $willReturn = [
+            'pages' => 5,
+            'page' => 2,
+            'per_page' => 2,
+            'total' => 10,
+            'list' => [],
+        ];
 
         $di = new \Pimple\Container();
 
         $pager = $this->getMockBuilder('Box_Pagination')->getMock();
         $pager->expects($this->atLeastOnce())
             ->method('getSimpleResultSet')
-            ->will($this->returnValue($willReturn));
+            ->willReturn($willReturn);
 
-
-        $client      = new \Model_Client();
+        $client = new \Model_Client();
         $client->loadBean(new \DummyBean());
-        $client->id  = 5;
+        $client->id = 5;
         $di['pager'] = $pager;
         $service->setDi($di);
 
@@ -2634,18 +2620,18 @@ class ServiceTest extends \BBTestCase
         $this->assertArrayHasKey('total', $result);
     }
 
-    public function testKb_findActiveArticleById()
+    public function testKbFindActiveArticleById()
     {
         $service = new \Box\Mod\Support\Service();
 
         $model = new \Model_SupportKbArticle();
         $model->loadBean(new \DummyBean());
-        $db    = $this->getMockBuilder('Box_Database')->getMock();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -2654,17 +2640,17 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($result, $model);
     }
 
-    public function testKb_findActiveArticleBySlug()
+    public function testKbFindActiveArticleBySlug()
     {
         $service = new \Box\Mod\Support\Service();
 
         $model = new \Model_SupportKbArticle();
-        $db    = $this->getMockBuilder('Box_Database')->getMock();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -2673,15 +2659,15 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($result, $model);
     }
 
-    public function testKb_findActive()
+    public function testKbFindActive()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('find')
-            ->will($this->returnValue(array()));
-        $di       = new \Pimple\Container();
+            ->willReturn([]);
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -2689,20 +2675,20 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_hitView()
+    public function testKbHitView()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue(5));
+            ->willReturn(5);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
-        $modelKb        = new \Model_SupportKbArticle();
+        $modelKb = new \Model_SupportKbArticle();
         $modelKb->loadBean(new \DummyBean());
         $modelKb->views = 10;
 
@@ -2710,25 +2696,24 @@ class ServiceTest extends \BBTestCase
         $this->assertNull($result);
     }
 
-    public function testKb_rm()
+    public function testKbRm()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('trash')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
-        $modelKb        = new \Model_SupportKbArticle();
+        $modelKb = new \Model_SupportKbArticle();
         $modelKb->loadBean(new \DummyBean());
-        $modelKb->id    = 1;
+        $modelKb->id = 1;
         $modelKb->views = 10;
-
 
         $result = $service->kbRm($modelKb);
         $this->assertNull($result);
@@ -2736,131 +2721,130 @@ class ServiceTest extends \BBTestCase
 
     public static function kbToApiArrayProvider()
     {
-        $model                         = new \Model_SupportKbArticle();
+        $model = new \Model_SupportKbArticle();
         $model->loadBean(new \DummyBean());
-        $model->id                     = random_int(1, 100);
-        $model->slug                   = 'article-slug';
-        $model->title                  = "Title";
-        $model->views                  = random_int(1, 100);
-        $model->content                = 'Content';
-        $model->created_at             = '2013-01-01 12:00:00';
-        $model->updated_at             = '2014-01-01 12:00:00';
-        $model->status                 = 'active';
+        $model->id = random_int(1, 100);
+        $model->slug = 'article-slug';
+        $model->title = 'Title';
+        $model->views = random_int(1, 100);
+        $model->content = 'Content';
+        $model->created_at = '2013-01-01 12:00:00';
+        $model->updated_at = '2014-01-01 12:00:00';
+        $model->status = 'active';
         $model->kb_article_category_id = random_int(1, 100);
 
-        $category        = new \Model_SupportKbArticleCategory();
+        $category = new \Model_SupportKbArticleCategory();
         $category->loadBean(new \DummyBean());
-        $category->id    = random_int(1, 100);
-        $category->slug  = 'category-slug';
+        $category->id = random_int(1, 100);
+        $category->slug = 'category-slug';
         $category->title = 'category-title';
 
-        return array(
-            array(
+        return [
+            [
                 $model,
-                array(
-                    'id'         => $model->id,
-                    'slug'       => $model->slug,
-                    'title'      => $model->title,
-                    'views'      => $model->views,
+                [
+                    'id' => $model->id,
+                    'slug' => $model->slug,
+                    'title' => $model->title,
+                    'views' => $model->views,
                     'created_at' => $model->created_at,
                     'updated_at' => $model->updated_at,
-                    'category'   => array(
-                        'id'    => $category->id,
-                        'slug'  => $category->slug,
+                    'category' => [
+                        'id' => $category->id,
+                        'slug' => $category->slug,
                         'title' => $category->title,
-                    ),
-                    'status'                 => $model->status,
-                ),
+                    ],
+                    'status' => $model->status,
+                ],
                 false,
                 null,
-                $category
-            ),
-            array(
+                $category,
+            ],
+            [
                 $model,
-                array(
-                    'id'         => $model->id,
-                    'slug'       => $model->slug,
-                    'title'      => $model->title,
-                    'views'      => $model->views,
+                [
+                    'id' => $model->id,
+                    'slug' => $model->slug,
+                    'title' => $model->title,
+                    'views' => $model->views,
                     'created_at' => $model->created_at,
                     'updated_at' => $model->updated_at,
-                    'category'   => array(
-                        'id'    => $category->id,
-                        'slug'  => $category->slug,
+                    'category' => [
+                        'id' => $category->id,
+                        'slug' => $category->slug,
                         'title' => $category->title,
-                    ),
-                    'content'    => $model->content,
-                    'status'     => $model->status,
-                ),
+                    ],
+                    'content' => $model->content,
+                    'status' => $model->status,
+                ],
                 true,
                 null,
-                $category
-            ),
-            array(
+                $category,
+            ],
+            [
                 $model,
-                array(
-                    'id'                     => $model->id,
-                    'slug'                   => $model->slug,
-                    'title'                  => $model->title,
-                    'views'                  => $model->views,
-                    'created_at'             => $model->created_at,
-                    'updated_at'             => $model->updated_at,
-                    'category'   => array(
-                        'id'    => $category->id,
-                        'slug'  => $category->slug,
+                [
+                    'id' => $model->id,
+                    'slug' => $model->slug,
+                    'title' => $model->title,
+                    'views' => $model->views,
+                    'created_at' => $model->created_at,
+                    'updated_at' => $model->updated_at,
+                    'category' => [
+                        'id' => $category->id,
+                        'slug' => $category->slug,
                         'title' => $category->title,
-                    ),
-                    'content'                => $model->content,
-                    'status'                 => $model->status,
-                    'kb_article_category_id' => $model->kb_article_category_id
-                ),
+                    ],
+                    'content' => $model->content,
+                    'status' => $model->status,
+                    'kb_article_category_id' => $model->kb_article_category_id,
+                ],
                 true,
                 new \Model_Admin(),
-                $category
-            ),
-
-        );
+                $category,
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('kbToApiArrayProvider')]
-    public function testKb_toApiArray($model, $expected, $deep, $identity, $category)
+    public function testKbToApiArray($model, $expected, $deep, $identity, $category)
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($category));
-        $di       = new \Pimple\Container();
+            ->willReturn($category);
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
-        $result  = $service->kbToApiArray($model, $deep, $identity);
+        $result = $service->kbToApiArray($model, $deep, $identity);
         $this->assertEquals($result, $expected);
     }
 
-    public function testKb_createArticle()
+    public function testKbCreateArticle()
     {
         $service = new \Box\Mod\Support\Service();
-        $randId  = random_int(1, 100);
-        $db      = $this->getMockBuilder('Box_Database')->getMock();
+        $randId = random_int(1, 100);
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
         $model = new \Model_SupportKbArticle();
         $model->loadBean(new \DummyBean());
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $tools = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->onlyMethods(array('slug'))->getMock();
+        $tools = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->onlyMethods(['slug'])->getMock();
         $tools->expects($this->atLeastOnce())
             ->method('slug')
-            ->will($this->returnValue('article-slug'));
+            ->willReturn('article-slug');
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
-        $di['tools']  = $tools;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $di['tools'] = $tools;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $service->setDi($di);
@@ -2869,31 +2853,31 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($result, $randId);
     }
 
-    public function testKb_updateArticle()
+    public function testKbUpdateArticle()
     {
         $service = new \Box\Mod\Support\Service();
-        $randId  = random_int(1, 100);
+        $randId = random_int(1, 100);
 
         $model = new \Model_SupportKbArticle();
         $model->loadBean(new \DummyBean());
 
         $kb_article_category_id = random_int(1, 100);
-        $title                  = 'Title';
-        $slug                   = 'article-slug';
-        $status                 = 'active';
-        $content                = 'content';
-        $views                  = random_int(1, 100);
+        $title = 'Title';
+        $slug = 'article-slug';
+        $status = 'active';
+        $content = 'content';
+        $views = random_int(1, 100);
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $service->setDi($di);
@@ -2902,29 +2886,28 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testKb_updateArticleNotFoundException()
+    public function testKbUpdateArticleNotFoundException()
     {
         $service = new \Box\Mod\Support\Service();
-        $randId  = random_int(1, 100);
-
+        $randId = random_int(1, 100);
 
         $kb_article_category_id = random_int(1, 100);
-        $title                  = 'Title';
-        $slug                   = 'article-slug';
-        $status                 = 'active';
-        $content                = 'content';
-        $views                  = random_int(1, 100);
+        $title = 'Title';
+        $slug = 'article-slug';
+        $status = 'active';
+        $content = 'content';
+        $views = random_int(1, 100);
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $db->expects($this->never())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $service->setDi($di);
@@ -2936,61 +2919,60 @@ class ServiceTest extends \BBTestCase
 
     public static function kbCategoryGetSearchQueryProvider()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 '
                 SELECT kac.*
                 FROM support_kb_article_category kac
                 LEFT JOIN support_kb_article ka ON kac.id  = ka.kb_article_category_id GROUP BY kac.id ORDER BY kac.id DESC',
-                array(),
-            ),
-            array(
-                array(
-                    'article_status' => "active"
-                ),
+                [],
+            ],
+            [
+                [
+                    'article_status' => 'active',
+                ],
                 'SELECT kac.*
                  FROM support_kb_article_category kac
                  LEFT JOIN support_kb_article ka ON kac.id  = ka.kb_article_category_id
                  WHERE ka.status = :status GROUP BY kac.id ORDER BY kac.id DESC',
-                array(
+                [
                     ':status' => 'active',
-                ),
-            ),
-            array(
-                array(
-                    'q' => "search query"
-                ),
+                ],
+            ],
+            [
+                [
+                    'q' => 'search query',
+                ],
                 'SELECT kac.*
                  FROM support_kb_article_category kac
                  LEFT JOIN support_kb_article ka ON kac.id  = ka.kb_article_category_id
                  WHERE (ka.title LIKE :title OR ka.content LIKE :content) GROUP BY kac.id ORDER BY kac.id DESC',
-                array(
-                    ':title'   => '%search query%',
+                [
+                    ':title' => '%search query%',
                     ':content' => '%search query%',
-                ),
-            ),
-            array(
-                array(
-                    'q'              => "search query",
-                    'article_status' => "active"
-                ),
+                ],
+            ],
+            [
+                [
+                    'q' => 'search query',
+                    'article_status' => 'active',
+                ],
                 'SELECT kac.*
                  FROM support_kb_article_category kac
                  LEFT JOIN support_kb_article ka ON kac.id  = ka.kb_article_category_id
                  WHERE ka.status = :status AND (ka.title LIKE :title OR ka.content LIKE :content) GROUP BY kac.id ORDER BY kac.id DESC',
-                array(
-                    ':title'   => '%search query%',
+                [
+                    ':title' => '%search query%',
                     ':content' => '%search query%',
-                    ':status'  => 'active',
-                ),
-            ),
-
-        );
+                    ':status' => 'active',
+                ],
+            ],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('kbCategoryGetSearchQueryProvider')]
-    public function testKb_categoryGetSearchQuery($data, $query, $bindings)
+    public function testKbCategoryGetSearchQuery($data, $query, $bindings)
     {
         $service = new \Box\Mod\Support\Service();
 
@@ -3003,21 +2985,20 @@ class ServiceTest extends \BBTestCase
         $this->assertIsString($result[0]);
         $this->assertIsArray($result[1]);
 
-        $this->assertEquals(trim(preg_replace('/\s+/', '', str_replace("\n", " ", $result[0]))), trim(preg_replace('/\s+/', '', str_replace("\n", " ", $query))));
+        $this->assertEquals(trim(preg_replace('/\s+/', '', str_replace("\n", ' ', $result[0]))), trim(preg_replace('/\s+/', '', str_replace("\n", ' ', $query))));
         $this->assertEquals($result[1], $bindings);
-
     }
 
-    public function testKb_categoryFindAll()
+    public function testKbCategoryFindAll()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -3025,16 +3006,16 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_categoryGetPairs()
+    public function testKbCategoryGetPairs()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getAssoc')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -3042,23 +3023,23 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testKb_categoryRm()
+    public function testKbCategoryRm()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
-        $model            = new \Model_SupportKbArticleCategory();
+        $model = new \Model_SupportKbArticleCategory();
         $model->loadBean(new \DummyBean());
-        $model->id        = random_int(1, 100);
+        $model->id = random_int(1, 100);
         $model->KbArticle = new \Model_SupportKbArticleCategory();
         $model->KbArticle->loadBean(new \DummyBean());
 
@@ -3066,23 +3047,23 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testKb_categoryRmHasArticlesException()
+    public function testKbCategoryRmHasArticlesException()
     {
         $service = new \Box\Mod\Support\Service();
 
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
-        $model            = new \Model_SupportKbArticleCategory();
+        $model = new \Model_SupportKbArticleCategory();
         $model->loadBean(new \DummyBean());
-        $model->id        = random_int(1, 100);
+        $model->id = random_int(1, 100);
         $model->KbArticle = new \Model_SupportKbArticle();
         $model->KbArticle->loadBean(new \DummyBean());
 
@@ -3091,7 +3072,7 @@ class ServiceTest extends \BBTestCase
         $this->assertNull($result);
     }
 
-    public function testKb_createCategory()
+    public function testKbCreateCategory()
     {
         $service = new \Box\Mod\Support\Service();
 
@@ -3100,52 +3081,51 @@ class ServiceTest extends \BBTestCase
         $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
         $articleCategoryModel = new \Model_SupportKbArticleCategory();
         $articleCategoryModel->loadBean(new \DummyBean());
 
         $db->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($articleCategoryModel));
+            ->willReturn($articleCategoryModel);
 
-        $tools = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->onlyMethods(array('slug'))->getMock();
+        $tools = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->onlyMethods(['slug'])->getMock();
         $tools->expects($this->atLeastOnce())
             ->method('slug')
-            ->will($this->returnValue('article-slug'));
+            ->willReturn('article-slug');
 
         $systemService = $this->getMockBuilder(\Box\Mod\System\Service::class)->getMock();
         $systemService->expects($this->atLeastOnce())
             ->method('checkLimits')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
-        $di                = new \Pimple\Container();
-        $di['db']          = $db;
-        $di['tools']       = $tools;
-        $di['logger']      = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
-        $di['mod_service'] = $di->protect(fn() => $systemService);
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
+        $di['tools'] = $tools;
+        $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
+        $di['mod_service'] = $di->protect(fn () => $systemService);
         $service->setDi($di);
 
         $result = $service->kbCreateCategory('Title', 'Description');
         $this->assertIsInt($result);
         $this->assertEquals($result, $randId);
-
     }
 
-    public function testKb_updateCategory()
+    public function testKbUpdateCategory()
     {
         $service = new \Box\Mod\Support\Service();
-        $randId  = random_int(1, 100);
-        $db      = $this->getMockBuilder('Box_Database')->getMock();
+        $randId = random_int(1, 100);
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('store')
-            ->will($this->returnValue($randId));
+            ->willReturn($randId);
 
-        $di           = new \Pimple\Container();
-        $di['db']     = $db;
+        $di = new \Pimple\Container();
+        $di['db'] = $db;
         $di['logger'] = $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
         $service->setDi($di);
 
-        $model     = new \Model_SupportKbArticleCategory();
+        $model = new \Model_SupportKbArticleCategory();
         $model->loadBean(new \DummyBean());
         $model->id = random_int(1, 100);
 
@@ -3153,17 +3133,17 @@ class ServiceTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testKb_FindCategoryById()
+    public function testKbFindCategoryById()
     {
         $service = new \Box\Mod\Support\Service();
 
         $model = new \Model_SupportKbArticleCategory();
-        $db    = $this->getMockBuilder('Box_Database')->getMock();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('getExistingModelById')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 
@@ -3172,17 +3152,17 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($result, $model);
     }
 
-    public function testKb_FindCategoryBySlug()
+    public function testKbFindCategoryBySlug()
     {
         $service = new \Box\Mod\Support\Service();
 
         $model = new \Model_SupportKbArticleCategory();
-        $db    = $this->getMockBuilder('Box_Database')->getMock();
+        $db = $this->getMockBuilder('Box_Database')->getMock();
         $db->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($model));
+            ->willReturn($model);
 
-        $di       = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['db'] = $db;
         $service->setDi($di);
 

--- a/tests/modules/System/Api/AdminTest.php
+++ b/tests/modules/System/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\System\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\System\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\System\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,15 +22,15 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_params()
+    public function testgetParams()
     {
-        $data = array(
-        );
+        $data = [
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getParams')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -39,15 +38,15 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testupdate_params()
+    public function testupdateParams()
     {
-        $data = array(
-        );
+        $data = [
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateParams')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
@@ -58,8 +57,8 @@ class AdminTest extends \BBTestCase {
 
     public function testmessages()
     {
-        $data = array(
-        );
+        $data = [
+        ];
 
         $di = new \Pimple\Container();
 
@@ -68,7 +67,7 @@ class AdminTest extends \BBTestCase {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getMessages')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($serviceMock);
 
@@ -76,16 +75,16 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testtemplate_exists()
+    public function testtemplateExists()
     {
-        $data = array(
+        $data = [
             'file' => 'testing.txt',
-        );
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('templateExists')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($serviceMock);
 
@@ -94,16 +93,16 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function teststring_render()
+    public function teststringRender()
     {
-        $data = array(
-            '_tpl' => 'default'
-        );
+        $data = [
+            '_tpl' => 'default',
+        ];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('renderString')
-            ->will($this->returnValue('returnStringType'));
+            ->willReturn('returnStringType');
         $di = new \Pimple\Container();
 
         $this->api->setDi($di);
@@ -115,12 +114,12 @@ class AdminTest extends \BBTestCase {
 
     public function testenv()
     {
-        $data = array();
+        $data = [];
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getEnv')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 
@@ -131,23 +130,23 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testis_allowed()
+    public function testisAllowed()
     {
-        $data = array(
+        $data = [
             'mod' => 'extension',
-        );
+        ];
 
         $staffServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Staff\Service::class)->getMock();
         $staffServiceMock->expects($this->atLeastOnce())
             ->method('hasPermission')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $di                = new \Pimple\Container();
+        $di = new \Pimple\Container();
         $di['mod_service'] = $di->protect(function ($serviceName) use ($staffServiceMock) {
             if ($serviceName == 'Staff') {
                 return $staffServiceMock;

--- a/tests/modules/System/Api/GuestTest.php
+++ b/tests/modules/System/Api/GuestTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\System\Api;
 
-
-class GuestTest extends \BBTestCase {
+class GuestTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\System\Api\Guest
+     * @var Guest
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\System\Api\Guest();
+        $this->api = new Guest();
     }
 
     public function testgetDi()
@@ -22,11 +21,12 @@ class GuestTest extends \BBTestCase {
         $getDi = $this->api->getDi();
         $this->assertEquals($di, $getDi);
     }
+
     public function testVersionAdmin()
     {
         $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authorizationMock->expects($this->atLeastOnce())
-            ->method("isAdminLoggedIn")
+            ->method('isAdminLoggedIn')
             ->willReturn(true);
 
         $di = new \Pimple\Container();
@@ -49,7 +49,7 @@ class GuestTest extends \BBTestCase {
     {
         $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authorizationMock->expects($this->atLeastOnce())
-            ->method("isAdminLoggedIn")
+            ->method('isAdminLoggedIn')
             ->willReturn(false);
 
         $di = new \Pimple\Container();
@@ -76,7 +76,7 @@ class GuestTest extends \BBTestCase {
     {
         $authorizationMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authorizationMock->expects($this->atLeastOnce())
-            ->method("isAdminLoggedIn")
+            ->method('isAdminLoggedIn')
             ->willReturn(false);
 
         $di = new \Pimple\Container();
@@ -98,7 +98,7 @@ class GuestTest extends \BBTestCase {
 
     public function testCompanyShowPublicOn()
     {
-        $companyData = array('companyName' => 'TestCo');
+        $companyData = ['companyName' => 'TestCo'];
 
         $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authMock->method('isAdminLoggedIn')->willReturn(false);
@@ -122,9 +122,10 @@ class GuestTest extends \BBTestCase {
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
     }
+
     public function testCompanyShowPublicOff()
     {
-        $companyData = array(
+        $companyData = [
             'companyName' => 'TestCo',
             'vat_number' => 'Test VAT',
             'email' => 'test@email.com',
@@ -134,7 +135,7 @@ class GuestTest extends \BBTestCase {
             'address_1' => 'Test Address 1',
             'address_2' => 'Test Address 2',
             'address_3' => 'Test Address 3',
-        );
+        ];
 
         $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
         $authMock->method('isAdminLoggedIn')->willReturn(false);
@@ -166,18 +167,14 @@ class GuestTest extends \BBTestCase {
         $this->assertArrayNotHasKey('address_3', $result);
     }
 
-
-
-
-    public function testphone_codes()
+    public function testphoneCodes()
     {
-        $data = array(
-
-        );
+        $data = [
+        ];
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('getPhoneCodes')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($servuceMock);
 
@@ -190,7 +187,7 @@ class GuestTest extends \BBTestCase {
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('getStates')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($servuceMock);
 
@@ -198,12 +195,12 @@ class GuestTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testcountries_eunion()
+    public function testcountriesEunion()
     {
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('getEuCountries')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($servuceMock);
 
@@ -216,7 +213,7 @@ class GuestTest extends \BBTestCase {
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('getCountries')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($servuceMock);
 
@@ -230,14 +227,14 @@ class GuestTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testperiod_title()
+    public function testperiodTitle()
     {
-        $data = array('code' => 'periodCode');
+        $data = ['code' => 'periodCode'];
 
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('getPeriod')
-            ->will($this->returnValue('periodTtitleValue'));
+            ->willReturn('periodTtitleValue');
         $di = new \Pimple\Container();
 
         $this->api->setDi($di);
@@ -247,9 +244,9 @@ class GuestTest extends \BBTestCase {
         $this->assertIsString($result);
     }
 
-    public function testperiod_titleMissingCode()
+    public function testperiodTitleMissingCode()
     {
-        $data = array();
+        $data = [];
         $expected = '-';
         $di = new \Pimple\Container();
 
@@ -259,16 +256,16 @@ class GuestTest extends \BBTestCase {
         $this->assertEquals($expected, $result);
     }
 
-    public function testtemplate_exists()
+    public function testtemplateExists()
     {
-        $data = array(
+        $data = [
             'file' => 'testing.txt',
-        );
+        ];
 
         $servuceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $servuceMock->expects($this->atLeastOnce())
             ->method('templateExists')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->api->setService($servuceMock);
 
@@ -277,10 +274,10 @@ class GuestTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testtemplate_existsFileParamMissing()
+    public function testtemplateExistsFileParamMissing()
     {
-        $data = array(
-        );
+        $data = [
+        ];
 
         $result = $this->api->template_exists($data);
         $this->assertIsBool($result);
@@ -292,7 +289,7 @@ class GuestTest extends \BBTestCase {
         $setLang = 'en_US';
         $di = new \Pimple\Container();
 
-        $di['config'] = [ 'i18n' => ['locale' => 'en_US' ] ];
+        $di['config'] = ['i18n' => ['locale' => 'en_US']];
 
         $this->api->setDi($di);
 
@@ -302,10 +299,10 @@ class GuestTest extends \BBTestCase {
         $this->assertEquals($setLang, $result);
     }
 
-    public function testget_pending_messages()
+    public function testgetPendingMessages()
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
-        $messageArr = array('Important message to user');
+        $messageArr = ['Important message to user'];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPendingMessages')
             ->willReturn($messageArr);
@@ -318,5 +315,4 @@ class GuestTest extends \BBTestCase {
         $this->assertIsArray($result);
         $this->assertEquals($messageArr, $result);
     }
-
 }

--- a/tests/modules/System/ServiceTest.php
+++ b/tests/modules/System/ServiceTest.php
@@ -7,18 +7,18 @@ use Twig\Environment;
 class ServiceTest extends \BBTestCase
 {
     /**
-     * @var \Box\Mod\System\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service = new \Box\Mod\System\Service();
+        $this->service = new Service();
     }
 
     public function testgetParamValueMissingKeyParam()
     {
-        $param = array();
+        $param = [];
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Parameter key is missing');
 
@@ -27,45 +27,45 @@ class ServiceTest extends \BBTestCase
 
     public function testgetCompany()
     {
-        $config = array('url' => 'www.fossbilling.org');
-        $expected = array(
-            'www'                   => 'http://localhost/',
-            'name'                  => 'Inc. Test',
-            'email'                 => 'work@example.eu',
-            'tel'                   =>   NULL,
-            'signature'             =>   NULL,
-            'logo_url'              =>   NULL,
-            'logo_url_dark'         =>   NULL,
-            'favicon_url'           =>   NULL,
-            'address_1'             =>   NULL,
-            'address_2'             =>   NULL,
-            'address_3'             =>   NULL,
-            'account_number'        =>   NULL,
-            'bank_name'             =>   NULL,
-            'bic'    =>   NULL,
-            'display_bank_info'     =>   NULL,
-            'bank_info_pagebottom'  =>   NULL,
-            'number'                =>   NULL,
-            'note'                  =>   NULL,
-            'privacy_policy'        =>   NULL,
-            'tos'                   =>   NULL,
-            'vat_number'            =>   NULL,
-        );
+        $config = ['url' => 'www.fossbilling.org'];
+        $expected = [
+            'www' => 'http://localhost/',
+            'name' => 'Inc. Test',
+            'email' => 'work@example.eu',
+            'tel' => null,
+            'signature' => null,
+            'logo_url' => null,
+            'logo_url_dark' => null,
+            'favicon_url' => null,
+            'address_1' => null,
+            'address_2' => null,
+            'address_3' => null,
+            'account_number' => null,
+            'bank_name' => null,
+            'bic' => null,
+            'display_bank_info' => null,
+            'bank_info_pagebottom' => null,
+            'number' => null,
+            'note' => null,
+            'privacy_policy' => null,
+            'tos' => null,
+            'vat_number' => null,
+        ];
 
-        $multParamsResults = array(
-            array(
+        $multParamsResults = [
+            [
                 'param' => 'company_name',
                 'value' => 'Inc. Test',
-            ),
-            array(
+            ],
+            [
                 'param' => 'company_email',
                 'value' => 'work@example.eu',
-            ),
-        );
+            ],
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($multParamsResults));
+            ->willReturn($multParamsResults);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -86,40 +86,40 @@ class ServiceTest extends \BBTestCase
 
     public function testgetParams()
     {
-        $expected = array(
-            'company_name'               => 'Inc. Test',
-            'company_email'              => 'work@example.eu',
-        );
-        $multParamsResults = array(
-            array(
+        $expected = [
+            'company_name' => 'Inc. Test',
+            'company_email' => 'work@example.eu',
+        ];
+        $multParamsResults = [
+            [
                 'param' => 'company_name',
                 'value' => 'Inc. Test',
-            ),
-            array(
+            ],
+            [
                 'param' => 'company_email',
                 'value' => 'work@example.eu',
-            ),
-        );
+            ],
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAll')
-            ->will($this->returnValue($multParamsResults));
+            ->willReturn($multParamsResults);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
 
-        $result = $this->service->getParams(array());
+        $result = $this->service->getParams([]);
         $this->assertIsArray($result);
         $this->assertEquals($expected, $result);
     }
 
     public function testupdateParams()
     {
-        $data = array(
-            'company_name' => 'newValue'
-        );
+        $data = [
+            'company_name' => 'newValue',
+        ];
 
         $eventMock = $this->getMockBuilder('\Box_EventManager')->getMock();
         $eventMock->expects($this->atLeastOnce())
@@ -127,10 +127,10 @@ class ServiceTest extends \BBTestCase
 
         $logMock = $this->getMockBuilder('\Box_Log')->getMock();
 
-        $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->onlyMethods(array('setParamValue'))->getMock();
+        $systemServiceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['setParamValue'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('setParamValue')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['events_manager'] = $eventMock;
@@ -147,22 +147,22 @@ class ServiceTest extends \BBTestCase
         $latestVersion = '1.0.0';
         $type = 'info';
 
-        $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->onlyMethods(['getParamValue'])->getMock();
+        $systemServiceMock = $this->getMockBuilder('\\' . Service::class)->onlyMethods(['getParamValue'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('getParamValue')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $updaterMock = $this->getMockBuilder('\\' . \FOSSBilling\Update::class)->getMock();
         $updaterMock->expects($this->atLeastOnce())
             ->method('isUpdateAvailable')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $updaterMock->expects($this->atLeastOnce())
             ->method('getLatestVersion')
-            ->will($this->returnValue($latestVersion));
+            ->willReturn($latestVersion);
 
         $di = new \Pimple\Container();
         $di['updater'] = $updaterMock;
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
 
         $systemServiceMock->setDi($di);
 
@@ -172,14 +172,14 @@ class ServiceTest extends \BBTestCase
 
     public function testtemplateExistsEmptyPaths()
     {
-        $getThemeResults = array('paths' => array());
-        $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->addMethods(array('getThemeConfig'))->getMock();
+        $getThemeResults = ['paths' => []];
+        $systemServiceMock = $this->getMockBuilder('\\' . Service::class)->addMethods(['getThemeConfig'])->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('getThemeConfig')
-            ->will($this->returnValue($getThemeResults));
+            ->willReturn($getThemeResults);
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
         $this->service->setDi($di);
 
         $result = $this->service->templateExists('defaultFile.cp');
@@ -189,18 +189,16 @@ class ServiceTest extends \BBTestCase
 
     public function testrenderStringTemplateException()
     {
-        $vars = array(
-            '_client_id' => 1
-        );
-
+        $vars = [
+            '_client_id' => 1,
+        ];
 
         $this
             ->getMockBuilder('Drupal\Core\Template\TwigEnvironment')
             ->disableOriginalConstructor()
             ->getMock();
 
-
-        $twigMock = $this->getMockBuilder('\\' . \Twig\Environment::class)->disableOriginalConstructor()->getMock();
+        $twigMock = $this->getMockBuilder('\\' . Environment::class)->disableOriginalConstructor()->getMock();
         $twigMock->expects($this->atLeastOnce())
             ->method('addGlobal');
         $twigMock->method('createTemplate')
@@ -209,7 +207,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(new \Model_Client()));
+            ->willReturn(new \Model_Client());
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -223,9 +221,9 @@ class ServiceTest extends \BBTestCase
 
     public function testrenderStringTemplate()
     {
-        $vars = array(
-            '_client_id' => 1
-        );
+        $vars = [
+            '_client_id' => 1,
+        ];
 
         $twigMock = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
@@ -243,7 +241,7 @@ class ServiceTest extends \BBTestCase
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('load')
-            ->will($this->returnValue(new \Model_Client()));
+            ->willReturn(new \Model_Client());
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -260,7 +258,7 @@ class ServiceTest extends \BBTestCase
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
             ->method('emptyFolder')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $di = new \Pimple\Container();
         $di['tools'] = $toolsMock;
@@ -284,14 +282,13 @@ class ServiceTest extends \BBTestCase
 
     public function testgetCountries()
     {
-
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array('countries' => 'US')));
+            ->willReturn(['countries' => 'US']);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn() => $modMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
 
         $this->service->setDi($di);
         $result = $this->service->getCountries();
@@ -303,10 +300,10 @@ class ServiceTest extends \BBTestCase
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getConfig')
-            ->will($this->returnValue(array('countries' => 'US')));
+            ->willReturn(['countries' => 'US']);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(fn() => $modMock);
+        $di['mod'] = $di->protect(fn () => $modMock);
 
         $this->service->setDi($di);
         $result = $this->service->getEuCountries();
@@ -321,7 +318,7 @@ class ServiceTest extends \BBTestCase
 
     public function testgetPhoneCodes()
     {
-        $data = array();
+        $data = [];
         $result = $this->service->getPhoneCodes($data);
         $this->assertIsArray($result);
     }
@@ -341,7 +338,7 @@ class ServiceTest extends \BBTestCase
         $sessionMock->expects($this->atLeastOnce())
             ->method('get')
             ->with('pending_messages')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $di['session'] = $sessionMock;
 
@@ -350,7 +347,7 @@ class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testgetPendingMessages_GetReturnsNotArray()
+    public function testgetPendingMessagesGetReturnsNotArray()
     {
         $di = new \Pimple\Container();
 
@@ -369,12 +366,12 @@ class ServiceTest extends \BBTestCase
 
     public function testsetPendingMessage()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)
-            ->onlyMethods(array('getPendingMessages'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getPendingMessages'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getPendingMessages')
-            ->willReturn(array());
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 

--- a/tests/modules/Theme/Api/AdminTest.php
+++ b/tests/modules/Theme/Api/AdminTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Box\Mod\Theme\Api;
 
-
-class AdminTest extends \BBTestCase {
+class AdminTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Theme\Api\Admin
+     * @var Admin
      */
-    protected $api = null;
+    protected $api;
 
     public function setup(): void
     {
-        $this->api= new \Box\Mod\Theme\Api\Admin();
+        $this->api = new Admin();
     }
 
     public function testgetDi()
@@ -23,34 +22,34 @@ class AdminTest extends \BBTestCase {
         $this->assertEquals($di, $getDi);
     }
 
-    public function testget_list()
+    public function testgetList()
     {
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('getThemes')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $this->api->setService($systemServiceMock);
 
-        $result = $this->api->get_list(array());
+        $result = $this->api->get_list([]);
         $this->assertIsArray($result);
     }
 
     public function testget()
     {
-        $data = array(
+        $data = [
             'code' => 'themeCode',
-        );
+        ];
 
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
             ->method('loadTheme')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -61,21 +60,21 @@ class AdminTest extends \BBTestCase {
         $this->assertIsArray($result);
     }
 
-    public function testselect_NotAdminTheme()
+    public function testselectNotAdminTheme()
     {
-        $data = array(
+        $data = [
             'code' => 'pjw',
-        );
+        ];
 
         $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('isAdminAreaTheme')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTheme')
-            ->will($this->returnValue($themeMock));
+            ->willReturn($themeMock);
 
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
@@ -85,12 +84,12 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $loggerMock = $this->getMockBuilder('\Box_Log')->getMock();
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
         $di['logger'] = $loggerMock;
         $di['validator'] = $validatorMock;
 
@@ -99,24 +98,23 @@ class AdminTest extends \BBTestCase {
 
         $result = $this->api->select($data);
         $this->assertTrue($result);
-
     }
 
-    public function testselect_AdminTheme()
+    public function testselectAdminTheme()
     {
-        $data = array(
+        $data = [
             'code' => 'pjw',
-        );
+        ];
 
         $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('isAdminAreaTheme')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTheme')
-            ->will($this->returnValue($themeMock));
+            ->willReturn($themeMock);
 
         $systemServiceMock = $this->getMockBuilder('\\' . \Box\Mod\System\Service::class)->getMock();
         $systemServiceMock->expects($this->atLeastOnce())
@@ -126,12 +124,12 @@ class AdminTest extends \BBTestCase {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $loggerMock = $this->getMockBuilder('\Box_Log')->getMock();
 
         $di = new \Pimple\Container();
-        $di['mod_service'] = $di->protect(fn() => $systemServiceMock);
+        $di['mod_service'] = $di->protect(fn () => $systemServiceMock);
         $di['logger'] = $loggerMock;
         $di['validator'] = $validatorMock;
 
@@ -140,29 +138,28 @@ class AdminTest extends \BBTestCase {
 
         $result = $this->api->select($data);
         $this->assertTrue($result);
-
     }
 
-    public function testpreset_delete()
+    public function testpresetDelete()
     {
-        $data = array(
+        $data = [
             'code' => 'themeCode',
             'preset' => 'themePreset',
-        );
+        ];
 
         $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTheme')
-            ->will($this->returnValue($themeMock));
+            ->willReturn($themeMock);
         $serviceMock->expects($this->atLeastOnce())
             ->method('deletePreset');
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;
@@ -174,26 +171,26 @@ class AdminTest extends \BBTestCase {
         $this->assertTrue($result);
     }
 
-    public function testpreset_select()
+    public function testpresetSelect()
     {
-        $data = array(
+        $data = [
             'code' => 'themeCode',
             'preset' => 'themePreset',
-        );
+        ];
 
         $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
 
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTheme')
-            ->will($this->returnValue($themeMock));
+            ->willReturn($themeMock);
         $serviceMock->expects($this->atLeastOnce())
             ->method('setCurrentThemePreset');
 
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;

--- a/tests/modules/Theme/Controller/AdminTest.php
+++ b/tests/modules/Theme/Controller/AdminTest.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace Box\Mod\Theme\Controller;
 
-
-class AdminTest extends \BBTestCase {
-
+class AdminTest extends \BBTestCase
+{
     public function testDi()
     {
-        $controller = new \Box\Mod\Theme\Controller\Admin();
+        $controller = new Admin();
 
         $di = new \Pimple\Container();
         $db = $this->getMockBuilder('Box_Database')->getMock();
@@ -25,11 +23,11 @@ class AdminTest extends \BBTestCase {
         $boxAppMock->expects($this->exactly(1))
             ->method('get');
 
-        $controller = new \Box\Mod\Theme\Controller\Admin();
+        $controller = new Admin();
         $controller->register($boxAppMock);
     }
 
-    public function testget_theme()
+    public function testgetTheme()
     {
         $boxAppMock = $this->getMockBuilder('\Box_App')->disableOriginalConstructor()->getMock();
         $boxAppMock->expects($this->atLeastOnce())
@@ -51,7 +49,6 @@ class AdminTest extends \BBTestCase {
             ->method('isAssetsPathWritable')
             ->willReturn(false);
 
-
         $themeServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)->getMock();
         $themeServiceMock->expects($this->atLeastOnce())
             ->method('getTheme')
@@ -64,23 +61,21 @@ class AdminTest extends \BBTestCase {
         $themeServiceMock->expects($this->atLeastOnce())
             ->method('getThemePresets');
 
-
         $modMock = $this->getMockBuilder('\Box_Mod')->disableOriginalConstructor()->getMock();
         $modMock->expects($this->atLeastOnce())
             ->method('getService')
             ->willReturn($themeServiceMock);
 
         $di = new \Pimple\Container();
-        $di['mod'] = $di->protect(function ($name) use($modMock){
-            if ($name == 'theme')
-            {
+        $di['mod'] = $di->protect(function ($name) use ($modMock) {
+            if ($name == 'theme') {
                 return $modMock;
             }
         });
 
-        $di['is_admin_logged']  = true;
+        $di['is_admin_logged'] = true;
 
-        $controller = new \Box\Mod\Theme\Controller\Admin();
+        $controller = new Admin();
         $controller->setDi($di);
         $controller->get_theme($boxAppMock, 'huraga');
     }

--- a/tests/modules/Theme/Model/ThemeTest.php
+++ b/tests/modules/Theme/Model/ThemeTest.php
@@ -1,16 +1,14 @@
 <?php
 
-
 namespace Box\Mod\Theme\Model;
 
-
-class ThemeTest extends \BBTestCase {
-
+class ThemeTest extends \BBTestCase
+{
     private ?string $existingTheme = 'huraga';
 
     public function testgetName()
     {
-        $themeModel = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $themeModel = new Theme($this->existingTheme);
         $this->assertEquals($this->existingTheme, $themeModel->getName());
     }
 
@@ -19,75 +17,75 @@ class ThemeTest extends \BBTestCase {
         $themeName = 'not existing theme';
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage(sprintf('Theme "%s" does not exist', $themeName));
-        new \Box\Mod\Theme\Model\Theme($themeName);
+        new Theme($themeName);
     }
 
     public function testisAdminAreaTheme()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->isAdminAreaTheme();
         $this->assertIsBool($result);
     }
 
     public function testisAssetsPathWritable()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->isAssetsPathWritable();
         $this->assertIsBool($result);
     }
 
     public function testgetSnippets()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getSnippets();
         $this->assertIsArray($result);
     }
 
     public function testgetUploadedAssets()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getUploadedAssets();
         $this->assertIsArray($result);
     }
 
     public function testgetSettingsPageHtml()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getSettingsPageHtml();
         $this->assertIsString($result);
     }
 
     public function testgetPresetsFromSettingsDataFile()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPresetsFromSettingsDataFile();
         $this->assertIsArray($result);
     }
 
     public function testgetCurrentPreset()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getCurrentPreset();
         $this->assertIsString($result);
     }
 
     public function testgetPresetFromSettingsDataFile()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPresetFromSettingsDataFile('default');
         $this->assertIsArray($result);
     }
 
     public function testgetUrl()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getUrl();
         $this->assertIsString($result);
     }
 
     public function testgetPathConfig()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPathConfig();
         $this->assertIsString($result);
         $this->assertTrue(str_contains($result, 'config'));
@@ -95,7 +93,7 @@ class ThemeTest extends \BBTestCase {
 
     public function testgetPathAssets()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPathAssets();
         $this->assertIsString($result);
         $this->assertTrue(str_contains($result, 'assets'));
@@ -103,7 +101,7 @@ class ThemeTest extends \BBTestCase {
 
     public function testgetPathHtml()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPathHtml();
         $this->assertIsString($result);
         $this->assertTrue(str_contains($result, 'html'));
@@ -111,11 +109,9 @@ class ThemeTest extends \BBTestCase {
 
     public function testgetPathSettingsDataFile()
     {
-        $theme = new \Box\Mod\Theme\Model\Theme($this->existingTheme);
+        $theme = new Theme($this->existingTheme);
         $result = $theme->getPathSettingsDataFile();
         $this->assertIsString($result);
         $this->assertTrue(str_contains($result, 'settings_data.json'));
     }
-
 }
- 

--- a/tests/modules/Theme/ServiceTest.php
+++ b/tests/modules/Theme/ServiceTest.php
@@ -1,20 +1,18 @@
 <?php
 
-
 namespace Box\Mod\Theme;
 
-
-class ServiceTest extends \BBTestCase {
+class ServiceTest extends \BBTestCase
+{
     /**
-     * @var \Box\Mod\Theme\Service
+     * @var Service
      */
-    protected $service = null;
+    protected $service;
 
     public function setup(): void
     {
-        $this->service= new \Box\Mod\Theme\Service();
+        $this->service = new Service();
     }
-
 
     public function testgetDi()
     {
@@ -27,14 +25,13 @@ class ServiceTest extends \BBTestCase {
     public function testgetTheme()
     {
         $result = $this->service->getTheme('huraga');
-        $this->assertInstanceOf('\\' . \Box\Mod\Theme\Model\Theme::class, $result);
+        $this->assertInstanceOf('\\' . Model\Theme::class, $result);
     }
 
     public function testgetCurrentThemePreset()
     {
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)
-            ->onlyMethods(array('setCurrentThemePreset'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['setCurrentThemePreset'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('setCurrentThemePreset');
@@ -42,16 +39,16 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getCurrentPreset')
-            ->will($this->returnValue('CurrentPresetString'));
+            ->willReturn('CurrentPresetString');
 
         $di = new \Pimple\Container();
 
-        $di['theme'] = $di->protect(fn() => $themeMock);
+        $di['theme'] = $di->protect(fn () => $themeMock);
         $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
@@ -65,14 +62,14 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('exec');
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $di = new \Pimple\Container();
 
-        $di['theme'] = $di->protect(fn() => $themeMock);
+        $di['theme'] = $di->protect(fn () => $themeMock);
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -87,14 +84,14 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('exec');
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $di = new \Pimple\Container();
 
-        $di['theme'] = $di->protect(fn() => $themeMock);
+        $di['theme'] = $di->protect(fn () => $themeMock);
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
@@ -105,8 +102,8 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetThemePresets()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)
-            ->onlyMethods(array('updateSettings'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['updateSettings'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('updateSettings');
@@ -115,62 +112,62 @@ class ServiceTest extends \BBTestCase {
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc');
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
-        $corePresets = array(
-            'default' => array(),
-            'red_black' => array(),
-        );
+        $corePresets = [
+            'default' => [],
+            'red_black' => [],
+        ];
         $themeMock->expects($this->atLeastOnce())
             ->method('getPresetsFromSettingsDataFile')
-            ->will($this->returnValue($corePresets));
+            ->willReturn($corePresets);
 
         $di = new \Pimple\Container();
 
-        $di['theme'] = $di->protect(fn() => $themeMock);
+        $di['theme'] = $di->protect(fn () => $themeMock);
         $di['db'] = $dbMock;
 
         $serviceMock->setDi($di);
         $result = $serviceMock->getThemePresets($themeMock, 'dark_blue');
         $this->assertIsArray($result);
 
-        $expected= array(
+        $expected = [
             'default' => 'default',
             'red_black' => 'red_black',
-        );
+        ];
         $this->assertEquals($expected, $result);
     }
 
-    public function testgetThemePresets_themeDoNotHaveSettingsDataFile()
+    public function testgetThemePresetsThemeDoNotHaveSettingsDataFile()
     {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getAssoc');
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $themeMock->expects($this->atLeastOnce())
             ->method('getPresetsFromSettingsDataFile')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 
-        $di['theme'] = $di->protect(fn() => $themeMock);
+        $di['theme'] = $di->protect(fn () => $themeMock);
         $di['db'] = $dbMock;
         $this->service->setDi($di);
 
         $result = $this->service->getThemePresets($themeMock);
         $this->assertIsArray($result);
 
-        $expected= array(
+        $expected = [
             'Default' => 'Default',
-        );
+        ];
         $this->assertEquals($expected, $result);
     }
 
@@ -183,12 +180,12 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue($extensionMetaModel));
+            ->willReturn($extensionMetaModel);
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $di = new \Pimple\Container();
 
@@ -201,25 +198,25 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetThemeSettingsWithEmptyPresets()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)
-            ->onlyMethods(array('getCurrentThemePreset'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getCurrentThemePreset'])
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCurrentThemePreset')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
         $themeMock->expects($this->atLeastOnce())
             ->method('getPresetFromSettingsDataFile')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
 
@@ -228,7 +225,7 @@ class ServiceTest extends \BBTestCase {
 
         $result = $serviceMock->getThemeSettings($themeMock);
         $this->assertIsArray($result);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
     }
 
     public function testupdateSettings()
@@ -239,24 +236,24 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('findOne')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
-            ->will($this->returnValue($extensionMetaModel));
+            ->willReturn($extensionMetaModel);
         $dbMock->expects($this->atLeastOnce())
             ->method('store');
 
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getName')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
         $di = new \Pimple\Container();
 
         $di['db'] = $dbMock;
 
         $this->service->setDi($di);
-        $params = array();
+        $params = [];
         $result = $this->service->updateSettings($themeMock, 'default', $params);
         $this->assertIsBool($result);
         $this->assertTrue($result);
@@ -264,31 +261,30 @@ class ServiceTest extends \BBTestCase {
 
     public function testregenerateThemeSettingsDataFile()
     {
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)
-            ->onlyMethods(array('getThemePresets', 'getThemeSettings', 'getCurrentThemePreset'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getThemePresets', 'getThemeSettings', 'getCurrentThemePreset'])
             ->getMock();
 
-        $presets = array(
+        $presets = [
             'default' => 'Defaults',
             'red_black' => 'Red Black',
-        );
+        ];
         $serviceMock->expects($this->atLeastOnce())
             ->method('getThemePresets')
-            ->will($this->returnValue($presets));
+            ->willReturn($presets);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getThemeSettings')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getCurrentThemePreset')
-            ->will($this->returnValue('default'));
+            ->willReturn('default');
 
-
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getPathSettingsDataFile')
-            ->will($this->returnValue('location/Of/Assets/file'));
+            ->willReturn('location/Of/Assets/file');
 
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         $toolsMock->expects($this->atLeastOnce())
@@ -301,15 +297,14 @@ class ServiceTest extends \BBTestCase {
         $result = $serviceMock->regenerateThemeSettingsDataFile($themeMock);
         $this->assertIsBool($result);
         $this->assertTrue($result);
-
     }
 
-    public function testregenerateThemeCssAndJsFiles_EmptyFiles()
+    public function testregenerateThemeCssAndJsFilesEmptyFiles()
     {
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getPathAssets')
-            ->will($this->returnValue('location/Of/'));
+            ->willReturn('location/Of/');
 
         $di = new \Pimple\Container();
         $this->service->setDi($di);
@@ -321,13 +316,13 @@ class ServiceTest extends \BBTestCase {
 
     public function testgetCurrentAdminAreaTheme()
     {
-        $configMock = array(
-            'url' => 'fossbilling.org/'
-        );
+        $configMock = [
+            'url' => 'fossbilling.org/',
+        ];
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(''));
+            ->willReturn('');
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -335,16 +330,16 @@ class ServiceTest extends \BBTestCase {
 
         $this->service->setDi($di);
 
-        $result =$this->service->getCurrentAdminAreaTheme();
+        $result = $this->service->getCurrentAdminAreaTheme();
         $this->assertIsArray($result);
     }
 
     public function testgetCurrentClientAreaTheme()
     {
-        $themeMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Model\Theme::class)->disableOriginalConstructor()->getMock();
+        $themeMock = $this->getMockBuilder('\\' . Model\Theme::class)->disableOriginalConstructor()->getMock();
 
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Theme\Service::class)
-            ->onlyMethods(array('getCurrentClientAreaThemeCode', 'getTheme'))
+        $serviceMock = $this->getMockBuilder('\\' . Service::class)
+            ->onlyMethods(['getCurrentClientAreaThemeCode', 'getTheme'])
             ->getMock();
 
         $serviceMock->expects($this->atLeastOnce())
@@ -352,10 +347,10 @@ class ServiceTest extends \BBTestCase {
 
         $serviceMock->expects($this->atLeastOnce())
             ->method('getTheme')
-            ->will($this->returnValue($themeMock));
+            ->willReturn($themeMock);
 
         $result = $serviceMock->getCurrentClientAreaTheme();
-        $this->assertInstanceOf('\\' . \Box\Mod\Theme\Model\Theme::class, $result);
+        $this->assertInstanceOf('\\' . Model\Theme::class, $result);
     }
 
     public function testgetCurrentClientAreaThemeCode()
@@ -363,7 +358,7 @@ class ServiceTest extends \BBTestCase {
         $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getCell')
-            ->will($this->returnValue(array()));
+            ->willReturn([]);
 
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
@@ -373,6 +368,4 @@ class ServiceTest extends \BBTestCase {
         $this->assertIsString($result);
         $this->assertEquals('huraga', $result);
     }
-
-
 }


### PR DESCRIPTION
This pull request makes the following improvements to our Rector & PHP-CS-Fixer configs:

- The workflow now uses both Rector's and PHP-CS-Fixer's cache.
- PHP-CS-Fixer is now enabled for both `src` and `tests`. I've already run it on both in this PR