### PR TITLE
Added the WYSIWYG editor to the huraga theme

### DIFF
--- a/src/modules/Support/html_admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_admin/mod_support_ticket.html.twig
@@ -290,7 +290,7 @@
 </div>
 
 <div class="card" id="reply-box">
-    <form method="post" action="{{ 'api/admin/support/ticket_reply'|link }}" class="api-form" data-api-redirect="{{ 'support'|alink({ 'status': 'open' }) }}">
+    <form method="post" action="{{ 'api/admin/support/ticket_reply'|link }}" class="api-form" data-api-reload="1">
         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="card-body">
             <div class="d-flex">

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -6,7 +6,13 @@
 
 {% block body_class %}support-contact-us{% endblock %}
 {% block breadcrumb %}
-    <li class="breadcrumb-item active" aria-current="page">{{ 'Contact us'|trans }}</li>{% endblock %}
+    <li class="breadcrumb-item active" aria-current="page">{{ 'Contact us'|trans }}</li>
+{% endblock %}
+
+{% block head %}
+    {{ mf.wysiwyg('.editor-textarea') }}
+{% endblock %}
+
 {% block content %}
     {% set company = guest.system_company %}
     <div class="row">
@@ -37,7 +43,7 @@
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="message">{{ 'Message'|trans }}</label>
-                            <textarea class="form-control" name="message" cols="5" rows="5" required="required" id="message">{{ request.message }}</textarea>
+                            <textarea class="editor-textarea form-control" name="message" cols="5" rows="5" required="required" id="message">{{ request.message }}</textarea>
                         </div>
 
                         {{ mf.recaptcha }}

--- a/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us_conversation.html.twig
@@ -10,6 +10,9 @@
 <li class="breadcrumb-item active" aria-current="page">{{ ticket.subject }}</li>
 {% endblock %}
 
+{% block head %}
+    {{ mf.wysiwyg('.editor-textarea') }}
+{% endblock %}
 
 {% block content %}
 <div class="row">
@@ -84,7 +87,7 @@
                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <input type="hidden" name="hash" value="{{ ticket.hash }}" />
                     
-                    <textarea name="message" cols="5" rows="10" class="form-control" required="required" id="ticket-reply-text"></textarea>
+                    <textarea name="message" cols="5" rows="10" class="editor-textarea form-control" required="required" id="ticket-reply-text"></textarea>
                     <button class="btn btn-primary btn-large mt-1" type="submit" id="submit-support-message" value="{{ 'Post'|trans }}" onclick="">{{ 'Post'|trans }}</button>
                 </form>
             {% elseif ticket.status == 'closed' %}

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -6,6 +6,7 @@
 
 {% block head %}
     {{ encore_entry_link_tags('markdown') }}
+    {{ mf.wysiwyg('.editor-textarea') }}
 {% endblock %}
 
 {% block body_class %}support-ticket{% endblock %}
@@ -135,7 +136,7 @@
                                 <form id="ticket-reply-form">
                                     <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                                     <input type="hidden" name="id" value="{{ ticket.id }}">
-                                    <textarea name="content" cols="5" rows="10" class="form-control" required="required"
+                                    <textarea name="content" cols="5" rows="10" class="editor-textarea form-control" required="required"
                                               id="ticket-reply-text"></textarea>
                                     <button class="mt-2 btn btn-primary" type="submit" id="post-reply-btn"
                                             value="{{ 'Post'|trans }}"

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -8,6 +8,10 @@
 {% block body_class %}support-tickets{% endblock %}
 {% block breadcrumb %}<li class="breadcrumb-item active" aria-current="page">{{ 'Support tickets'|trans }}</li>{% endblock %}
 
+{% block head %}
+    {{ mf.wysiwyg('.editor-textarea') }}
+{% endblock %}
+
 {% block content %}
 <div class="row">
     <div class="col-md-12">
@@ -69,7 +73,7 @@
 </div>
 
 
-<div class="modal fade" id="open-ticket-modal" tabindex="-1" aria-labelledby="open-ticket-modal" aria-hidden="true">
+<div class="modal modal-lg fade" id="open-ticket-modal" tabindex="-1" aria-labelledby="open-ticket-modal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -91,7 +95,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="message" class="form-label">{{ 'Message'|trans }}</label>
-                        <textarea name="content" class="form-control" id="message" aria-describedby="message" rows="5" required>{{ request.content|e }}</textarea>
+                        <textarea name="content" class="editor-textarea form-control" id="message" aria-describedby="message" rows="5" required>{{ request.content|e }}</textarea>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/src/modules/Wysiwyg/html_client/mod_wysiwyg_js.html.twig
+++ b/src/modules/Wysiwyg/html_client/mod_wysiwyg_js.html.twig
@@ -1,0 +1,19 @@
+{{ 'ckeditor/ckeditor.js' | mod_asset_url('wysiwyg') | script_tag }}
+<script type="text/javascript">
+    const editors = [];
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll('.{{ class }}').forEach(function (element) {
+            let required = false;
+            CKEditor
+                .create(element)
+                .then(editor => {
+                    if (element.hasAttribute('required')) {
+                        element.removeAttribute('required');
+                        required = true;
+                    }
+                    editors[element.name] = { editor, 'required': required };
+                })
+                .catch(error => { console.error(error) });
+        });
+    });
+</script>

--- a/src/modules/Wysiwyg/html_client/mod_wysiwyg_js.html.twig
+++ b/src/modules/Wysiwyg/html_client/mod_wysiwyg_js.html.twig
@@ -15,5 +15,13 @@
                 })
                 .catch(error => { console.error(error) });
         });
+
+        {% if 'dark' in settings.theme %}
+        setTimeout(() => {
+            document.querySelectorAll('.ck-editor__main').forEach(function (element) {
+                element.style.color="#1d273b";
+            });
+        }, 1000);
+        {% endif %}
     });
 </script>

--- a/src/themes/huraga/html/macro_functions.html.twig
+++ b/src/themes/huraga/html/macro_functions.html.twig
@@ -77,3 +77,11 @@
     {% endif %}
 {% endif %}
 {% endmacro %}
+
+{% macro wysiwyg(selector) %}
+{% if guest.extension_is_on({"mod":"wysiwyg"}) %}
+{% include "mod_wysiwyg_js.html.twig" with {"class":selector|trim('.#')} %}
+{% else %}
+<!-- No WYSIWYG, no fancy stuff. Enable the WYSIWYG extension for a better management experience. -->
+{% endif %}
+{% endmacro %}


### PR DESCRIPTION
This PR adds the WYSIWYG editor to the huraga client area, offering an improved client experience.

Submitting a ticket:
![Screenshot 2024-08-04 at 01-23-24 Support tickets](https://github.com/user-attachments/assets/859f9701-3b64-4689-97b3-3f3fe2014f98)

Replying to a ticket:
![Screenshot 2024-08-04 at 01-23-51 A support ticket using the WYSIWYG Editor](https://github.com/user-attachments/assets/3b885a0d-7197-43e2-a6cd-1ed63f469324)

