### PR TITLE
Introduce zstd & brotli compression + output buffering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update \
   && docker-php-ext-install -j$(nproc) opcache \
   && docker-php-ext-configure pdo_mysql \
   && docker-php-ext-install -j$(nproc) pdo_mysql \
+  && pecl install brotli \
+  && docker-php-ext-enable brotli \
+  && pecl install zstd \
+  && docker-php-ext-enable zstd \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "filp/whoops": "^2.14",
         "gabordemooij/redbean": "^5.7",
         "geoip2/geoip2": "^3.0.0",
+        "hostbybelle/compressionbuffer": "^1.0",
         "io-developer/php-whois": "^4.1",
         "lcharette/webpack-encore-twig": "^1.2.0",
         "league/commonmark": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08b744c6a4c8e1a0f880570457a581cb",
+    "content-hash": "9b6fd56ed203486b5a99e3ed8887b12d",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -52,6 +52,61 @@
                 "source": "https://github.com/AntCMS-org/AntLoader/tree/2.0.4"
             },
             "time": "2024-03-12T22:17:58+00:00"
+        },
+        {
+            "name": "asispts/http-accept",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asispts/http-accept.git",
+                "reference": "7beca5a724ef329bb5a0094b5aef7bfeab1193ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asispts/http-accept/zipball/7beca5a724ef329bb5a0094b5aef7bfeab1193ae",
+                "reference": "7beca5a724ef329bb5a0094b5aef7bfeab1193ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "asispts/ptscs": "^1.0",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^8.5|^9.5|^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HttpAccept\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Asis Pattisahusiwa",
+                    "email": "asispts@gmail.com"
+                }
+            ],
+            "description": "PHP Parser to deal with HTTP Accept, Accept-Language, Accept-Encoding, and Content-Type headers",
+            "homepage": "https://github.com/asispts/http-accept",
+            "keywords": [
+                "accept",
+                "accept-encoding",
+                "accept-language",
+                "content-type",
+                "http-header-parser",
+                "http-headers"
+            ],
+            "support": {
+                "issues": "https://github.com/asispts/http-accept/issues",
+                "source": "https://github.com/asispts/http-accept/tree/v1.0.0"
+            },
+            "time": "2023-04-28T02:59:23+00:00"
         },
         {
             "name": "brick/math",
@@ -898,6 +953,56 @@
                 }
             ],
             "time": "2023-12-03T20:05:35+00:00"
