### PR TITLE
Prevent the generation of invalid usernames for WHM

### DIFF
--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -96,7 +96,7 @@ class Server_Manager_Whm extends Server_Manager
         }
 
         // WHM doesn't allow usernames to start with a number, so automatically append the letter 'a' to the start of a username that does. 
-        if (is_numeric($username, 0, 1)) {
+        if (is_numeric(substr($username, 0, 1))) {
             $username = 'a' . $username;
         }
 

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -87,8 +87,8 @@ class Server_Manager_Whm extends Server_Manager
     // https://docs.cpanel.net/knowledge-base/accounts/reserved-invalid-and-misconfigured-username/
     public function generateUsername($domainName)
     {
-        $procsessedDomain = strtolower(preg_replace('/[^A-Za-z0-9]/', '', $domainName));
-        $username = substr($procsessedDomain, 0, 7) . random_int(0, 9);
+        $processedDomain = strtolower(preg_replace('/[^A-Za-z0-9]/', '', $domainName));
+        $username = substr($processedDomain, 0, 7) . random_int(0, 9);
 
         // WHM doesn't allow usernames to start with "test", so replace it with a random string if it does (test3456 would then become something like a62f93456).
         if (str_starts_with($username, 'test')) {

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -92,12 +92,12 @@ class Server_Manager_Whm extends Server_Manager
 
         // WHM doesn't allow usernames to start with "test", so replace it with a random string if it does (test3456 would then become something like a62f93456).
         if (str_starts_with($username, 'test')) {
-            $username = str_replace('test', 'a' . bin2hex(random_bytes(2)), $username);
+            $username = substr_replace($username, 'a' . bin2hex(random_bytes(2)), 0, 5);
         }
 
         // WHM doesn't allow usernames to start with a number, so automatically append the letter 'a' to the start of a username that does. 
         if (is_numeric(substr($username, 0, 1))) {
-            $username = 'a' . $username;
+            $username = substr_replace($username, 'a', 0, 1);
         }
 
         return $username;


### PR DESCRIPTION
This pull request implements custom username generation for the WHM server manager to ensure it can't generate an invalid username for WHM / cPanel.

Specifically:

- It ensures the username will be all lowercase letters.
- It ensures the username will not start with the string "test" or with a number.

I don't have a WHM server to explicitly test this against, but the function itself outputs the expected results:
`test.com` -> `ab4b9om3`
`example.com` -> `example0`
`whattimeisitrightnow.com` -> `whattim8`
`1111.com` -> `a111com0`