### PR TITLE
Added some debugging for session fingerprinting

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -21,6 +21,7 @@ return [
         'force_https' => true,
         'session_lifespan' => 7200,
         'perform_session_fingerprinting' => true,
+        'debug_fingerprint' => false,
     ],
 
     'debug_and_monitoring' => [

--- a/src/library/FOSSBilling/Fingerprint.php
+++ b/src/library/FOSSBilling/Fingerprint.php
@@ -174,7 +174,7 @@ class Fingerprint
             $percentageWrong = round($percentageWrong * 100, 3);
             $failureThreshold = round($failureThreshold * 100, 3);
 
-            error_log("The session with the ID '$ID' failed it's fingerprint check with a (weighted) $percentageWrong% of difference compared to the allowed $failureThreshold%. $itemCount properties were used in the check.");
+            error_log("The session with the ID '$ID' failed it's fingerprint check with a (weighted) difference of $percentageWrong% compared to the allowed $failureThreshold%. $itemCount properties were used in the check.");
             $output = PHP_EOL;
             foreach ($differing as $name) {
                 $output .= '    ' . $name . PHP_EOL;

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -138,8 +138,8 @@ class Session implements InjectionAwareInterface
 
         $storedFingerprint = json_decode($session->fingerprint, true);
         if (!$fingerprint->checkFingerprint($storedFingerprint) && Config::getProperty('security.perform_session_fingerprinting', true)) {
-            $invalid = true;
             // TODO: Trying to use monolog here causes a 503 error with an empty error log. Would love to find out why and use it instead of error_log
+            $invalid = true;
             error_log("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.");
             // $this->di['logger']->setChannel('security')->info("Session ID $sessionID has potentially been hijacked as it failed the fingerprint check. The session has automatically been destroyed.");
         }

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -54,6 +54,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $newConfig['security']['force_https'] ??= true;
         $newConfig['security']['session_lifespan'] ??= $newConfig['security']['cookie_lifespan'] ?? 7200;
         $newConfig['security']['perform_session_fingerprinting'] ??= true;
+        $newConfig['security']['debug_fingerprint'] ??= false;
         $newConfig['update_branch'] ??= 'release';
         $newConfig['log_stacktrace'] ??= true;
         $newConfig['stacktrace_length'] ??= 25;


### PR DESCRIPTION
Relates to #2051.

Logs something similar to this:
```
[22-Jan-2024 04:11:58 UTC] The session with the ID 'someid' failed it's fingerprint check with a (weighted) difference of 2030% compared to the allowed 50%. 10 properties were used in the check.
[22-Jan-2024 04:11:58 UTC] The following properties were wrong:
    agentString
    browser
    browserVersion
    os
```