+        },
+        {
+            "name": "hostbybelle/compressionbuffer",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/HostByBelle/CompressionBuffer.git",
+                "reference": "a5ed8b63c9657a235f5551db1b2b7de37801f253"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/HostByBelle/CompressionBuffer/zipball/a5ed8b63c9657a235f5551db1b2b7de37801f253",
+                "reference": "a5ed8b63c9657a235f5551db1b2b7de37801f253",
+                "shasum": ""
+            },
+            "require": {
+                "asispts/http-accept": "^1.0",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.53",
+                "phpstan/phpstan": "^1.10"
+            },
+            "suggest": {
+                "ext-brotli": "For brotli output compression",
+                "ext-zlib": "For gzip & deflate output compression",
+                "ext-zstd": "For zstd output compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HostByBelle\\": "src/HostByBelle"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Belle Aerni",
+                    "email": "belleaerni@gmail.com"
+                }
+            ],
+            "description": "CompressionBuffer provides easy access to zstd, brotli, and gzip output buffering with PHP on any webserver.",
+            "support": {
+                "issues": "https://github.com/HostByBelle/CompressionBuffer/issues",
+                "source": "https://github.com/HostByBelle/CompressionBuffer/tree/1.0.0"
+            },
+            "time": "2024-04-08T22:57:40+00:00"
         },
         {
             "name": "io-developer/php-whois",

--- a/cspell.json
+++ b/cspell.json
@@ -393,7 +393,8 @@
         "intval",
         "thisfiledoesnotexist",
         "exchangerate",
-        "currencydata"
+        "currencydata",
+        "brotli"
     ],
     "ignorePaths": [
         "tests-legacy/**",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,8 +26,6 @@ parameters:
 		- '#^Function __trans not found\.$#'
 		- '#^Function __pluralTrans not found\.$#'
 		- '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
-		- message: '#^Result of function header \(void\) is used\.$#'
-		  path: src/modules/Custompages/Controller/Client.php
 		- message: '#^Variable \$ext_id on left side of \?\?\= is never defined\.$#'
 		  path: src/modules/Extension/Service.php
 		- '#^Access to an undefined property RedBeanPHP\\SimpleModel\:\:\$updated_at\.$#'

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -48,26 +48,44 @@ return [
         'report_errors' => false,
     ],
 
+    'system' => [
+        /*
+         * Full URL where FOSSBilling is installed with trailing slash.
+         */
+        'url' => 'http://localhost/',
+
+        /*
+         * The URL prefix to access the BB admin area. Ex: '/admin' for https://example.com/admin.
+         */
+        'admin_area_prefix' => '/admin',
+
+        /*
+         * Configure the update branch for the automatic updater.
+         * Currently acceptable options are "release" or "preview".
+         */
+        'update_branch' => 'release',
+
+        /*
+         * FOSSBilling will automatically execute cron when you login to the admin panel if it hasn't been executed in awhile. You can disable this fallback here.
+         */
+        'disable_auto_cron' => false,
+
+        /*
+         * Set location to store sensitive data.
+         */
+        'path_data' => __DIR__ . '/data',
+
+        /*
+         * FOSSBilling will automatically perform zstd, brotli, gzip, or deflate output compression depending on installed extensions and the client connecting.
+         * Disable this here if you want to not use output compression or control it outside of FOSSBilling itself (such as your webserver)
+         */
+        'do_output_compression' => true,
+    ],
+
     'info' => [
         'salt' => bin2hex(random_bytes(16)),
         'instance_id' => 'XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXX',
     ],
-
-    /*
-     * Full URL where FOSSBilling is installed with trailing slash.
-     */
-    'url' => 'http://localhost/',
-
-    /*
-     * The URL prefix to access the BB admin area. Ex: '/admin' for https://example.com/admin.
-     */
-    'admin_area_prefix' => '/admin',
-
-    /*
-     * Configure the update branch for the automatic updater.
-     * Currently acceptable options are "release" or "preview".
-     */
-    'update_branch' => 'release',
 
     'maintenance_mode' => [
         /*
@@ -90,11 +108,6 @@ return [
         'allowed_ips' => [],
     ],
 
-    /*
-     * FOSSBilling will automatically execute cron when you login to the admin panel if it hasn't been executed in awhile. You can disable this fallback here.
-     */
-    'disable_auto_cron' => false,
-
     /* 
      * These configuration options allow you to configure the default localisation.
      */
@@ -111,11 +124,6 @@ return [
         // @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax
         'datetime_pattern' => '',
     ],
-
-    /*
-     * Set location to store sensitive data.
-     */
-    'path_data' => __DIR__ . '/data',
 
     'db' => [
         /*
@@ -168,7 +176,7 @@ return [
         // How many requests allowed per time span
         'rate_limit' => 1000,
 
-        /**
+        /*
          * Note about rate-limiting login attempts:
          * When the limit is reached, a default delay of 2 seconds is added to the request.
          * This makes brute-forcing a password useless while not outright blocking legitimate traffic.
@@ -184,13 +192,13 @@ return [
         'rate_limit_login' => 20,
 
         /*
-        * This enables the usage of a token to protect the system from CSRF attacks.
-        * Disabling this is highly discouraged and opens your instance to a known vulnerability.
-        * This option is only here for backwards compatibility.
-        */
+         * This enables the usage of a token to protect the system from CSRF attacks.
+         * Disabling this is highly discouraged and opens your instance to a known vulnerability.
+         * This option is only here for backwards compatibility.
+         */
         'CSRFPrevention' => true,
 
-        /**
+        /*
          * Any IP address within this list will not be put through the rate-limiter system.
          * This is useful if you have an application with a static IP address that needs to make frequent API requests to FOSSBilling.
          */

--- a/src/di.php
+++ b/src/di.php
@@ -406,6 +406,7 @@ $di['is_admin_logged'] = function () use ($di) {
         $di['set_return_uri'];
 
         header(sprintf('Location: %s', $di['url']->adminLink('staff/login')));
+        ob_end_flush();
         exit;
     }
 
@@ -439,6 +440,7 @@ $di['loggedin_client'] = function () use ($di) {
             // Redirect to login page if browser request
             $login_url = $di['url']->link('login');
             header("Location: $login_url");
+            ob_end_flush();
             exit;
         }
     }
@@ -477,6 +479,7 @@ $di['loggedin_admin'] = function () use ($di) {
             // Redirect to login page if browser request
             $login_url = $di['url']->adminLink('staff/login');
             header("Location: $login_url");
+            ob_end_flush();
             exit;
         }
     }
@@ -528,6 +531,7 @@ $di['api'] = $di->protect(function ($role) use ($di) {
             // If they aren't attempting to access their profile, redirect them to it.
             $login_url = $di['url']->link('client/profile');
             header("Location: $login_url");
+            ob_end_flush();
             exit;
         }
     }
@@ -834,6 +838,7 @@ $di['table_export_csv'] = $di->protect(function (string $table, string $outputNa
     $csv->output($outputName);
 
     // Prevent further output from being added to the end of the CSV
+    ob_end_flush();
     exit;
 });
 

--- a/src/index.php
+++ b/src/index.php
@@ -1,4 +1,5 @@
 <?php
+use HostByBelle\CompressionBuffer;
 
 /**
  * Copyright 2022-2024 FOSSBilling
@@ -38,10 +39,11 @@ if ($url === '/run-patcher') {
         $patcher->applyCorePatches();
         $di['tools']->emptyFolder(PATH_CACHE);
 
-        exit('Any missing config migrations or database patches have been applied and the cache has been cleared');
+        echo 'Any missing config migrations or database patches have been applied and the cache has been cleared';
     } catch (Exception $e) {
-        exit('An error occurred while attempting to apply patches: <br>' . $e->getMessage());
+        echo 'An error occurred while attempting to apply patches: <br>' . $e->getMessage();
     }
+    exit;
 }
 
 $debugBar['time']->startMeasure('session_start', 'Starting / restoring the session');
@@ -90,6 +92,9 @@ if (!is_null($http_err_code)) {
     exit;
 }
 
-// If no HTTP error passed, run the app.
-echo $app->run();
+// Start output buffering & run the app
+ob_start(CompressionBuffer::handler(...));
+header('X-Accel-Buffering: no');
+$app->run();
+ob_end_flush();
 exit;

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -112,7 +112,7 @@ class Box_App
         $this->event('delete', $url, $methodName, $conditions, $class);
     }
 
-    public function run(): string
+    public function run(): void
     {
         $this->debugBar['time']->startMeasure('registerModule', 'Registering module routes');
         $this->registerModule();
@@ -126,7 +126,7 @@ class Box_App
         $this->checkPermission();
         $this->debugBar['time']->stopMeasure('checkperm');
 
-        return $this->processRequest();
+        echo $this->processRequest();
     }
 
     /**
@@ -136,6 +136,7 @@ class Box_App
     {
         $location = $this->di['url']->link($path);
         header("Location: $location");
+        ob_end_flush();
         exit;
     }
 

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -34,6 +34,7 @@ class Box_AppAdmin extends Box_App
             http_response_code(403);
             $e = new FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $this->mod], 403);
             echo $this->render('error', ['exception' => $e]);
+            ob_end_flush();
             exit;
         }
     }
@@ -49,6 +50,7 @@ class Box_AppAdmin extends Box_App
     {
         $location = $this->di['url']->adminLink($path);
         header("Location: $location");
+        ob_end_flush();
         exit;
     }
 

--- a/src/library/FOSSBilling/CentralAlerts.php
+++ b/src/library/FOSSBilling/CentralAlerts.php
@@ -77,7 +77,7 @@ class CentralAlerts implements InjectionAwareInterface
         }
 
         if ($version) {
-            if (Config::getProperty('update_branch', 'release') === 'preview') {
+            if (Config::getProperty('system.update_branch', 'release') === 'preview') {
                 $alerts = array_filter($alerts, fn ($alert) => $alert['include_preview_branch']);
             } else {
                 $alerts = array_filter($alerts, function ($alert) use ($version) {

--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -324,6 +324,7 @@ class ErrorPage
             </body>
         </html>';
         echo $page;
+        ob_end_flush();
         exit;
     }
 }

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -136,7 +136,7 @@ class ExtensionManager implements InjectionAwareInterface
     {
         $latest = $this->getLatestExtensionRelease($extension);
 
-        if (Config::getProperty('update_branch', 'release') === 'release') {
+        if (Config::getProperty('system.update_branch', 'release') === 'release') {
             if (version_compare(Version::VERSION, $latest['min_fossbilling_version'], '<')) {
                 return false;
             }

--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -36,6 +36,8 @@ class Requirements
             'bz2' => 'optional support for bzip2 archives',
             'simplexml' => 'the Plesk integration',
             'xml' => 'the Plesk integration',
+            'brotli' => 'output compression using brotli',
+            'zstd' => 'output compression using zstd',
         ],
         'min_version' => '8.1',
     ];

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -42,7 +42,7 @@ class Update implements InjectionAwareInterface
      */
     public function getUpdateBranch(): string
     {
-        return Config::getProperty('update_branch', 'release');
+        return Config::getProperty('system.update_branch', 'release');
     }
 
     /**

--- a/src/load.php
+++ b/src/load.php
@@ -15,6 +15,7 @@ use FOSSBilling\SentryHelper;
 use Symfony\Component\Filesystem\Filesystem;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
+use HostByBelle\CompressionBuffer;
 
 const PATH_ROOT = __DIR__;
 const PATH_VENDOR = PATH_ROOT . DIRECTORY_SEPARATOR . 'vendor';
@@ -245,12 +246,12 @@ require PATH_LIBRARY . DIRECTORY_SEPARATOR . 'FOSSBilling' . DIRECTORY_SEPARATOR
 
 // Set globals and relevant settings based on the config.
 date_default_timezone_set(Config::getProperty('i18n.timezone', 'UTC'));
-define('ADMIN_PREFIX', Config::getProperty('admin_area_prefix'));
+define('ADMIN_PREFIX', Config::getProperty('system.admin_area_prefix'));
 define('DEBUG', (bool) Config::getProperty('debug_and_monitoring.debug', false));
-define('PATH_DATA', Config::getProperty('path_data'));
+define('PATH_DATA', Config::getProperty('system.path_data'));
 define('PATH_CACHE', PATH_DATA . DIRECTORY_SEPARATOR . 'cache');
 define('PATH_LOG', PATH_DATA . DIRECTORY_SEPARATOR . 'log');
-define('SYSTEM_URL', Config::getProperty('url'));
+define('SYSTEM_URL', Config::getProperty('system.url'));
 define('INSTANCE_ID', Config::getProperty('info.instance_id', 'Unknown'));
 
 // Initial setup and checks passed, now we setup our custom autoloader.
@@ -284,4 +285,10 @@ if (DEBUG) {
 } else {
     ini_set('display_errors', '0');
     ini_set('display_startup_errors', '0');
+}
+
+// Setup output handling and then disable it if needed
+CompressionBuffer::setUp();
+if (!Config::getProperty('system.do_output_compression', true)) {
+    CompressionBuffer::disable();
 }

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -290,6 +290,7 @@ class Client implements InjectionAwareInterface
             $result = ['result' => $data, 'error' => null];
         }
         echo json_encode($result);
+        ob_end_flush();
         exit;
     }
 

--- a/src/modules/Client/Controller/Admin.php
+++ b/src/modules/Client/Controller/Admin.php
@@ -118,6 +118,7 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
 
         header('HTTP/1.1 301 Moved Permanently');
         header('Location: ' . $this->di['tools']->url($redirect_to));
+        ob_end_flush();
         exit;
     }
 }

--- a/src/modules/Custompages/Controller/Client.php
+++ b/src/modules/Custompages/Controller/Client.php
@@ -49,7 +49,9 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         if (isset($page['id'])) {
             return $app->render('mod_custompages_content', ['page' => $page]);
         } else {
-            exit(header('Location: ' . $this->di['url']->get('')));
+            header('Location: ' . $this->di['url']->get(''));
+            ob_end_flush();
+            exit;
         }
     }
 }

--- a/src/modules/Custompages/Service.php
+++ b/src/modules/Custompages/Service.php
@@ -96,7 +96,9 @@ class Service
         $ex = $this->di['pdo']->prepare('SELECT id from custom_pages WHERE slug = ? AND id <> ?');
         $ex->execute([$slug, $id]);
         if ($ex->rowCount() > 0) {
-            exit(json_encode(['result' => null, 'error' => ['message' => 'You need to set unique slug.', 'code' => 9999]]));
+            echo json_encode(['result' => null, 'error' => ['message' => 'You need to set unique slug.', 'code' => 9999]]);
+            ob_end_flush();
+            exit;
         }
         $this->di['pdo']->prepare('UPDATE custom_pages SET title = ?, description = ?, keywords = ?, content = ?, slug = ? WHERE id = ?')->execute([$title, $description, $keywords, $content, $slug, $id]);
         $this->di['logger']->info('Updated custom page #%s', $id);

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -745,6 +745,7 @@ class Service implements InjectionAwareInterface
             $e = new \FOSSBilling\InformationException('You do not have permission to access the :mod: module', [':mod:' => $module], 403);
             if (!is_null($app)) {
                 echo $app->render('error', ['exception' => $e]);
+                ob_end_flush();
                 exit;
             } else {
                 throw $e;
@@ -759,6 +760,7 @@ class Service implements InjectionAwareInterface
             $e = new \FOSSBilling\InformationException('You do not have permission to perform this action', [], 403);
             if (!is_null($app)) {
                 echo $app->render('error', ['exception' => $e]);
+                ob_end_flush();
                 exit;
             } else {
                 throw $e;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1231,6 +1231,7 @@ class Service implements InjectionAwareInterface
         $pdf->loadHtml($html);
         $pdf->render();
         $pdf->stream($invoice['serie_nr'], ['Attachment' => false]);
+        ob_end_flush();
         exit(0);
     }
 

--- a/src/modules/Redirect/Controller/Client.php
+++ b/src/modules/Redirect/Controller/Client.php
@@ -51,6 +51,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         $target = $service->getRedirectByPath($app->uri);
         header('HTTP/1.1 301 Moved Permanently');
         header('Location: ' . $target);
+        ob_end_flush();
         exit;
     }
 }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -277,7 +277,7 @@ class Service
         }
 
         $last_exec = $this->getParamValue('last_cron_exec');
-        $disableAutoCron = Config::getProperty('disable_auto_cron', false);
+        $disableAutoCron = Config::getProperty('system.disable_auto_cron', false);
 
         /*
          * Here we check if cron has been run at all or within a recent timeframe.


### PR DESCRIPTION
This PR will allow FOSSBilling to provide zstd, brotli, gzip, and deflate output compression on any webserver so long as the needed extensions are installed & opens up the ability for us to have programmatic control of it within the application.

The most interesting of these would be zstd which doesn't have official support by either NGINX or Apache. It's faster than any of the other options and overall matches brotli for compression, making it by far the superior choice for output compression.

This does have the chance to break stuff, however due to introducing output buffering. Essentially any instance where code uses `exit` will first need to use `ob_end_flush` to ensure the output is sent to the client.

Also output compression in FOSSBilling can be disabled so it can instead be handled by the webserver if desired, although I personally am in favor of being able to control as many aspects of FOSSBilling's behavior within the app itself as it helps minimize potential changes to config files once we have more webservers we provide support for (further down the line, I presume after most of the routing has been rewritten).

I plan on leaving this as a draft till others comment on what they think, as I am not entirely sure if there is perhaps a better way to make these changes.

For example: since this would already be messing with how the app outputs data, maybe we should go one step further and port a lot of the core functionality to a micro-framework such as [Flight](https://docs.flightphp.com/?lang=en) & eliminate most of the custom routing / response handling in FOSSBilling which would benefit the app in the long-run.