### PR TITLE
Minor logging improvements & session class cleanup

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FOSSBilling configuration file example.
  *
@@ -19,6 +20,7 @@ return [
         'mode' => 'strict',
         'force_https' => true,
         'session_lifespan' => 7200,
+        'perform_session_fingerprinting' => true,
     ],
 
     'debug_and_monitoring' => [

--- a/src/di.php
+++ b/src/di.php
@@ -229,14 +229,7 @@ $di['events_manager'] = function () use ($di) {
  */
 $di['session'] = function () use ($di) {
     $handler = new PdoSessionHandler($di['pdo']);
-
-    $mode = $di['config']['security']['mode'] ?? 'strict';
-
-    // Mark the cookie as secure either if force HTTPS is enabled or if we can detect that HTTPS is being used.
-    $forceSSL = $di['config']['security']['force_https'] ?? true;
-    $secure = ($forceSSL || FOSSBilling\Tools::isHTTPS());
-
-    $session = new FOSSBilling\Session($handler, $mode, $secure);
+    $session = new FOSSBilling\Session($handler);
     $session->setDi($di);
     $session->setupSession();
 

--- a/src/library/Box/LogDb.php
+++ b/src/library/Box/LogDb.php
@@ -10,7 +10,7 @@
  */
 class Box_LogDb
 {
-    private array $ignoredChannels = ['billing', 'routing'];
+    private array $ignoredChannels = ['billing', 'routing', 'security'];
 
     /**
      * Class constructor.

--- a/src/library/Box/LogDb.php
+++ b/src/library/Box/LogDb.php
@@ -10,7 +10,7 @@
  */
 class Box_LogDb
 {
-    private array $ignoredChannels = ['billing', 'routing', 'security'];
+    private array $ignoredChannels = ['billing', 'routing', 'security', 'email'];
 
     /**
      * Class constructor.

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -34,7 +34,8 @@ class Monolog
         'event',
         'routing',
         'billing',
-        'security'
+        'security',
+        'email'
     ];
 
     public function __construct()

--- a/src/library/FOSSBilling/Monolog.php
+++ b/src/library/FOSSBilling/Monolog.php
@@ -34,6 +34,7 @@ class Monolog
         'event',
         'routing',
         'billing',
+        'security'
     ];
 
     public function __construct()

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -54,7 +54,8 @@ class SentryHelper
     {
         $sentryDSN = '--replace--this--during--release--process--';
 
-        $httpClient = new class() implements HttpClientInterface {
+        $httpClient = new class() implements HttpClientInterface
+        {
             public function sendRequest(Request $request, Options $options): Response
             {
                 $dsn = $options->getDsn();
@@ -189,7 +190,7 @@ class SentryHelper
     // Checks if either the module producing the error or the instance ID of this installation is blacklisted
     public static function isBlacklisted(string $module = null): bool
     {
-        if (INSTANCE_ID === 'Unknown') {
+        if (INSTANCE_ID === 'Unknown' || INSTANCE_ID === 'XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXX') {
             return true;
         }
 

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -139,7 +139,7 @@ class Session implements InjectionAwareInterface
             $invalid = true;
             // TODO: Trying to use monolog here causes a 503 error with an empty error log. Would love to find out why and use it instead of error_log
             error_log("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.");
-            #$this->di['logger']->setChannel('security')->info("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.);
+            #$this->di['logger']->setChannel('security')->info("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.");
         }
 
         if ($session->created_at <= $maxAge) {

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -26,7 +26,7 @@ class Session implements InjectionAwareInterface
         return $this->di;
     }
 
-    public function __construct(private readonly \PdoSessionHandler $handler, private readonly string $securityMode = 'regular', private bool $secure = true)
+    public function __construct(private readonly \PdoSessionHandler $handler)
     {
     }
 
@@ -52,7 +52,7 @@ class Session implements InjectionAwareInterface
         $currentCookieParams = session_get_cookie_params();
         $currentCookieParams['httponly'] = true;
         $currentCookieParams['lifetime'] = 0;
-        $currentCookieParams['secure'] = $this->secure;
+        $currentCookieParams['secure'] = $this->shouldBeSecure();
 
         $cookieParams = [
             'lifetime' => $currentCookieParams['lifetime'],
@@ -62,7 +62,7 @@ class Session implements InjectionAwareInterface
             'httponly' => $currentCookieParams['httponly'],
         ];
 
-        if ($this->securityMode == 'strict') {
+        if ($this->di['config']['security']['mode'] == 'strict') {
             $cookieParams['samesite'] = 'Strict';
         }
 
@@ -97,12 +97,10 @@ class Session implements InjectionAwareInterface
         switch ($type) {
             case 'admin':
                 $this->delete('admin');
-
                 break;
             case 'client':
                 $this->delete('client');
                 $this->delete('client_id');
-
                 break;
         }
 
@@ -115,6 +113,7 @@ class Session implements InjectionAwareInterface
      */
     private function canUseSession(): void
     {
+        $invalid = false;
         if (empty($_COOKIE['PHPSESSID'])) {
             return;
         }
@@ -135,7 +134,19 @@ class Session implements InjectionAwareInterface
             $this->di['db']->store($session);
         }
 
-        if (!$fingerprint->checkFingerprint(json_decode($session->fingerprint, true)) || $session->created_at <= $maxAge) {
+        $storedFingerprint = json_decode($session->fingerprint, true);
+        if (!$fingerprint->checkFingerprint($storedFingerprint) && $this->di['config']['security']['perform_session_fingerprinting']) {
+            $invalid = true;
+            // TODO: Trying to use monolog here causes a 503 error with an empty error log. Would love to find out why and use it instead of error_log
+            error_log("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.");
+            #$this->di['logger']->setChannel('security')->info("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.);
+        }
+
+        if ($session->created_at <= $maxAge) {
+            $invalid = true;
+        }
+
+        if ($invalid) {
             $this->di['db']->trash($session);
             unset($_COOKIE['PHPSESSID']);
         }
@@ -148,12 +159,23 @@ class Session implements InjectionAwareInterface
     {
         $sessionID = $_COOKIE['PHPSESSID'] ?? session_id();
         $session = $this->di['db']->findOne('session', 'id = :id', [':id' => $sessionID]);
+        $fingerprint = new Fingerprint();
+
+        if ($this->di['config']['security']['perform_session_fingerprinting']) {
+            $updatedFingerprint = $fingerprint->fingerprint();
+        } else {
+            $updatedFingerprint = [];
+        }
 
         // Fix for the installer which temporarily uses FS sessions before FOSSBilling is completely setup.
         if (!is_null($session)) {
-            $fingerprint = new Fingerprint();
-            $session->fingerprint = json_encode($fingerprint->fingerprint());
+            $session->fingerprint = json_encode($updatedFingerprint);
             $this->di['db']->store($session);
         }
+    }
+
+    private function shouldBeSecure(): bool
+    {
+        return $this->di['config']['security']['force_https'] ?? true || Tools::isHTTPS();;
     }
 }

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -311,7 +311,7 @@ class Tools
             if ($throw) {
                 $friendlyName = ucfirst(__trans('Email address'));
 
-                throw new Exception(':friendlyName: is invalid', [':friendlyName:' => $friendlyName]);
+                throw new InformationException(':friendlyName: is invalid', [':friendlyName:' => $friendlyName]);
             } else {
                 return false;
             }

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -47,7 +47,7 @@ class UpdatePatcher implements InjectionAwareInterface
         // Create backup of current configuration.
         try {
             $filesystem->copy(PATH_CONFIG, substr(PATH_CONFIG, 0, -4) . '.old.php');
-        } catch (FileNotFoundException|IOException) {
+        } catch (FileNotFoundException | IOException) {
             throw new Exception('Unable to create backup of configuration file');
         }
 
@@ -55,6 +55,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['security']['mode'] ??= 'strict';
         $newConfig['security']['force_https'] ??= true;
         $newConfig['security']['session_lifespan'] ??= $newConfig['security']['cookie_lifespan'] ?? 7200;
+        $newConfig['security']['perform_session_fingerprinting'] ??= true;
         $newConfig['update_branch'] ??= 'release';
         $newConfig['log_stacktrace'] ??= true;
         $newConfig['stacktrace_length'] ??= 25;

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -335,7 +335,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         if (Environment::isTesting()) {
             if (DEBUG) {
-                error_log('Skipping email sending in test environment');
+                $this->di['logger']->setChannel('email')->info('Skipping email sending in test environment');
             }
 
             return true;
@@ -632,8 +632,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $mail = new \FOSSBilling\Mail($sender, $recipient, $queue->subject, $queue->content, $transport, $settings['custom_dsn'] ?? null);
 
             if (!Environment::isProduction()) {
-                error_log('Skip email sending. Application ENV: ' . Environment::getCurrentEnvironment());
-
+                $this->di['logger']->setChannel('email')->info('Skip email sending. Application ENV: ' . Environment::getCurrentEnvironment());
                 return true;
             }
 
@@ -648,11 +647,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             try {
                 $this->di['db']->trash($queue);
             } catch (\Exception $e) {
-                error_log($e->getMessage());
+                $this->di['logger']->setChannel('email')->err($e->getMessage());
             }
         } catch (\Exception $e) {
             $message = $e->getMessage();
-            error_log($message);
+            $this->di['logger']->setChannel('email')->err($e->getMessage());
 
             if ($queue->priority) {
                 --$queue->priority;


### PR DESCRIPTION
This PR performs a minor cleanup to our session class, adds a new config option, and improves logging / reporting a bit.

- The session class no longer needs to be instanced the security options. It already uses the DI, so I've updated it to simply pull the config via the DI.
- When a session fails the fingerprint check, an error is logged for improved visibility.
- There's a new `perform_session_fingerprinting` config option which allows someone to disable the fingerprinting system.
- I've added a new "email" logging channel and and any exceptions thrown when sending emails will be sent to that channel, which I think will make it easier for someone to find errors related to sending emails.
- I've switch the "email address is not valid" message to be an `InformationException` as we don't need that being sent via error reporting.