### PR TITLE
Improve clarity when marking unpaid invoices without a set gateway

### DIFF
--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -70,7 +70,7 @@ class Admin extends \Api_Abstract
         $gateway_id = ['id' => $invoice->gateway_id];
 
         if (!$gateway_id['id']) {
-            throw new InformationException('You must set the payment gateway in the invoice "manage" tab before marking it as paid.');
+            throw new InformationException('You must set the payment gateway in the invoice manage tab before marking it as paid.');
         }
 
         $payGateway = $this->gateway_get($gateway_id);

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2023 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -13,6 +14,8 @@
  */
 
 namespace Box\Mod\Invoice\Api;
+
+use FOSSBilling\InformationException;
 
 class Admin extends \Api_Abstract
 {
@@ -65,6 +68,11 @@ class Admin extends \Api_Abstract
         }
         $invoice = $this->_getInvoice($data);
         $gateway_id = ['id' => $invoice->gateway_id];
+
+        if (!$gateway_id['id']) {
+            throw new InformationException('You must set the payment gateway in the invoice "manage" tab before marking it as paid.');
+        }
+
         $payGateway = $this->gateway_get($gateway_id);
         $charge = false;
 

--- a/tests-legacy/modules/Invoice/Api/AdminTest.php
+++ b/tests-legacy/modules/Invoice/Api/AdminTest.php
@@ -91,9 +91,11 @@ class AdminTest extends \BBTestCase
         $validatorMock->expects($this->atLeastOnce())
             ->method('checkRequiredParamsForArray');
 
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $model = new \Model_Invoice();
         $model->loadBean(new \DummyBean());
+        $model->gateway_id = '1';
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
         $dbMock->expects($this->atLeastOnce())
             ->method('getExistingModelById')
             ->willReturn($model);


### PR DESCRIPTION
If someone tries to mark an invoice as paid when a payment gateway wasn't set, it produced a non-descriptive message stating "Gateway id not passed (9999)" which has produced some confusion.

This changes that to instead tell them that they need to set the gateway on the manage tab.