### PR TITLE
Prevent a potential error

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -609,6 +609,7 @@ class Service implements InjectionAwareInterface
                 $config = $this->di['tools']->decodeJ($config);
             }
 
+            $config['ext'] = $ext;
             return $config;
         });
     }

--- a/tests-legacy/modules/Extension/ServiceTest.php
+++ b/tests-legacy/modules/Extension/ServiceTest.php
@@ -692,7 +692,7 @@ class ServiceTest extends \BBTestCase
         $result = $this->service->getConfig($data['ext']);
 
         $this->assertIsArray($result);
-        $this->assertEquals([], $result);
+        $this->assertEquals(['ext' => 'extensionName'], $result);
     }
 
     public function testsetConfig()


### PR DESCRIPTION
`getConfig` creates a new config and returns it if one doesn't already exist.

The software is built with the expectation that a config file for a module will also contain a key name `ext` which contains the extension's name. If this isn't there, that could cause issues so this patch simply adds it in.