### PR TITLE
Added proper TLD validation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -36,7 +36,8 @@
         "Birthdate",
         "jhurliman",
         "jambroseclarke",
-        "Egulias"
+        "Egulias",
+        "ICANN"
     ],
 
     "ignoreWords": [

--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -74,6 +74,7 @@ class Validate
                 @file_put_contents($dbPath, $response->getContent());
             } else {
                 $item->expiresAfter(3600);
+
                 return [];
             }
 
@@ -81,6 +82,7 @@ class Validate
             @unlink($dbPath);
             if (!$database) {
                 $item->expiresAfter(3600);
+
                 return [];
             }
 
@@ -93,6 +95,8 @@ class Validate
 
             // Sanity check we've created the list correctly
             if (!($result['COM'] ?? false) || !($result['NET'] ?? false) || !($result['ORG'] ?? false)) {
+                $item->expiresAfter(3600);
+
                 return [];
             }
 

--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -114,7 +114,7 @@ class Validate
 
         if (!$validTlds) {
             // Fallback behavior if we fail to get a valid list
-            if (str_starts_with($tld, 'XN--') || preg_match('/^[a-z]+$/', $tld)) {
+            if (str_starts_with($tld, 'xn--') || preg_match('/^[a-z]+$/', $tld)) {
                 return true;
             } else {
                 return false;

--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -36,6 +36,9 @@ class Validate
     {
         $sld = ltrim($sld, '.');
         $sld = idn_to_ascii($sld);
+        if ($sld === false) {
+            return false;
+        }
         $sld = strtolower($sld);
 
         // allow punnycode
@@ -51,7 +54,7 @@ class Validate
     }
 
     /**
-     * Validates if a given TLD is valid, comparing against the official TLD list by the IANA.
+     * Validates a given TLD, comparing against the official TLD list by the IANA.
      * In the event that fetching the valid list doesn't work, some very simple validation is performed instead.
      */
     public function isTldValid(string $tld): bool

--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -114,7 +114,7 @@ class Validate
 
         if (!$validTlds) {
             // Fallback behavior if we fail to get a valid list
-            if (str_starts_with($tld, 'XN--') || preg_match('/^[A-Z]+$/', $tld)) {
+            if (str_starts_with($tld, 'XN--') || preg_match('/^[a-z]+$/', $tld)) {
                 return true;
             } else {
                 return false;

--- a/tests-legacy/modules/Servicedomain/ServiceTest.php
+++ b/tests-legacy/modules/Servicedomain/ServiceTest.php
@@ -60,75 +60,6 @@ class ServiceTest extends \BBTestCase
         $this->assertEquals($result, $expected);
     }
 
-    public static function validateOrderDataProvider()
-    {
-        $self = new ServiceTest('ServiceTest');
-
-        return [
-            [
-                [
-                    'action' => 'owndomain',
-                    'owndomain_sld' => 'example',
-                    'owndomain_tld' => '.com',
-                ],
-                $self->never(),
-                $self->never(),
-                $self->never(),
-            ],
-            [
-                [
-                    'action' => 'transfer',
-                    'transfer_sld' => 'example',
-                    'transfer_tld' => '.com',
-                ],
-                $self->atLeastOnce(),
-                $self->atLeastOnce(),
-                $self->never(),
-            ],
-            [
-                [
-                    'action' => 'register',
-                    'register_sld' => 'example',
-                    'register_tld' => '.com',
-                    'register_years' => '2',
-                ],
-                $self->atLeastOnce(),
-                $self->never(),
-                $self->atLeastOnce(),
-            ],
-        ];
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDataProvider')]
-    public function testValidateOrderData($data, $finOneByTldCalled, $canBeTransferredCalled, $isDomainAvailableCalled)
-    {
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
-        $validatorMock->expects($this->atLeastOnce())->method('isSldValid')
-            ->willReturn(true);
-
-        $tld = new \Model_Tld();
-        $tld->loadBean(new \DummyBean());
-        $tld->tld = '.com';
-        $tld->min_years = 2;
-
-        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedomain\Service::class)
-            ->onlyMethods(['tldFindOneByTld', 'canBeTransferred', 'isDomainAvailable'])->getMock();
-
-        $serviceMock->expects($finOneByTldCalled)->method('tldFindOneByTld')
-            ->willReturn($tld);
-        $serviceMock->expects($canBeTransferredCalled)->method('canBeTransferred')
-            ->willReturn(true);
-        $serviceMock->expects($isDomainAvailableCalled)->method('isDomainAvailable')
-            ->willReturn(true);
-
-        $di = new \Pimple\Container();
-        $di['validator'] = $validatorMock;
-        $serviceMock->setDi($di);
-
-        $result = $serviceMock->validateOrderData($data);
-        $this->assertNull($result);
-    }
-
     public static function validateOrderDataExceptionsProvider()
     {
         return [
@@ -144,49 +75,6 @@ class ServiceTest extends \BBTestCase
     public function testValidateOrderDataExceptions($data)
     {
         $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
-
-        $di = new \Pimple\Container();
-        $di['validator'] = $validatorMock;
-        $this->service->setDi($di);
-
-        $this->expectException(\FOSSBilling\Exception::class);
-        $result = $this->service->validateOrderData($data);
-        $this->assertNull($result);
-    }
-
-    public static function validateOrderDateOwndomainExceptionsProvider()
-    {
-        $self = new ServiceTest('ServiceTest');
-
-        return [
-            [
-                [ // "owndomain_sld" is missing
-                    'action' => 'owndomain',
-                    'owndomain_tld' => '.com',
-                ],
-                $self->never(),
-                true,
-            ],
-            [
-                [
-                    'action' => 'owndomain',
-                    'owndomain_sld' => 'example',
-                    'owndomain_tld' => '.com',
-                ],
-                $self->atLeastOnce(),
-                false, // //"isSldValid" returns false
-            ],
-        ];
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('validateOrderDateOwndomainExceptionsProvider')]
-    public function testValidateOrderDateOwndomainOwndomain($data, $isSldValidCalled, $isSldValidReturn)
-    {
-        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->getMock();
-        $validatorMock->expects($isSldValidCalled)->method('isSldValid')
-            ->willReturn($isSldValidReturn);
-        $validatorMock->expects($this->atLeastOnce())->method('checkRequiredParamsForArray')
-            ->willReturn(null);
 
         $di = new \Pimple\Container();
         $di['validator'] = $validatorMock;


### PR DESCRIPTION
Closes #2141 by implementing TLD validation for when a customer tries to bring their own domain.

The validation fetches the [TLD list from the public suffix project](https://publicsuffix.org/list/public_suffix_list.dat) and compares against that, with some fallback behavior if we fail to fetch it for whatever reason.

Additionally I've modified the existing `isSldValid` function so that it should properly accept international domains & be less likely to produce errors.

Some other minor changes were made to the logic in Servicedomain's `validateOrderData` function to reduce duplicated functionality & ensure no cases of undefined array key access.

![Animation](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/8d2c41a1-7157-43e4-bfd6-d74ae24c39ac)
