### PR TITLE
2 new tools and & fix for additional IP address processing logic

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -273,18 +273,9 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         return sprintf('%d %s ', $no, $pds[$v]);
     }
 
-    public function twig_size_filter($value)
+    public function twig_size_filter($value): string
     {
-        $precision = 2;
-        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
-
-        $bytes = max($value, 0);
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-        $pow = min($pow, count($units) - 1);
-
-        $bytes /= 1024 ** $pow;
-
-        return round($bytes, $precision) . ' ' . $units[$pow];
+        return \FOSSBilling\Tools::humanReadableBytes($value);
     }
 
     public function twig_markdown_filter(Twig\Environment $env, $value)

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -412,4 +412,39 @@ class Tools
 
         return null;
     }
+
+    /**
+     * Checks if the given IP address is in the given subnet.
+     * Only supports IPv4 addresses for now.
+     * 
+     * @param string $ip
+     * @param string $subnet
+     * @return bool
+     */
+    public static function ipInSubnet(string $ip, string $subnet)
+    {
+        list($subnetAddr, $prefix) = explode('/', $subnet);
+        
+        $ip = ip2long($ip);
+        $subnetAddr = ip2long($subnetAddr);
+        
+        $mask = -1 << (32 - $prefix);
+        
+        return ($ip & $mask) === ($subnetAddr & $mask);
+    }
+
+    /**
+     * Converts bytes to a human-readable format (KB, MB, GB).
+     *
+     * @param int $bytes
+     * @return string
+     */
+    public static function humanReadableBytes(int $bytes)
+    {
+        if ($bytes < 1024) return $bytes . ' B';
+        if ($bytes < 1048576) return round($bytes / 1024, 2) . ' KB';
+        if ($bytes < 1073741824) return round($bytes / 1048576, 2) . ' MB';
+        
+        return round($bytes / 1073741824, 2) . ' GB';
+    }
 }

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -435,7 +435,7 @@ class Tools
     }
 
     /**
-     * Converts bytes to a human-readable format (KB, MB, GB).
+     * Converts bytes to a human-readable format (B, KB, MB, GB and TB).
      *
      * @param int $bytes
      * @return string
@@ -445,7 +445,8 @@ class Tools
         if ($bytes < 1024) return $bytes . ' B';
         if ($bytes < 1048576) return round($bytes / 1024, 2) . ' KB';
         if ($bytes < 1073741824) return round($bytes / 1048576, 2) . ' MB';
-        
-        return round($bytes / 1073741824, 2) . ' GB';
+        if ($bytes < 1099511627776) return round($bytes / 1073741824, 2) . ' GB';
+    
+        return round($bytes / 1099511627776, 2) . ' TB';
     }
 }

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -424,6 +424,7 @@ class Tools
     public static function ipInSubnet(string $ip, string $subnet)
     {
         list($subnetAddr, $prefix) = explode('/', $subnet);
+        $prefix = (int) $prefix;
         
         $ip = ip2long($ip);
         $subnetAddr = ip2long($subnetAddr);

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -414,33 +414,12 @@ class Tools
     }
 
     /**
-     * Checks if the given IP address is in the given subnet.
-     * Only supports IPv4 addresses for now.
-     * 
-     * @param string $ip
-     * @param string $subnet
-     * @return bool
-     */
-    public static function ipInSubnet(string $ip, string $subnet)
-    {
-        list($subnetAddr, $prefix) = explode('/', $subnet);
-        $prefix = (int) $prefix;
-        
-        $ip = ip2long($ip);
-        $subnetAddr = ip2long($subnetAddr);
-        
-        $mask = -1 << (32 - $prefix);
-        
-        return ($ip & $mask) === ($subnetAddr & $mask);
-    }
-
-    /**
      * Converts bytes to a human-readable format (B, KB, MB, GB and TB).
      *
      * @param int $bytes
      * @return string
      */
-    public static function humanReadableBytes(int $bytes)
+    public static function humanReadableBytes(int $bytes): string
     {
         if ($bytes < 1024) return $bytes . ' B';
         if ($bytes < 1048576) return round($bytes / 1024, 2) . ' KB';

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -1090,7 +1090,7 @@ class Service implements InjectionAwareInterface
      * Post-processing for the assigned IPs. 
      * The data from the server management form (/admin/servicehosting/server/{id}) sends the data like this:
      * assigned_ips: "10.0.0.1\n10.0.0.2\n"
-     * As you see, it isn't really an array, it also doesn't filter out empty lines and blankspaces at all.
+     * As you see, it isn't really an array, it also doesn't filter out empty lines and whitespaces at all.
      * 
      * We can't rely on it as-is. So we need to make sure only the valid IP addresses are going inside the array.
      * We'll split on any type of line break (\n, \r\n, or \r) and make sure each IP address is valid.


### PR DESCRIPTION
The old logic was broken on Windows as `PHP_EOL` is the platform-dependent newline. It would be `\n` on Linux and `\r\n` in Windows. The form data is sent as e.g. `"10.0.0.1\n10.0.0.2\n"`, so it wouldn't work.

Also added 2 new tools, `ipInSubnet` and `humanReadableBytes` to the Tools class. I'm going to use them in a custom module and thought that the common toolkit can benefit from them.