### PR TITLE
Fix renewal date extension issue when marking first invoice as paid. 

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -421,6 +421,16 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
+    public function findPaidInvoicesForOrder(\Model_ClientOrder $order): array
+    {
+        $bindings = [
+            ':rel_id' => $order->id,
+            ':status' => \Model_Invoice::STATUS_PAID,
+        ];
+
+        return $this->di['db']->find('Invoice', 'id IN (SELECT invoice_id FROM invoice_item WHERE rel_id = :rel_id) AND status = :status', $bindings);
+    }
+
     public function getNextInvoiceNumber()
     {
         $systemService = $this->di['mod_service']('system');

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -421,6 +421,14 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
+    /**
+     * Finds all paid invoices associated with a given client order.
+     *
+     * @param \Model_ClientOrder $order The client order for which to find paid invoices.
+     * 
+     * @return array An array of paid invoices. Each element in the array represents an invoice record
+     *               as returned by the database, typically as an associative array or an object.
+     */
     public function findPaidInvoicesForOrder(\Model_ClientOrder $order): array
     {
         $bindings = [

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -631,7 +631,7 @@ class Service implements InjectionAwareInterface
 
             $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
 
-            // mark order as paid on creation
+            // mark invoice as paid on creation
             if (!empty($data['mark_invoice_paid']) && $invoice instanceof \Model_Invoice) {
                 $invoiceService->markAsPaid($invoice);
             }

--- a/src/modules/Order/html_admin/mod_order_new.html.twig
+++ b/src/modules/Order/html_admin/mod_order_new.html.twig
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="mb-3 row">
-                <label class="form-label col-3 col-form-label">{{ 'Activate order'|trans }}:</label>
+                <label class="form-label col-3 col-form-label">{{ 'Activate order'|trans }}</label>
                 <div class="col">
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" id="radioEnabledYes" type="radio" name="activate" value="1" checked>
@@ -67,6 +67,16 @@
             {% if admin.system_template_exists({ 'file': product_order }) %}
                 {% include product_order %}
             {% endif %}
+
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Mark invoice as paid'|trans }}</label>
+                <div class="col">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="mark_invoice_paid" name="mark_invoice_paid" value="1">
+                        <label class="form-check-label" for="mark_invoice_paid">{{ 'Confirm that the first invoice has already been paid by the client'|trans }}.</label>
+                    </div>
+                </div>
+            </div>
 
             <input type="hidden" name="client_id" value="{{ client.id }}">
             <input type="hidden" name="product_id" value="{{ product.id }}">

--- a/tests-legacy/modules/Order/ServiceTest.php
+++ b/tests-legacy/modules/Order/ServiceTest.php
@@ -1737,23 +1737,21 @@ class ServiceTest extends \BBTestCase
             ->getMock();
         $serviceMock->expects($this->atLeastOnce())
             ->method('_callOnService');
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('saveStatusChange');
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
         $clientOrderModel->period = '1Y';
 
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
-        $periodMock->expects($this->atLeastOnce())
-            ->method('getExpirationTime');
 
         $dbMock = $this->getMockBuilder('Box_Database')->getMock();
-        $dbMock->expects($this->atLeastOnce())
-            ->method('store')
-            ->with($clientOrderModel);
+
+        $invoiceServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Invoice\Service::class)->getMock();
+        $invoiceServiceMock->expects($this->atLeastOnce())
+            ->method('findPaidInvoicesForOrder');
 
         $di = new \Pimple\Container();
         $di['mod_config'] = $di->protect(fn ($name) => []);
+        $di['mod_service'] = $di->protect(fn () => $invoiceServiceMock);
         $di['period'] = $di->protect(fn () => $periodMock);
         $di['db'] = $dbMock;
 


### PR DESCRIPTION
Should resolve #2693 

Checks if any previous invoices have been paid and does not extend renewal date upon being marked as paid if this is the first invoice for a service. Subsequent invoices continue to extend renewal date as expected. 

Also introduces a checkbox on the admin create order page, to mark an order as paid on creation. 

Notes:

@admdly I know you are doing stuff with orders, I'm 99.99% certain that this won't have any effect on anything you are touching, but just glance in case. 

The admin create order page looks very disjointed because the activation option is a radio button and I've just introduced a checkbox for payment. I prefer the checkbox because it feels like more of an explicit choice, but I'd like opinions. Also there are some weird vertical alignment issues between columns in that form, but I'll look at those separately. 