### PR TITLE
Reduce the final size of our vendor folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "lcharette/webpack-encore-twig": "^1.2.0",
         "league/commonmark": "^2.3",
         "league/csv": "^9.8",
+        "liborm85/composer-vendor-cleaner": "^1.7",
         "mattketmo/email-checker": "^2.2",
         "maximebf/debugbar": "^1.19",
         "monolog/monolog": "^3.5",
@@ -73,7 +74,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "liborm85/composer-vendor-cleaner": true
         },
         "vendor-dir": "src/vendor"
     },
@@ -82,5 +84,25 @@
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php80": "*",
         "symfony/polyfill-php81": "*"
+    },
+    "extra": {
+        "dev-files": {
+            "/": [
+                "tests/",
+                "docs/",
+                ".travis.yml",
+                ".github/",
+                ".devcontainer/"
+            ],
+            "gabordemooij/redbean": [
+                "testing/"
+            ],
+            "mattketmo/email-checker": [
+                "res/"
+            ],
+            "maxmind-db/reader": [
+                "ext"
+            ]
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08b744c6a4c8e1a0f880570457a581cb",
+    "content-hash": "7820a1cc7f8f3bbd418e7d2f832a0c7d",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -1356,6 +1356,66 @@
                 }
             ],
             "time": "2024-02-20T20:00:00+00:00"
+        },
+        {
+            "name": "liborm85/composer-vendor-cleaner",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/liborm85/composer-vendor-cleaner.git",
+                "reference": "3d0feeb847c764d6eed2d993041101efbac67dcc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/liborm85/composer-vendor-cleaner/zipball/3d0feeb847c764d6eed2d993041101efbac67dcc",
+                "reference": "3d0feeb847c764d6eed2d993041101efbac67dcc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.10.23 || ^2.1.9",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Liborm85\\ComposerVendorCleaner\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liborm85\\ComposerVendorCleaner\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Libor M.",
+                    "email": "liborm85@gmail.com"
+                }
+            ],
+            "description": "Composer Vendor Cleaner removes unnecessary development files and directories from vendor directory.",
+            "keywords": [
+                ".gitattributes",
+                "cleaner",
+                "cleanup",
+                "composer",
+                "composer-plugin",
+                "delete",
+                "ignore",
+                "php",
+                "remove"
+            ],
+            "support": {
+                "issues": "https://github.com/liborm85/composer-vendor-cleaner/issues",
+                "source": "https://github.com/liborm85/composer-vendor-cleaner"
+            },
+            "time": "2023-06-02T14:36:46+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7820a1cc7f8f3bbd418e7d2f832a0c7d",
+    "content-hash": "7981ff6823bbabac60c71d6742ad3e33",
     "packages": [
         {
             "name": "antcms/antloader",
@@ -3007,16 +3007,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v13.17.0",
+            "version": "v13.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "24d3d9ed8406e10d24452af44597300173655f69"
+                "reference": "02abb043b103766f4ed920642ae56ffdc58c7467"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/24d3d9ed8406e10d24452af44597300173655f69",
-                "reference": "24d3d9ed8406e10d24452af44597300173655f69",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/02abb043b103766f4ed920642ae56ffdc58c7467",
+                "reference": "02abb043b103766f4ed920642ae56ffdc58c7467",
                 "shasum": ""
             },
             "require": {
@@ -3060,9 +3060,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v13.17.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v13.18.0"
             },
-            "time": "2024-04-04T22:16:10+00:00"
+            "time": "2024-04-09T21:08:04+00:00"
         },
         {
             "name": "symfony/asset",


### PR DESCRIPTION
This PR adds [liborm85/composer-vendor-cleaner](https://github.com/liborm85/composer-vendor-cleaner) to our composer plugins. This will automatically scan through our vendor folder and cleanup the glob patterns defined in the `extra` portion of our `composer.json`, reducing the size.

Before: 79.7 MB
After: 75.3 MB

I'm sure there are some other files we can cleanup than what I've added here, but as-is this is about a 5% size reduction & we can add more if we notice them down the line.