### PR TITLE
Tiny little fixes

### DIFF
--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -183,16 +183,17 @@
                     <p id="time-note" class="float-right-margin" hidden="true">Installation may take up to 30 seconds depending on the speed of your system.</p>
                 </div>
         </form>
-
-            <!-- Below is the "learn more" modal for error and performance reporting -->
-            <dialog id="learn-reporting">
-                <article>
-                    <a href="#close"
-                        aria-label="Close"
-                        class="close"
-                        data-target="learn-reporting"
-                        onClick="toggleModal(event)">
-                    </a>
+        {% endif %}
+        
+        <!-- Below is the "learn more" modal for error and performance reporting -->
+        <dialog id="learn-reporting">
+            <article>
+                <a href="#close"
+                    aria-label="Close"
+                    class="close"
+                    data-target="learn-reporting"
+                    onClick="toggleModal(event)">
+                </a>
                 <h3>Error reporting</h3>
                 <p>FOSSBilling optionally includes automated error reporting which allows us to improve the software and offer better technical support.</p>
                 <p>Reports are collected using <a href="https://sentry.io/welcome/" target='_blank' data-tooltip="Opens in a new tab.">Sentry.io</a> and data is <a href="https://sentry.io/security/" target='_blank' data-tooltip="Opens in a new tab.">retained securely</a> for up to 90 days.</p>
@@ -206,9 +207,8 @@
                         Got it
                     </a>
                 </footer>
-                </article>
-            </dialog>
-        {% endif %}
+            </article>
+        </dialog>
     {% endif %}
 {% endblock %}
 

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_product_configuration.html.twig
@@ -52,6 +52,18 @@
                                     {% endif %}
                                 </div>
                             </div>
+                            {# TODO: This does not seem to be implemented on the back-end
+                            {% if product.allow_quantity_select %}
+                            <div class="row mt-3"> 
+                                <div class="col-12 col-md-4 col-xl-3"> 
+                                    <span>{{ 'Quantity'|trans }}</span> 
+                                </div> 
+                                <div class="col"> 
+                                    <input type="number" name="quantity" value="1" min="1" class="form-control w-50" style="max-width: 120px; text-align: center;"> 
+                                </div> 
+                            </div> 
+                            {% endif %} 
+                            #}
                         </div>
                     {% endset %}
 

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -168,6 +168,7 @@
                             </div>
                         </div>
                     </div>
+                    {# TODO: This does not seem to be implemented on the back-end
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Allow quantity selection on order form'|trans }}:</label>
                         <div class="col">
@@ -181,6 +182,7 @@
                             </div>
                         </div>
                     </div>
+                    #}
                     <div class="form-group mb-3 row">
                         <label class="form-label col-3 col-form-label">{{ 'Quantity in stock'|trans }}:</label>
                         <div class="col">

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -72,7 +72,7 @@ class Guest extends \Api_Abstract
         $config = $this->getMod()->getConfig();
 
         // check ip
-        if (isset($config['allowed_ips']) && isset($config['check_ip']) && $config['check_ip']) {
+        if (!empty($config['allowed_ips']) && isset($config['check_ip']) && $config['check_ip']) {
             $allowed_ips = explode(PHP_EOL, $config['allowed_ips']);
             if ($allowed_ips) {
                 $allowed_ips = array_map(trim(...), $allowed_ips);

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -142,7 +142,7 @@
                             </div>
                             <div class="mb-3 row" id="check_ip"{% if not params.check_ip %} style="display:none;"{% endif %}>
                                 <div class="alert alert-danger" role="alert">
-                                    {{ 'An incorrect configuration of allowed IPs can lead to a complete lockout of the administrator panel. Only use when you have static IP addresses.'|trans }}
+                                    {{ 'WARNING! Incorrect configuration of allowed IPs can lead to a complete lockout of the administrator panel. Only use when you have static IP addresses.'|trans }}
                                 </div>                                  
                                 <label class="col-md-3 col-form-label">{{ 'Allowed IPs. One per line'|trans }}</label>
                                 <div class="col-md-6">

--- a/src/modules/Staff/html_admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_settings.html.twig
@@ -141,6 +141,9 @@
                                 </div>
                             </div>
                             <div class="mb-3 row" id="check_ip"{% if not params.check_ip %} style="display:none;"{% endif %}>
+                                <div class="alert alert-danger" role="alert">
+                                    {{ 'An incorrect configuration of allowed IPs can lead to a complete lockout of the administrator panel. Only use when you have static IP addresses.'|trans }}
+                                </div>                                  
                                 <label class="col-md-3 col-form-label">{{ 'Allowed IPs. One per line'|trans }}</label>
                                 <div class="col-md-6">
                                     <textarea class="form-control" name="allowed_ips" rows="2" placeholder="{{ admin.system_env({ 'ip': 1 }) }}">{{ params.allowed_ips }}</textarea>


### PR DESCRIPTION
Closes #2596 by fixing the modal.

Hides the quantity control options from the UI as it is not implemented in the back-end and otherwise will just create confusion for people. Relates to #2573.

Also made a small change to the IP address lockout functionality for the admin panel, to prevent people from saving an empty list that then prevents them from logging in at all.