### PR TITLE
Fix: old translations were being downloaded

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: 'Download Latest Translations'
         run: |
-          wget https://github.com/FOSSBilling/locale/releases/download/latest/translations.zip -O translations.zip
+          wget https://github.com/FOSSBilling/locale/releases/latest/download/translations.zip -O translations.zip
           mkdir -p ./src/locale
           unzip -o translations.zip -d ./src/locale
 


### PR DESCRIPTION
Turns out, this was downloading the (old, but still existing) release that was tagged as `latest` before we swapped to generating translation tags as a form of versioning. As a result, translations were from June of 2024.

This URL will always point to the most recent one...

Closes #2563