### PR TITLE
✨Add prefix for generated users (continuation)

### DIFF
--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -392,8 +392,10 @@ class Server_Manager_Directadmin extends Server_Manager
      */
     public function generateUsername(string $domain): string
     {
+        $prefix = $this->_config['config']['userprefix'] ?? '';
+
         // Username must be alphanumeric.
-        $username = preg_replace('/[^A-Za-z0-9]/', '', $domain);
+        $username = preg_replace('/[^A-Za-z0-9]/', '', $prefix . $domain);
 
         // Username must start with a-z.
         $username = is_numeric(substr($username, 0, 1)) ? substr_replace($username, chr(random_int(97, 122)), 0, 1) : $username;

--- a/src/library/Server/Manager/Hestia.php
+++ b/src/library/Server/Manager/Hestia.php
@@ -78,7 +78,8 @@ class Server_Manager_Hestia extends Server_Manager
     public function generateUsername(string $domain): string
     {
         $processedDomain = strtolower(preg_replace('/[^A-Za-z0-9]/', '', $domain));
-        $username = substr($processedDomain, 0, 7) . random_int(0, 9);
+        $prefix = $this->_config['config']['userprefix'] ?? '';
+        $username = $prefix . substr($processedDomain, 0, 7) . random_int(0, 9);
 
         // HestiaCP doesn't allow usernames to start with a number, so automatically append the letter 'a' to the start of a username that does.
         // See: https://github.com/hestiacp/hestiacp/pull/4195

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -112,7 +112,7 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Users prefix'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="userprefix" value="{{ server.config.userprefix }}" placeholder="{{ 'Prefix for created users (especially for database)'|trans }}">
+                    <input class="form-control" type="text" name="userprefix" value="{{ server.config.userprefix }}" placeholder="{{ 'Prefix for created users (especially for database) | Ignored for CPanel'|trans }}">
                 </div>
             </div>
 

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -113,7 +113,7 @@
                 <label class="form-label col-3 col-form-label">{{ 'Users prefix'|trans }}:</label>
                 <div class="col">
                     <input class="form-control" type="text" name="userprefix" value="{{ server.config.userprefix }}" placeholder="{{ 'Prefix for created users (especially for database)'|trans }}">
-                    <span class="text-muted">{{ 'Some server managers may ignore this option due to limitations / requirements for username imposed by the control panel.'|trans }}</span>
+                    <span class="text-muted">{{ 'Some server managers may ignore this option due to limitations / requirements for usernames imposed by the control panel.'|trans }}</span>
                 </div>
             </div>
 

--- a/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
+++ b/src/modules/Servicehosting/html_admin/mod_servicehosting_server.html.twig
@@ -112,7 +112,8 @@
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Users prefix'|trans }}:</label>
                 <div class="col">
-                    <input class="form-control" type="text" name="userprefix" value="{{ server.config.userprefix }}" placeholder="{{ 'Prefix for created users (especially for database) | Ignored for CPanel'|trans }}">
+                    <input class="form-control" type="text" name="userprefix" value="{{ server.config.userprefix }}" placeholder="{{ 'Prefix for created users (especially for database)'|trans }}">
+                    <span class="text-muted">{{ 'Some server managers may ignore this option due to limitations / requirements for username imposed by the control panel.'|trans }}</span>
                 </div>
             </div>
 

--- a/src/modules/System/html_client/mod_system_maintenance.html.twig
+++ b/src/modules/System/html_client/mod_system_maintenance.html.twig
@@ -1,39 +1,41 @@
-{% extends "layout_public.html.twig" %}
-
-{% block meta_title %}{{ 'System undergoing maintenance'|trans }}{% endblock %}
-
-{% block body_class %}page-login{% endblock %}
-
-{% block body %}
-    <div>
-        <div class="row h-75 justify-content-center align-items-center">
-            <div class="col-md-6 col-lg-4">
-                {% if settings.login_page_show_logo %}
-                    <div class="d-flex justify-content-center">
-                        <a href="{{ settings.login_page_logo_url|default('/') }}" target="_blank">
-                            <img class="my-4" height="50px" src="{{ guest.system_company.logo_url }}" alt="{{ guest.system_company.name }}"/>
-                        </a>
-                    </div>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    {% set company = guest.system_company %}
-    <div style="margin: 50px 40px; font-size: 16px; text-align: center;">
+{% set company = guest.system_company %}
+<html>
+<head>
+    <title>{{ 'System undergoing maintenance'|trans }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+    <style>
+        body {
+            background-color: #eee;
+        }
+        h1, h2, h3, h4, p, li {
+            font-family: Arial, Helvetica, sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <div style="margin:50px 40px; font-size: 16px;">
         <h1>{{ 'System undergoing maintenance'|trans }}</h1>
-        <p>{{ 'Our systems are undergoing maintenance. We\'ll be back soon.'|trans }}</p>
+        <p>{{ 'Our systems are undergoing a maintenance. We\'ll be back soon.'|trans }}</p>
         <hr>
-        <h4>{{ 'While we\'re away, you can still reach us over other channels.'|trans }}</h4>
-        <ul style="list-style-type: none; padding: 0;">
-            <li>{{ company.name }}</li>
-            <li>{{ company.address_1 }}</li>
-            <li>{{ company.address_2 }}</li>
-            <li>{{ company.address_3 }}</li>
-            <li>{{ company.tel }}</li>
-            <li>{{ company.email }}</li>
-        </ul>
+        <h4>{{ 'While we\'re away, you can still reach us over other channels.'|trans }}</h1>
+        <li>
+            {{ company.name }}
+        </li>
+        <li>
+            {{ company.address_1 }}
+        </li>
+        <li>
+            {{ company.address_2 }}
+        </li>
+        <li>
+            {{ company.address_3 }}
+        </li>
+        <li>
+            {{ company.tel }}
+        </li>
+        <li>
+            {{ company.email }}
+        </li>
     </div>
-{% endblock %}
-
-
+</body>
+</html>

--- a/src/modules/System/html_client/mod_system_maintenance.html.twig
+++ b/src/modules/System/html_client/mod_system_maintenance.html.twig
@@ -1,41 +1,39 @@
-{% set company = guest.system_company %}
-<html>
-<head>
-    <title>{{ 'System undergoing maintenance'|trans }}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-    <style>
-        body {
-            background-color: #eee;
-        }
-        h1, h2, h3, h4, p, li {
-            font-family: Arial, Helvetica, sans-serif;
-        }
-    </style>
-</head>
-<body>
-    <div style="margin:50px 40px; font-size: 16px;">
-        <h1>{{ 'System undergoing maintenance'|trans }}</h1>
-        <p>{{ 'Our systems are undergoing a maintenance. We\'ll be back soon.'|trans }}</p>
-        <hr>
-        <h4>{{ 'While we\'re away, you can still reach us over other channels.'|trans }}</h1>
-        <li>
-            {{ company.name }}
-        </li>
-        <li>
-            {{ company.address_1 }}
-        </li>
-        <li>
-            {{ company.address_2 }}
-        </li>
-        <li>
-            {{ company.address_3 }}
-        </li>
-        <li>
-            {{ company.tel }}
-        </li>
-        <li>
-            {{ company.email }}
-        </li>
+{% extends "layout_public.html.twig" %}
+
+{% block meta_title %}{{ 'System undergoing maintenance'|trans }}{% endblock %}
+
+{% block body_class %}page-login{% endblock %}
+
+{% block body %}
+    <div>
+        <div class="row h-75 justify-content-center align-items-center">
+            <div class="col-md-6 col-lg-4">
+                {% if settings.login_page_show_logo %}
+                    <div class="d-flex justify-content-center">
+                        <a href="{{ settings.login_page_logo_url|default('/') }}" target="_blank">
+                            <img class="my-4" height="50px" src="{{ guest.system_company.logo_url }}" alt="{{ guest.system_company.name }}"/>
+                        </a>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
     </div>
-</body>
-</html>
+
+    {% set company = guest.system_company %}
+    <div style="margin: 50px 40px; font-size: 16px; text-align: center;">
+        <h1>{{ 'System undergoing maintenance'|trans }}</h1>
+        <p>{{ 'Our systems are undergoing maintenance. We\'ll be back soon.'|trans }}</p>
+        <hr>
+        <h4>{{ 'While we\'re away, you can still reach us over other channels.'|trans }}</h4>
+        <ul style="list-style-type: none; padding: 0;">
+            <li>{{ company.name }}</li>
+            <li>{{ company.address_1 }}</li>
+            <li>{{ company.address_2 }}</li>
+            <li>{{ company.address_3 }}</li>
+            <li>{{ company.tel }}</li>
+            <li>{{ company.email }}</li>
+        </ul>
+    </div>
+{% endblock %}
+
+


### PR DESCRIPTION
Good evening,

as mentioned in the PR #1378, it would be interesting to have the possibility of generating a prefix for the users created on the different managers.

I see that in some managers, the method is overridden.
I therefore still wanted to include this option.
Ignored option for CPanel due to restrictions (max 16 characters). This is specified on the front and translated into a few languages.

Thank you so much