### PR TITLE
Make Curl mandatory again

### DIFF
--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -18,6 +18,7 @@ class Requirements
 
     public array $php_reqs = [
         'required_extensions' => [
+            'curl',
             'intl',
             'openssl',
             'pdo_mysql',
@@ -28,7 +29,6 @@ class Requirements
             'zlib',
         ],
         'suggested_extensions' => [
-            'curl',
             'mbstring',
             'opcache',
             'imagick',


### PR DESCRIPTION
HTTP Client still depends on PHP Curl to be present