### PR TITLE
Fixed a case where an incorrect translation tag was being used

### DIFF
--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -128,7 +128,7 @@
         <form method="get" action="">
             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <input type="hidden" name="_url" value="{{request._url}}"/>
-            <label>{% trans %}Search:{% endtrans %} <input type="text" name="search" placeholder="{% trans %}Enter search text..{% endtrans %}" value="{{request.search}}"><div class="srch"></div></label>
+            <label>{{ 'Search:'|trans }} <input type="text" name="search" placeholder="{{ 'Enter search text..'|trans }}" value="{{ request.search }}"><div class="srch"></div></label>
         </form>
     </div>
 </div>


### PR DESCRIPTION
This ended up being processed by the twig translation extension so it didn't actually translate (it was otherwise unused and unconfigured). This fixes that & ensures there won't be an error now that the extension is removed