### PR TITLE
Ensure random passwords meet the requirements

### DIFF
--- a/tests/Modules/Cart/ClientTest.php
+++ b/tests/Modules/Cart/ClientTest.php
@@ -46,7 +46,7 @@ final class ClientTest extends TestCase
         $startingCart = $result->getResult();
 
         // Generate a new test user
-        $password = 'A' . bin2hex(random_bytes(6));
+        $password = 'A1' . bin2hex(random_bytes(6));
         $result = Request::makeRequest('guest/client/create', [
             'email' => 'client@example.com',
             'first_name' => 'Test',

--- a/tests/Modules/Client/GuestTest.php
+++ b/tests/Modules/Client/GuestTest.php
@@ -12,7 +12,7 @@ final class GuestTest extends TestCase
     public function testCreateAndDestroyClient(): void
     {
         // Generate a new test user
-        $password = 'A' . bin2hex(random_bytes(6));
+        $password = 'A1' . bin2hex(random_bytes(6));
         $result = Request::makeRequest('guest/client/create', [
             'email' => 'client@example.com',
             'first_name' => 'Test',

--- a/tests/Modules/Product/ClientTest.php.skip
+++ b/tests/Modules/Product/ClientTest.php.skip
@@ -17,7 +17,7 @@ final class ClientTest extends TestCase
     {
         parent::setUp();
         // Generate a new test user
-        $this->clientPassword = 'A' . bin2hex(random_bytes(6));
+        $this->clientPassword = 'A1' . bin2hex(random_bytes(6));
         $result = Request::makeRequest('guest/client/create', [
             'email' => 'client@example.com',
             'first_name' => 'Test',

--- a/tests/Modules/Spamchecker/GuestTest.php
+++ b/tests/Modules/Spamchecker/GuestTest.php
@@ -18,7 +18,7 @@ final class GuestTest extends TestCase
         $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
 
         // Generate a new test user with by using a throwaway email address, which should fail
-        $password = 'A' . bin2hex(random_bytes(6));
+        $password = 'A1' . bin2hex(random_bytes(6));
         $result = Request::makeRequest('guest/client/create', [
             'email' => 'email@yopmail.net',
             'first_name' => 'Test',
@@ -49,7 +49,7 @@ final class GuestTest extends TestCase
          *
          * @see http://api.stopforumspam.org/api?email=email@example.com
          */
-        $password = 'A' . bin2hex(random_bytes(6));
+        $password = 'A1' . bin2hex(random_bytes(6));
         $result = Request::makeRequest('guest/client/create', [
             'email' => 'email@example.com',
             'first_name' => 'Test',


### PR DESCRIPTION
I made a mistake when I setup the random password generation for the live tests and forgot that `bin2hex(random_bytes(6));` wasn't guaranteed to actually generate something with a number, this change fixes that to ensure one will be set.