### PR TITLE
Add TOS / Privacy policy to the checkout & signup pages

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -182,18 +182,20 @@
                                         {% if enough_in_balance %}
                                             <p>{{ 'Total amount will be deducted from account balance'|trans }}</p>
                                         {% endif %}
+                                        {% if settings.checkout_tos == 'explicit' %}
+                                            <div class="form-check mb-1">
+                                                <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
+                                                <label class="form-check-label" for="flexCheckDefault">
+                                                    {# TODO: Make this translatable once support for placeholders is implemented #}
+                                                    <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
+                                                </label>
+                                            </div>
+                                        {% endif %}
                                         <button class="btn btn-primary btn-large" type="submit">{{ 'Checkout'|trans }}</button>
                                     </div>
                                 </div>
                             </fieldset>
-                            {% if settings.require_tos_accept %}
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
-                                    <label class="form-check-label" for="flexCheckDefault">
-                                        <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
-                                    </label>
-                                </div>
-                            {% else %}
+                            {% if settings.checkout_tos == 'implicit' %}
                                 {# TODO: Make this translatable once support for placeholders is implemented #}
                                 <span class="text-muted">By completing your order, you agree to our <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}</a>.</span>
                             {% endif %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -178,7 +178,7 @@
                                     </div>
                                 {% endif %}
                                 <div class="control-group">
-                                    <div class="controls">
+                                    <div class="controls mt-3">
                                         {% if enough_in_balance %}
                                             <p>{{ 'Total amount will be deducted from account balance'|trans }}</p>
                                         {% endif %}
@@ -186,6 +186,17 @@
                                     </div>
                                 </div>
                             </fieldset>
+                            {% if settings.require_tos_accept %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
+                                    <label class="form-check-label" for="flexCheckDefault">
+                                        <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
+                                    </label>
+                                </div>
+                            {% else %}
+                                {# TODO: Make this translatable once support for placeholders is implemented #}
+                                <span class="text-muted">By completing your order, you agree to our <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}</a>.</span>
+                            {% endif %}
                         </form>
                     </div>
                 </div>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_client.html.twig
@@ -238,13 +238,29 @@
                                 {% endif %}
                             {% endfor %}
                             {{ mf.recaptcha }}
+                            {% if settings.signup_tos == 'explicit' %}
+                                <div class="form-check mb-1">
+                                    <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
+                                    <label class="form-check-label" for="flexCheckDefault">
+                                        {# TODO: Make this translatable once support for placeholders is implemented #}
+                                        <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
+                                    </label>
+                                </div>
+                            {% endif %}
                             <div class="d-flex gap-2">
                                 <button class="btn btn-sm btn-primary" type="submit">{{ 'Sign up'|trans }}</button>
                                 <button class="btn btn-sm btn-link active" id="in-tab" data-bs-toggle="tab"
                                         data-bs-target="#sign-in" type="button" role="tab"
                                         aria-controls="sign-in"
-                                        aria-selected="true">{{ 'Already a user?'|trans }}</button>
+                                        aria-selected="true">{{ 'Already a user?'|trans }}
+                                </button>
                             </div>
+                            {% if settings.signup_tos == 'implicit' %}
+                                <div class="mb-1">
+                                    {# TODO: Make this translatable once support for placeholders is implemented #}
+                                    <span class="text-muted mb-1">By creating an account, you agree to our <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}</a>.</span>
+                                </div>
+                            {% endif %}
                         </form>
                     </div>
                 </div>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -161,9 +161,26 @@
 
                             {{ mf.recaptcha }}
 
+                            {% if settings.signup_tos == 'explicit' %}
+                                <div class="form-check mb-1">
+                                    <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
+                                    <label class="form-check-label" for="flexCheckDefault">
+                                        {# TODO: Make this translatable once support for placeholders is implemented #}
+                                        <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
+                                    </label>
+                                </div>
+                            {% endif %}
+
                             <div class="form-actions mb-3">
                                 <button class="btn btn-primary w-100" type="submit">{{ 'Sign up'|trans }}</button>
                             </div>
+
+                            {% if settings.signup_tos == 'implicit' %}
+                                <div class="mb-1">
+                                    {# TODO: Make this translatable once support for placeholders is implemented #}
+                                    <span class="text-muted mb-1">By creating an account, you agree to our <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}</a>.</span>
+                                </div>
+                            {% endif %}
                         </form>
                         <div class="row">
                             <div class="col">

--- a/src/modules/Page/html_client/mod_page_sitemap.xml
+++ b/src/modules/Page/html_client/mod_page_sitemap.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" ?>
- <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{# products #}
-{% for i, product in guest.product_get_list({"per_page": 50}).list %}
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {# products #}
+    {% for i, product in guest.product_get_list({"per_page": 50}).list %}
     <url>
-       <loc>{{ 'order'|link }}/{{product.slug}}</loc>
-       <lastmod>{{product.updated_at|date('Y-m-d')}}</lastmod>
-       <priority>0.9</priority>
-       <changefreq>weekly</changefreq>
+        <loc>{{ 'order'|link }}/{{product.slug}}</loc>
+        <lastmod>{{product.updated_at|date('Y-m-d')}}</lastmod>
+        <priority>0.9</priority>
+        <changefreq>weekly</changefreq>
     </url>
-{% endfor %}
+    {% endfor %}
 
-{# news items #}
-{% if guest.extension_is_on({"mod":'news'}) %}
-{% for i, article in guest.news_get_list({"per_page": 50}).list %}
+    {# news items #}
+    {% if guest.extension_is_on({"mod":'news'}) %}
+    {% for i, article in guest.news_get_list({"per_page": 50}).list %}
     <url>
-       <loc>{{ 'news'|link }}/{{article.slug}}</loc>
-       <lastmod>{{article.updated_at|date('Y-m-d')}}</lastmod>
-       <priority>0.9</priority>
-       <changefreq>weekly</changefreq>
+        <loc>{{ 'news'|link }}/{{article.slug}}</loc>
+        <lastmod>{{article.updated_at|date('Y-m-d')}}</lastmod>
+        <priority>0.9</priority>
+        <changefreq>weekly</changefreq>
     </url>
-{% endfor %}
-{% endif %}
+    {% endfor %}
+    {% endif %}
 
-{# knowledge base items #}
-{% if if guest.support_kb_enabled() %}
-{% for i, article in guest.support_kb_article_get_list({"per_page":50}).list %}
+    {# knowledge base items #}
+    {% if guest.support_kb_enabled() %}
+    {% for i, article in guest.support_kb_article_get_list({"per_page":50}).list %}
     <url>
-       <loc>{{ 'support/kb'|link }}/{{article.category.slug}}/{{article.slug}}</loc>
-       <lastmod>{{article.updated_at|date('Y-m-d')}}</lastmod>
-       <priority>0.9</priority>
-       <changefreq>weekly</changefreq>
+        <loc>{{ 'support/kb'|link }}/{{article.category.slug}}/{{article.slug}}</loc>
+        <lastmod>{{article.updated_at|date('Y-m-d')}}</lastmod>
+        <priority>0.9</priority>
+        <changefreq>weekly</changefreq>
     </url>
-{% endfor %}
-{% endif %}
- </urlset>
+    {% endfor %}
+    {% endif %}
+</urlset>

--- a/src/modules/Page/html_client/mod_page_sitemap.xml
+++ b/src/modules/Page/html_client/mod_page_sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {# products #}
     {% for i, product in guest.product_get_list({"per_page": 50}).list %}
     <url>

--- a/src/themes/huraga/config/settings.html
+++ b/src/themes/huraga/config/settings.html
@@ -282,10 +282,29 @@
     <legend>Checkout</legend>
     <table>
     <tr>
-        <td><label>Require clients to indicate they've read and accept your terms of service / privacy policy</label></td>
+        <td><label>Terms of service / privacy policy requirement for the checkout screen</label></td>
         <td>
-            <label><input type="radio" name="require_tos_accept" value="1"/>Yes</label>
-            <label><input type="radio" name="require_tos_accept" value="0" checked="checked"/>No</label>
+            <select name="checkout_tos">
+                <option value="explicit">Explicit agreement</option>
+                <option value="implicit">Implicit agreement</option>
+                <option value="none">None</option>
+            </select>
+        </td>
+    </tr>
+    </table>
+</fieldset>
+
+<fieldset>
+    <legend>Signup page</legend>
+    <table>
+    <tr>
+        <td><label>Terms of service / privacy policy requirement for the signup page</label></td>
+        <td>
+            <select name="signup_tos">
+                <option value="explicit">Explicit agreement</option>
+                <option value="implicit">Implicit agreement</option>
+                <option value="none">None</option>
+            </select>
         </td>
     </tr>
     </table>

--- a/src/themes/huraga/config/settings.html
+++ b/src/themes/huraga/config/settings.html
@@ -277,3 +277,16 @@
     </tr>
     </table>
 </fieldset>
+
+<fieldset>
+    <legend>Checkout</legend>
+    <table>
+    <tr>
+        <td><label>Require clients to indicate they've read and accept your terms of service / privacy policy</label></td>
+        <td>
+            <label><input type="radio" name="require_tos_accept" value="1"/>Yes</label>
+            <label><input type="radio" name="require_tos_accept" value="0" checked="checked"/>No</label>
+        </td>
+    </tr>
+    </table>
+</fieldset>


### PR DESCRIPTION
This PR implements a TOS / privacy policy requirement to the checkout and sign up pages. These can be individually configured by the system administrator to be explicit, implicit, or not shown at all.

Additionally, I fixed a bug introduced by #1180 which broke the sitemap.

## Explicit

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/d53bfcc9-0b4b-44ed-bd66-ab6c75439b99)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/5d85a951-900c-4774-9110-8828ed437d47)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/e82a9483-9bfe-4e64-9b90-7e7bbd60e2fa)


## Implicit
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/8784667b-4378-408d-bf65-04a315ceee93)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/6d46eb7b-573a-415d-851a-c764e089c5c4)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/7405f409-9059-4933-9374-d2783147a1ae)
