### PR TITLE
Fixed bug: now removing only related to item addons

### DIFF
--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -237,10 +237,16 @@ class Service implements InjectionAwareInterface
         }
 
         if ($removeAddons) {
+            $config_main = json_decode($cartProduct->config, true);
+            $domain_name = $config_main['domain_name'] ?? '';
             $allCartProducts = $this->di['db']->find('CartProduct', 'cart_id = :cart_id', [':cart_id' => $cart->id]);
             foreach ((array) $allCartProducts as $cProduct) {
                 $config = json_decode($cProduct->config, true);
                 if (isset($config['parent_id']) && $config['parent_id'] == $cartProduct->product_id) {
+                    $domain_name_addon = $config['domain_name'] ?? '';
+                    if ($domain_name && $domain_name != $domain_name_addon) {
+                        continue; // Delete addons only for the domain name
+                    }
                     $this->di['db']->trash($cProduct);
                     $this->di['logger']->info('Removed product addon from shopping cart');
                 }


### PR DESCRIPTION
Deleting a product with a domain name from cart now only removes related addons for that domain name, rather than all addons of the same type from the cart.