### PR TITLE
Fix the message for the dangerous functions check

### DIFF
--- a/src/modules/Security/Checks/dangerousFunctions.php
+++ b/src/modules/Security/Checks/dangerousFunctions.php
@@ -78,7 +78,7 @@ class dangerousFunctions implements \FOSSBilling\Interfaces\SecurityCheckInterfa
             }
         }
 
-        if ($state === 'pass') {
+        if ($state === SecurityCheckResultEnum::PASS) {
             return new SecurityCheckResult(SecurityCheckResultEnum::PASS, __trans('No potentially dangerous PHP functions were detected as enabled'));
         } else {
             return new SecurityCheckResult(SecurityCheckResultEnum::WARN, $result);


### PR DESCRIPTION
This check was comparing against the wrong value, causing it to always fail and end up displaying a confusing screen for users:
![image](https://github.com/user-attachments/assets/087b9f2f-8f6c-4681-8f24-4fe6c7e88f0f)
