### PR TITLE
Fixes an error when saving a plaintext textarea field when CKEditor is loaded and there are no textareas it initialized.

### DIFF
--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -150,7 +150,7 @@ globalThis.bb = {
           const formData = new FormData(formElement);
 
           // Get all CKEditor instances and replace the original textarea values with the updated content.
-          if (typeof editors !== "undefined" && Array.isArray(editors)) {
+          if (typeof editors !== "undefined" && Array.isArray(editors) && editors.length > 0) {
             let editorContentOnRequiredAttr = false;
             Object.keys(editors).forEach(function (name) {
               editorContentOnRequiredAttr = editors[name].required


### PR DESCRIPTION
Thanks to @BelleNottelling for providing this fix. 

There was an issue when in a twig-template, when no instances of wysiwyg textareas were rendered due to conditions. Saving a form containing a plaintext textarea (without the class that ckeditor looks for) would lead to an error, and could not be saved.

This code fixes that.