### PR TITLE
Fix the required params not working in the client profile

### DIFF
--- a/src/modules/Client/html_client/mod_client_profile.html.twig
+++ b/src/modules/Client/html_client/mod_client_profile.html.twig
@@ -6,6 +6,7 @@
     <li class="breadcrumb-item active" aria-current="page">{{ 'Profile'|trans }}</li>{% endblock %}
 
 {% block body_class %}client-profile{% endblock %}
+{% set required = guest.client_required %}
 {% block content %}
     {% if (guest.client_is_email_validation_required) and (not profile.email_approved) %}
         <div class="alert alert-block alert-danger">


### PR DESCRIPTION
This fixes a bug where the client's required params were not being set in the profile tab because the `required` variable was never actually being set