### PR TITLE
Change of heading level for semantic improvement in client themes

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -2,8 +2,6 @@ name: Perform Live Tests
 
 on:
   push:
-  pull_request:
-    branches: main
 
 env:
     DB_HOST: 127.0.0.1
@@ -50,7 +48,7 @@ jobs:
           key: huraga-${{ hashFiles('./package-lock.json', './src/themes/huraga/assets/huraga.js', './src/themes/huraga/assets/scss/*.scss') }}
 
       - name: 'Install Node.js and Enable Caching'
-        if: steps.cache-admin_default.outputs.cache-hit != 'true' && steps.cache-huraga.outputs.cache-hit != 'true'
+        if: steps.cache-admin_default.outputs.cache-hit != 'true' || steps.cache-huraga.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
@@ -58,11 +56,11 @@ jobs:
           node-version: 20
 
       - name: 'Install Node.js Dependencies'
-        if: steps.cache-admin_default.outputs.cache-hit != 'true' && steps.cache-huraga.outputs.cache-hit != 'true'
+        if: steps.cache-admin_default.outputs.cache-hit != 'true' || steps.cache-huraga.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: 'Build Frontend Assets'
-        if: steps.cache-admin_default.outputs.cache-hit != 'true' && steps.cache-huraga.outputs.cache-hit != 'true'
+        if: steps.cache-admin_default.outputs.cache-hit != 'true' || steps.cache-huraga.outputs.cache-hit != 'true'
         run: npm run build
 
       - name: 'Download Latest Translations'
@@ -89,7 +87,10 @@ jobs:
       - name: Setup Apache
         run: |
           sudo apt-get update
-          sudo apt-get install libapache2-mod-php8.3
+          sudo apt-get install --no-install-recommends \
+            libapache2-mod-php8.3 php8.3 php8.3-common php8.3-intl \
+            php8.3-mysql php8.3-xml php8.3-curl php8.3-fpm php8.3-mbstring \
+            php8.3-opcache php8.3-gd
           sudo a2enmod php8.3
           sudo systemctl start apache2
           sudo a2enmod rewrite

--- a/src/modules/Client/html_client/mod_client_balance.html.twig
+++ b/src/modules/Client/html_client/mod_client_balance.html.twig
@@ -15,7 +15,7 @@
                 <div class="card-header py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Wallet'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Wallet'|trans }}</h1>
                             <span class="small text-muted">{{ 'Here you can manage and track your account balance.'|trans }}</span>
                         </div>
                         <form method="post" class="form-inline api-form d-flex gap-2 justify-content-end" action="{{ 'api/client/invoice/funds_invoice'|link }}" data-api-jsonp="onAfterInvoiceCreated">

--- a/src/modules/Custompages/html_client/mod_custompages_content.html.twig
+++ b/src/modules/Custompages/html_client/mod_custompages_content.html.twig
@@ -13,7 +13,7 @@
             <div class="card mb-4">
                 <div class="card-header py-3">
                     <div class="d-flex justify-content-between align-items-center">
-                        <h5 class="mb-1">{{ page.title }}</h5>
+                        <h1 class="mb-1">{{ page.title }}</h1>
                     </div>
                 </div>
                 <div class="card-body">

--- a/src/modules/Email/html_client/mod_email_index.html.twig
+++ b/src/modules/Email/html_client/mod_email_index.html.twig
@@ -14,7 +14,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Emails'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Emails'|trans }}</h1>
                             <span class="small text-muted">{{ "Here you can find all the emails we've sent you."|trans }}</span>
                         </div>
                     </div>

--- a/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_banklink.html.twig
@@ -13,7 +13,7 @@
     <div class="col-md-12">
         <div class="card mb-4">
             <div class="card-header">
-                <h5>{{ 'Processing payment ...'|trans }}</h5>
+                <h1>{{ 'Processing payment ...'|trans }}</h1>
                 <p>{{ 'Thank you for your patience.'|trans }}</p>
             </div>
             <div class="card-body">

--- a/src/modules/Invoice/html_client/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_client/mod_invoice_index.html.twig
@@ -15,7 +15,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Invoices'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Invoices'|trans }}</h1>
                             <span class="small text-muted">
                                 {{ 'All of your invoices can be found here. You can choose to see either paid or unpaid invoices by clicking corresponding button.'|trans }}
                             </span>

--- a/src/modules/News/html_client/mod_news_index.html.twig
+++ b/src/modules/News/html_client/mod_news_index.html.twig
@@ -13,7 +13,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'News & Announcements'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'News & Announcements'|trans }}</h1>
                             <span class="small text-muted">{{ 'Track our latest information.'|trans }}</span>
                         </div>
                     </div>

