### PR TITLE
Fix meta title suffix (and add prefix) fields in Huraga options

### DIFF
--- a/src/themes/huraga/config/settings.html
+++ b/src/themes/huraga/config/settings.html
@@ -185,8 +185,13 @@
 
     <table>
         <tr>
-            <td><label for="meta_title">Meta title suffix</label></td>
-            <td><input type="text" name="meta_title" id="meta_title" value=""></td>
+            <td><label for="meta_title_prefix">Meta title prefix</label></td>
+            <td><input type="text" name="meta_title_prefix" id="meta_title_prefix" value=""></td>
+        </tr>
+
+        <tr>
+            <td><label for="meta_title_suffix">Meta title suffix</label></td>
+            <td><input type="text" name="meta_title_suffix" id="meta_title_suffix" value=""></td>
         </tr>
 
         <tr>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -2,7 +2,7 @@
 <html lang="en" data-bs-theme="{{ settings.theme|default('light') }}">
 <head>
     <meta charset="utf-8">
-    <title>{% block meta_title %}{{ settings.meta_title }}{% endblock %}</title>
+   <title>{{ settings.meta_title_prefix }} {% block meta_title %}{% endblock %} {{ settings.meta_title_suffix }}</title>
 
     <meta property="bb:url" content="{{ constant('SYSTEM_URL') }}">
     <meta property="bb:client_area" content="{{ '/'|link }}">

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en" data-bs-theme="{{ settings.theme|default('light') }}">
 <head>
     <meta charset="utf-8">
-    <title>{% block meta_title %}{{ settings.meta_title }}{% endblock %}</title>
+    <title>{{ settings.meta_title_prefix }} {% block meta_title %}{% endblock %} {{ settings.meta_title_suffix }}</title>
 
     <meta property="bb:url" content="{{ constant('SYSTEM_URL') }}">
     <meta property="bb:client_area" content="{{ '/'|link }}">


### PR DESCRIPTION
In the Huraga theme options there are various meta fields.

One of them is for a title suffix. The option could be set but the suffix was not shown in page titles. 

This PR fixes the suffix display issue and also adds a title prefix field. 

Options page and result displayed in page title as in attached screenshots. 

![Screenshot_20250429_000646](https://github.com/user-attachments/assets/a53540ad-41b7-4f48-8112-c6d9ae5373f9)

![Screenshot_20250429_000602](https://github.com/user-attachments/assets/93924a65-9142-420d-819b-19202d52d2be)
