### PR TITLE
PDF Fixes

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -318,7 +318,7 @@ VALUES
 	(1,'last_patch','40',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
-	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(5,'company_logo','themes/huraga/assets/img/logo.svg',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(6,'company_logo_dark','themes/huraga/assets/img/logo_white.svg',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(7,'company_address_1','Demo address line 1',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/content_test.sql
+++ b/src/install/sql/content_test.sql
@@ -483,7 +483,7 @@ VALUES
 	(1,'last_patch','39',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','FOSSBilling demo',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','demo@fossbilling.org',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
-	(4,'company_signature','FOSSBilling.org - Client Management, Invoice and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(5,'company_logo','themes/huraga/assets/img/logo.svg',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(6,'company_logo_dark','themes/huraga/assets/img/logo_white.svg',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(7,'company_address_1','Demo address line 1',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1198,6 +1198,7 @@ class Service implements InjectionAwareInterface
         $pdf->setPaper($document_format, 'portrait');
         $options = $pdf->getOptions();
         $options->setChroot($_SERVER['DOCUMENT_ROOT']);
+        $options->setDefaultFont('DejaVu Sans');
 
         $sellerLines = 0;
         $buyerLines = 0;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1496,7 +1496,7 @@ class Service implements InjectionAwareInterface
         ];
 
         foreach ($sourceData as $label => $data) {
-            if (empty(trim($data))) {
+            if ($data === null || empty(trim($data))) {
                 unset($sourceData[$label]);
             } else {
                 ++$lines;
@@ -1512,11 +1512,15 @@ class Service implements InjectionAwareInterface
             'Company' => $invoice['buyer']['company'],
             'Name' => $invoice['buyer']['first_name'] . ' ' . $invoice['buyer']['last_name'],
             'Address' => $invoice['buyer']['address'],
+            'City' => $invoice['buyer']['city'],
+            'State' => $invoice['buyer']['state'],
+            'Zip' => $invoice['buyer']['zip'],
+            'Country' => $invoice['buyer']['country'],
             'Phone' => $invoice['buyer']['phone'],
         ];
 
         foreach ($sourceData as $label => $data) {
-            if (empty(trim($data))) {
+            if ($data === null || empty(trim($data))) {
                 unset($sourceData[$label]);
             } else {
                 ++$lines;
@@ -1546,7 +1550,7 @@ class Service implements InjectionAwareInterface
         ];
 
         foreach ($sourceData as $label => $data) {
-            if ($data !== null && empty(trim($data))) {
+            if ($data === null || empty(trim($data))) {
                 unset($sourceData[$label]);
             }
         }

--- a/src/modules/Invoice/pdf_template/default-pdf.css
+++ b/src/modules/Invoice/pdf_template/default-pdf.css
@@ -57,6 +57,7 @@ div.ClientInfo {
 div.Breakdown {
     position: absolute;
     width: 100%;
+    z-index: 9999;
 }
 
 table {
@@ -87,6 +88,7 @@ body {
  * The following CSS is used to style the invoice footer.
  */
 div.InvoiceFooter {
+    z-index: 1;
     position: absolute;
     bottom: 0px;
     width: 100%;

--- a/src/modules/Invoice/pdf_template/default-pdf.css
+++ b/src/modules/Invoice/pdf_template/default-pdf.css
@@ -5,7 +5,7 @@
  * The backend used for PDF generation is Dompdf, which has fairly limited CSS support, roughly CSS 2.1
  */
 
- hr.Rounded {
+hr.Rounded {
     border-top: 8px solid #bbb;
     border-radius: 5px;
     position: relative;
@@ -24,14 +24,13 @@ img.CompanyLogo {
     left: 40px;
     top: 7px;
 }
-
-h3.CompanyInfo{
+h3.CompanyInfo {
     position: absolute;
     left: 25px;
     top: 110px;
 }
 
-div.CompanyInfo{
+div.CompanyInfo {
     position: absolute;
     left: 25px;
     top: 145px;
@@ -40,13 +39,13 @@ div.CompanyInfo{
     max-width: 300px;
 }
 
-h3.ClientInfo{
+h3.ClientInfo {
     position: absolute;
     top: 110px;
     left: 410px;
 }
 
-div.ClientInfo{
+div.ClientInfo {
     position: absolute;
     top: 145px;
     left: 410px;
@@ -55,7 +54,7 @@ div.ClientInfo{
     max-width: 45%;
 }
 
-div.Breakdown{
+div.Breakdown {
     position: absolute;
     width: 100%;
 }
@@ -69,11 +68,11 @@ p {
 }
 
 tr:nth-of-type(odd) {
-    background-color:#ccc;
+    background-color: #ccc;
 }
 
-.right{
-    text-align:right;
+.right {
+    text-align: right;
 }
 
 /**
@@ -93,4 +92,9 @@ div.InvoiceFooter {
     width: 100%;
     text-align: center;
     font-size: 10px;
+}
+
+.muted-text {
+    color: #656665;
+    font-size: 0.75em;
 }

--- a/src/modules/Invoice/pdf_template/default-pdf.twig
+++ b/src/modules/Invoice/pdf_template/default-pdf.twig
@@ -1,7 +1,7 @@
 {% if buyer_lines >= seller_lines %}
-	{% set top = 325 + (25 * buyer_lines) %}
+	{% set top = 275 + (25 * buyer_lines) %}
 {% else %}
-	{% set top = 325 + (25 * seller_lines) %}
+	{% set top = 275 + (25 * seller_lines) %}
 {% endif %}
 
 {% set address_lines = [] %}

--- a/src/modules/Invoice/pdf_template/default-pdf.twig
+++ b/src/modules/Invoice/pdf_template/default-pdf.twig
@@ -96,7 +96,7 @@
 					<th style='text-align: right'>{{ invoice.total|money(currency_code) }}</th>
 				</tr>
 			</table>
-		<p>{{ footer.signature }}</p>
+		<span class="muted-text">{{ footer.signature }}</span>
 		</div>
 		<div class='InvoiceFooter'>
 			{% if footer.display_bank_info == 1 %}


### PR DESCRIPTION
- Fixes an issue where the client wasn't displaying their city, state, zip-code, and country.
- Fixed some PHP deprecation errors that could be produced.
- Adjusted the CSS so that the invoice line items can't be covered by the invoice footer. This is just a band-aid fix since I am not very good with CSS and DomPDF's support is terrible. I would rather redo the template using something like [Simple Grid+](https://simplegrid.hostbybelle.com/), but the CSS support is too out of date for this to use. Otherwise, fixing the layout issues would be pretty trivial for me to do.

## Before
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/c3690d9f-6a2e-4f6a-9128-0deca310ad0b)


## After
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/e396bdc5-77a7-4c9a-b52c-33b14a132a43)