--- a/src/modules/Order/html_client/mod_order_index.html.twig
+++ b/src/modules/Order/html_client/mod_order_index.html.twig
@@ -20,7 +20,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="w-100">
-                            <h5 class="mb-1">{{ 'Products'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Products'|trans }}</h1>
                             {% include 'mod_orderbutton_currency.html.twig' %}
                         </div>
                     </div>

--- a/src/modules/Order/html_client/mod_order_list.html.twig
+++ b/src/modules/Order/html_client/mod_order_list.html.twig
@@ -16,7 +16,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Services'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Services'|trans }}</h1>
                             <span class="small text-muted">{{ 'All of your orders are displayed here. Click on any service to get full information about it.'|trans }}</span>
                         </div>
                     </div>

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -23,7 +23,7 @@
                 <div class="card-header py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Service details'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Service details'|trans }}</h1>
                             <span class="small text-secondary">{{ 'All information about your service'|trans }}</span>
                         </div>
                     </div>
@@ -123,7 +123,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Addons'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Addons'|trans }}</h1>
                             <span class="small text-secondary">{{ 'Addons you have ordered with this service'|trans }}</span>
                         </div>
                     </div>

--- a/src/modules/Order/html_client/mod_order_product.html.twig
+++ b/src/modules/Order/html_client/mod_order_product.html.twig
@@ -20,7 +20,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div class="w-100">
-                            <h5 class="mb-1">{{ 'Products'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Products'|trans }}</h1>
                             {% include 'mod_orderbutton_currency.html.twig' %}
                         </div>
                     </div>

--- a/src/modules/Page/html_client/mod_page_about-us.html.twig
+++ b/src/modules/Page/html_client/mod_page_about-us.html.twig
@@ -16,7 +16,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'About us'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'About us'|trans }}</h1>
                             <span class="small text-muted">
                                 {{ company.signature }}
                             </span>

--- a/src/modules/Page/html_client/mod_page_login.html.twig
+++ b/src/modules/Page/html_client/mod_page_login.html.twig
@@ -24,7 +24,7 @@
             {% endif %}
             <div class="card">
                 <div class="card-body">
-                    <h5 class="text-center m-4">{{ 'Login to your account'|trans }}</h5>
+                    <h1 class="text-center m-4">{{ 'Login to your account'|trans }}</h1>
                     <form class="api-form auth" action="{{ 'api/guest/client/login'|link }}" method="post" data-api-redirect="{{ redirect_uri|default('/')|link }}">
                         <div class="mb-3">
                             <label class="form-label" for="email">{{ 'Email'|trans }}</label>

--- a/src/modules/Page/html_client/mod_page_password-reset.html.twig
+++ b/src/modules/Page/html_client/mod_page_password-reset.html.twig
@@ -23,7 +23,7 @@
             {% endif %}
             <div class="card">
                 <div class="card-body">
-                    <h5 class="text-center m-4">{{ 'Reset your password'|trans }}</h5>
+                    <h1 class="text-center m-4">{{ 'Reset your password'|trans }}</h1>
                     <form class="api-form auth" action="{{ 'api/guest/client/reset_password'|link }}" method="post" data-api-msg="{{ 'A password reset confirmation email will be sent to you if we found an account with that email address.'|trans }}">
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="mb-3">

--- a/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
+++ b/src/modules/Page/html_client/mod_page_privacy-policy.html.twig
@@ -16,7 +16,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ company.name }} {{ 'Privacy Policy'|trans }}</h5>
+                            <h1 class="mb-1">{{ company.name }} {{ 'Privacy Policy'|trans }}</h1>
                             <span class="small text-muted">
                                 {{ company.signature }}
                             </span>

--- a/src/modules/Page/html_client/mod_page_signup.html.twig
+++ b/src/modules/Page/html_client/mod_page_signup.html.twig
@@ -26,7 +26,7 @@
                 {% endif %}
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="text-center m-4">{{ 'Create a new account'|trans }}</h5>
+                        <h1 class="text-center m-4">{{ 'Create a new account'|trans }}</h1>
                         <form class="api-form auth" action="{{ 'api/guest/client/create'|link }}" method="post" data-api-redirect="{{ '/'|link }}">
                             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             {% set r = guest.client_required %}

