### PR TITLE
Mitigate cache-related patching errors

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -405,7 +405,7 @@ class UpdatePatcher implements InjectionAwareInterface
     /**
      * If we end up needing a newly introduced package during the update process, composer's autoloader won't have it until the next load.
      * As a workaround, we can register AntLoader and point it at the Vendor folder which will then act as fallback to find the needed classes.
-     * This isn't particulalry fast though as it'll scan the entire vendor, so only use it if we know a needed class is missing.
+     * This isn't particularly fast though as it'll scan the entire vendor, so only use it if we know a needed class is missing.
      */
     private function registerFallbackAutoloader()
     {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -372,9 +372,12 @@ class UpdatePatcher implements InjectionAwareInterface
             },
             42 => function () {
                 // This patch will migrate previous currency exchange rate data provider settings to the new ones
+                // @see https://github.com/FOSSBilling/FOSSBilling/pull/2189
                 $ext_service = $this->di['mod_service']('extension');
-                $config = $ext_service->getConfig('mod_currency');
                 $pairs = $this->di['db']->getAssoc('SELECT `param`, `value` FROM setting');
+                $config = $ext_service->getConfig('mod_currency');
+
+                $config['ext'] = 'mod_currency'; // This should automatically be set, but some appear to be having cache issues that causes it to not be
 
                 // Migrate the old currency exchange rate sync settings
                 $key = $pairs['currencylayer'] ?? '';
@@ -399,6 +402,11 @@ class UpdatePatcher implements InjectionAwareInterface
         return array_filter($patches, fn ($key) => $key > $patchLevel, ARRAY_FILTER_USE_KEY);
     }
 
+    /**
+     * If we end up needing a newly introduced package during the update process, composer's autoloader won't have it until the next load.
+     * As a workaround, we can register AntLoader and point it at the Vendor folder which will then act as fallback to find the needed classes.
+     * This isn't particulalry fast though as it'll scan the entire vendor, so only use it if we know a needed class is missing.
+     */
     private function registerFallbackAutoloader()
     {
         $loader = new \AntCMS\AntLoader([


### PR DESCRIPTION
As the tin says.
Some appear to be having cache-related issues when performing patches, this should mitigate that by clearing the cache before applying patches & explicitly working around where the issue was cropping up as well