### PR TITLE
Slightly improve session fingerprinting

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,7 +37,8 @@
         "jhurliman",
         "jambroseclarke",
         "Egulias",
-        "ICANN"
+        "ICANN",
+        "failovers"
     ],
 
     "ignoreWords": [

--- a/src/di.php
+++ b/src/di.php
@@ -711,7 +711,7 @@ $di['license_server'] = function () use ($di) {
  *
  * @return \FOSSBilling\GeoIP\Reader
  */
-$di['geoip'] = fn (): FOSSBilling\GeoIP\Reader => new FOSSBilling\GeoIP\Reader(PATH_LIBRARY . '/FOSSBilling/GeoIP/Databases/CC0-Country.mmdb');
+$di['geoip'] = fn (): FOSSBilling\GeoIP\Reader => new FOSSBilling\GeoIP\Reader();
 
 /*
  * @param void

--- a/src/library/FOSSBilling/GeoIP/ASN.php
+++ b/src/library/FOSSBilling/GeoIP/ASN.php
@@ -14,8 +14,8 @@ namespace FOSSBilling\GeoIP;
 
 class ASN implements \JsonSerializable
 {
-    private readonly int|float $asnNumber;
-    private readonly string $asnOrg;
+    public readonly int|float $asnNumber;
+    public readonly string $asnOrg;
 
     public function __construct(array $asnRecord)
     {

--- a/src/library/FOSSBilling/GeoIP/Reader.php
+++ b/src/library/FOSSBilling/GeoIP/Reader.php
@@ -24,16 +24,34 @@ class Reader
     private readonly LanguageAlpha2 $language;
 
     /**
+     * Returns the path to the system's `country` database
+     */
+    public static function getCountryDatabase(): string
+    {
+        return PATH_LIBRARY . '/FOSSBilling/GeoIP/Databases/CC0-Country.mmdb';
+    }
+
+    /**
+     * Returns the path to the system's `asn` database
+     */
+    public static function getAsnDatabase(): string
+    {
+        return PATH_LIBRARY . '/FOSSBilling/GeoIP/Databases/PDDL-ASN.mmdb';
+    }
+
+    /**
      * Constructs a new GeoIP reader instance.
      *
-     * @param string $database a path to the database to load
-     * @param string $locale   (Optional) the locale to use for country names. Defaults to the locale being used by FOSSBilling.
+     * @param string|null $database (Optional) a path to the database to load> Will default to the system's country database.
+     * @param string|null $locale   (Optional) the locale to use for country names. Defaults to the locale being used by FOSSBilling.
      *
      * @throws \InvalidArgumentException for invalid database path or unknown arguments
      * @throws InvalidDatabaseException  if the database is invalid or there is an error reading from it
      */
-    public function __construct(string $database, ?string $locale = null)
+    public function __construct(?string $database = null, ?string $locale = null)
     {
+        $database ??= self::getCountryDatabase();
+
         $this->reader = new MaxMindReader($database);
 
         if ($locale === null) {

--- a/src/modules/Security/Service.php
+++ b/src/modules/Security/Service.php
@@ -14,6 +14,7 @@ namespace Box\Mod\Security;
 use FOSSBilling\GeoIP\IncompleteRecord;
 use FOSSBilling\InformationException;
 use FOSSBilling\Interfaces\SecurityCheckInterface;
+use FOSSBilling\GeoIP\Reader;
 
 class Service
 {
@@ -135,7 +136,8 @@ class Service
         }
 
         try {
-            $asnReader = new \FOSSBilling\GeoIP\Reader(PATH_LIBRARY . '/FOSSBilling/GeoIP/Databases/PDDL-ASN.mmdb');
+            $asnPath = Reader::getAsnDatabase();
+            $asnReader = new Reader($asnPath);
             $asnInfo = $asnReader->asn($ip);
         } catch (IncompleteRecord) {
             $asnInfo = [];


### PR DESCRIPTION
This slightly improves session fingerprinting by adding IP country data without a dependency on cloudflare and also introduces the usage of the IP's ASN number.

If it wasn't for tools like Cloudflare potentially causing the ASN to change during typical usage, I likely would have weighed that much more heavily.