### PR TITLE
Fix oversight in protocol handling

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2930,16 +2930,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v17.3.0",
+            "version": "v17.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c"
+                "reference": "893946057e43b145826b0dfd7f398673e381e2ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c",
-                "reference": "cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/893946057e43b145826b0dfd7f398673e381e2ae",
+                "reference": "893946057e43b145826b0dfd7f398673e381e2ae",
                 "shasum": ""
             },
             "require": {
@@ -2983,9 +2983,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v17.3.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v17.4.0"
             },
-            "time": "2025-05-28T18:59:29+00:00"
+            "time": "2025-07-01T20:23:15+00:00"
         },
         {
             "name": "symfony/asset",

--- a/src/load.php
+++ b/src/load.php
@@ -79,7 +79,7 @@ function checkSSL(): void
     global $request;
 
     if (!empty(Config::getProperty('security.force_https')) && Config::getProperty('security.force_https') && !Environment::isCLI()) {
-        if (!FOSSBilling\Tools::isHTTPS()) {
+        if (!Tools::isHTTPS()) {
             header('Location: https://' . $request->getHost() . $request->getRequestUri());
             exit;
         }
@@ -257,8 +257,8 @@ function init(): void
     define('INSTANCE_ID', Config::getProperty('info.instance_id', 'Unknown'));
 
     // Set the system URL.
-    $scheme = Config::getProperty('security.force_https', true) || FOSSBilling\Tools::isHTTPS() ? 'https://' : 'http://';
-    
+    $scheme = Config::getProperty('security.force_https', true) || Tools::isHTTPS() ? 'https://' : 'http://';
+
     // Keep the app working correctly if the URL didn't get correctly updated
     $url = str_replace(['https://', 'http://'], '', Config::getProperty('url'));
     define('SYSTEM_URL', $scheme . $url);


### PR DESCRIPTION
As an oversight when using Symfony request, FOSSBilling no longer correctly works with reverse proxies.

This PR temporarily reverts back to using out own SSL check to restore the app back to it's previous behavior.

Additionally, I added some code to help handle situations where the apps URL doesn't get updated as someone on our discord experienced that issue