### PR TITLE
Fix downloadable products

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -405,6 +405,78 @@ class UpdatePatcher implements InjectionAwareInterface
                 ];
                 $this->executeFileActions($fileActions);
             },
+            44 => function (): void {
+                // Patch to fix servicedownloadable products where filename was lost from config
+                // due to bug in saveProductConfig that reset config to empty array
+                // @see https://github.com/FOSSBilling/FOSSBilling/issues/xxxx
+                
+                $filesystem = new \Symfony\Component\Filesystem\Filesystem();
+                
+                // Find all downloadable products
+                $q = "SELECT p.id, p.config FROM product p WHERE p.type = 'downloadable'";
+                $products = $this->di['pdo']->query($q)->fetchAll(\PDO::FETCH_ASSOC);
+                
+                foreach ($products as $product) {
+                    $productConfig = json_decode($product['config'], true);
+                    if (!is_array($productConfig)) {
+                        $productConfig = [];
+                    }
+                    
+                    // Skip if product already has a filename configured
+                    if (isset($productConfig['filename']) && !empty($productConfig['filename'])) {
+                        continue;
+                    }
+                    
+                    // Find orders for this product
+                    $orderQuery = "SELECT co.id, co.config, co.service_id FROM client_order co WHERE co.product_id = :product_id";
+                    $orderStmt = $this->di['pdo']->prepare($orderQuery);
+                    $orderStmt->execute(['product_id' => $product['id']]);
+                    $orders = $orderStmt->fetchAll(\PDO::FETCH_ASSOC);
+                    
+                    $foundFilename = null;
+                    
+                    // Check each order for a valid filename
+                    foreach ($orders as $order) {
+                        $orderConfig = json_decode($order['config'], true);
+                        if (!is_array($orderConfig) || !isset($orderConfig['filename'])) {
+                            continue;
+                        }
+                        
+                        $order_filename = $orderConfig['filename'];
+                        $hashedFilename = md5($order_filename);
+                        $filePath = PATH_UPLOADS . DIRECTORY_SEPARATOR . $hashedFilename;
+                        
+                        // Check if the file exists
+                        if ($filesystem->exists($filePath)) {
+                            $foundFilename = $order_filename;
+
+                            // Update the related servicedownloadable record that might have wrong filename
+                            $updateServiceQuery = "UPDATE service_downloadable SET filename = :filename WHERE id = :service_id";
+                            $updateServiceStmt = $this->di['pdo']->prepare($updateServiceQuery);
+                            $updateServiceStmt->execute([
+                                'filename' => $foundFilename,
+                                'service_id' => $order['service_id']
+                            ]);
+                            break;
+                        }
+                    }
+
+                    // If we found a valid filename, update the product config
+                    if ($foundFilename !== null) {
+                        $productConfig['filename'] = $foundFilename;
+                        $newConfigJson = json_encode($productConfig);
+                        $updateProductQuery = "UPDATE product SET config = :config, updated_at = :updated_at WHERE id = :id";
+                        $updateProductStmt = $this->di['pdo']->prepare($updateProductQuery);
+                        $updateProductStmt->execute([
+                            'config' => $newConfigJson,
+                            'updated_at' => date('Y-m-d H:i:s'),
+                            'id' => $product['id']
+                        ]);
+                        
+                        
+                    }
+                }
+            },
         ];
         ksort($patches, SORT_NATURAL);
 

--- a/src/modules/Servicedownloadable/Api/Admin.php
+++ b/src/modules/Servicedownloadable/Api/Admin.php
@@ -90,7 +90,6 @@ class Admin extends \Api_Abstract
         return $service->saveProductConfig($model, $data);
     }
 
-
     /**
      * Send file for download for a specific product.
      * This is similar to the client send_file but uses product instead of order.

--- a/src/modules/Servicedownloadable/Api/Admin.php
+++ b/src/modules/Servicedownloadable/Api/Admin.php
@@ -89,4 +89,26 @@ class Admin extends \Api_Abstract
 
         return $service->saveProductConfig($model, $data);
     }
+
+
+    /**
+     * Send file for download for a specific product.
+     * This is similar to the client send_file but uses product instead of order.
+     *
+     * @return bool
+     */
+    public function send_file($data)
+    {
+        $required = [
+            'id' => 'Product ID is missing',
+        ];
+
+        $this->di['validator']->checkRequiredParamsForArray($required, $data);
+
+        $model = $this->di['db']->getExistingModelById('Product', $data['id'], 'Product not found');
+
+        $service = $this->getService();
+
+        return (bool) $service->sendProductFile($model);
+    }
 }

