### PR TITLE
Wording consistency

### DIFF
--- a/src/themes/huraga/html/mobile_menu.html.twig
+++ b/src/themes/huraga/html/mobile_menu.html.twig
@@ -116,7 +116,7 @@
             <div class="row pt-2">
                 <div class="col">
                     <a class="btn btn-outline-primary mb-2 w-100"
-                       href="{{ 'login'|link }}">{{ 'Sign in'|trans }}</a>
+                       href="{{ 'login'|link }}">{{ 'Login'|trans }}</a>
                 </div>
                 <div class="col">
                     <a class="btn btn-outline-primary mb-2 w-100"


### PR DESCRIPTION
All other portions of the app say "Login" rather than "Sign in".
Changing for consistency & to ensure we don't have a random 1-off translation for a single location in the app