### PR TITLE
Adds keywords meta tag to huraga pages

### DIFF
--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -9,6 +9,7 @@
     <meta name="csrf-token" content="{{ CSRFToken }}">
 
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
+    <meta name="keywords" content="{{ settings.meta_keywords }}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
     <meta name="generator" content="FOSSBilling">

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -9,6 +9,7 @@
     <meta name="csrf-token" content="{{ CSRFToken }}">
 
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
+    <meta name="keywords" content="{{ settings.meta_keywords }}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">
     <meta name="generator" content="FOSSBilling">


### PR DESCRIPTION
Meta tags can be currently specified in huraga theme settings, and all were being displayed as they should except for keywords that was not displayed. 

This PR corrects that. 