### PR TITLE
Adding #chevron-down

### DIFF
--- a/src/themes/admin_default/assets/icons/chevron-down.svg
+++ b/src/themes/admin_default/assets/icons/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-chevron-down"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 9l6 6l6 -6" /></svg>


### PR DESCRIPTION
I'm using it for a custom module, it makes sense to have it included here for accordions and other stuff.
![image](https://github.com/user-attachments/assets/a035a0cf-d62c-41e9-a8e0-8da82e5ba153)
