### PR TITLE
New endpoint to list the accounts of a hosting server & Fixes

### DIFF
--- a/src/modules/Servicehosting/Api/Admin.php
+++ b/src/modules/Servicehosting/Api/Admin.php
@@ -163,8 +163,9 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Get a paginated list of servers.
+     * Get a paginated list of hosting accounts.
      *
+     * @param $data array Accepts the optional "server_id" property
      * @return array
      */
     public function account_get_list($data)

--- a/src/modules/Servicehosting/Api/Admin.php
+++ b/src/modules/Servicehosting/Api/Admin.php
@@ -149,10 +149,9 @@ class Admin extends \Api_Abstract
         $result = $this->di['pager']->getSimpleResultSet($sql, $params, $per_page);
 
         foreach ($result['list'] as $key => $server) {
-            $bean = \RedBeanPHP\R::dispense('ServiceHostingServer');
+            $bean = $this->di['db']->dispense('ServiceHostingServer')->unbox();
             $bean->import($server);
-            $model = new \Model_ServiceHostingServer();
-            $model->loadBean($bean);
+            $model = $bean->box();
 
             $result['list'][$key] = $this->getService()->toHostingServerApiArray($model, false, $this->getIdentity());
         }
@@ -174,10 +173,9 @@ class Admin extends \Api_Abstract
         $orderService = $this->di['mod_service']('order');
 
         foreach ($result['list'] as $key => $account) {
-            $bean = \RedBeanPHP\R::dispense('ServiceHosting');
+            $bean = $this->di['db']->dispense('ServiceHosting')->unbox();
             $bean->import($account);
-            $model = new \Model_ServiceHosting();
-            $model->loadBean($bean);
+            $model = $bean->box();
 
             $order = $this->di['db']->findOne('ClientOrder', 'service_id = :service_id', [':service_id' => $model->id]);
 

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -567,7 +567,6 @@ class Service implements InjectionAwareInterface
         if ($identity instanceof \Model_Admin) {
             $result['ip'] = $model->ip;
             $result['username'] = $model->username;
-            $result['password'] = $model->pass;
             $result['created_at'] = $model->created_at;
             $result['updated_at'] = $model->updated_at;
         }

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -567,7 +567,7 @@ class Service implements InjectionAwareInterface
         if ($identity instanceof \Model_Admin) {
             $result['ip'] = $model->ip;
             $result['username'] = $model->username;
-            $result['password'] = $model->password;
+            $result['password'] = $model->pass;
             $result['created_at'] = $model->created_at;
             $result['updated_at'] = $model->updated_at;
         }
@@ -702,6 +702,23 @@ class Service implements InjectionAwareInterface
                 order by id ASC';
 
         return [$sql, []];
+    }
+
+    public function getAccountsSearchQuery($data): array
+    {
+        $sql = 'SELECT * FROM service_hosting';
+        $params = [];
+
+        $serverID = $data['server_id'] ?? null;
+
+        if (!empty($serverID)) {
+            $sql = $sql . " WHERE service_hosting_server_id = :server_id";
+            $params['server_id'] = $serverID;
+        }
+
+        $sql = $sql . " ORDER BY id ASC";
+
+        return [$sql, $params];
     }
 
     public function createServer($name, $ip, $manager, $data)

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -552,6 +552,29 @@ class Service implements InjectionAwareInterface
         return $result;
     }
 
+    public function toHostingAccountApiArray(\Model_ServiceHosting $model, $deep = false, $identity = null): array
+    {
+        $result = [
+            'id' => $model->id,
+            'sld' => $model->sld,
+            'tld' => $model->tld,
+            'client_id' => $model->client_id,
+            'server_id' => $model->service_hosting_server_id,
+            'plan_id' => $model->service_hosting_hp_id,
+            'reseller' => $model->reseller,
+        ];
+
+        if ($identity instanceof \Model_Admin) {
+            $result['ip'] = $model->ip;
+            $result['username'] = $model->username;
+            $result['password'] = $model->password;
+            $result['created_at'] = $model->created_at;
+            $result['updated_at'] = $model->updated_at;
+        }
+
+        return $result;
+    }
+
     private function _getDomainTuple($data): array
     {
         $required = [

--- a/tests-legacy/modules/Servicehosting/Api/AdminTest.php
+++ b/tests-legacy/modules/Servicehosting/Api/AdminTest.php
@@ -243,11 +243,6 @@ class AdminTest extends \BBTestCase
             ->method('getSimpleResultSet')
             ->willReturn(['list' => []]);
 
-        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('find')
-            ->willReturn([]);
-
         $di = new \Pimple\Container();
         $di['pager'] = $pagerMock;
         $di['db'] = $dbMock;

--- a/tests-legacy/modules/Servicehosting/Api/AdminTest.php
+++ b/tests-legacy/modules/Servicehosting/Api/AdminTest.php
@@ -231,6 +231,29 @@ class AdminTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
+    public function testaccountGetList(): void
+    {
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('getAccountsSearchQuery')
+            ->willReturn(['SQLstring', []]);
+
+        $pagerMock = $this->getMockBuilder('\Box_Pagination')->getMock();
+        $pagerMock->expects($this->atLeastOnce())
+            ->method('getSimpleResultSet')
+            ->willReturn(['list' => []]);
+
+        $di = new \Pimple\Container();
+        $di['pager'] = $pagerMock;
+        $di['db'] = $dbMock;
+
+        $this->api->setDi($di);
+        $this->api->setService($serviceMock);
+
+        $result = $this->api->account_get_list([]);
+        $this->assertIsArray($result);
+    }
+    
     public function testserverGetList(): void
     {
         $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicehosting\Service::class)->getMock();

--- a/tests-legacy/modules/Servicehosting/Api/AdminTest.php
+++ b/tests-legacy/modules/Servicehosting/Api/AdminTest.php
@@ -244,6 +244,7 @@ class AdminTest extends \BBTestCase
             ->willReturn(['list' => []]);
 
         $di = new \Pimple\Container();
+        $di['mod_service'] = $di->protect(fn ($name) => $systemServiceMock);
         $di['pager'] = $pagerMock;
         $di['db'] = $dbMock;
 


### PR DESCRIPTION
Introducing a new endpoint for the Servicehosting module: `account_get_list`.

I think a better name should be used, but I've tried to keep it consistent with `server_get_list`.

Also fixed the server_get_list endpoint. Previously, it was executing the same query twice: once directly via a database call, and again through the pager. The result from the first query was then overwriting the paginated result, breaking the pagination logic. I've removed the redundant first query and the pagination now works.

Regarding the RedBean part, I'm not a big fan of RedBean, if there is a better way to do it, please lmk.