### PR TITLE
Added a patch to migrate currency exchange rate settings

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -315,7 +315,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','41',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
+	(1,'last_patch','42',0,NULL,NULL,'2024-01-04 12:00:00','2024-01-04 12:00:00'),
 	(2,'company_name','Company Name',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','company@email.com',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/install/sql/content_test.sql
+++ b/src/install/sql/content_test.sql
@@ -480,7 +480,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','41',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
+	(1,'last_patch','42',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(2,'company_name','FOSSBilling demo',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(3,'company_email','demo@fossbilling.org',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -371,6 +371,7 @@ class UpdatePatcher implements InjectionAwareInterface
                 $this->executeSql($q);
             },
             42 => function () {
+                // This patch will migrate previous currency exchange rate data provider settings to the new ones
                 $ext_service = $this->di['mod_service']('extension');
                 $config = $ext_service->getConfig('mod_currency');
                 $pairs = $this->di['db']->getAssoc('SELECT `param`, `value` FROM setting');

--- a/src/modules/Currency/Api/Admin.php
+++ b/src/modules/Currency/Api/Admin.php
@@ -144,15 +144,6 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Gets the API key for currencylayer.
-     * @deprecated as this will only return the OLD key from before currency data got refactored. Current keys are stored in the module's config.
-     */
-    public function get_key($data)
-    {
-        return $this->getService()->getKey();
-    }
-
-    /**
      * See if CRON jobs are enabled for currency rates.
      */
     public function is_cron_enabled($data): bool

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -345,37 +345,12 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Returns the old API key. Kept to ensure updating doesn't break a config
-     */
-    public function getKey(): string
-    {
-        $sql = 'SELECT `param`, `value` FROM setting';
-        $db = $this->di['db'];
-
-        $pairs = $db->getAssoc($sql);
-
-        return $pairs['currencylayer'] ?? '';
-    }
-
-    /**
      * See if we should update exchange rates whenever the CRON jobs are run.
      */
     public function isCronEnabled(): bool
     {
         $config = $this->di['mod_config']('currency');
-        $sql = 'SELECT `param`, `value` FROM setting';
-        $db = $this->di['db'];
-
-        $pairs = $db->getAssoc($sql);
-
-        // Keeping backwards compatibility with old settings
-        if (isset($pairs['currency_cron_enabled']) && $pairs['currency_cron_enabled'] == '1' && empty($config['sync_rate'])) {
-            return true;
-        } elseif (isset($pairs['currency_cron_enabled']) && $pairs['currency_cron_enabled'] == '0' && empty($config['sync_rate'])) {
-            return false;
-        } else {
-            return ($config['sync_rate'] ?? 'auto') !== 'never';
-        }
+        return ($config['sync_rate'] ?? 'auto') !== 'never';
     }
 
     public function toApiArray(\Model_Currency $model)
@@ -500,11 +475,10 @@ class Service implements InjectionAwareInterface
         };
 
         if ($config['provider'] === 'currency_data_api') {
-            $key = $config['currencydata_key'] ?? $this->getKey();
-            if (empty($key)) {
+            if (empty($config['currencydata_key'])) {
                 throw new InformationException('You must configure your API key to use Currency Data API as an exchange rate data source.');
             }
-            $rates = $this->getCurrencyDataRates($from, $validFor, $key);
+            $rates = $this->getCurrencyDataRates($from, $validFor, $config['currencydata_key']);
         } elseif ($config['provider'] === 'currencylayer') {
             if (empty($config['currencylayer_key'])) {
                 throw new InformationException('You must configure your API key to use currencylayer as an exchange rate data source.');

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -4,7 +4,6 @@
 
 {% set active_menu = 'system' %}
 {% set params = admin.extension_config_get({ 'ext': 'mod_currency' }) %}
-{% set old_key = admin.currency_get_key %}
 
 {% block meta_title %}{{ 'Currency settings'|trans }}{% endblock %}
 
@@ -232,7 +231,7 @@
                             <div class="form-group mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'API key'|trans }}</label>
                                 <div class="col-md-6">
-                                    <input class="form-control" type="text" name="currencydata_key" id="currencydata" value="{{ params.currencydata_key|default(old_key) }}" hidden="true">
+                                    <input class="form-control" type="text" name="currencydata_key" id="currencydata" value="{{ params.currencydata_key }}" hidden="true">
                                     <input class="form-control" type="text" name="currencylayer_key" id="currencylayer" value="{{ params.currencylayer_key }}"  hidden="true">
                                     <input class="form-control" type="text" name="exchangerate_api_key" id="exchangerate_api" value="{{ params.exchangerate_api_key }}" hidden="true">
                                     <span class="text-muted" id="exchangerate_api_help_text" hidden="true">{{ 'Leave this blank to use the ExchangeRate-API "Open Access Endpoint".'|trans }}</span>


### PR DESCRIPTION
Follow up to #2189 to add a patch that will migrate the old config.
This just results in cleaner code VS referencing both the old and new configs and makes it easier for someone to check the correct config is setup after updating