### PR TITLE
Misc fixes + product configuration page improvements

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,4 +44,5 @@ return (new PhpCsFixer\Config())
             ->notPath(
                 'config-sample.php'
             )
-    );
+    )
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());

--- a/cspell.json
+++ b/cspell.json
@@ -394,7 +394,8 @@
         "thisfiledoesnotexist",
         "exchangerate",
         "currencydata",
-        "oninput"
+        "oninput",
+        "evenodd"
     ],
     "ignorePaths": [
         "tests-legacy/**",

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 use Rector\Set\ValueObject\SetList;
+use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([__DIR__ . '/src'])
@@ -23,7 +24,8 @@ return RectorConfig::configure()
     ->withSkip([
         JsonThrowOnErrorRector::class,
         LongArrayToShortArrayRector::class,
-        NullToStrictStringFuncCallArgRector::class
+        NullToStrictStringFuncCallArgRector::class,
+        MixedTypeRector::class,
     ])
     ->withRules([ExplicitNullableParamTypeRector::class])
     ->withCache('./cache/rector', FileCacheStorage::class)

--- a/src/modules/Formbuilder/Service.php
+++ b/src/modules/Formbuilder/Service.php
@@ -179,7 +179,7 @@ class Service implements InjectionAwareInterface
                 $field['options'] = json_encode($field['options'], JSON_FORCE_OBJECT);
             }
             if ($field['type'] == 'textarea') {
-                if ((is_countable($field['textarea_size']) ? count($field['textarea_size']) : 0) != count((array) array_filter($field['textarea_size'], 'is_numeric'))) {
+                if ((is_countable($field['textarea_size']) ? count($field['textarea_size']) : 0) != count(array_filter($field['textarea_size'], 'is_numeric'))) {
                     throw new \FOSSBilling\InformationException('Textarea size options must be integer values', null, 3510);
                 }
                 $field['options'] = array_combine($field['textarea_option'], $field['textarea_size']);

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -174,7 +174,7 @@ class Service implements InjectionAwareInterface
         $result['client_id'] = $invoice->client_id;
 
         $nr = (is_numeric($result['nr'])) ? $result['nr'] : $result['id'];
-        $result['serie_nr'] = $result['serie'] . sprintf('%0'.$invoice_number_padding.'s', $nr);
+        $result['serie_nr'] = $result['serie'] . sprintf('%0' . $invoice_number_padding . 's', $nr);
 
         $result['hash'] = $row['hash'];
         $result['gateway_id'] = $row['gateway_id'];
@@ -1351,7 +1351,7 @@ class Service implements InjectionAwareInterface
         $invoice_number_padding = $invoice_number_padding !== null && $invoice_number_padding !== '' ? $invoice_number_padding : 5;
 
         $params = [
-            ':id' => sprintf('%0'.$invoice_number_padding.'s', $proforma['nr']),
+            ':id' => sprintf('%0' . $invoice_number_padding . 's', $proforma['nr']),
             ':serie' => $proforma['serie'],
             ':title' => $first_title,
         ];

--- a/src/modules/Order/html_client/mod_order_index.html.twig
+++ b/src/modules/Order/html_client/mod_order_index.html.twig
@@ -20,8 +20,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="w-100">
-                            <h5 class="mb-1">{{ 'Order Product'|trans }}</h5>
-                            <span class="small text-muted row ms-2">{{ 'Choose products we offer for selling'|trans }}</span>
+                            <h5 class="mb-1">{{ 'Products'|trans }}</h5>
                             {% include 'mod_orderbutton_currency.html.twig' %}
                         </div>
                     </div>

--- a/src/modules/Order/html_client/mod_order_product.html.twig
+++ b/src/modules/Order/html_client/mod_order_product.html.twig
@@ -20,8 +20,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="w-100">
-                            <h5 class="mb-1">{{ 'Order Product'|trans }}</h5>
-                            <span class="small text-muted row ms-2">{{ 'Choose products we offer for selling'|trans }}</span>
+                            <h5 class="mb-1">{{ 'Products'|trans }}</h5>
                             {% include 'mod_orderbutton_currency.html.twig' %}
                         </div>
                     </div>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
@@ -43,7 +43,7 @@
             id="addon_{{ addon.id }}" autocomplete="off">
           <label class="btn btn-outline-success" for="addon_{{ addon.id }}" data-bs-toggle="tooltip"
             data-bs-title="{{ 'Add to cart'|trans }}">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.5em">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.25em">
               <path d="M3.11 7.17L.048 4.106l1.144-1.144 3.062 3.062z" />
               <path d="M8.063 2.208L3.735 6.536l-1.22-1.22L6.843.988z" />
             </svg>
@@ -53,7 +53,7 @@
             id="addon_{{ addon.id }}_decline" autocomplete="off" checked>
           <label class="btn btn-outline-danger" for="addon_{{ addon.id }}_decline" data-bs-toggle="tooltip"
             data-bs-title="{{ 'Remove from cart'|trans }}">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.5em">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.25em">
               <g fill-rule="evenodd">
                 <path d="M2.048.77l5.18 5.182L5.953 7.23.77 2.048 2.048.77z" />
                 <path d="M5.952.77L7.23 2.05 2.048 7.23.77 5.952 5.953.772z" />

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
@@ -1,55 +1,70 @@
 {% if product.addons|length > 0 %}
-    <div class="card mt-1 mb-1">
-        <div class="card-header">
-            <h5>{{ 'Addons & extras'|trans }}</h5>
+<h5 class="mt-4 mb-1"><strong>{{ 'Addons & extras'|trans }}</strong></h5>
+<table class="table table-sm table-borderless table-striped">
+  <tbody>
+    {% for addon in product.addons %}
+    <tr>
+      <td {% if not addon.icon_url %}style="display: none" {% endif %}>
+        <label><img src="{{ addon.icon_url }}" alt="" width="36" /></label>
+      </td>
+
+      <td>
+        <label>
+          <h6><strong>{{ addon.title }}</strong></h6>
+        </label>
+        {{ addon.description|markdown }}
+      </td>
+
+      <td>
+        <label class="currency">
+          {% if addon.pricing.type is same as('recurrent') %}
+          {% set periods = guest.system_periods %}
+          <select class="form-select" name="addons[{{ addon.id }}][period]" rel="addon-periods-{{ addon.id }}">
+            {% for code, prices in addon.pricing.recurrent %}
+            {% if prices.enabled %}
+            <option value="{{ code }}">{{ periods[code] }} {{ prices.price | money_convert }} {% if prices.setup !=
+              '0.00' %}{{ 'Setup:'|trans }} {{ prices.setup | money_convert }}{% endif %}</option>
+            {% endif %}
+            {% endfor %}
+          </select>
+          {% endif %}
+
+          {% if addon.pricing.type is same as('once') %}
+          <span class="badge bg-success">{{ (addon.pricing.once.price + addon.pricing.once.setup) | money_convert }}</span>
+          {% endif %}
+
+          {% if addon.pricing.type is same as('free') %}
+          <span class="badge bg-success">{{ 0 | money_convert }}</span>
+          {% endif %}
+        </label>
+
+        <div class="float-end">
+          <input type="radio" class="btn-check" name="addons[{{ addon.id }}][selected]" value="1"
+            id="addon_{{ addon.id }}" autocomplete="off">
+          <label class="btn btn-outline-success" for="addon_{{ addon.id }}" data-bs-toggle="tooltip"
+            data-bs-title="{{ 'Add to cart'|trans }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.5em">
+              <path d="M3.11 7.17L.048 4.106l1.144-1.144 3.062 3.062z" />
+              <path d="M8.063 2.208L3.735 6.536l-1.22-1.22L6.843.988z" />
+            </svg>
+          </label>
+
+          <input type="radio" class="btn-check" name="addons[{{ addon.id }}][selected]" value="0"
+            id="addon_{{ addon.id }}_decline" autocomplete="off" checked>
+          <label class="btn btn-outline-danger" for="addon_{{ addon.id }}_decline" data-bs-toggle="tooltip"
+            data-bs-title="{{ 'Remove from cart'|trans }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.5em">
+              <title>Shape + Shape</title>
+              <g fill-rule="evenodd">
+                <path d="M2.048.77l5.18 5.182L5.953 7.23.77 2.048 2.048.77z" />
+                <path d="M5.952.77L7.23 2.05 2.048 7.23.77 5.952 5.953.772z" />
+              </g>
+            </svg>
+          </label>
         </div>
-        <div class="card-body">
-        <table class="table table-sm table-borderless table-striped">
-        <tbody>
-          {% for addon in product.addons %}
-            <tr>
-              <td>
-                <input type="hidden" name="addons[{{ addon.id }}][selected]" value="0">
-                <input type="checkbox" class="form-check-input" name="addons[{{ addon.id }}][selected]" value="1" id="addon_{{ addon.id }}">
-              </td>
-
-              <td {% if not addon.icon_url %}style="display: none"{% endif %}>
-                <label for="addon_{{ addon.id }}"><img src="{{ addon.icon_url }}" alt="" width="36" /></label>
-              </td>
-
-              <td>
-                <label for="addon_{{ addon.id }}">
-                  <h6>{{ addon.title }}</h6>
-                </label>
-                {{ addon.description|markdown }}
-              </td>
-
-              <td class="currency">
-                <label for="addon_{{ addon.id }}">
-                  {% if addon.pricing.type is same as('recurrent') %}
-                    {% set periods = guest.system_periods %}
-                    <select class="form-select" name="addons[{{ addon.id }}][period]" rel="addon-periods-{{ addon.id }}">
-                      {% for code, prices in addon.pricing.recurrent %}
-                        {% if prices.enabled %}
-                          <option value="{{ code }}">{{ periods[code] }} {{ prices.price | money_convert }} {% if prices.setup != '0.00' %}{{ 'Setup:'|trans }} {{ prices.setup | money_convert }}{% endif %}</option>
-                        {% endif %}
-                      {% endfor %}
-                    </select>
-                  {% endif %}
-
-                  {% if addon.pricing.type is same as('once') %}
-                    {{ (addon.pricing.once.price + addon.pricing.once.setup) | money_convert }}
-                  {% endif %}
-
-                  {% if addon.pricing.type is same as('free') %}
-                    {{ 0 | money_convert }}
-                  {% endif %}
-                </label>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-</div>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endif %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
@@ -22,8 +22,8 @@
           <select class="form-select" name="addons[{{ addon.id }}][period]" rel="addon-periods-{{ addon.id }}">
             {% for code, prices in addon.pricing.recurrent %}
             {% if prices.enabled %}
-            <option value="{{ code }}">{{ periods[code] }} {{ prices.price | money_convert }} {% if prices.setup !=
-              '0.00' %}{{ 'Setup:'|trans }} {{ prices.setup | money_convert }}{% endif %}</option>
+            <option value="{{ code }}">{{ prices.price | money_convert }} {% if prices.setup !=
+              '0.00' %}{{ 'Setup:'|trans }} {{ prices.setup | money_convert }}{% endif %} ({{ periods[code] }})</option>
             {% endif %}
             {% endfor %}
           </select>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_addons.html.twig
@@ -54,7 +54,6 @@
           <label class="btn btn-outline-danger" for="addon_{{ addon.id }}_decline" data-bs-toggle="tooltip"
             data-bs-title="{{ 'Remove from cart'|trans }}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="1.5em">
-              <title>Shape + Shape</title>
               <g fill-rule="evenodd">
                 <path d="M2.048.77l5.18 5.182L5.953 7.23.77 2.048 2.048.77z" />
                 <path d="M5.952.77L7.23 2.05 2.048 7.23.77 5.952 5.953.772z" />

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -187,7 +187,7 @@
                                                 <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
                                                 <label class="form-check-label" for="flexCheckDefault">
                                                     {# TODO: Make this translatable once support for placeholders is implemented #}
-                                                    <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}.</span>
+                                                    <span>I agree to the <a href="{{ '/tos'|link }}" target="_blank">{{ 'terms of service'|trans }}</a> and <a href="{{ '/privacy-policy'|link }}" target="_blank">{{ 'privacy policy'|trans }}</a>.</span>
                                                 </label>
                                             </div>
                                         {% endif %}

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -41,7 +41,7 @@
                                     <select class="form-select" name="period" id="period-selector">
                                         {% for code,prices in product.pricing.recurrent %}
                                             {% if prices.enabled %}
-                                                <option value="{{code}}" data-bb-price="{{ prices.price | money_convert }}" name="period">{{ periods[code] }} - {{ prices.price | money_convert }}</option>
+                                                <option value="{{code}}" data-bb-price="{{ prices.price | money_convert }}" name="period">{{ prices.price | money_convert }} ({{ periods[code] }})</option>
                                             {% endif %}
                                         {% endfor %}
                                     </select>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -18,23 +18,40 @@
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     {% set product_details %}
                         <div class="well">
-                            <strong>{{ product.title }}</strong>
-                            {{ product.description | markdown }}
-
-                            {% if product.pricing.type == 'recurrent' %}
-                                {% set periods = guest.system_periods %}
-                                <select class="form-select" name="period" id="period-selector">
-                                    {% for code,prices in product.pricing.recurrent %}
-                                        {% if prices.enabled %}
-                                            <option value="{{code}}" data-bb-price="{{ prices.price | money_convert }}" name="period">{{ periods[code] }} - {{ prices.price | money_convert }}</option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
-                            {% elseif product.pricing.type == 'free' %}
-                                <span class="badge bg-success">{{ 'FREE'|trans }}</span>
-                            {% else %}
-                                <span class="badge bg-success">{{ product.pricing.once.price | money_convert }}</span>
+                            <h3>{{ product.title }}</h3>
+                            {% if product.description %}
+                                {{ product.description | markdown }}
                             {% endif %}
+
+                            <hr>
+
+                            <h5 class="mt-4 mb-1"><strong>{{ 'Billing'|trans }}</strong></h5>
+
+                            <div class="row">
+                                <div class="col-12 col-md-4 col-xl-3">
+                                    {% if product.pricing.type == 'recurrent' %}
+                                    <span>{{ 'Billing cycle'|trans }}</span>
+                                    {% else %}
+                                    <span>{{ 'One-time payment'|trans }}</span>
+                                    {% endif %}
+                                </div>
+                                <div class="col">
+                                    {% if product.pricing.type == 'recurrent' %}
+                                    {% set periods = guest.system_periods %}
+                                    <select class="form-select" name="period" id="period-selector">
+                                        {% for code,prices in product.pricing.recurrent %}
+                                            {% if prices.enabled %}
+                                                <option value="{{code}}" data-bb-price="{{ prices.price | money_convert }}" name="period">{{ periods[code] }} - {{ prices.price | money_convert }}</option>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </select>
+                                    {% elseif product.pricing.type == 'free' %}
+                                    <span class="badge bg-success">{{ 0 | money_convert }}</span>
+                                    {% else %}
+                                    <span class="badge bg-success">{{ product.pricing.once.price | money_convert }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
                         </div>
                     {% endset %}
 
@@ -53,7 +70,7 @@
 
                     <input type="hidden" name="multiple" value="1" />
                     <input type="hidden" name="id" value="{{ product.id }}" />
-                    <div class="mb-0">
+                    <div class="mt-2 mb-0">
                         <button type="submit" class="btn btn-primary" id="config-next">{{ 'Next'|trans }}</button>
                     </div>
                 </form>

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -222,7 +222,7 @@ class Service
     }
 
     /**
-     * @depricated Please use the \FOSSBilling\i18n::getLocales function, which provides the same functionality.
+     * @deprecated please use the \FOSSBilling\i18n::getLocales function, which provides the same functionality
      *
      * @param bool $deep
      */

--- a/src/themes/huraga/config/settings.html
+++ b/src/themes/huraga/config/settings.html
@@ -3,8 +3,8 @@
 
     <h3>Theme</h3>
     <select name="theme">
-        <option value="light" selected>Light</option>
-        <option value="dark">Dark</option>
+        <option value="light" selected>Bootstrap Light</option>
+        <option value="dark">Bootstrap Dark</option>
     </select>
 </fieldset>
 


### PR DESCRIPTION
This PR removes a rector rule that was causing unwanted behavior and brings some nice improvements to the the product configuration page, primarily with the free / one time pricing + the addon selection.

I also fixed a missing closing tag for a hyperlink which caused elements on the page to unintentionally be links to the privacy policy.

Closes #2242 and closes #2272.

## Before

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/dd5a766c-8d8d-4d2e-b91d-9e59ec12c086)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/fd432eba-f69d-4aff-9cc7-31e1e1dbf6eb)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/ebecfd25-bfff-402f-84e6-c99a1486ebef)

## After

![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/4e6955dc-eb2b-45b7-b943-049bd5b4aa2d)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/a3e8cfa7-9cf7-44f9-b16a-b58a0598e66c)
![image](https://github.com/FOSSBilling/FOSSBilling/assets/17304943/ee6db271-737a-4273-8a31-d836857e2ccf)
