### PR TITLE
Transfer carts when logging in

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -49,7 +49,7 @@ class Service implements InjectionAwareInterface
         $cart = $this->getSessionCart($sessionID);
         $cart->session_id = $this->di['session']->getId();
         $this->di['db']->store($cart);
-        return true
+        return true;
     }
 
     /**

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -43,12 +44,20 @@ class Service implements InjectionAwareInterface
         return [$sql, []];
     }
 
+    public function transferFromOtherSession(string $sessionID): void
+    {
+        $cart = $this->getSessionCart($sessionID);
+        $cart->session_id = $this->di['session']->getId();
+        $this->di['db']->store($cart);
+    }
+
     /**
      * @return \Model_Cart
      */
-    public function getSessionCart()
+    public function getSessionCart(?string $sessionID = null)
     {
-        $sqlBindings = [':session_id' => $this->di['session']->getId()];
+        $sessionID ??= $this->di['session']->getId();
+        $sqlBindings = [':session_id' => $sessionID];
         $cart = $this->di['db']->findOne('Cart', 'session_id = :session_id', $sqlBindings);
 
         if ($cart instanceof \Model_Cart) {
@@ -65,7 +74,7 @@ class Service implements InjectionAwareInterface
         }
 
         $cart = $this->di['db']->dispense('Cart');
-        $cart->session_id = $this->di['session']->getId();
+        $cart->session_id = $sessionID;
         $cart->currency_id = $currency->id;
         $cart->created_at = date('Y-m-d H:i:s');
         $cart->updated_at = date('Y-m-d H:i:s');

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -44,11 +44,12 @@ class Service implements InjectionAwareInterface
         return [$sql, []];
     }
 
-    public function transferFromOtherSession(string $sessionID): void
+    public function transferFromOtherSession(string $sessionID): bool
     {
         $cart = $this->getSessionCart($sessionID);
         $cart->session_id = $this->di['session']->getId();
         $this->di['db']->store($cart);
+        return true
     }
 
     /**

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -132,12 +132,15 @@ class Guest extends \Api_Abstract
 
         $this->di['events_manager']->fire(['event' => 'onAfterClientLogin', 'params' => ['id' => $client->id, 'ip' => $this->ip]]);
 
+        $oldSession = $this->di['session']->getId();
         session_regenerate_id();
         $result = $service->toSessionArray($client);
         $this->di['session']->set('client_id', $client->id);
 
         $this->di['logger']->info('Client #%s logged in', $client->id);
         $this->di['session']->delete('redirect_uri');
+
+        $this->di['mod_service']('cart')->transferFromOtherSession($oldSession);
 
         return $result;
     }

--- a/src/modules/Product/Api/Admin.php
+++ b/src/modules/Product/Api/Admin.php
@@ -83,7 +83,7 @@ class Admin extends \Api_Abstract
     public function prepare($data)
     {
         $required = [
-            'title' => 'Notification is required',
+            'title' => 'You must specify a title',
             'type' => 'Type is missing',
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
@@ -192,7 +192,7 @@ class Admin extends \Api_Abstract
     public function addon_create($data)
     {
         $required = [
-            'title' => 'Notification is required',
+            'title' => 'You must specify a title',
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
 

--- a/tests-legacy/modules/Client/Api/AdminTest.php
+++ b/tests-legacy/modules/Client/Api/AdminTest.php
@@ -110,6 +110,11 @@ class AdminTest extends \BBTestCase
         $sessionMock->expects($this->atLeastOnce())->
         method('set');
 
+        $cartServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)->getMock();
+        $cartServiceMock->expects($this->once())
+            ->method('transferFromOtherSession')
+            ->willReturn(true);
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
@@ -120,6 +125,7 @@ class AdminTest extends \BBTestCase
             ->method('checkRequiredParamsForArray')
             ->willReturn(null);
         $di['validator'] = $validatorMock;
+        $di['mod_service'] = $di->protect(fn () => $cartServiceMock);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);

--- a/tests-legacy/modules/Client/Api/AdminTest.php
+++ b/tests-legacy/modules/Client/Api/AdminTest.php
@@ -110,11 +110,6 @@ class AdminTest extends \BBTestCase
         $sessionMock->expects($this->atLeastOnce())->
         method('set');
 
-        $cartServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)->getMock();
-        $cartServiceMock->expects($this->once())
-            ->method('transferFromOtherSession')
-            ->willReturn(true);
-
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
         $di['mod_service'] = $di->protect(fn ($name) => $serviceMock);
@@ -125,7 +120,6 @@ class AdminTest extends \BBTestCase
             ->method('checkRequiredParamsForArray')
             ->willReturn(null);
         $di['validator'] = $validatorMock;
-        $di['mod_service'] = $di->protect(fn () => $cartServiceMock);
 
         $admin_Client = new \Box\Mod\Client\Api\Admin();
         $admin_Client->setDi($di);

--- a/tests-legacy/modules/Client/Api/GuestTest.php
+++ b/tests-legacy/modules/Client/Api/GuestTest.php
@@ -186,6 +186,11 @@ class GuestTest extends \BBTestCase
         $sessionMock->expects($this->atLeastOnce())
             ->method('set');
 
+        $cartServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)->getMock();
+        $cartServiceMock->expects($this->once())
+            ->method('transferFromOtherSession')
+            ->willReturn(true);
+
         $toolsMock = $this->getMockBuilder('\\' . \FOSSBilling\Tools::class)->getMock();
         // $toolsMock->expects($this->atLeastOnce())->method('validateAndSanitizeEmail');
 
@@ -200,6 +205,7 @@ class GuestTest extends \BBTestCase
         $di['logger'] = new \Box_Log();
         $di['validator'] = $validatorMock;
         $di['tools'] = $toolsMock;
+        $di['mod_service'] = $di->protect(fn () => $cartServiceMock);
 
         $client = new Guest();
         $client->setDi($di);

--- a/tests/APIHelper.php
+++ b/tests/APIHelper.php
@@ -15,7 +15,7 @@ class Request
      */
     public static function makeRequest(string $endpoint, array $payload = [], string $role = null, string $apiKey = null, string $method = 'POST', string $baseUrl = null): Response
     {
-        $cookie = tempnam(sys_get_temp_dir(), 'cookie.txt');
+        $cookie = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cookie.txt';
         if (!$role) {
             $role = str_starts_with($endpoint, 'admin') ? 'admin' : 'client';
         }
@@ -46,6 +46,11 @@ class Request
         curl_close($ch);
 
         return new Response($httpCode, $output);
+    }
+
+    public static function resetCookies()
+    {
+        unlink(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cookie.txt');
     }
 }
 

