### PR TITLE
Fixing Direct Server Login from Orders Tab

### DIFF
--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -82,30 +82,26 @@ class Server_Manager_Whm extends Server_Manager
      *
      * @return string the login URL
      */
-    public function getLoginUrl(?Server_Account $account = null): string
+ public function getLoginUrl(?Server_Account $account = null): string
     {
         if ($account) {
-            // API action for creating a user session
+            $action = 'create_user_session';
             $params = [
                 'api.version' => 2,
                 'user' => $account->getUsername(),
                 'service' => 'cpaneld',
             ];
-
+    
             try {
-                // Call the request function
                 $response = $this->request($action, $params);
-                // Check if the response is an object and access it accordingly
                 if (isset($response->data->url)) {
                     return $response->data->url;
                 } else {
                     $this->getLog()->err('Unexpected API response: ' . print_r($response, true));
-
                     return 'https://' . $this->_config['host'] . '/cpanel';
                 }
             } catch (Server_Exception $e) {
                 $this->getLog()->err('Failed to get login URL: ' . $e->getMessage());
-
                 return 'https://' . $this->_config['host'] . '/cpanel';
             }
         } else {


### PR DESCRIPTION
The $action variable was not defined in the original causing a error.

This fixes the issue.