### PR TITLE
CI Disable upload to S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,18 +92,6 @@ jobs:
           mkdir ./dist
           mv ./FOSSBilling-preview.zip ./dist
 
-      - name: 'Upload Downloadable Preview to S3'
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: '--acl public-read --follow-symlinks'
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
-          SOURCE_DIR: './dist'
-
       - name: 'Upload Downloadable Preview to GitHub'
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Is currently down disabling S3 storage and switch to Cloudflare worker with Github API