--- a/tests/Modules/Cart/CartTest.php
+++ b/tests/Modules/Cart/CartTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use APIHelper\Request;
+use PHPUnit\Framework\TestCase;
+
+final class CartTest extends TestCase
+{
+    public function testDoesCartTransferOnLogin(): void
+    {
+        // First we need a dummy product
+        $result = Request::makeRequest('admin/product/prepare', [
+            'title' => 'Dummy Product',
+            'type' => 'custom',
+        ]);
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertIsNumeric($result->getResult());
+        $productID = intval($result->getResult());
+
+        // Now configure it
+        $result = Request::makeRequest('admin/product/prepare', [
+            'id' => $productID,
+            'status' => 'enabled',
+            'pricing' => [
+                'type' => 'free'
+            ]
+        ]);
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertTrue($result->getResult());
+
+        // Next add that product to the cart
+        $result = Request::makeRequest('guest/cart/add_item', [
+            'id' => $productID,
+        ]);
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertTrue($result->getResult());
+
+        // Get the cart as-is
+        $result = Request::makeRequest('guest/cart/get');
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertIsArray($result->getResult());
+        $startingCart = $result->getResult();
+
+        // Generate a new test user
+        $password = 'A' . bin2hex(random_bytes(6));
+        $result = Request::makeRequest('guest/client/create', [
+            'email' => 'client@example.com',
+            'first_name' => 'Test',
+            'password' => $password,
+            'password_confirm' => $password,
+        ]);
+
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertIsNumeric($result->getResult());
+
+        $id = intval($result->getResult());
+
+        // Login as that user
+        $result = Request::makeRequest('guest/client/login', [
+            'email' => 'client@example.com',
+            'password' => $password,
+        ]);
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+
+        // Get the cart again and verify it matches the original one
+        $result = Request::makeRequest('guest/cart/get');
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertIsArray($result->getResult());
+        $this->assertEquals($startingCart, $result->getResult());
+
+        // Finally perform some cleanup
+        $result = Request::makeRequest('admin/client/delete', ['id' => $id]);
+        $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
+        $this->assertTrue($result->getResult());
+        Request::resetCookies();
+    }
+}

--- a/tests/Modules/Cart/CartTest.php
+++ b/tests/Modules/Cart/CartTest.php
@@ -20,7 +20,7 @@ final class CartTest extends TestCase
         $productID = intval($result->getResult());
 
         // Now configure it
-        $result = Request::makeRequest('admin/product/prepare', [
+        $result = Request::makeRequest('admin/product/update', [
             'id' => $productID,
             'status' => 'enabled',
             'pricing' => [

--- a/tests/Modules/Cart/CartTest.php
+++ b/tests/Modules/Cart/CartTest.php
@@ -13,6 +13,7 @@ final class CartTest extends TestCase
         $result = Request::makeRequest('admin/product/prepare', [
             'title' => 'Dummy Product',
             'type' => 'custom',
+            'product_category_id' => 1,
         ]);
         $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
         $this->assertIsNumeric($result->getResult());


### PR DESCRIPTION
Closes #2026 and implements a workaround for the unwanted behavior where logging in results in the cart being lost since it's tied to the session ID.

When logging in, the old session ID is kept temporarily and then the old cart in the DB is updated to the new ID.

Makes the existing system more bearable until it's rebuilt.