### PR TITLE
fix: improve HTTPS detection in system URL initialization

### DIFF
--- a/src/load.php
+++ b/src/load.php
@@ -257,7 +257,7 @@ function init(): void
     define('INSTANCE_ID', Config::getProperty('info.instance_id', 'Unknown'));
 
     // Set the system URL.
-    $scheme = Config::getProperty('security.force_https', true) || $request->isSecure() ? 'https://' : 'http://';
+    $scheme = Config::getProperty('security.force_https', true) || FOSSBilling\Tools::isHTTPS() ? 'https://' : 'http://';
     define('SYSTEM_URL', $scheme . Config::getProperty('url'));
 
     // Set the default interface.


### PR DESCRIPTION
The current implementation for detecting SSL relies solely on the connection itself, which fails when the server is behind a reverse proxy. In such cases, the connection may appear as HTTP, even though the end user accesses the site over HTTPS.

This PR replaces `$request->isSecure` with `FOSSBilling\Tools::isHTTPS`, which properly accounts for reverse proxy headers and aligns with the logic used during the installation process at https://github.com/FOSSBilling/FOSSBilling/blob/6076b4083876f8bcd433b0a5836ab3db21910338/src/install/install.php#L62 . 