### PR TITLE
Re-enable the network interface tests

### DIFF
--- a/tests/Modules/System/AdminTest.php
+++ b/tests/Modules/System/AdminTest.php
@@ -59,10 +59,6 @@ final class AdminTest extends TestCase
         }
     }
 
-    /*
-     * The following tests are disabled as they require reworking and are causing test failures.
-     *
-
     public function testGetAndSetNetworkInterfaces(): void
     {
         // Get the list of network interfaces, validate the response is as expected
@@ -129,6 +125,4 @@ final class AdminTest extends TestCase
         $this->assertTrue($result->wasSuccessful(), $result->generatePHPUnitMessage());
         $this->assertTrue($result->getResult());
     }
-
-    */
 }


### PR DESCRIPTION
I am pretty sure a Symfomy HTTP client bug was causing the issue we saw. Some time ago they published fixes related to the BIND_TO option with IPv6