--- a/src/modules/Page/html_client/mod_page_tos.html.twig
+++ b/src/modules/Page/html_client/mod_page_tos.html.twig
@@ -16,7 +16,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ company.name }} {{ 'Terms and Conditions'|trans }}</h5>
+                            <h1 class="mb-1">{{ company.name }} {{ 'Terms and Conditions'|trans }}</h1>
                             <span class="small text-muted">
                                 {{ company.signature }}
                             </span>

--- a/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/html_client/mod_servicedomain_manage.html.twig
@@ -2,7 +2,7 @@
     <div class="card mb-4">
         <div class="card-header">
             <div class="flex-column align-items-center py-2">
-                <h5 class="mb-1">{{ 'Manage'|trans }} {{ service.domain }}</h5>
+                <h1 class="mb-1">{{ 'Manage'|trans }} {{ service.domain }}</h1>
             </div>
             <nav class="nav nav-tabs card-header-tabs">
                 <a class="nav-link active" id="details-tab" data-bs-toggle="tab" data-bs-target="#details-tab-pane"

--- a/src/modules/Support/html_client/mod_support_contact_us.html.twig
+++ b/src/modules/Support/html_client/mod_support_contact_us.html.twig
@@ -21,7 +21,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Contact us'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Contact us'|trans }}</h1>
                             <span class="small text-muted">{{ company.signature }}</span>
                         </div>
                     </div>

--- a/src/modules/Support/html_client/mod_support_kb_article.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_article.html.twig
@@ -19,7 +19,7 @@
         <div class="card mb-4">
             <div class="card-header py-3 py-3">
                 <div class="d-flex justify-content-between align-items-center">
-                        <h5 class="mb-1">{{ article.title }}</h5>
+                        <h1 class="mb-1">{{ article.title }}</h1>
                         <span class="small text-muted">{{ article.views }} {{ 'views'|trans }}</span>
                 </div>
             </div>

--- a/src/modules/Support/html_client/mod_support_kb_category.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_category.html.twig
@@ -15,7 +15,7 @@
             <div class="card-header py-3 py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h5 class="mb-1">{{ category.title }}</h5>
+                        <h1 class="mb-1">{{ category.title }}</h1>
                         <span class="small text-muted">{{ category.description }}</span>
                     </div>
                 </div>

--- a/src/modules/Support/html_client/mod_support_kb_index.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_index.html.twig
@@ -27,7 +27,7 @@
                 <div class="card-header py-3 py-3">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <h5 class="mb-1">{{ 'Categories'|trans }}</h5>
+                            <h1 class="mb-1">{{ 'Categories'|trans }}</h1>
                             <span class="small text-muted">{{ 'Explore our knowledge base categories and their associated articles below.'|trans }}</span>
                         </div>
                         <form method="get" action="" class="form-inline">

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -19,7 +19,7 @@
             <div class="card-header py-3 py-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <div>
-                        <h5 class="mb-1">{{ 'Support tickets'|trans }}</h5>
+                        <h1 class="mb-1">{{ 'Support tickets'|trans }}</h1>
                         <span class="mt-1 small text-secondary">{{ 'Need an answer? We are here to help!'|trans }}</span>
                     </div>
                     <div>

--- a/src/themes/huraga/assets/scss/huraga.scss
+++ b/src/themes/huraga/assets/scss/huraga.scss
@@ -40,6 +40,10 @@ body {
     }
 }
 
+.card-header h1 {
+    font-size: 1.25rem;
+}
+
 .card-body {
     @at-root table {
         >thead {

--- a/src/themes/huraga/assets/scss/huraga.scss
+++ b/src/themes/huraga/assets/scss/huraga.scss
@@ -40,7 +40,7 @@ body {
     }
 }
 
-.card-header h1 {
+.card-header h1, .page-password-reset .card h1, .page-login .card h1, .page-signup .card h1 {
     font-size: 1.25rem;
 }
 


### PR DESCRIPTION
Heading levels are used wrongly throughout modules, with most pages ending up with no h1 - h4 headings and the main page title being h5, with some random h6 thrown in here and there. 

This PR does not resolve all of the semantic heading issues (which I will revisit in the near future) but it does change the ones that are most obviously wrong, so that the main title/heading of most pages in the client area is an h1.

Why?

Semantic headings are important for screen-readers, so when they skip levels it is an accessibility issue. Headings shouldn't skip levels for no reason -  using h5 here implies there are h1–h4 headings above it (which there aren't).

These should be h1 because they are the main heading of the page’s primary content, and are always the first, and in most cases  the only, heading inside the main content area of the page.

Also included is a small CSS addition so that there is no visual change from the way that these titles are currently displayed in Huraga.