--- a/src/modules/Servicedownloadable/Controller/Admin.php
+++ b/src/modules/Servicedownloadable/Controller/Admin.php
@@ -33,11 +33,11 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     public function get_download(\Box_App $app, $id)
     {
         $this->di['is_admin_logged'];
-        
+
         $api = $this->di['api_admin'];
         $data = [
             'id' => $id,
         ];
         $api->servicedownloadable_send_file($data);
     }
-} 
+}

--- a/src/modules/Servicedownloadable/Controller/Admin.php
+++ b/src/modules/Servicedownloadable/Controller/Admin.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright 2022-2025 FOSSBilling
+ * Copyright 2011-2021 BoxBilling, Inc.
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace Box\Mod\Servicedownloadable\Controller;
+
+class Admin implements \FOSSBilling\InjectionAwareInterface
+{
+    protected ?\Pimple\Container $di = null;
+
+    public function setDi(\Pimple\Container $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function getDi(): ?\Pimple\Container
+    {
+        return $this->di;
+    }
+
+    public function register(\Box_App &$app)
+    {
+        $app->get('/servicedownloadable/get-file/:id', 'get_download', ['id' => '[0-9]+'], static::class);
+    }
+
+    public function get_download(\Box_App $app, $id)
+    {
+        $this->di['is_admin_logged'];
+        
+        $api = $this->di['api_admin'];
+        $data = [
+            'id' => $id,
+        ];
+        $api->servicedownloadable_send_file($data);
+    }
+} 

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -321,8 +321,8 @@ class Service implements InjectionAwareInterface
      * This method sends a file attached to a product for admin download.
      * Unlike the regular sendFile method, this doesn't increment download counts.
      *
-     * @param \Model_Product $product
      * @return bool
+     *
      * @throws \FOSSBilling\Exception
      */
     public function sendProductFile(\Model_Product $product)
@@ -337,7 +337,7 @@ class Service implements InjectionAwareInterface
         $filesystem = new Filesystem();
         $fileName = $config['filename'];
         $filePath = Path::normalize(PATH_UPLOADS . md5($fileName));
-        
+
         if (!$filesystem->exists($filePath)) {
             throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
         }

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -198,9 +198,8 @@ class Service implements InjectionAwareInterface
             foreach ($orders as $order) {
                 $ordermodel = $this->di['db']->getExistingModelById('ClientOrder', $order['id']);
                 $serviceDownloadable = $orderService->getOrderService($ordermodel);
-                $this->updateProductFile($serviceDownloadable, $ordermodel);
 
-                // Update the filename
+                // Update the filename in the order config
                 $oldconfig = json_decode($order['config'], 1);
                 $oldconfig['filename'] = $fileName;
 
@@ -208,6 +207,11 @@ class Service implements InjectionAwareInterface
                 $ordermodel->config = json_encode($oldconfig);
                 $ordermodel->updated_at = date('Y-m-d H:i:s');
                 $this->di['db']->store($ordermodel);
+                // Update the filename in the servicedownloadable record
+                $serviceDownloadable->filename = $fileName;
+                $serviceDownloadable->updated_at = date('Y-m-d H:i:s');
+                $this->di['db']->store($serviceDownloadable);
+                
             }
         }
 

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -211,7 +211,6 @@ class Service implements InjectionAwareInterface
                 $serviceDownloadable->filename = $fileName;
                 $serviceDownloadable->updated_at = date('Y-m-d H:i:s');
                 $this->di['db']->store($serviceDownloadable);
