### PR TITLE
Add body class to layout_public

### DIFF
--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -27,7 +27,7 @@
     {% block head %}{% endblock %}
     {% block js %}{% endblock %}
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
     {% block body %}{% endblock %}
     <div aria-live="polite" aria-atomic="true" class="position-relative">
         <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1070;"></div>


### PR DESCRIPTION
`<body class="{% block body_class %}{% endblock %}">` was implemented in layout_default but not layout_public meaning that styles on login, signup, etc. pages that are targetted at, for example, `.page-login .card h1` were not being applied. 