### PR TITLE
Prevent potential issues for various order variables

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -537,15 +537,17 @@ class Service implements InjectionAwareInterface
              * It will, however, avoid instances like this when a domain name is entered with a capital letter:
              * https://github.com/boxbilling/boxbilling/discussions/1022#discussioncomment-1311819
              */
-            $item['register_sld'] = (isset($item['register_sld'])) ? strtolower($item['register_sld']) : null;
-            $item['transfer_sld'] = (isset($item['transfer_sld'])) ? strtolower($item['transfer_sld']) : null;
-            $item['sld'] = (isset($item['sld'])) ? strtolower($item['sld']) : null;
-            $item['domain']['owndomain_sld'] = (isset($item['domain']['owndomain_sld'])) ? strtolower($item['domain']['owndomain_sld']) : null;
-            $item['domain']['register_sld'] = (isset($item['domain']['register_sld'])) ? strtolower($item['domain']['register_sld']) : null;
-            $item['domain']['transfer_sld'] = (isset($item['domain']['transfer_sld'])) ? strtolower($item['domain']['transfer_sld']) : null;
+            if ($item['type'] === 'domain' || $item['type'] === 'hosting') {
+                $item['register_sld'] = (isset($item['register_sld'])) ? strtolower($item['register_sld']) : null;
+                $item['transfer_sld'] = (isset($item['transfer_sld'])) ? strtolower($item['transfer_sld']) : null;
+                $item['sld'] = (isset($item['sld'])) ? strtolower($item['sld']) : null;
+                $item['domain']['owndomain_sld'] = (isset($item['domain']['owndomain_sld'])) ? strtolower($item['domain']['owndomain_sld']) : null;
+                $item['domain']['register_sld'] = (isset($item['domain']['register_sld'])) ? strtolower($item['domain']['register_sld']) : null;
+                $item['domain']['transfer_sld'] = (isset($item['domain']['transfer_sld'])) ? strtolower($item['domain']['transfer_sld']) : null;
 
-            // Domain TLD must begin with a period - add if not present for owndomain.
-            $item['domain']['owndomain_tld'] = (isset($item['domain']['owndomain_tld'])) ? (str_contains($item['domain']['owndomain_tld'], '.') ? $item['domain']['owndomain_tld'] : '.' . $item['domain']['owndomain_tld']) : null;
+                // Domain TLD must begin with a period - add if not present for owndomain.
+                $item['domain']['owndomain_tld'] = (isset($item['domain']['owndomain_tld'])) ? (str_contains($item['domain']['owndomain_tld'], '.') ? $item['domain']['owndomain_tld'] : '.' . $item['domain']['owndomain_tld']) : null;
+            }
 
             $order = $this->di['db']->dispense('ClientOrder');
             $order->client_id = $client->id;


### PR DESCRIPTION
This PR closes #2169 by ensuring we are only applying custom handling to these order variables when the service type is `hosting` or `domain`, ensuring these can safely be used for other use-cases.