-                
             }
         }
 

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -304,11 +304,64 @@ class Service implements InjectionAwareInterface
 
     public function saveProductConfig(\Model_Product $productModel, $data)
     {
-        $config = [];
+        $config = json_decode($productModel->config, 1);
+        if (!is_array($config)) {
+            $config = [];
+        }
         $config['update_orders'] = isset($data['update_orders']) && (bool) $data['update_orders'];
         $productModel->config = json_encode($config);
         $productModel->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($productModel);
+
+        return true;
+    }
+
+    /**
+     * Send product file for download.
+     * This method sends a file attached to a product for admin download.
+     * Unlike the regular sendFile method, this doesn't increment download counts.
+     *
+     * @param \Model_Product $product
+     * @return bool
+     * @throws \FOSSBilling\Exception
+     */
+    public function sendProductFile(\Model_Product $product)
+    {
+        $config = $product->config;
+        isset($config) ? $config = json_decode($config, true) : $config = [];
+
+        if (!isset($config['filename'])) {
+            throw new \FOSSBilling\Exception('No file associated with this product', null, 404);
+        }
+
+        $filesystem = new Filesystem();
+        $fileName = $config['filename'];
+        $filePath = Path::normalize(PATH_UPLOADS . md5($fileName));
+        
+        if (!$filesystem->exists($filePath)) {
+            throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
+        }
+
+        // Send the file for download, unless in testing environment.
+        if (!Environment::isTesting()) {
+            $response = new Response($filesystem->readFile($filePath));
+
+            $disposition = $response->headers->makeDisposition(
+                HeaderUtils::DISPOSITION_ATTACHMENT,
+                $fileName
+            );
+
+            $response->headers->set('Content-Type', 'application/force-download');
+            $response->headers->set('Content-Type', 'application/octet-stream');
+            $response->headers->set('Content-Type', 'application/download');
+            $response->headers->set('Content-Description', 'File Transfer');
+            $response->headers->set('Content-Disposition', $disposition);
+            $response->headers->set('Content-Transfer-Encoding', 'binary');
+
+            $response->send();
+        }
+
+        $this->di['logger']->info('Downloaded product %s file by admin', $product->id);
 
         return true;
     }

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
@@ -1,10 +1,7 @@
-<div class="card-nody">
+<div class="card-body">
     <h5>{{ 'File'|trans }}</h5>
-
-
-    <form method="post" action="{{ '/api/admin/servicedownloadable/config_save'|link }}" class="api-form" data-api-msg="Settings updated">
-
         <div class="row mb-3">
+            <form method="post" action="{{ '/api/admin/servicedownloadable/config_save'|link }}" class="api-form" data-api-msg="Settings updated">
             <label class="col-md-3 form-label">
                 {{ 'Keep Orders Updated'|trans }}
             </label>
@@ -18,40 +15,39 @@
                     <label class="form-check-label">No</label>
                 </div>
             </div>
+            <input type="hidden" name="id" value="{{ product.id }}">
+            <input type="submit" value="{{ 'Save config'|trans }}" class="btn btn-primary w-100" id="upload-button">
+        </form>
         </div>
-        <input type="hidden" name="id" value="{{ product.id }}">
-        <input type="submit" value="{{ 'Save config'|trans }}" class="btn btn-primary w-100" id="bb-upload-button">
-    </form>
-    <form method="post" action="" class="" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
-        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
-        {% if product.config.filename  %}
-        <div class="mb-3 row">
-            <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>
-            <div class="col">
-                {{ product.config.filename  }}
+    <div class="row mb-3">
+        <form method="post" action="" class="" enctype="multipart/form-data" target="uploadframe" id="upload-form">
+            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+            {% if product.config.filename  %}
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>
+                <div class="col align-content-center">
+                    <a href="{{ 'servicedownloadable/get-file'|alink }}/{{ product.id }}" target="_blank">{{ product.config.filename }}</a>
+                </div>
             </div>
-        </div>
-        {% endif %}
+            {% endif %}
 
-        <div class="mb-3 row">
-            <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
-            <div class="col">
-                <input class="form-control" type="file" name="file_data" id="file_data">
+            <div class="mb-3 row">
+                <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
+                <div class="col">
+                    <input class="form-control" type="file" name="file_data" id="file_data">
+                </div>
             </div>
