### PR TITLE
Replace the GitHub release API with our own

### DIFF
--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -72,7 +72,7 @@ class Update implements InjectionAwareInterface
     /**
      * Builds a complete changelog for all updates between the the newest FOSSBilling version and an ending version number.
      *
-     * @param string|null $end      What version number to end on. Defaults to the current version of this installation if `null` is passed.
+     * @param string $end (optional) What version number to end on. Defaults to the current version.
      */
     private function buildCompleteChangelog(string $end = Version::VERSION): string
     {

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -158,7 +158,6 @@ class Update implements InjectionAwareInterface
                     'next_check' => date('Y-m-d H:i:s', time() + 3600),
                     'branch' => $branch,
                     'minimum_php_version' => $releaseInfo['minimum_php_version'],
-                    ''
                 ];
             });
         }

--- a/src/library/FOSSBilling/Version.php
+++ b/src/library/FOSSBilling/Version.php
@@ -72,8 +72,8 @@ final class Version
         }
     }
 
-    public static function isPreviewVersion(): bool
+    public static function isPreviewVersion(string $version = Version::VERSION): bool
     {
-        return (preg_match(self::semverRegex, Version::VERSION, $matches) !== 0) ? false : true;
+        return ($version !== '0.0.1' && preg_match(self::semverRegex, $version, $matches) !== 0) ? false : true;
     }
 }

--- a/src/modules/System/html_admin/mod_system_update.html.twig
+++ b/src/modules/System/html_admin/mod_system_update.html.twig
@@ -12,7 +12,12 @@
         </div>
         <div class="card-body">
             {% if admin.system_update_available or update_info['branch'] == 'preview' %}
-                <h2 class="card-title">{{ 'Update release notes'|trans }} ({{ FOSSBillingVersion }} => {{ update_info['version'] }})</h2>
+                {% if update_info['branch'] == 'preview' %}
+                    <h2 class="card-title">{{ 'Update release notes'|trans }}</h2>
+                {% else %}
+                    <h2 class="card-title mb-0">{{ 'Update release notes'|trans }} ({{ FOSSBillingVersion }} => {{ update_info['version'] }})</h2>
+                    <span>{{ 'Required PHP version:'|trans }} {{ update_info['minimum_php_version'] }}</span>
+                {% endif %}
                 {% if update_info['update_type'] == 2 %}
                     <div class="alert alert-danger" role="alert">
                         <span>{{ 'This update is considered to be a major update, you should check the release notes for any breaking changes.'|trans }}</span>


### PR DESCRIPTION
This PR replaces our usage of GitHub's release API with instead our own API.
Specifically, these two endpoints are used:

- https://api.fossbilling.org/versions/latest
- https://api.fossbilling.org/versions/build_changelog/@current_version

Now FOSSBilling also has access to the minimum PHP version for a release and will prevent updates when that minimum is not met.
In the future, we can also start to record checksums and add it to the API which will then give us the chance to check those before performing an update.