### PR TITLE
Add delays to prevent email enumeration

### DIFF
--- a/src/library/Box/Authorization.php
+++ b/src/library/Box/Authorization.php
@@ -26,15 +26,16 @@ class Box_Authorization
         return (bool) $this->session->get('admin');
     }
 
-    public function authorizeUser(object|null $user, string $plainTextPassword)
+    public function authorizeUser(?object $user, string $plainTextPassword)
     {
-        if($user === null){
+        if ($user === null) {
             // 25 to 100ms delay
             usleep(random_int(25000, 100000));
             $this->di['password']->dummyVerify($plainTextPassword);
+
             return null;
         }
-    
+
         $user = $this->passwordBackwardCompatibility($user, $plainTextPassword);
         if ($this->di['password']->verify($plainTextPassword, $user->pass)) {
             if ($this->di['password']->needsRehash($user->pass)) {

--- a/src/library/Box/Authorization.php
+++ b/src/library/Box/Authorization.php
@@ -26,8 +26,15 @@ class Box_Authorization
         return (bool) $this->session->get('admin');
     }
 
-    public function authorizeUser($user, $plainTextPassword)
+    public function authorizeUser(object|null $user, string $plainTextPassword)
     {
+        if($user === null){
+            // 25 to 100ms delay
+            usleep(random_int(25000, 100000));
+            $this->di['password']->dummyVerify($plainTextPassword);
+            return null;
+        }
+    
         $user = $this->passwordBackwardCompatibility($user, $plainTextPassword);
         if ($this->di['password']->verify($plainTextPassword, $user->pass)) {
             if ($this->di['password']->needsRehash($user->pass)) {

--- a/src/library/FOSSBilling/PasswordManager.php
+++ b/src/library/FOSSBilling/PasswordManager.php
@@ -88,8 +88,6 @@ class PasswordManager
     /**
      * Performs a random `password_verify` check.
      * Does not serve a purpose other than to spend some CPU & eliminate timing differences between login attempts on accounts that do and do not exist.
-     * 
-     * @return void
      */
     public function dummyVerify(string $password): void
     {

--- a/src/library/FOSSBilling/PasswordManager.php
+++ b/src/library/FOSSBilling/PasswordManager.php
@@ -84,4 +84,15 @@ class PasswordManager
     {
         return password_needs_rehash($hash, $this->algo, $this->options);
     }
+
+    /**
+     * Performs a random `password_verify` check.
+     * Does not serve a purpose other than to spend some CPU time equal & eliminate timing differences between login attempts on accounts that do and do not exist.
+     * 
+     * @return void
+     */
+    public function dummyVerify(string $password): void
+    {
+        password_verify($password, '$2y$10$v5x5RsGeA.HJebQ2XPMCuO/ae3nws6oA1B.dOvnGxN6f8mNdYMzHe');
+    }
 }

--- a/src/library/FOSSBilling/PasswordManager.php
+++ b/src/library/FOSSBilling/PasswordManager.php
@@ -87,7 +87,7 @@ class PasswordManager
 
     /**
      * Performs a random `password_verify` check.
-     * Does not serve a purpose other than to spend some CPU time equal & eliminate timing differences between login attempts on accounts that do and do not exist.
+     * Does not serve a purpose other than to spend some CPU & eliminate timing differences between login attempts on accounts that do and do not exist.
      * 
      * @return void
      */

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -108,7 +108,7 @@ class Client implements InjectionAwareInterface
             $rate_span = $this->_api_config['rate_span_login'];
             $rate_limit = $this->_api_config['rate_limit_login'];
             
-            // 25 to 250 Ms delay to help prevent email enumeration.
+            // 25 to 250ms delay to help prevent email enumeration.
             usleep(random_int(25000, 250000));
         } else {
             $rate_span = $this->_api_config['rate_span'];

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -107,7 +107,7 @@ class Client implements InjectionAwareInterface
             $isLoginMethod = true;
             $rate_span = $this->_api_config['rate_span_login'];
             $rate_limit = $this->_api_config['rate_limit_login'];
-            
+
             // 25 to 250ms delay to help prevent email enumeration.
             usleep(random_int(25000, 250000));
         } else {

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -102,10 +102,14 @@ class Client implements InjectionAwareInterface
         }
 
         $isLoginMethod = false;
+
         if ($method == 'staff_login' || $method == 'client_login') {
+            $isLoginMethod = true;
             $rate_span = $this->_api_config['rate_span_login'];
             $rate_limit = $this->_api_config['rate_limit_login'];
-            $isLoginMethod = true;
+            
+            // 25 to 250 Ms delay to help prevent email enumeration.
+            usleep(random_int(25000, 250000));
         } else {
             $rate_span = $this->_api_config['rate_span'];
             $rate_limit = $this->_api_config['rate_limit'];

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -592,6 +592,7 @@ class Service implements InjectionAwareInterface
     public function authorizeClient($email, $plainTextPassword)
     {
         $model = $this->di['db']->findOne('Client', 'email = ? AND status = ?', [$email, \Model_Client::ACTIVE]);
+
         return $this->di['auth']->authorizeUser($model, $plainTextPassword);
     }
 

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -592,10 +592,6 @@ class Service implements InjectionAwareInterface
     public function authorizeClient($email, $plainTextPassword)
     {
         $model = $this->di['db']->findOne('Client', 'email = ? AND status = ?', [$email, \Model_Client::ACTIVE]);
-        if ($model == null) {
-            return null;
-        }
-
         return $this->di['auth']->authorizeUser($model, $plainTextPassword);
     }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -765,6 +765,7 @@ class Service implements InjectionAwareInterface
     public function authorizeAdmin($email, $plainTextPassword)
     {
         $model = $this->di['db']->findOne('Admin', 'email = ? AND status = ?', [$email, \Model_Admin::STATUS_ACTIVE]);
+
         return $this->di['auth']->authorizeUser($model, $plainTextPassword);
     }
 }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -765,10 +765,6 @@ class Service implements InjectionAwareInterface
     public function authorizeAdmin($email, $plainTextPassword)
     {
         $model = $this->di['db']->findOne('Admin', 'email = ? AND status = ?', [$email, \Model_Admin::STATUS_ACTIVE]);
-        if ($model == null) {
-            return null;
-        }
-
         return $this->di['auth']->authorizeUser($model, $plainTextPassword);
     }
 }

--- a/tests-legacy/modules/Client/ServiceTest.php
+++ b/tests-legacy/modules/Client/ServiceTest.php
@@ -978,8 +978,15 @@ class ServiceTest extends \BBTestCase
             ->with('Client')
             ->willReturn(null);
 
+        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authMock->expects($this->atLeastOnce())
+            ->method('authorizeUser')
+            ->with(null, $password)
+            ->willReturn(null);
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
+        $di['auth'] = $authMock;
 
         $service = new \Box\Mod\Client\Service();
         $service->setDi($di);

--- a/tests-legacy/modules/Staff/ServiceTest.php
+++ b/tests-legacy/modules/Staff/ServiceTest.php
@@ -1625,8 +1625,15 @@ class ServiceTest extends \BBTestCase
             ->with('Admin', 'email = ? AND status = ?')
             ->willReturn(null);
 
+        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authMock->expects($this->atLeastOnce())
+            ->method('authorizeUser')
+            ->with(null, $password)
+            ->willReturn(null);
+
         $di = new \Pimple\Container();
         $di['db'] = $dbMock;
+        $di['auth'] = $authMock;
 
         $service = new Service();
         $service->setDi($di);

--- a/tests-legacy/modules/Staff/ServiceTest.php
+++ b/tests-legacy/modules/Staff/ServiceTest.php
@@ -95,9 +95,16 @@ class ServiceTest extends \BBTestCase
             ->method('findOne')
             ->willReturn(null);
 
+        $authMock = $this->getMockBuilder('\Box_Authorization')->disableOriginalConstructor()->getMock();
+        $authMock->expects($this->atLeastOnce())
+            ->method('authorizeUser')
+            ->with(null, $password)
+            ->willReturn(null);
+
         $di = new \Pimple\Container();
         $di['events_manager'] = $emMock;
         $di['db'] = $dbMock;
+        $di['auth'] = $authMock;
 
         $service = new Service();
         $service->setDi($di);


### PR DESCRIPTION
This PR adds in delays to help prevent email enumeration by monitoring the request timings when attempting logins.
Without these changes, the timings are rather consistent and it's always longer when email addresses that exist are entered into the box.

This PR makes the timings for all login attempts somewhat random by implementing a random delay and closes the timing gap between attempts with existing email addresses and ones that aren't in the database by performing a dummy password hash verification and adding a small delay to mimic the time it takes to pull added data from the database. 