### PR TITLE
Allow admins to force deletion of orders

### DIFF
--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -213,7 +213,7 @@ class Admin extends \Api_Abstract
     {
         $order = $this->_getOrder($data);
         $delete_addons = isset($data['delete_addons']) ? (bool) $data['delete_addons'] : false;
-        $forceDelete = (bool) $data['force_delete'] ?? false;
+        $forceDelete = (bool) ($data['force_delete'] ?? false);
 
         if ($delete_addons) {
             $list = $this->getService()->getOrderAddonsList($order);

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2024 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -212,15 +213,16 @@ class Admin extends \Api_Abstract
     {
         $order = $this->_getOrder($data);
         $delete_addons = isset($data['delete_addons']) ? (bool) $data['delete_addons'] : false;
+        $forceDelete = (bool) $data['force_delete'] ?? false;
 
         if ($delete_addons) {
             $list = $this->getService()->getOrderAddonsList($order);
             foreach ($list as $addon) {
-                $this->getService()->deleteFromOrder($addon);
+                $this->getService()->deleteFromOrder($addon, $forceDelete);
             }
         }
 
-        return $this->getService()->deleteFromOrder($order);
+        return $this->getService()->deleteFromOrder($order, $forceDelete);
     }
 
     /**

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -517,7 +517,7 @@ class Service implements InjectionAwareInterface
         $cartService = $this->di['mod_service']('cart');
         // check stock
         if (!$cartService->isStockAvailable($product, $qty)) {
-            throw new \FOSSBilling\InformationException('Product :id is out of stock.', [':id' => $product->id], 831);
+            throw new InformationException('Product :id is out of stock.', [':id' => $product->id], 831);
         }
 
         // Addons must have defined master order
@@ -981,7 +981,7 @@ class Service implements InjectionAwareInterface
         }
 
         if ($order->status != \Model_ClientOrder::STATUS_ACTIVE) {
-            throw new \FOSSBilling\InformationException('Only active orders can be suspended');
+            throw new InformationException('Only active orders can be suspended');
         }
 
         $this->_callOnService($order, \Model_ClientOrder::ACTION_SUSPEND);
@@ -1137,7 +1137,7 @@ class Service implements InjectionAwareInterface
             if (!$forceDelete) {
                 throw $e;
             } else {
-                error_log($e->getMessage() . "in " . $e->getFile() . ":" . $e->getFile());
+                error_log($e->getMessage() . 'in ' . $e->getFile() . ':' . $e->getFile());
             }
         }
 

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2022-2024 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.
@@ -10,6 +11,7 @@
 
 namespace Box\Mod\Order;
 
+use FOSSBilling\InformationException;
 use FOSSBilling\InjectionAwareInterface;
 
 class Service implements InjectionAwareInterface
@@ -1121,7 +1123,7 @@ class Service implements InjectionAwareInterface
         $this->di['db']->trash($model);
     }
 
-    public function deleteFromOrder(\Model_ClientOrder $order)
+    public function deleteFromOrder(\Model_ClientOrder $order, bool $forceDelete = false)
     {
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminOrderDelete', 'params' => ['id' => $order->id]]);
 
@@ -1129,7 +1131,16 @@ class Service implements InjectionAwareInterface
             $this->rmInvoiceItemByOrder($order);
         }
 
-        $this->_callOnService($order, \Model_ClientOrder::ACTION_DELETE);
+        try {
+            $this->_callOnService($order, \Model_ClientOrder::ACTION_DELETE);
+        } catch (\Exception $e) {
+            if (!$forceDelete) {
+                throw $e;
+            } else {
+                error_log($e->getMessage() . "in " . $e->getFile() . ":" . $e->getFile());
+            }
+        }
+
         $id = $order->id;
         $this->rmClientOrderStatusByOrder($order);
         $this->rmOrder($order);

--- a/src/modules/Order/html_admin/mod_order_manage.html.twig
+++ b/src/modules/Order/html_admin/mod_order_manage.html.twig
@@ -270,15 +270,12 @@
                     </a>
                     {% endif %}
 
-                    <a class="btn btn-primary api-link"
-                        href="{{ 'api/admin/order/delete'|link({ 'id': order.id, 'CSRFToken': CSRFToken }) }}"
-                        data-api-confirm="{{ 'Are you sure?'|trans }}"
-                        data-api-redirect="{{ 'order'|alink }}">
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal">
                         <svg class="icon" width="24" height="24">
                             <use xlink:href="#delete" />
                         </svg>
                         <span>{{ 'Delete'|trans }}</span>
-                    </a>
+                    </button>
 
                     {% if not order.unpaid_invoice_id %}
                     <a class="btn btn-primary api-link"
@@ -294,6 +291,30 @@
                 {% endset %}
 
                 {{ order_actions }}
+            </div>
+        </div>
+
+        <div class="modal modal-blur fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-sm">
+                <div class="modal-content">
+                    <form method="post" action="{{ 'api/admin/order/delete'|link }}" class="api-form" data-api-redirect="{{ 'order'|alink }}">
+                        <div class="modal-status bg-danger"></div>
+                        <div class="modal-body">
+                            <div class="modal-title">{{ 'Are you sure?'|trans }}</div>
+                            <input name="id" type="number" hidden value="{{ order.id }}">
+                            <p>{{ 'Are you sure you want to delete the selected item?'|trans }}</p>
+                            <div class="mb-3 form-check">
+                                <input type="checkbox" name="force_delete" class="form-check-input" id="forceDelete">
+                                <label class="form-check-label"for="forceDelete">{{ 'Force the deletion of the item'|trans }}</label>
+                            </div>
+                            <span class="text-muted">{{ 'Selecting this will force the item to be removed from the database even if errors occurs.'|trans }}</span>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Cancel'|trans }}</button>
+                            <button type="submit" class="btn btn-primary">{{ 'Delete'|trans }}</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
Relates to #2161 (and I *think* closes it?).

Simply replaces the delete prompt to add a checkbox which an admin can use to ignore an error when deleting an order, meaning they can still have it removed from the DB / UI even if their two systems get out of sync
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/05650a4d-730e-4c85-b75e-eb78d54e37a8)
 