### PR TITLE
Allow multiple select for payment gateways

### DIFF
--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -35,6 +35,15 @@
             {% endfor %}
             </select>
         </div>
+        {% elseif element[0] == 'multiselect' %}
+        <label class="form-label col-3 col-form-label">{{ element[1].label }}{% if element[1].description %} - {{ element[1].description }}{% endif %}</label>
+        <div class="col">
+            <select class="form-select" name="config[{{ name }}]" multiple>
+            {% for k, v in element[1].multiOptions %}
+                <option value="{{ k }}"{% if k == values[name] %} selected{% endif %}/><label>{{ v }}</label>
+            {% endfor %}
+            </select>
+        </div>
         {% elseif element[0] == 'radio' %}
         <label class="form-label col-3 col-form-label">{{ element[1].label }}{% if element[1].description %} - {{ element[1].description }}{% endif %}</label>
         <div class="col">


### PR DESCRIPTION
For the BTCPay integration, I'd like to display a select box which allows to choose multiple options. Configured like so:

```php
                'payment_method' => [
                    'multiselect',
                    [
                        'multiOptions' => [
                            "ALL"                => "ALL",
                            "BTC_LightningLike"  => "BTC (Lightning)",
                            "BTC"                => "BTC",
                            "LTC"                => "LTC",
                            "DASH"               => "DASH",
                        ],
                        'label'        => 'Payment method :',
                    ],
                ]
```

I hope this template extension is all thats needed.