### PR TITLE
Display permission errors on API endpoints

### DIFF
--- a/src/library/Api/Handler.php
+++ b/src/library/Api/Handler.php
@@ -17,6 +17,10 @@ final class Api_Handler implements InjectionAwareInterface
     protected $ip;
     protected ?Pimple\Container $di = null;
 
+    /**
+     * @var bool $_acl_exception When true, ACL permission denials are reported as exceptions.
+     *                          Defaults to true.
+     */
     private bool $_acl_exception = true;
 
     public function __construct(protected $identity)


### PR DESCRIPTION
I don't know why this was disabled, but it really makes diagnostics harder. I spent quite some time wondering why the API was returning null for seemingly no reason.

For modules that the user was denied access from, this used to return:
```json
{
    "result": null,
    "error": null
}
```

Now this returns:
```json
{
    "result": null,
    "error": {
        "message": "You do not have access to the servicehosting module",
        "code": 725
    }
}
```