### PR TITLE
Fix permission & navigation bugs

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -698,19 +698,14 @@ class Service implements InjectionAwareInterface
                 continue;
             }
 
-            // If getSpecificModulePermissions returns false, we need to skip that module and not include it in the permissions list
-            $permissions = $this->getSpecificModulePermissions($module, true);
-            if ($permissions === false) {
-                continue;
-            } else {
-                $modules[$module]['permissions'] = $permissions;
-            }
+            $permissions = $this->getSpecificModulePermissions($module);
+            $modules[$module]['permissions'] = $permissions;
         }
 
         return $modules;
     }
 
-    public function getSpecificModulePermissions(string $module, bool $buildingCompleteList = false): array|false
+    public function getSpecificModulePermissions(string $module): array|false
     {
         $class = 'Box\Mod\\' . ucfirst($module) . '\Service';
         if (class_exists($class) && method_exists($class, 'getModulePermissions')) {
@@ -720,22 +715,20 @@ class Service implements InjectionAwareInterface
             }
             $permissions = $moduleService->getModulePermissions();
 
-            if (isset($permissions['hide_permissions']) && $permissions['hide_permissions']) {
-                return $buildingCompleteList ? false : [];
-            } else {
+            if (isset($permissions['hide_permissions']) && !$permissions['hide_permissions']) {
                 unset($permissions['hide_permissions']);
-
-                // Fill in the manage_settings permission as it will always be the same
-                if (isset($permissions['manage_settings'])) {
-                    $permissions['manage_settings'] = [
-                        'type' => 'bool',
-                        'display_name' => __trans('Manage settings'),
-                        'description' => __trans('Allows the staff member to edit settings for this module.'),
-                    ];
-                }
-
-                return $permissions;
             }
+
+            // Fill in the manage_settings permission as it will always be the same
+            if (isset($permissions['manage_settings'])) {
+                $permissions['manage_settings'] = [
+                    'type' => 'bool',
+                    'display_name' => __trans('Manage settings'),
+                    'description' => __trans('Allows the staff member to edit settings for this module.'),
+                ];
+            }
+
+            return $permissions;
         }
 
         return [];

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -272,7 +272,7 @@ class Service implements InjectionAwareInterface
 
         $modules = $this->di['mod']('extension')->getCoreModules();
         $installed = $this->getInstalledMods();
-        $list = array_merge($modules, $installed);
+        $list = array_unique(array_merge($modules, $installed));
         foreach ($list as $mod) {
             if (!$staff_service->hasPermission($admin, $mod)) {
                 continue;

--- a/src/modules/Security/Service.php
+++ b/src/modules/Security/Service.php
@@ -34,7 +34,6 @@ class Service
     {
         return [
             'can_always_access' => true,
-            'hide_permissions' => false,
             'run_checks' => [
                 'type' => 'bool',
                 'display_name' => __trans('Run security checks'),

--- a/src/modules/Security/Service.php
+++ b/src/modules/Security/Service.php
@@ -34,7 +34,7 @@ class Service
     {
         return [
             'can_always_access' => true,
-            'hide_permissions' => true,
+            'hide_permissions' => false,
             'run_checks' => [
                 'type' => 'bool',
                 'display_name' => __trans('Run security checks'),

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -162,7 +162,7 @@ class Service implements InjectionAwareInterface
         $modulePermissions = $extensionService->getSpecificModulePermissions($module);
         $permissions = $this->getPermissions($member->id);
 
-        if ($modulePermissions === false || $modulePermissions === []) {
+        if ($modulePermissions['hide_permissions'] ?? false) {
             $canAlwaysAccess = true;
         } else {
             $canAlwaysAccess = $modulePermissions['can_always_access'] ?? false;

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -162,7 +162,12 @@ class Service implements InjectionAwareInterface
         $modulePermissions = $extensionService->getSpecificModulePermissions($module);
         $permissions = $this->getPermissions($member->id);
 
-        $canAlwaysAccess = $modulePermissions['can_always_access'] ?? false;
+        if ($modulePermissions === false || $modulePermissions === []) {
+            $canAlwaysAccess = true;
+        } else {
+            $canAlwaysAccess = $modulePermissions['can_always_access'] ?? false;
+        }
+
         if (!$canAlwaysAccess) {
             // They have no permissions or don't have any access to that module
             if (empty($permissions) || !array_key_exists($module, $permissions) || !is_array($permissions[$module]) || !($permissions[$module]['access'] ?? false)) {
@@ -170,15 +175,17 @@ class Service implements InjectionAwareInterface
             }
         }
 
-        // If this passes, the permission key isn't assigned to them and they therefore don't have permission
-        if ((!is_null($key) && !is_array($permissions[$module])) || (!is_null($key) && !array_key_exists($key, $permissions[$module]))) {
-            return false;
-        }
+        if (!is_null($key)) {
+            // If this passes, the permission key isn't assigned to them and they therefore don't have permission
+            if (!is_array($permissions[$module]) || !array_key_exists($key, $permissions[$module])) {
+                return false;
+            }
 
-        if (!is_null($key) && !is_null($constraint)) {
-            return $permissions[$module][$key] === $constraint;
-        } elseif (!is_null($key)) {
-            return (bool) $permissions[$module][$key];
+            if (!is_null($constraint)) {
+                return $permissions[$module][$key] === $constraint;
+            } else {
+                return (bool) $permissions[$module][$key];
+            }
         }
 
         return true;

--- a/src/modules/Staff/html_admin/mod_staff_manage.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_manage.html.twig
@@ -148,7 +148,7 @@
 								<input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">
 								<input type="hidden" name="permissions[default]" value="">
 
-								{% for modName, mod in mods %}
+								{% for modName, mod in mods|filter(mod => mod.permissions.hide_permissions is not true) %}
 									<div class="row">
 										<div class="col-1"></div>
 										<div class="col-2">


### PR DESCRIPTION
- Fixed an issue with the permissions system reporting no access if a module has it's permissions hidden.
- Fixed where I accidentally hid the permissions for the security module. That + plus the other issue caused it to be hidden for any non-admin accounts. Closes #2738
- Fixed an oversight with the navigation generation logic which allowed module navigation to be registered multiple times, duplicating entries.
- Slightly cleaned up the permissions logic to remove a tiny bit of complexity