### PR TITLE
Improve CLI check, added PHP dev server to sentry helper

### DIFF
--- a/src/library/FOSSBilling/Environment.php
+++ b/src/library/FOSSBilling/Environment.php
@@ -60,6 +60,6 @@ class Environment
      */
     public static function isCLI(): bool
     {
-        return php_sapi_name() === 'cli' || !http_response_code();
+        return PHP_SAPI === 'cli' || defined('STDIN') || !http_response_code();
     }
 }

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -52,7 +52,8 @@ class SentryHelper
     {
         $sentryDSN = '--replace--this--during--release--process--';
 
-        $httpClient = new class() implements HttpClientInterface {
+        $httpClient = new class() implements HttpClientInterface
+        {
             public function sendRequest(Request $request, Options $options): Response
             {
                 $dsn = $options->getDsn();
@@ -179,6 +180,8 @@ class SentryHelper
             return 'Litespeed';
         } elseif (stripos(strtolower($serverSoftware), 'nginx') !== false) {
             return 'NGINX';
+        } elseif (PHP_SAPI === 'cli-server') {
+            return 'PHP Development Server';
         } else {
             return 'Unknown';
         }


### PR DESCRIPTION
I've noticed an extremely large quantity of events in Sentry regarding the [checkSSL](https://github.com/FOSSBilling/FOSSBilling/blob/main/src/load.php#L114C10-L114C18) function in the loading script. I *think* these are from cron being called via the CLI when it's not properly detected CLI, but I'm kinda guessing.

Either way, this adds in a new way to check for CLI & also adds the PHP dev server identifier to the web-server estimation for Sentry reporting. 

In this case, `STDIN` should only be defined if PHP is being run via the CLI

>  The CLI SAPI defines a few constants for I/O streams to make programming for the command line a bit easier. 

See: https://www.php.net/manual/en/features.commandline.io-streams.php