### PR TITLE
Added a link to the documentation for the instance ID

### DIFF
--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -528,12 +528,12 @@ ZW=Zimbabwe
                                 <div class="datagrid-content">{{ constant('PHP_VERSION') }}</div>
                             </div>
                             <div class="datagrid-item">
-                                <div class="datagrid-title">{{ 'Instance ID'|trans }}</div>
+                                <div class="datagrid-title">{{ 'Instance ID'|trans }} (<a href="https://fossbilling.org/docs/faq/error-reporting#what-is-the-instance-id-and-where-do-i-find-it" target="_blank">?</a>)</div>
                                 <div class="datagrid-content">{{ admin.system_instance_id }}</div>
                             </div>
                             <div class="datagrid-item">
                                 <div class="datagrid-title">{{ 'License'|trans }}</div>
-                                <div class="datagrid-content"><a href="https://github.com/FOSSBilling/FOSSBilling/blob/main/LICENSE">Apache 2.0</a></div>
+                                <div class="datagrid-content"><a href="https://github.com/FOSSBilling/FOSSBilling/blob/main/LICENSE" target="_blank">Apache 2.0</a></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Added a little [link](https://fossbilling.org/docs/faq/error-reporting#what-is-the-instance-id-and-where-do-i-find-it) to the instance ID label so people know what it's for.

Before:
![image](https://github.com/user-attachments/assets/cf6fcdb1-6118-447b-9e85-996f7f4e180d)

After:
![image](https://github.com/user-attachments/assets/f6914a01-95e1-4470-9c57-0f2a7bafe0b4)

Also made the license link open in a new tab when clicked.