### PR TITLE
Fix Email Template Preview on dark theme.

### DIFF
--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -67,8 +67,8 @@
 
 
                             <div class="mt-3" id="preview" style="display: none;">
-                                <div class="p-3 esubject mb-3" style="background: white; border: 1px dashed grey; overflow: auto;"></div>
-                                <div class="p-3 econtent" style="background: white; border: 1px dashed grey; overflow: auto;"></div>
+                                <div class="p-3 esubject mb-3" style="background: white; border: 1px dashed grey; overflow: auto; color: black;"></div>
+                                <div class="p-3 econtent" style="background: white; border: 1px dashed grey; overflow: auto; color: black;"></div>
                             </div>
                         </div>
                         <div class="card-footer d-flex justify-content-between">


### PR DESCRIPTION
I just added a CSS inline value to make the text black, not sure why the CSS is inline here or why its white bg 100% of the time, but that is for someone else to figure out, this at least makes text visible on dark mode.