### PR TITLE
Eliminate the extension manifest column from the DB

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -131,12 +131,12 @@ UNLOCK TABLES;
 LOCK TABLES `extension` WRITE;
 /*!40000 ALTER TABLE `extension` DISABLE KEYS */;
 
-INSERT INTO `extension` (`id`, `type`, `name`, `status`, `version`, `manifest`)
+INSERT INTO `extension` (`id`, `type`, `name`, `status`, `version`)
 VALUES
-	(1,'mod','news','installed','1.0.0','{\"id\":\"news\",\"type\":\"mod\",\"name\":\"News\",\"description\":\"News module for FOSSBilling\",\"homepage_url\":\"https:\\/\\/github.com\\/FOSSBilling\",\"author\":\"FOSSBilling\",\"author_url\":\"http:\\/\\/extensions.fossbilling.org\\/\",\"license\":\"https:\\/\\/github.com\\/FOSSBilling\\/FOSSBilling\\/blob\\/main\\/LICENSE\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/News\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-	(2,'mod','branding','installed','0.0.1','{\"id\":\"branding\",\"type\":\"mod\",\"name\":\"Branding\",\"description\":\"Show your support by voluntarily displaying references to FOSSBilling.\",\"homepage_url\":\"https:\\/\\/fossbilling.org\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/fossbilling.org\",\"license\":\"https:\\/\\/github.com\\/FOSSBilling\\/FOSSBilling\\/blob\\/main\\/LICENSE\",\"version\":\"0.0.1\",\"icon_url\":\"\\/modules\\/Branding\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-	(3,'mod','redirect','installed','1.0.0','{\"id\":\"redirect\",\"type\":\"mod\",\"name\":\"Redirect\",\"description\":\"Manage redirects\",\"homepage_url\":\"https:\\/\\/fossbilling.org\\/\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/www.fossbilling.org\",\"license\":\"N\\/A\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/Redirect\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-	(4,'mod','wysiwyg','installed','1.0.0','{\"id\":\"wysiwyg\",\"type\":\"mod\",\"name\":\"Wysiwyg\",\"description\":\"Integrates a What You See Is What You Get (WYSIWYG) editor to your admin panel.\",\"homepage_url\":\"https:\\/\\/fossbilling.org\\/\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"license\":\"N\\/A\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/Wysiwyg\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}');
+	(1,'mod','news','installed','1.0.0'),
+	(2,'mod','branding','installed','0.0.1'),
+	(3,'mod','redirect','installed','1.0.0'),
+	(4,'mod','wysiwyg','installed','1.0.0');
 
 /*!40000 ALTER TABLE `extension` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -315,7 +315,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','40',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
+	(1,'last_patch','41',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/content_test.sql
+++ b/src/install/sql/content_test.sql
@@ -160,12 +160,12 @@ UNLOCK TABLES;
 LOCK TABLES `extension` WRITE;
 /*!40000 ALTER TABLE `extension` DISABLE KEYS */;
 
-INSERT INTO `extension` (`id`, `type`, `name`, `status`, `version`, `manifest`)
+INSERT INTO `extension` (`id`, `type`, `name`, `status`, `version`)
 VALUES
-    (1,'mod','news','installed','1.0.0','{\"id\":\"news\",\"type\":\"mod\",\"name\":\"News\",\"description\":\"News module for FOSSBilling\",\"homepage_url\":\"https:\\/\\/github.com\\/FOSSBilling\",\"author\":\"FOSSBilling\",\"author_url\":\"http:\\/\\/extensions.fossbilling.org\\/\",\"license\":\"https:\\/\\/github.com\\/FOSSBilling\\/FOSSBilling\\/blob\\/main\\/LICENSE\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/News\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-    (2,'mod','branding','installed','0.0.1','{\"id\":\"branding\",\"type\":\"mod\",\"name\":\"Branding\",\"description\":\"Show your support by voluntarily displaying references to FOSSBilling.\",\"homepage_url\":\"https:\\/\\/fossbilling.org\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/fossbilling.org\",\"license\":\"https:\\/\\/github.com\\/FOSSBilling\\/FOSSBilling\\/blob\\/main\\/LICENSE\",\"version\":\"0.0.1\",\"icon_url\":\"\\/modules\\/Branding\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-    (3,'mod','redirect','installed','1.0.0','{\"id\":\"redirect\",\"type\":\"mod\",\"name\":\"Redirect\",\"description\":\"Manage redirects\",\"homepage_url\":\"https:\\/\\/fossbilling.org\\/\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/www.fossbilling.org\",\"license\":\"N\\/A\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/Redirect\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}'),
-    (4,'mod','wysiwyg','installed','1.0.0','{\"id\":\"wysiwyg\",\"type\":\"mod\",\"name\":\"Wysiwyg\",\"description\":\"Integrates a What You See Is What You Get (WYSIWYG) editor to your admin panel.\",\"homepage_url\":\"https:\\/\\/fossbilling.org\\/\",\"author\":\"FOSSBilling\",\"author_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"license\":\"N\\/A\",\"version\":\"1.0.0\",\"icon_url\":\"\\/modules\\/Wysiwyg\\/icon.svg\",\"download_url\":null,\"project_url\":\"https:\\/\\/extensions.fossbilling.org\\/\",\"minimum_boxbilling_version\":null,\"maximum_boxbilling_version\":null}');
+    (1,'mod','news','installed','1.0.0'),
+    (2,'mod','branding','installed','0.0.1'),
+    (3,'mod','redirect','installed','1.0.0'),
+    (4,'mod','wysiwyg','installed','1.0.0');
 
 /*!40000 ALTER TABLE `extension` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -480,7 +480,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','39',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','41',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','FOSSBilling demo',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','demo@fossbilling.org',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -453,7 +453,6 @@ CREATE TABLE `extension` (
   `name` varchar(255) DEFAULT NULL,
   `status` varchar(100) DEFAULT NULL,
   `version` varchar(100) DEFAULT NULL,
-  `manifest` text,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/src/library/Box/Mod.php
+++ b/src/library/Box/Mod.php
@@ -10,6 +10,7 @@
  */
 
 use FOSSBilling\Config;
+use Symfony\Component\Filesystem\Path;
 
 class Box_Mod
 {
@@ -66,7 +67,7 @@ class Box_Mod
 
     public function hasManifest()
     {
-        return file_exists($this->_getModPath() . 'manifest.json');
+        return file_exists(Path::normalize($this->_getModPath() . 'manifest.json'));
     }
 
     public function getManifest()
@@ -74,11 +75,13 @@ class Box_Mod
         if (!$this->hasManifest()) {
             throw new FOSSBilling\Exception('Module :mod manifest file is missing', [':mod' => $this->mod], 5897);
         }
-        $file = $this->_getModPath() . 'manifest.json';
-        $json = json_decode(file_get_contents($file), true);
-        if (empty($json)) {
+
+        $contents = file_get_contents(Path::normalize($this->_getModPath() . 'manifest.json'));
+        if (!json_validate($contents)) {
             throw new FOSSBilling\Exception('Module :mod manifest file is invalid. Check file syntax and permissions.', [':mod' => $this->mod]);
         }
+
+        $json = json_decode($contents, true);
 
         // default module info if some fields are missing
         $info = [

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -365,6 +365,11 @@ class UpdatePatcher implements InjectionAwareInterface
                 $q = 'ALTER TABLE service_hosting_server ADD COLUMN `password_length` TINYINT DEFAULT NULL;';
                 $this->executeSql($q);
             },
+            41 => function () {
+                // Remove the  `manifest` column from the extensions table since it's no longer used
+                $q = 'ALTER TABLE extension DROP COLUMN manifest;';
+                $this->executeSql($q);
+            },
         ];
         ksort($patches, SORT_NATURAL);
 

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -106,6 +106,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             'domain-name' => $domain->getName(),
         ];
         $result = $this->_makeRequest('domains/validate-transfer', $params, 'GET');
+
         return strtolower($result) == 'true';
     }
 
@@ -477,6 +478,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
         $params = [...$optional_params, ...$params];
         $customer_id = $this->_makeRequest('customers/signup', $params, 'POST');
+
         return $customer_id;
     }
 
@@ -532,6 +534,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         }
 
         $id = $this->_makeRequest('contacts/add', $contact, 'POST');
+
         return $id;
     }
 
