### PR TITLE
Fix DirectAdmin package matching and reseller account creation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -68,19 +68,19 @@ parameters:
 		-
 			message: '#^Call to an undefined method Server_Package\:\:getMaxEmailAutoresponders\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 4
 			path: src/library/Server/Manager/Directadmin.php
 
 		-
 			message: '#^Call to an undefined method Server_Package\:\:getMaxEmailForwarders\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 4
 			path: src/library/Server/Manager/Directadmin.php
 
 		-
 			message: '#^Call to an undefined method Server_Package\:\:getMaxEmailLists\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 4
 			path: src/library/Server/Manager/Directadmin.php
 
 		-

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -410,8 +410,7 @@ class Server_Manager_Directadmin extends Server_Manager
         if ($account->getReseller()) {
             $command = 'ACCOUNT_RESELLER';
 
-            $fields['ips'] = 1; // Number of ips that will be allocated to the Reseller upon account during account
-            $fields['ip'] = 'assign';
+            $fields['ip'] = 'shared'; // Workaround: use shared IP for reseller accounts until support for dedicated IPs is added.
         }
 
         try {

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -182,7 +182,7 @@ class Server_Manager_Directadmin extends Server_Manager
                 'bandwidth' => $package->getBandwidth(), // Bandwidth quota in MB
                 'catchall' => $package->getCustomValue('catchall') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
                 'cgi' => $package->getCustomValue('cgi') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-                'cron' => $package->getCustomValue('cron') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to creat cronjobs.
+                'cron' => $package->getCustomValue('cron') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to create cronjobs.
                 'dnscontrol' => $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be able to modify his/her dns records.
                 'domainptr' => $package->getMaxParkedDomains(), // Domain pointer quota
                 'ftp' => $package->getMaxFtp(), // FTP account quota


### PR DESCRIPTION
Fix DirectAdmin package matching to use server package where package names match for account creation and package change. Resolves #505.

Also, add workaround to fix DirectAdmin reseller account creation pending support for dedicated/multiple IPs. Closes #2306.