-        </div>
-
-
-
-        <input type="hidden" name="id" value="{{ product.id }}">
-        <input type="submit" value="{{ 'Upload'|trans }}" class="btn btn-primary w-100" id="bb-upload-button">
-    </form>
+            <input type="hidden" name="id" value="{{ product.id }}">
+            <input type="submit" value="{{ 'Upload'|trans }}" class="btn btn-primary w-100" id="upload-button">
+        </form>
+    </div>
 </div>
 
 <script>
 $(function() {
     $('body').append('<iframe id="uploadframe" name="uploadframe" style="display:none" />');
 
-    $('#bb-upload-form').on('submit', function() {
+    $('#upload-form').on('submit', function() {
         $(this).attr('action', bb.restUrl('admin/servicedownloadable/upload'));
 
         iframe = $('#uploadframe').load(function() {

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
@@ -22,7 +22,7 @@
     <h3>{{ 'Upload new file for this order'|trans }}</h3>
     <p class="text-muted">{{ 'Use this function to update existing order file. Client will be able to download new file from client area'|trans }}</p>
 
-    <form method="post" action="" enctype="multipart/form-data" target="uploadframe" id="bb-upload-form">
+    <form method="post" action="" enctype="multipart/form-data" target="uploadframe" id="upload-form">
         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
@@ -31,7 +31,7 @@
             </div>
         </div>
 
-        <input type="submit" value="{{ 'Upload'|trans }}" class="btn btn-primary submitForm" id="bb-upload-button">
+        <input type="submit" value="{{ 'Upload'|trans }}" class="btn btn-primary submitForm" id="upload-button">
 
         <input type="hidden" name="order_id" value="{{ order.id }}">
     </form>
@@ -41,7 +41,7 @@
 $(function() {
     $('body').append('<iframe id="uploadframe" name="uploadframe" style="display:none" />');
 
-    $('#bb-upload-form').on('submit', function(){
+    $('#upload-form').on('submit', function(){
         $(this).attr('action', bb.restUrl('admin/servicedownloadable/update'));
 
         iframe = $('#uploadframe').load(function() {

--- a/tests-legacy/modules/Servicedownloadable/Api/AdminTest.php
+++ b/tests-legacy/modules/Servicedownloadable/Api/AdminTest.php
@@ -88,4 +88,97 @@ class AdminTest extends \BBTestCase
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
+
+    public function testconfig_save(): void
+    {
+        $data = [
+            'id' => 1,
+            'update_orders' => true,
+        ];
+
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $productModel->config = '{"filename": "test.txt"}';
+
+        $serviceMock = $this->getMockBuilder('\\' . \Box\Mod\Servicedownloadable\Service::class)->getMock();
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('saveProductConfig')
+            ->with($productModel, $data)
+            ->willReturn(true);
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('getExistingModelById')
+            ->with('Product', $data['id'], 'Product not found')
+            ->willReturn($productModel);
+
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->with(['id' => 'Product ID is missing'], $data)
+            ->willReturn(null);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['validator'] = $validatorMock;
+
+        $this->api->setDi($di);
+        $this->api->setService($serviceMock);
+        
+        $result = $this->api->config_save($data);
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+    }
+
+    public function testconfig_save_MissingId(): void
+    {
+        $data = [
+            'update_orders' => true,
+        ];
+
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->with(['id' => 'Product ID is missing'], $data)
+            ->willThrowException(new \FOSSBilling\Exception('Product ID is missing'));
+
+        $di = new \Pimple\Container();
+        $di['validator'] = $validatorMock;
+
+        $this->api->setDi($di);
+        
+        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectExceptionMessage('Product ID is missing');
+        $this->api->config_save($data);
+    }
+
+    public function testconfig_save_ProductNotFound(): void
+    {
+        $data = [
+            'id' => 999,
+            'update_orders' => true,
+        ];
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('getExistingModelById')
+            ->with('Product', $data['id'], 'Product not found')
+            ->willThrowException(new \FOSSBilling\Exception('Product not found'));
+
+        $validatorMock = $this->getMockBuilder('\\' . \FOSSBilling\Validate::class)->disableOriginalConstructor()->getMock();
+        $validatorMock->expects($this->atLeastOnce())
+            ->method('checkRequiredParamsForArray')
+            ->with(['id' => 'Product ID is missing'], $data)
+            ->willReturn(null);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+        $di['validator'] = $validatorMock;
+
+        $this->api->setDi($di);
+        
+        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectExceptionMessage('Product not found');
+        $this->api->config_save($data);
+    }
 }

--- a/tests-legacy/modules/Servicedownloadable/Api/AdminTest.php
+++ b/tests-legacy/modules/Servicedownloadable/Api/AdminTest.php
@@ -89,7 +89,7 @@ class AdminTest extends \BBTestCase
         $this->assertTrue($result);
     }
 
-    public function testconfig_save(): void
+    public function testconfigSave(): void
     {
         $data = [
             'id' => 1,
@@ -124,13 +124,13 @@ class AdminTest extends \BBTestCase
 
         $this->api->setDi($di);
         $this->api->setService($serviceMock);
-        
+
         $result = $this->api->config_save($data);
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
 
-    public function testconfig_save_MissingId(): void
+    public function testconfigSaveMissingId(): void
     {
         $data = [
             'update_orders' => true,
@@ -146,13 +146,13 @@ class AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
-        
+
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Product ID is missing');
         $this->api->config_save($data);
     }
 
-    public function testconfig_save_ProductNotFound(): void
+    public function testconfigSaveProductNotFound(): void
     {
         $data = [
             'id' => 999,
@@ -176,7 +176,7 @@ class AdminTest extends \BBTestCase
         $di['validator'] = $validatorMock;
 
         $this->api->setDi($di);
-        
+
         $this->expectException(\FOSSBilling\Exception::class);
         $this->expectExceptionMessage('Product not found');
         $this->api->config_save($data);

--- a/tests-legacy/modules/Servicedownloadable/ServiceTest.php
+++ b/tests-legacy/modules/Servicedownloadable/ServiceTest.php
@@ -118,10 +118,10 @@ class ServiceTest extends \BBTestCase
 
         $this->service->setDi($di);
         $result = $this->service->saveProductConfig($productModel, $data);
-        
+
         $this->assertIsBool($result);
         $this->assertTrue($result);
-        
+
         // Verify the config was updated correctly
         $updatedConfig = json_decode($productModel->config, true);
         $this->assertIsArray($updatedConfig);
@@ -151,10 +151,10 @@ class ServiceTest extends \BBTestCase
 
         $this->service->setDi($di);
         $result = $this->service->saveProductConfig($productModel, $data);
-        
+
         $this->assertIsBool($result);
         $this->assertTrue($result);
-        
+
         // Verify the config was updated correctly
         $updatedConfig = json_decode($productModel->config, true);
         $this->assertIsArray($updatedConfig);
@@ -184,10 +184,10 @@ class ServiceTest extends \BBTestCase
 
         $this->service->setDi($di);
         $result = $this->service->saveProductConfig($productModel, $data);
-        
+
         $this->assertIsBool($result);
         $this->assertTrue($result);
-        
+
         // Verify the config was created correctly
         $updatedConfig = json_decode($productModel->config, true);
         $this->assertIsArray($updatedConfig);

--- a/tests-legacy/modules/Servicedownloadable/ServiceTest.php
+++ b/tests-legacy/modules/Servicedownloadable/ServiceTest.php
@@ -96,4 +96,102 @@ class ServiceTest extends \BBTestCase
         $this->service->setDi($di);
         $this->service->action_delete($clientOrderModel);
     }
+
+    public function testsaveProductConfig(): void
+    {
+        $data = [
+            'update_orders' => true,
+        ];
+
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $productModel->config = '{"filename": "test.txt"}';
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('store')
+            ->with($productModel)
+            ->willReturn(1);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+
+        $this->service->setDi($di);
+        $result = $this->service->saveProductConfig($productModel, $data);
+        
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+        
+        // Verify the config was updated correctly
+        $updatedConfig = json_decode($productModel->config, true);
+        $this->assertIsArray($updatedConfig);
+        $this->assertEquals('test.txt', $updatedConfig['filename']);
+        $this->assertTrue($updatedConfig['update_orders']);
+        $this->assertNotNull($productModel->updated_at);
+    }
+
+    public function testsaveProductConfigWithExistingConfig(): void
+    {
+        $data = [
+            'update_orders' => false,
+        ];
+
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $productModel->config = '{"filename": "existing.txt", "update_orders": true}';
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('store')
+            ->with($productModel)
+            ->willReturn(1);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+
+        $this->service->setDi($di);
+        $result = $this->service->saveProductConfig($productModel, $data);
+        
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+        
+        // Verify the config was updated correctly
+        $updatedConfig = json_decode($productModel->config, true);
+        $this->assertIsArray($updatedConfig);
+        $this->assertEquals('existing.txt', $updatedConfig['filename']);
+        $this->assertFalse($updatedConfig['update_orders']);
+        $this->assertNotNull($productModel->updated_at);
+    }
+
+    public function testsaveProductConfigWithNoExistingConfig(): void
+    {
+        $data = [
+            'update_orders' => true,
+        ];
+
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $productModel->config = null;
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->getMock();
+        $dbMock->expects($this->atLeastOnce())
+            ->method('store')
+            ->with($productModel)
+            ->willReturn(1);
+
+        $di = new \Pimple\Container();
+        $di['db'] = $dbMock;
+
+        $this->service->setDi($di);
+        $result = $this->service->saveProductConfig($productModel, $data);
+        
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+        
+        // Verify the config was created correctly
+        $updatedConfig = json_decode($productModel->config, true);
+        $this->assertIsArray($updatedConfig);
+        $this->assertTrue($updatedConfig['update_orders']);
+        $this->assertNotNull($productModel->updated_at);
+    }
 }


### PR DESCRIPTION
This PR fixes some issues with the downloadable products implementation. 

- [x] fixes a bug in the downloadable products that overwrote the product configuration when the product configuration was saved by an admin. This caused downloads not to work because the original filename was lost.
- [x] Tries to restore the filenames from orders that have not yet been touched. 
- [x] Fixes that downloadable products could not be overwritten when in a broken state
- [x] Fixes layout of the form 
- [x] Removes some `bb-` naming
- [x] Adds tests for the configuration saving 
- [x] Adds ability for admin to download file