@@ -696,13 +699,14 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception(sprintf('HttpClientException: %s', $error->getMessage()));
             $this->getLog()->err($e);
+
             throw $e;
         }
 
-        if($result->getContent(false) == 'true'){
+        if ($result->getContent(false) == 'true') {
             return $result->getContent(false);
         }
-        if(is_numeric($result->getContent(false))){
+        if (is_numeric($result->getContent(false))) {
             return $data = $result->getContent(false);
         }
         $json = $result->toArray(false);
@@ -730,6 +734,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
             throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
+
         return $json;
     }
 
@@ -974,28 +979,28 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         return [$reg_contact_id, $admin_contact_id, $tech_contact_id, $billing_contact_id];
     }
 
-   private function _getContact($contact, $customer_id, $type = 'Contact')
-   {
-       try {
-           $params = [
-               'customer-id' => $customer_id,
-               'no-of-records' => 20,
-               'page-no' => 1,
-               'status' => 'Active',
-               'type' => $type,
-           ];
-           $result = $this->_makeRequest('contacts/search', $params, 'GET', 'json');
-           if ($result['recsonpage'] < 1) {
-               throw new Registrar_Exception('Contact not found');
-           }
-           $existing_contact_id = $result['result'][0]['entity.entityid'];
-           $this->_makeRequest('contacts/delete', ['contact-id' => $existing_contact_id], 'POST');
-       } catch (Registrar_Exception $e) {
-           $this->getLog()->info($e->getMessage());
-       }
+    private function _getContact($contact, $customer_id, $type = 'Contact')
+    {
+        try {
+            $params = [
+                'customer-id' => $customer_id,
+                'no-of-records' => 20,
+                'page-no' => 1,
+                'status' => 'Active',
+                'type' => $type,
+            ];
+            $result = $this->_makeRequest('contacts/search', $params, 'GET', 'json');
+            if ($result['recsonpage'] < 1) {
+                throw new Registrar_Exception('Contact not found');
+            }
+            $existing_contact_id = $result['result'][0]['entity.entityid'];
+            $this->_makeRequest('contacts/delete', ['contact-id' => $existing_contact_id], 'POST');
+        } catch (Registrar_Exception $e) {
+            $this->getLog()->info($e->getMessage());
+        }
 
-       return $this->_makeRequest('contacts/add', $contact, 'POST');
-   }
+        return $this->_makeRequest('contacts/add', $contact, 'POST');
+    }
 
     private function getCARegistrantAgreementVersion()
     {


### PR DESCRIPTION
This column was literally only used in one place instead of reading from the file on disk and the only real effect it had was minor annoying things like module icons being outdated unless an extension is uninstalled and then reinstalled.

This PR drops the column entirely and instead loads the manifest from the JSON file, fixing the annoyance & reducing the DB usage a little.