### PR TITLE
Feat: allow selection of the default network interface

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -386,7 +386,9 @@
         "COOKIEJAR",
         "COOKIEFILE",
         "nonaggregated",
-        "bindto"
+        "bindto",
+        "ipify",
+        "hestiacp"
     ],
     "ignorePaths": [
         "tests-legacy/**",

--- a/cspell.json
+++ b/cspell.json
@@ -385,7 +385,8 @@
         "USERPWD",
         "COOKIEJAR",
         "COOKIEFILE",
-        "nonaggregated"
+        "nonaggregated",
+        "bindto"
     ],
     "ignorePaths": [
         "tests-legacy/**",

--- a/src/index.php
+++ b/src/index.php
@@ -44,6 +44,7 @@ if ($url === '/run-patcher') {
     }
 }
 
+$debugBar['time']->startMeasure('session_start', 'Starting / restoring the session');
 /*
  * Workaround: Session IDs get reset when using PGs like PayPal because of the `samesite=strict` cookie attribute, resulting in the client getting logged out.
  * Internally the return and cancel URLs get a restore_session GET parameter attached to them with the proper session ID to restore, so we do so here.
@@ -53,6 +54,11 @@ if (!empty($_GET['restore_session'])) {
 }
 
 $di['session'];
+$debugBar['time']->stopMeasure('session_start');
+
+$debugBar['time']->startMeasure('default_net_interface', 'Fetching the default network interface');
+define('BIND_TO', $di['tools']->getDefaultInterface());
+$debugBar['time']->stopMeasure('default_net_interface');
 
 if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
     define('ADMIN_AREA', true);

--- a/src/index.php
+++ b/src/index.php
@@ -56,10 +56,6 @@ if (!empty($_GET['restore_session'])) {
 $di['session'];
 $debugBar['time']->stopMeasure('session_start');
 
-$debugBar['time']->startMeasure('default_net_interface', 'Fetching the default network interface');
-define('BIND_TO', $di['tools']->getDefaultInterface());
-$debugBar['time']->stopMeasure('default_net_interface');
-
 if (strncasecmp($url, ADMIN_PREFIX, strlen(ADMIN_PREFIX)) === 0) {
     define('ADMIN_AREA', true);
     $appUrl = str_replace(ADMIN_PREFIX, '', preg_replace('/\?.+/', '', $url));

--- a/src/library/FOSSBilling/CentralAlerts.php
+++ b/src/library/FOSSBilling/CentralAlerts.php
@@ -107,7 +107,7 @@ class CentralAlerts implements InjectionAwareInterface
         $url = $this->_url . $endpoint;
 
         try {
-            $httpClient = HttpClient::create();
+            $httpClient = HttpClient::create(['bindto' => BIND_TO]);
             $response = $httpClient->request('GET', $url, [
                 'timeout' => 5,
                 'query' => [...$params, 'fossbilling_version' => Version::VERSION],

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -163,7 +163,7 @@ class ExtensionManager implements InjectionAwareInterface
         return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
             $item->expiresAfter(60 * 60);
 
-            $httpClient = \Symfony\Component\HttpClient\HttpClient::create();
+            $httpClient = \Symfony\Component\HttpClient\HttpClient::create(['bindto' => BIND_TO]);
             $response = $httpClient->request('GET', $url, [
                 'timeout' => 5,
                 'query' => [...$params, 'fossbilling_version' => Version::VERSION],

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -52,7 +52,8 @@ class SentryHelper
     {
         $sentryDSN = '--replace--this--during--release--process--';
 
-        $httpClient = new class() implements HttpClientInterface {
+        $httpClient = new class() implements HttpClientInterface
+        {
             public function sendRequest(Request $request, Options $options): Response
             {
                 $dsn = $options->getDsn();
@@ -65,7 +66,7 @@ class SentryHelper
                     throw new \RuntimeException('The request data is empty.');
                 }
 
-                $client = HttpClient::create(); // TODO: Network interface is defined later than this point in the app's startup. Perhaps we need to be storing it in the config file instead of the DB?
+                $client = HttpClient::create(['bindto' => BIND_TO]);
                 $requestHeaders = \Sentry\Util\Http::getRequestHeaders($dsn, \Sentry\Client::SDK_IDENTIFIER, \Sentry\Client::SDK_VERSION);
                 $response = $client->request(
                     'POST',

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -65,7 +65,7 @@ class SentryHelper
                     throw new \RuntimeException('The request data is empty.');
                 }
 
-                $client = HttpClient::create();
+                $client = HttpClient::create(); // TODO: Network interface is defined later than this point in the app's startup. Perhaps we need to be storing it in the config file instead of the DB?
                 $requestHeaders = \Sentry\Util\Http::getRequestHeaders($dsn, \Sentry\Client::SDK_IDENTIFIER, \Sentry\Client::SDK_VERSION);
                 $response = $client->request(
                     'POST',

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -392,7 +392,6 @@ class Tools
      * Returns the public IP address of the current FOSSBilling instance.
      * Will try multiple services in order if they time out.
      * Try order: ipify.org, ifconfig.io, ip.hestiacp.com
-     * Will use  and then fallback onto 
      * 
      * @param bool $throw if the function should throw an exception on an error.
      * @param ?string $bind overrides the default network interface bind. Set to `null` to disable this behavior.

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -373,12 +373,12 @@ class Tools
      */
     public function getDefaultInterface(): string|int
     {
-        $customInterface = $this->di['mod_service']('system')->getParamValue('custom_interface_ip', '');
-        if ($customInterface) {
+        $customInterface = Config::getProperty('custom_interface_ip', '');
+        if (!empty($customInterface)) {
             return $customInterface;
         }
 
-        $interface = $this->di['mod_service']('system')->getParamValue('interface_ip', '0');
+        $interface = Config::getProperty('interface_ip', '0');
 
         try {
             $knownInterfaces = gethostbynamel(gethostname());

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -399,7 +399,7 @@ class Tools
      * 
      * @return ?string `null` if there was an error, otherwise an IP address will be returned.
      */
-    public static function getExternalIP(bool $throw, ?string $bind): ?string
+    public static function getExternalIP(bool $throw = true, ?string $bind = null): ?string
     {
         $services = ['https://api64.ipify.org', 'https://ifconfig.io/ip', 'https://ip.hestiacp.com/'];
         $bind ??= BIND_TO;

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -134,7 +134,7 @@ class Update implements InjectionAwareInterface
 
                 try {
                     $releaseInfoUrl = 'https://api.github.com/repos/FOSSBilling/FOSSBilling/releases';
-                    $httpClient = HttpClient::create();
+                    $httpClient = HttpClient::create(['bindto' => BIND_TO]);
                     $response = $httpClient->request('GET', $releaseInfoUrl);
                     $releases = $response->toArray();
                 } catch (TransportExceptionInterface|HttpExceptionInterface $e) {
@@ -218,6 +218,7 @@ class Update implements InjectionAwareInterface
             $httpClient = HttpClient::create([
                 'timeout' => 30,
                 'max_duration' => 120,
+                'bindto' => BIND_TO,
             ]);
             $response = $httpClient->request('GET', $this->getLatestVersionInfo($updateBranch)['download_url']);
 

--- a/src/library/Payment/AdapterAbstract.php
+++ b/src/library/Payment/AdapterAbstract.php
@@ -147,7 +147,7 @@ abstract class Payment_AdapterAbstract
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create(['bindto' => BIND_TO]);
     }
 
     /**

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -230,7 +230,7 @@ abstract class Registrar_AdapterAbstract
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create(['bindto' => BIND_TO]);
     }
 
     /**

--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -169,7 +169,7 @@ abstract class Server_Manager
      */
     public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
     {
-        return Symfony\Component\HttpClient\HttpClient::create();
+        return Symfony\Component\HttpClient\HttpClient::create(['bindto' => BIND_TO]);
     }
 
     /**

--- a/src/load.php
+++ b/src/load.php
@@ -258,6 +258,8 @@ require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR
 $loader = new FOSSBilling\AutoLoader();
 $loader->register();
 
+define('BIND_TO', FOSSBilling\Tools::getDefaultInterface());
+
 // Now that the config file is loaded, we can enable Sentry
 FOSSBilling\SentryHelper::registerSentry();
 

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -547,7 +547,7 @@ class Service implements InjectionAwareInterface
 
             throw new \FOSSBilling\Exception('Failed to get currency rates for :currency from the European Central Bank API', [':currency' => $to_Currency]);
         } else {
-            $client = HttpClient::create();
+            $client = HttpClient::create(['bindto' => BIND_TO]);
             $response = $client->request('GET', 'https://api.apilayer.com/currency_data/live', [
                 'query' => [
                     'currencies' => $to_Currency,

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -451,7 +451,7 @@ class Service implements InjectionAwareInterface
 
         // Download the extension archive and save it to the cache folder
         $fileHandler = fopen($zipPath, 'w');
-        $client = \Symfony\Component\HttpClient\HttpClient::create();
+        $client = \Symfony\Component\HttpClient\HttpClient::create(['bindto' => BIND_TO]);
         $response = $client->request('GET', $latest['download_url']);
 
         $code = $response->getStatusCode();

--- a/src/modules/Seo/Engines/Google.php
+++ b/src/modules/Seo/Engines/Google.php
@@ -41,7 +41,7 @@ class Google implements \FOSSBilling\InjectionAwareInterface
     public function pingSitemap(string $url)
     {
         $link = 'https://www.google.com/ping';
-        $httpClient = HttpClient::create();
+        $httpClient = HttpClient::create(['bindto' => BIND_TO]);
 
         $request = $httpClient->request('GET', $link, [
             'query' => [

--- a/src/modules/Spamchecker/Service.php
+++ b/src/modules/Spamchecker/Service.php
@@ -88,7 +88,7 @@ class Service implements InjectionAwareInterface
                     throw new \FOSSBilling\InformationException('You have to complete the CAPTCHA to continue');
                 }
 
-                $client = HttpClient::create();
+                $client = HttpClient::create(['bindto' => BIND_TO]);
                 $response = $client->request('POST', 'https://google.com/recaptcha/api/siteverify', [
                     'body' => [
                         'secret' => $config['captcha_recaptcha_privatekey'],
@@ -204,7 +204,7 @@ class Service implements InjectionAwareInterface
         return $this->di['cache']->get('CentralAlerts.getAlerts', function (ItemInterface $item) {
             $item->expiresAfter(86400); // The list is updated once every 24 hours, so we will cache it for that long
 
-            $client = HttpClient::create();
+            $client = HttpClient::create(['bindto' => BIND_TO]);
             $response = $client->request('GET', 'https://raw.githubusercontent.com/7c/fakefilter/main/txt/data.txt');
             $dbPath = PATH_CACHE . DIRECTORY_SEPARATOR . 'tempEmailDB.txt';
 

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -276,8 +276,17 @@ class Admin extends \Api_Abstract
     public function set_interface_ip($data): bool
     {
         $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'manage_network_interface');
-        $this->getService()->setParamValue('interface_ip', $data['interface']);
-        $this->getService()->setParamValue('custom_interface_ip', $data['custom_interface']);
+        $config = Config::getConfig();
+
+        if (isset($data['interface'])) {
+            $config['interface_ip'] = $data['interface'];
+        }
+
+        if (isset($data['custom_interface'])) {
+            $config['custom_interface_ip'] = $data['custom_interface'];
+        }
+
+        Config::setConfig($config);
         return true;
     }
 }

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -266,4 +266,18 @@ class Admin extends \Api_Abstract
     {
         return \FOSSBilling\SentryHelper::last_change;
     }
+
+    public function get_interface_ips(): array
+    {
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'manage_network_interface');
+        return \FOSSBilling\Tools::listHttpInterfaces();
+    }
+
+    public function set_interface_ip($data): bool
+    {
+        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'manage_network_interface');
+        $this->getService()->setParamValue('interface_ip', $data['interface']);
+        $this->getService()->setParamValue('custom_interface_ip', $data['custom_interface']);
+        return true;
+    }
 }

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -269,7 +269,6 @@ class Admin extends \Api_Abstract
 
     public function get_interface_ips(): array
     {
-        $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('system', 'manage_network_interface');
         return \FOSSBilling\Tools::listHttpInterfaces();
     }
 

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -473,12 +473,12 @@ class Service
         return true;
     }
 
-    public function getEnv($ip)
+    public function getEnv($ip = null)
     {
-        if (isset($ip)) {
+        if ($ip) {
             try {
                 $client = HttpClient::create(['bindto' => BIND_TO]);
-                $response = $client->request('GET', 'https://api.ipify.org', [
+                $response = $client->request('GET', 'https://api64.ipify.org', [
                     'timeout' => 2,
                 ]);
 

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -477,12 +477,7 @@ class Service
     {
         if ($ip) {
             try {
-                $client = HttpClient::create(['bindto' => BIND_TO]);
-                $response = $client->request('GET', 'https://api64.ipify.org', [
-                    'timeout' => 2,
-                ]);
-
-                return $response->getContent();
+                return \FOSSBilling\Tools::getExternalIP();
             } catch (\Exception) {
                 return '';
             }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -53,6 +53,11 @@ class Service
                 'display_name' => __trans('Update FOSSBilling'),
                 'description' => __trans('Allows the staff member to update FOSSBilling.'),
             ],
+            'manage_network_interface' => [
+                'type' => 'bool',
+                'display_name' => __trans('Manage the network interface'),
+                'description' => __trans('Allows the staff member to fetch a list of all local interface IP addresses and set the default network interface for FOSSBilling to use.'),
+            ],
         ];
     }
 
@@ -472,7 +477,7 @@ class Service
     {
         if (isset($ip)) {
             try {
-                $client = HttpClient::create();
+                $client = HttpClient::create(['bindto' => BIND_TO]);
                 $response = $client->request('GET', 'https://api.ipify.org', [
                     'timeout' => 2,
                 ]);

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -25,6 +25,8 @@
 {% block content %}
     {% set new_params = admin.extension_config_get({ 'ext': 'mod_system' }) %}
     {% set params = admin.system_get_params %}
+    {% set enviroment = admin.system_env %}
+    {% set external_ip = admin.system_env({ 'ip': true }) %}
     <div class="card-tabs">
         <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item" role="presentation">
@@ -44,6 +46,9 @@
             </li>
             <li class="nav-item" role="presentation">
                 <a class="nav-link" href="#tab-reporting" data-bs-toggle="tab" role="tab">{{ 'Error reporting'|trans }}</a>
+            </li>
+            <li class="nav-item" role="presentation">
+                <a class="nav-link" href="#network-interface" data-bs-toggle="tab" role="tab">{{ 'Network interface'|trans }}</a>
             </li>
         </ul>
 
@@ -565,6 +570,47 @@ ZW=Zimbabwe
                     </div>
                 </div>
 
+                <div class="tab-pane fade" id="network-interface" role="tabpanel">
+                    <div class="card-header">
+                        <h3 class="card-title">{{ 'Network interface'|trans }}</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="alert {% if external_ip %}alert-success{% else %}alert-danger{% endif %}" role="alert">
+                            {% if external_ip %}
+                                {{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }} {{ external_ip }}
+                            {% else %}
+                                {{ 'The currently selected network interface does not appear to be able to reach the internet!'|trans }}
+                            {% endif %}
+                        </div>
+
+                        <form class="api-form" method="post" action="{{ 'api/admin/system/set_interface_ip'|link }}" data-api-reload="1">
+                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+                            <p>{{ 'If your server has multiple network interfaces, you may select the default one for FOSSBilling to use when making requests here.'|trans }}</p>
+                            {% set interface_ips = admin.system_get_interface_ips %}
+                            <label for="interface">{{"Select the default network interface:"|trans }}</label>
+                            <select class="form-select" aria-label="Available network interfaces" name="interface" id="interface">
+                                <option value="0" {% if constant('BIND_TO') == 0 %} selected {%endif%}>{{ 'None (Default PHP Behavior)'|trans }}</option>
+                                {% for i, interface in interface_ips %}
+                                <option value="{{ interface }}" {% if constant('BIND_TO') == interface %} selected {% endif %}>{{ interface }}</option>
+                                {% endfor %}
+                            </select>
+
+                            <br>
+
+                            <label for="custom_interface">{{'Enter a custom interface to use:'|trans }}</label>
+                            {% if constant('BIND_TO') not in interface_ips and constant('BIND_TO') != 0%}
+                                <input class="form-control" type="text" name="custom_interface" id="custom_interface" value="{{ constant('BIND_TO') }}">
+                            {% else %}
+                                <input class="form-control" type="text" name="custom_interface" id="custom_interface">
+                            {% endif %}
+                            <span class="text-muted">{{ 'Not seeing the correct interface above? You may enter the IP address here of the correct interface to use.'|trans }}</span>
+
+                            <br>
+
+                            <input type="submit" class="btn btn-primary" value="{{ 'Update'|trans }}">
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -575,7 +575,7 @@ ZW=Zimbabwe
                         <h3 class="card-title">{{ 'Network interface'|trans }}</h3>
                     </div>
                     <div class="card-body">
-                        <div class="alert {% if external_ip %}alert-success{% else %}alert-danger{% endif %}" role="alert">
+                        <div class="alert {% if external_ip %}alert-success{% else %}alert-danger{% endif %}" role="alert" id="external-ip">
                             {% if external_ip %}
                                 {{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }} {{ external_ip }}
                             {% else %}
@@ -583,7 +583,7 @@ ZW=Zimbabwe
                             {% endif %}
                         </div>
 
-                        <form class="api-form" method="post" action="{{ 'api/admin/system/set_interface_ip'|link }}" data-api-reload="1">
+                        <form class="api-form" method="post" action="{{ 'api/admin/system/set_interface_ip'|link }}" data-api-jsonp="onAfterInterfaceSet">
                             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <p>{{ 'If your server has multiple network interfaces, you may select the default one for FOSSBilling to use when making requests here.'|trans }}</p>
                             {% set interface_ips = admin.system_get_interface_ips %}
@@ -614,6 +614,26 @@ ZW=Zimbabwe
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block js %}
+<script>
+    function onAfterInterfaceSet(result) {
+        API.admin.post('system/env', {
+            ip: true,
+            CSRFToken: "{{ CSRFToken }}"
+        }, function (ip) {
+            FOSSBilling.message(`{{ 'Network interface updated.'|trans }}`);
+            if(ip){
+                document.getElementById('external-ip').innerText = `{{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }}` + ip;
+                document.getElementById('external-ip').className = 'alert alert-success';
+            } else {
+                document.getElementById('external-ip').innerText = `{{ 'The currently selected network interface does not appear to be able to reach the internet!'|trans }}`;
+                document.getElementById('external-ip').className = 'alert alert-danger';
+            }
+        });
+    }
+</script>
 {% endblock %}
 
 {% block head %}{{ mf.bb_editor('.bb-textarea') }}{% endblock %}

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -587,27 +587,31 @@ ZW=Zimbabwe
                             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <p>{{ 'If your server has multiple network interfaces, you may select the default one for FOSSBilling to use when making requests here.'|trans }}</p>
                             {% set interface_ips = admin.system_get_interface_ips %}
-                            <label for="interface">{{"Select the default network interface:"|trans }}</label>
-                            <select class="form-select" aria-label="Available network interfaces" name="interface" id="interface">
-                                <option value="0" {% if constant('BIND_TO') == 0 %} selected {%endif%}>{{ 'None (Default PHP Behavior)'|trans }}</option>
-                                {% for i, interface in interface_ips %}
-                                <option value="{{ interface }}" {% if constant('BIND_TO') == interface %} selected {% endif %}>{{ interface }}</option>
-                                {% endfor %}
-                            </select>
+                            
+                            <div class="col-12 col-lg-3">
+                                <label for="interface">{{"Select the default network interface:"|trans }}</label>
+                                <select class="form-select" aria-label="Available network interfaces" name="interface" id="interface">
+                                    <option value="0" {% if constant('BIND_TO') == 0 %} selected {%endif%}>{{ 'None (Default PHP Behavior)'|trans }}</option>
+                                    {% for i, interface in interface_ips %}
+                                    <option value="{{ interface }}" {% if constant('BIND_TO') == interface %} selected {% endif %}>{{ interface }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
 
                             <br>
 
-                            <label for="custom_interface">{{'Enter a custom interface to use:'|trans }}</label>
-                            {% if constant('BIND_TO') not in interface_ips and constant('BIND_TO') != 0%}
-                                <input class="form-control" type="text" name="custom_interface" id="custom_interface" value="{{ constant('BIND_TO') }}">
-                            {% else %}
-                                <input class="form-control" type="text" name="custom_interface" id="custom_interface">
-                            {% endif %}
-                            <span class="text-muted">{{ 'Not seeing the correct interface above? You may enter the IP address here of the correct interface to use.'|trans }}</span>
-
+                            <div class="col-12 col-lg-3">
+                                <label for="custom_interface">{{'Enter a custom interface to use:'|trans }}</label>
+                                {% if constant('BIND_TO') not in interface_ips and constant('BIND_TO') != 0%}
+                                    <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface" value="{{ constant('BIND_TO') }}">
+                                {% else %}
+                                    <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface">
+                                {% endif %}
+                            </div>
+                            <span class="text-muted">{{ "If the dropdown doesn't contain the correct interface, you can enter the IP address of the correct one above."|trans }}</span>
                             <br>
 
-                            <input type="submit" class="btn btn-primary" value="{{ 'Update'|trans }}">
+                            <input type="submit" class="btn btn-primary mt-1" value="{{ 'Update'|trans }}">
                         </form>
                     </div>
                 </div>

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -608,7 +608,7 @@ ZW=Zimbabwe
                                     <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface">
                                 {% endif %}
                             </div>
-                            <span class="text-muted">{{ "If the dropdown doesn't contain the correct interface, you can enter the IP address of the correct one above."|trans }}</span>
+                            <span class="text-muted">{{ "If the dropdown menu doesn't have the appropriate network interface, please enter the IP address or name (e.g., eth0) of the correct one above."|trans }}</span>
                             <br>
 
                             <input type="submit" class="btn btn-primary mt-1" value="{{ 'Update'|trans }}">

--- a/tests/Modules/System/SystemAdminTest.php
+++ b/tests/Modules/System/SystemAdminTest.php
@@ -7,6 +7,15 @@ use PHPUnit\Framework\TestCase;
 
 final class SystemAdminTest extends TestCase
 {
+    private function ipifyWorking(): bool
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_URL, 'https://api64.ipify.org');
+        $ip = curl_exec($ch);
+        return filter_var($ip, FILTER_VALIDATE_IP);
+    }
+
     public function testClearCache(): void
     {
         // Clear the cache
@@ -37,5 +46,69 @@ final class SystemAdminTest extends TestCase
             $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
             $this->assertTrue($response->getResult());
         }
+    }
+
+    public function testGetAndSetNetworkInterfaces(): void
+    {
+        // Get the list of network interfaces, validate the response is as expected
+        $response = Request::makeRequest('admin/system/get_interface_ips');
+        $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+        $this->assertIsArray($response->getResult());
+        $this->assertNotEmpty($response->getResult());
+
+        // And then validate they are all valid IP addresses
+        foreach ($response->getResult() as $ip) {
+            $this->assertTrue(filter_var($ip, FILTER_VALIDATE_IP));
+        }
+
+        // Only test each found interface if ipify.org is functioning
+        if ($this->ipifyWorking()) {
+            foreach ($response->getResult() as $ip) {
+                $response = Request::makeRequest('admin/system/set_interface_ip', ['interface_ip' => $ip]);
+                $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+
+                $response = Request::makeRequest('admin/system/env', ['ip' => true]);
+                $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+                $this->assertTrue(filter_var($response->getResult(), FILTER_VALIDATE_IP));
+            }
+        }
+
+        // Finally, set it back to the default interface
+        Request::makeRequest('admin/system/set_interface_ip', ['interface_ip' => '0']);
+    }
+
+    public function testInterfaceIsIgnoredWhenNotValid(): void
+    {
+        // Set the network interface to one that's invalid
+        $response = Request::makeRequest('admin/system/set_interface_ip', ['interface_ip' => '12345']);
+        $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+        $this->assertTrue($response->getResult());
+
+        // Now we validate that the system is discarding it for not being one of the local interface IPs, ensuring that outbound communication still works
+        if ($this->ipifyWorking()) {
+            $response = Request::makeRequest('admin/system/env', ['ip' => true]);
+            $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+            $this->assertTrue(filter_var($response->getResult(), FILTER_VALIDATE_IP));
+        }
+    }
+
+    public function testCustomInterface(): void
+    {
+        // Validate that we can set the custom network interface without errors
+        $response = Request::makeRequest('admin/system/set_interface_ip', ['custom_interface_ip' => '12345']);
+        $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+        $this->assertTrue($response->getResult());
+
+        // And since we don't (can't) perform any checks against the custom interface, it should now be in use despite not being valid and as a result the system will be unable to get it's IP address
+        if ($this->ipifyWorking()) {
+            $response = Request::makeRequest('admin/system/env', ['ip' => true]);
+            $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+            $this->assertFalse(filter_var($response->getResult(), FILTER_VALIDATE_IP));
+        }
+
+        // Finally reset everything to ensure networking will continue to function
+        $response = Request::makeRequest('admin/system/set_interface_ip', ['custom_interface_ip' => '', 'interface_ip' => '0']);
+        $this->assertTrue($response->wasSuccessful(), $response->generatePHPUnitMessage());
+        $this->assertTrue($response->getResult());
     }
 }


### PR DESCRIPTION
This pull request implements the ability for administrators to select the default network interface for FOSSBilling to use when making requests which should reduce confusion for users as some have had issues where their servers has multiple network interfaces and experienced issues on services that rely on IP address whitelisting.

This also provides a convent location for people to check what their external IP address is as it's displayed on the page.

Based on another user's experience on Discord, this closes #1267 as they received the same error message due to the IP address mismatch (real clear, thanks Resellerclub)

## To-do

- [x] Minor cleanup, testing.
- [x] Move to storing the selected interface in the config file so it can also apply to the Sentry integration (Once #2066 is merged)
- [x] Write some tests

## Screenshots

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/2c355bcc-6112-4481-b767-02fc8be6d95d)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/0a90b4db-e0f9-4262-8532-c412e12b93b1)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/e6350c20-1ace-4bc0-9639-d124cab0a6af)
