### PR TITLE
Fix resellerclub ns issue

### DIFF
--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -6,10 +6,11 @@ use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
 {
     public $config = [
-        'api-user-id' => null,
+        'userid' => null,
+        'password' => null,
         'api-key' => null,
-        'username' => null,
-        'ip' => null,
+        'default_ns_1' => null, 
+        'default_ns_2' => null, 
     ];
 
     public function isKeyValueNotEmpty($array, $key)
@@ -52,36 +53,40 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
     public static function getConfig()
     {
         return [
-            'label' => 'Manages domains on Namecheap via API. Namecheap requires your server IP in order to work.',
+            'label' => 'Manages domains on ResellerClub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
             'form' => [
-                'api-user-id' => [
-                    'text', [
-                        'label' => 'Reseller ID',
-                        'description' => 'Namecheap Reseller ID. If you don\'t have one, leave this blank.',
-                        'required' => false,
+                'userid' => [
+                    'text',
+                    [
+                        'label' => 'Reseller ID. You can get this at ResellerClub control panel Settings > Personal information > Primary profile > Reseller ID',
+                        'description' => 'ResellerClub Reseller ID',
                     ],
                 ],
                 'api-key' => [
-                    'password', [
-                        'label' => 'API Key',
-                        'description' => 'You can get this at Namecheap control panel.',
-                        'required' => true,
+                    'password',
+                    [
+                        'label' => 'ResellerClub API Key',
+                        'description' => 'You can get this at ResellerClub control panel, go to Settings -> API',
+                        'required' => false,
                     ],
                 ],
-                'username' => [
-                    'text', [
-                        'label' => 'Namecheap Username',
-                        'description' => 'The username you use to login to the Namecheap control panel.',
-                        'required' => true,
+                'default_ns_1' => [
+                    'text',
+                    [
+                        'label' => 'Default NS1',
+                        'description' => 'NS1 to be used if no custom NS is provided.',
+                        'required' => false,
                     ],
                 ],
-                'ip' => [
-                    'text', [
-                        'label' => 'Server\'s Public IP Address',
-                        'description' => 'Public IP address of this server. Ensure that this IP is whitelisted under your NameCheap settings.',
-                        'required' => true,
+                'default_ns_2' => [
+                    'text',
+                    [
+                        'label' => 'Default NS2',
+                        'description' => 'NS2 to be used if no custom NS is provided.',
+                        'required' => false,
                     ],
                 ],
+
             ],
         ];
     }

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -6,11 +6,10 @@ use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
 {
     public $config = [
-        'userid' => null,
-        'password' => null,
+        'api-user-id' => null,
         'api-key' => null,
-        'default_ns_1' => null, 
-        'default_ns_2' => null, 
+        'username' => null,
+        'ip' => null,
     ];
 
     public function isKeyValueNotEmpty($array, $key)
@@ -53,40 +52,36 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
     public static function getConfig()
     {
         return [
-            'label' => 'Manages domains on ResellerClub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where FOSSBilling is installed to authorize it for API access.',
+            'label' => 'Manages domains on Namecheap via API. Namecheap requires your server IP in order to work.',
             'form' => [
-                'userid' => [
-                    'text',
-                    [
-                        'label' => 'Reseller ID. You can get this at ResellerClub control panel Settings > Personal information > Primary profile > Reseller ID',
-                        'description' => 'ResellerClub Reseller ID',
+                'api-user-id' => [
+                    'text', [
+                        'label' => 'Reseller ID',
+                        'description' => 'Namecheap Reseller ID. If you don\'t have one, leave this blank.',
+                        'required' => false,
                     ],
                 ],
                 'api-key' => [
-                    'password',
-                    [
-                        'label' => 'ResellerClub API Key',
-                        'description' => 'You can get this at ResellerClub control panel, go to Settings -> API',
-                        'required' => false,
+                    'password', [
+                        'label' => 'API Key',
+                        'description' => 'You can get this at Namecheap control panel.',
+                        'required' => true,
                     ],
                 ],
-                'default_ns_1' => [
-                    'text',
-                    [
-                        'label' => 'Default NS1',
-                        'description' => 'NS1 to be used if no custom NS is provided.',
-                        'required' => false,
+                'username' => [
+                    'text', [
+                        'label' => 'Namecheap Username',
+                        'description' => 'The username you use to login to the Namecheap control panel.',
+                        'required' => true,
                     ],
                 ],
-                'default_ns_2' => [
-                    'text',
-                    [
-                        'label' => 'Default NS2',
-                        'description' => 'NS2 to be used if no custom NS is provided.',
-                        'required' => false,
+                'ip' => [
+                    'text', [
+                        'label' => 'Server\'s Public IP Address',
+                        'description' => 'Public IP address of this server. Ensure that this IP is whitelisted under your NameCheap settings.',
+                        'required' => true,
                     ],
                 ],
-
             ],
         ];
     }

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -20,8 +20,8 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         'userid' => null,
         'password' => null,
         'api-key' => null,
-        'default_ns_1' => null, 
-        'default_ns_2' => null, 
+        'default-ns1' => null, 
+        'default-ns2' => null, 
     ];
 
 
@@ -52,14 +52,14 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         }
     
         // Assign default name servers if provided in the options
-        if (isset($options['default_ns_1']) && !empty($options['default_ns_1'])) {
-            $this->config['default_ns_1'] = $options['default_ns_1'];
-            unset($options['default_ns_1']);
+        if (isset($options['default-ns1']) && !empty($options['default-ns1'])) {
+            $this->config['default-ns1'] = $options['default-ns1'];
+            unset($options['default-ns1']);
         }
     
-        if (isset($options['default_ns_2']) && !empty($options['default_ns_2'])) {
-            $this->config['default_ns_2'] = $options['default_ns_2'];
-            unset($options['default_ns_2']);
+        if (isset($options['default-ns2']) && !empty($options['default-ns2'])) {
+            $this->config['default-ns2'] = $options['default-ns2'];
+            unset($options['default-ns2']);
         }
     }
     
@@ -84,7 +84,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
                         'required' => false,
                     ],
                 ],
-                'default_ns_1' => [
+                'default-ns1' => [
                     'text',
                     [
                         'label' => 'Default NS1',
@@ -92,7 +92,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
                         'required' => false,
                     ],
                 ],
-                'default_ns_2' => [
+                'default-ns2' => [
                     'text',
                     [
                         'label' => 'Default NS2',
@@ -333,11 +333,11 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     // Use default name servers if no NS values are provided
     if (empty($ns)) {
-        if (!empty($this->config['default_ns_1'])) {
-            $ns[] = $this->config['default_ns_1'];
+        if (!empty($this->config['default-ns1'])) {
+            $ns[] = $this->config['default-ns1'];
         }
-        if (!empty($this->config['default_ns_2'])) {
-            $ns[] = $this->config['default_ns_2'];
+        if (!empty($this->config['default-ns2'])) {
+            $ns[] = $this->config['default-ns2'];
         }
     }
 


### PR DESCRIPTION
There is an issue in the adapter located at `src/library/Registrar/Adapter/Resellerclub.php`. When attempting to register a domain without configuring at least one hosting server and without selecting the option "I want to use my nameservers," the functions `getNs1` and `getNs2` return empty values. As a result, the registration API request to Resellerclub returns the following error:

```
API RESULT: {"status":"ERROR","message":"Required parameter missing: ns"}
```
To prevent this error, it is sufficient to add two additional fields to the adapter's configuration to specify the nameservers (NS) that will be used if the user does not provide their own.


