### PR TITLE
Added mechanism to mask sensitive information from debug log files.

### DIFF
--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -68,14 +68,10 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
      * @param int $limit The regression limit
      * @return array The masked log parameters
      */
-    private function maskParams(array $params, int $depth = 0, int $limit = 10): array
+    public function maskParams(array $params, int $depth = 0, int $limit = 10): array
     {
         if ($depth >= $limit) {
-            error_log('Log parameter masking recursion limit reached. Masking all parameters.');
-            // return all parameters masked if the recursion limit has been reached.
-            return array_map(function($value) {
-                return '********';
-            }, $params);
+            throw new FOSSBilling\Exception('Recursion limit reached. Unable to mask parameters.');
         }
     
         foreach ($params as $key => $value) {
@@ -88,6 +84,7 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
     
         return $params;
     }
+
 
     /**
      * @throws FOSSBilling\Exception

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -40,6 +40,9 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
         self::DEBUG => 'DEBUG',
     ];
 
+    // List of keys whose values are to be masked in the log
+    protected array $_maskKeys = ['password', 'pass', 'token', 'key','apisecret','secret','api_token'];
+
     protected ?Pimple\Container $di = null;
     protected $_min_priority;
 
@@ -80,6 +83,20 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
                     }
 
                     break;
+            }
+             // Check if any of the keys in the params array match the keys in the maskKeys array
+             foreach ($params as $key => $value) {
+                if (is_array($value)) {
+                    foreach ($value as $k => $v) {
+                        if (in_array($k, $this->_maskKeys)) {
+                            $params[$key][$k] = '********';
+                        } else {
+                            $params[$key][$k] = $v;
+                        }
+                    }
+                } else if (in_array($key, $this->_maskKeys)) {
+                    $params[$key] = '********';
+                }
             }
             $this->log($message, $priority, $params);
         } else {

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -326,8 +326,9 @@ class Admin extends \Api_Abstract
         $this->di['validator']->isPasswordStrong($data['password']);
 
         $client = $this->di['db']->getExistingModelById('Client', $data['id'], 'Client not found');
-
-        $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientPasswordChange', 'params' => $data]);
+        $event_params = [];
+        $event_params['id'] = $client->id;
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminClientPasswordChange', 'params' => $event_params]);
 
         $client->pass = $this->di['password']->hashIt($data['password']);
         $client->updated_at = date('Y-m-d H:i:s');
@@ -336,7 +337,8 @@ class Admin extends \Api_Abstract
         $profileService = $this->di['mod_service']('profile');
         $profileService->invalidateSessions('client', $data['id']);
 
-        $this->di['events_manager']->fire(['event' => 'onAfterAdminClientPasswordChange', 'params' => ['id' => $client->id, 'password' => $data['password']]]);
+        $event_params['password'] = $data['password'];
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminClientPasswordChange', 'params' => $event_params]);
 
         $this->di['logger']->info('Changed client #%s password', $client->id);
 

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -117,7 +117,8 @@ class Guest extends \Api_Abstract
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
         $this->di['tools']->validateAndSanitizeEmail($data['email'], true, false);
 
-        $event_params = $data;
+        $event_params = [];
+        $event_params['email'] = $data['email'];
         $event_params['ip'] = $this->ip;
         $this->di['events_manager']->fire(['event' => 'onBeforeClientLogin', 'params' => $event_params]);
 

--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -37,7 +37,7 @@ class Service implements InjectionAwareInterface
     public function changeAdminPassword(\Model_Admin $admin, $new_password)
     {
         $event_params = [];
-        $event_params['password'] = $new_password;
+
         $event_params['id'] = $admin->id;
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffProfilePasswordChange', 'params' => $event_params]);
 
@@ -45,8 +45,7 @@ class Service implements InjectionAwareInterface
         $admin->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($admin);
 
-        $event_params = [];
-        $event_params['id'] = $admin->id;
+        $event_params['password'] = $new_password;
         $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffProfilePasswordChange', 'params' => $event_params]);
 
         $this->di['logger']->info('Changed profile password');
@@ -203,14 +202,14 @@ class Service implements InjectionAwareInterface
     public function changeClientPassword(\Model_Client $client, $new_password)
     {
         $event_params = [];
-        $event_params['password'] = $new_password;
         $event_params['id'] = $client->id;
         $this->di['events_manager']->fire(['event' => 'onBeforeClientProfilePasswordChange', 'params' => $event_params]);
 
         $client->pass = $this->di['password']->hashIt($new_password);
         $this->di['db']->store($client);
 
-        $this->di['events_manager']->fire(['event' => 'onAfterClientProfilePasswordChange', 'params' => ['id' => $client->id]]);
+        $event_params['password'] = $new_password;
+        $this->di['events_manager']->fire(['event' => 'onAfterClientProfilePasswordChange', 'params' => $event_params]);
 
         $this->di['logger']->info('Changed profile password');
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -533,8 +533,9 @@ class Service implements InjectionAwareInterface
         } else {
             $this->checkPermissionsAndThrowException('staff', 'reset_staff_password');
         }
-
-        $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffPasswordChange', 'params' => ['id' => $model->id]]);
+        $event_params = [];
+        $event_params['id'] = $model->id;
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminStaffPasswordChange', 'params' => $event_params]);
 
         $model->pass = $this->di['password']->hashIt($password);
         $model->updated_at = date('Y-m-d H:i:s');
@@ -543,7 +544,8 @@ class Service implements InjectionAwareInterface
         $profileService = $this->di['mod_service']('profile');
         $profileService->invalidateSessions('admin', $model->id);
 
-        $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffPasswordChange', 'params' => ['id' => $model->id]]);
+        $event_params['password'] = $password;
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffPasswordChange', 'params' => $event_params]);
 
         $this->di['logger']->info('Changed staff member %s password', $model->id);
 

--- a/tests-legacy/library/Box/Box_LogTest.php
+++ b/tests-legacy/library/Box/Box_LogTest.php
@@ -33,6 +33,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
                                             ],
                                         ],
                                     ],
+                                    'key' => 'SecondVerySecretValue',
                                 ],
                             ],
                         ],
@@ -42,59 +43,40 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
         ];
         $this->valid_params = $valid_params;
         $this->regression_test_params = $regression_test_params;
-        $this->regression_limit = 10;
+        $this->regression_limit = 8;
 
     }
     // test maskParams method
     public function testMaskParams(): void
     {
-        // test normal masking
-        $params = $this->valid_params;
+        // test normal masking with $this->valid_params and $log_message
+        $log_message = 'This is a log message';
+        $params = [];
+        $params = array_merge($this->valid_params, ['message' => $log_message]);
 
-        $this->assertEquals(
-            [
-                'foo' => [
-                    'bar' => [
-                        'baz' => '********',
-                    ],
-                ],
-            ],
-            $this->log->maskParams($params)
-        );
+        // target output
+        $output = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+            'key' => '********',
+            'message' => 'This is a log message',
+        ];
+
+        $this->assertEquals($output, $this->log->maskParams($params));
     }
 
     // test maskParams method with regression limit
     public function testMaskParamsWithRegressionLimit(): void
     {
         // test masking with regression limit
+        $params = [];
         $params = $this->regression_test_params;
 
-        $this->assertEquals(
-            [
-                'foo' => [
-                    'bar' => [
-                        'baz' => [
-                            'lorem' => [
-                                'ipsum' => [
-                                    'dolor' => [
-                                        'sit' => [
-                                            'amet' => [
-                                                'foo' => [
-                                                    'bar' => [
-                                                        'key' => '********',
-                                                    ],
-                                                ],
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            $this->log->maskParams($params, 0, $this->regression_limit)
-        );
+        // Expect FossBilling\Exception to be thrown
+        $this->expectException(FOSSBilling\Exception::class);
+        $this->log->maskParams($params, 0, $this->regression_limit);
+        
+
     }
 }
 

--- a/tests-legacy/library/Box/Box_LogTest.php
+++ b/tests-legacy/library/Box/Box_LogTest.php
@@ -1,0 +1,99 @@
+<?php
+
+#[PHPUnit\Framework\Attributes\Group('Core')]
+class Box_LogTest extends PHPUnit\Framework\TestCase
+{
+    protected array $valid_params;
+    protected array $regression_test_params;
+    protected int $regression_limit;
+
+    // Setup mask params for testing
+    protected function setUp(): void
+    {
+        $valid_params = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+            'key' => 'VerySecretValuePleaseDoNotSteal!',
+        ];
+        $regression_test_params = [
+            'foo' => [
+                'bar' => [
+                    'baz' => [
+                        'lorem' => [
+                            'ipsum' => [
+                                'dolor' => [
+                                    'sit' => [
+                                        'amet' => [
+                                            'foo' => [
+                                                'bar' => [
+                                                    'key' => 'VerySecretValuePleaseDoNotSteal!'
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $this->valid_params = $valid_params;
+        $this->regression_test_params = $regression_test_params;
+        $this->regression_limit = 10;
+
+    }
+    // test maskParams method
+    public function testMaskParams(): void
+    {
+        // test normal masking
+        $params = $this->valid_params;
+
+        $this->assertEquals(
+            [
+                'foo' => [
+                    'bar' => [
+                        'baz' => '********',
+                    ],
+                ],
+            ],
+            $log->maskParams($params)
+        );
+    }
+
+    // test maskParams method with regression limit
+    public function testMaskParamsWithRegressionLimit(): void
+    {
+        // test masking with regression limit
+        $params = $this->regression_test_params;
+
+        $this->assertEquals(
+            [
+                'foo' => [
+                    'bar' => [
+                        'baz' => [
+                            'lorem' => [
+                                'ipsum' => [
+                                    'dolor' => [
+                                        'sit' => [
+                                            'amet' => [
+                                                'foo' => [
+                                                    'bar' => [
+                                                        'key' => '********',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $log->maskParams($params, 0, $this->regression_limit)
+        );
+    }
+}
+
+

--- a/tests-legacy/library/Box/Box_LogTest.php
+++ b/tests-legacy/library/Box/Box_LogTest.php
@@ -11,7 +11,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // Setup mask params for testing
     protected function setUp(): void
     {
-        $this->log = new Box_Log();
+        $this->log = new Box_Log();        
         $valid_params = [
             'foo' => 'bar',
             'baz' => 'qux',
@@ -48,7 +48,6 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // test maskParams method
     public function testMaskParams(): void
     {
-        $log = new Box_Log();
         // test normal masking
         $params = $this->valid_params;
 
@@ -60,14 +59,13 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
                     ],
                 ],
             ],
-            $log->maskParams($params)
+            $this->log->maskParams($params)
         );
     }
 
     // test maskParams method with regression limit
     public function testMaskParamsWithRegressionLimit(): void
     {
-        $log = new Box_Log();
         // test masking with regression limit
         $params = $this->regression_test_params;
 
@@ -95,7 +93,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
                     ],
                 ],
             ],
-            $log->maskParams($params, 0, $this->regression_limit)
+            $this->log->maskParams($params, 0, $this->regression_limit)
         );
     }
 }

--- a/tests-legacy/library/Box/Box_LogTest.php
+++ b/tests-legacy/library/Box/Box_LogTest.php
@@ -11,7 +11,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // Setup mask params for testing
     protected function setUp(): void
     {
-        $this->log = new Box_Log();        
+        $this->log = new Box_Log('DEBUG');        
         $valid_params = [
             'foo' => 'bar',
             'baz' => 'qux',

--- a/tests-legacy/library/Box/Box_LogTest.php
+++ b/tests-legacy/library/Box/Box_LogTest.php
@@ -3,6 +3,7 @@
 #[PHPUnit\Framework\Attributes\Group('Core')]
 class Box_LogTest extends PHPUnit\Framework\TestCase
 {
+    protected Box_Log $log;
     protected array $valid_params;
     protected array $regression_test_params;
     protected int $regression_limit;
@@ -10,6 +11,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // Setup mask params for testing
     protected function setUp(): void
     {
+        $this->log = new Box_Log();
         $valid_params = [
             'foo' => 'bar',
             'baz' => 'qux',
@@ -46,6 +48,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // test maskParams method
     public function testMaskParams(): void
     {
+        $log = new Box_Log();
         // test normal masking
         $params = $this->valid_params;
 
@@ -64,6 +67,7 @@ class Box_LogTest extends PHPUnit\Framework\TestCase
     // test maskParams method with regression limit
     public function testMaskParamsWithRegressionLimit(): void
     {
+        $log = new Box_Log();
         // test masking with regression limit
         $params = $this->regression_test_params;
 


### PR DESCRIPTION
- I've added the ability to mask certain values from being logged to prevent possible leaks of sensitive data.

- I've also cleaned up the event data for change password events to be more consistent. 
  Specifically I think it makes sense that the event only gets the password after it has been stored in the database, as any plugin that works with the onBefore*PasswordChange event couldn't be sure the password really has been stored, so it only really makes sense in onAfter*PasswordChange.
  