### PR TITLE
Minor front-end improvements & fixes

### DIFF
--- a/src/modules/Order/html_client/mod_order_list.html.twig
+++ b/src/modules/Order/html_client/mod_order_list.html.twig
@@ -46,7 +46,7 @@
                                     <td>{% if order.expires_at %}{{ order.expires_at|format_date }}{% else %}-{% endif %}</td>
                                     <td>
                                     <span
-                                        class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% elseif order.status == 'failed_setup' or order.status == 'suspended' or order.status == 'failed_renew' %}bg-danger{% endif %}">{{ mf.status_name(order.status) }}</span>
+                                        class="badge {% if order.status == 'active' %}bg-success{% elseif order.status == 'pending_setup' %}bg-warning{% else %}bg-danger{% endif %}">{{ mf.status_name(order.status) }}</span>
                                     </td>
                                     <td class="actions">
                                         <a class="btn btn-sm btn-outline-primary"

--- a/src/modules/Order/html_client/mod_order_product.html.twig
+++ b/src/modules/Order/html_client/mod_order_product.html.twig
@@ -8,26 +8,30 @@
 {% set loader_url = ('img/assets/loaders/loader'~loader_nr~'.gif') %}
 
 {% block body_class %}order-product{% endblock %}
+{% block breadcrumb %}
+    <li class="active breadcrumb-item" aria-current="page">{{ 'Order'|trans }}</li>
+{% endblock %}
 {% block content_before %}{% endblock %}
 
 {% block content %}
-<div class="row">
-    <div class="col-md-12">
-        <div class="card">
-            <div class="card-header py-3 py-3">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div>
-                        <h5 class="mb-1">{{ 'Select Product'|trans }}</h5>
-                        <span class="small text-muted">{{ 'Choose products we offer for selling'|trans }}</span>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card mb-4">
+                <div class="card-header py-3 py-3">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="w-100">
+                            <h5 class="mb-1">{{ 'Order Product'|trans }}</h5>
+                            <span class="small text-muted row ms-2">{{ 'Choose products we offer for selling'|trans }}</span>
+                            {% include 'mod_orderbutton_currency.html.twig' %}
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="card-body overflow-hidden">
-                {% include 'mod_orderbutton_index.html.twig' %}
+                <div class="card-body overflow-hidden">
+                    {% include 'mod_orderbutton_index.html.twig' %}
+                </div>
             </div>
         </div>
     </div>
-</div>
 {% endblock %}
 
 {% block sidebar2 %}

--- a/src/themes/admin_default/html/layout_login.html.twig
+++ b/src/themes/admin_default/html/layout_login.html.twig
@@ -16,7 +16,15 @@
     {{ encore_entry_script_tags('fossbilling') }}
 </head>
 
-<body class="border-top-wide border-primary d-flex flex-column theme-light">
+<body class="border-top-wide border-primary d-flex flex-column" data-bs-theme="dark">
+    <script>
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.setAttribute("data-bs-theme", localStorage.getItem('theme'));
+        } else {
+            document.body.removeAttribute("data-bs-theme");
+        }
+    </script>
+
     {% block content %}{% endblock %}
     {% block js %}{% endblock %}
 


### PR DESCRIPTION
- The order slug template is now (mostly) identical with the normal one. Closes #2048.
- On the order list, canceled orders will now be colored. Closes #2049 
- The login page in the admin panel will use dark mode when enabled.

## Order slug 
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/6c9fd40c-1631-44dc-a3e6-e48888c1466b)

## Orders list
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/1e5783bd-3a5d-4814-b455-f55a90b0cca8)

## Dark mode admin login page
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/10cb01ba-97ae-42a6-a84e-39e8177bfb2e)
