### PR TITLE
Update postcss dependency override

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "autoprefixer": "^10.4.16",
     "core-js": "^3.33.3",
     "cypress": "^13.5.1",
-    "postcss": "^8.4.31",
+    "postcss": "^8.4.41",
     "postcss-loader": "^7.3.3",
     "sass": "^1.69.5",
     "sass-loader": "^14.0.0",
@@ -54,7 +54,7 @@
   },
   "overrides": {
     "braces": "^3.0.3",
-    "postcss": "^8.4.31",
+    "postcss": "^8.4.41",
     "@melloware/coloris": "^0.24.0",
     "imask": "^7.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "autoprefixer": "^10.4.16",
     "core-js": "^3.33.3",
     "cypress": "^13.5.1",
-    "postcss": "^8.4.41",
+    "postcss": "^8.4.31",
     "postcss-loader": "^7.3.3",
     "sass": "^1.69.5",
     "sass-loader": "^14.0.0",
@@ -54,7 +54,7 @@
   },
   "overrides": {
     "braces": "^3.0.3",
-    "postcss": "^8.4.41",
+    "postcss": "$postcss",
     "@melloware/coloris": "^0.24.0",
     "imask": "^7.1.3"
   }


### PR DESCRIPTION
Update `postcss` dependency override to refer to dependency. Fixes issue with Renovate being unable to update due to mismatch between bumped version and override in `package.json`.