### PR TITLE
Correct margin for multiple product categories

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_choose_product.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_choose_product.html.twig
@@ -9,7 +9,7 @@
     <div id="products" class="accordion-collapse collapse" data-bs-parent="#orderManager">
         <div class="accordion-body">
             {% for i, category in guest.product_category_get_list.list %}
-                <h5>{{ category.title }}</h5>
+                <h5 {% if i > 0 %} class="mt-3" {% endif %}>{{ category.title }}</h5>
                 <span>{{ category.description|markdown }}</span>
                 <div class="list-group">
                     {% for i, product in category.products|sort((a, b) => a.priority <=> b.priority) %}


### PR DESCRIPTION
The first category has margin / padding applied to it because of the accordion element, but anything after that had zero which resulted in a fairly poor looking UI.

This PR fixes that by adding margin to all categories after the first one.

## Before

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/05470dc9-7ad1-441a-8f03-a4badb95fcea)

## After

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/df9a1072-3e15-4cf0-9198-143a1e88ee2c)
 