### PR TITLE
Power chaos cwp tempfix

### DIFF
--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -177,23 +177,33 @@ class Mail
      *
      * @throws InformationException if the SMTP host or port is not configured
      */
-    private function __smtpDsn(array $options): string
-    {
-        if (empty($options['smtp_host']) || empty($options['smtp_port'])) {
-            throw new InformationException('SMTP host or port is not configured');
-        }
-
-        $host = urlencode(trim($options['smtp_host']));
-
-        if (!empty($options['smtp_username'])) {
-            $username = urlencode(trim($options['smtp_username']));
-            $pass = urlencode(trim($options['smtp_password'] ?? ''));
-
-            $authString = !empty($pass) ? $username . ':' . $pass : $username;
-
-            return "smtp://$authString@" . $host . ':' . $options['smtp_port'];
-        } else {
-            return 'smtp://' . $host . ':' . $options['smtp_port'];
-        }
+private function __smtpDsn(array $options): string
+{
+    if (empty($options['smtp_host']) || empty($options['smtp_port'])) {
+        throw new InformationException('SMTP host or port is not configured');
     }
+
+    $host = urlencode(trim($options['smtp_host']));
+    $port = (int) $options['smtp_port'];
+
+    if (!empty($options['smtp_username'])) {
+        $username = urlencode(trim($options['smtp_username']));
+        $pass = urlencode(trim($options['smtp_password'] ?? ''));
+        $authString = !empty($pass) ? $username . ':' . $pass : $username;
+
+        if ($port === 25) {
+            // Geen SSL, geen TLS, geen validatie
+            return "smtp://$authString@$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
+        }
+
+        return "smtp://$authString@$host:$port";
+    } else {
+        // Geen authenticatie
+        if ($port === 25) {
+            return "smtp://$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
+        }
+
+        return "smtp://$host:$port";
+    }
+}
 }

--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -177,33 +177,33 @@ class Mail
      *
      * @throws InformationException if the SMTP host or port is not configured
      */
-private function __smtpDsn(array $options): string
-{
-    if (empty($options['smtp_host']) || empty($options['smtp_port'])) {
-        throw new InformationException('SMTP host or port is not configured');
-    }
-
-    $host = urlencode(trim($options['smtp_host']));
-    $port = (int) $options['smtp_port'];
-
-    if (!empty($options['smtp_username'])) {
-        $username = urlencode(trim($options['smtp_username']));
-        $pass = urlencode(trim($options['smtp_password'] ?? ''));
-        $authString = !empty($pass) ? $username . ':' . $pass : $username;
-
-        if ($port === 25) {
-            // Geen SSL, geen TLS, geen validatie
-            return "smtp://$authString@$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
-        }
-
-        return "smtp://$authString@$host:$port";
-    } else {
-        // Geen authenticatie
-        if ($port === 25) {
-            return "smtp://$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
-        }
-
-        return "smtp://$host:$port";
-    }
-}
+	private function __smtpDsn(array $options): string
+	{
+		if (empty($options['smtp_host']) || empty($options['smtp_port'])) {
+			throw new InformationException('SMTP host or port is not configured');
+		}
+	
+		$host = urlencode(trim($options['smtp_host']));
+		$port = (int) $options['smtp_port'];
+	
+		if (!empty($options['smtp_username'])) {
+			$username = urlencode(trim($options['smtp_username']));
+			$pass = urlencode(trim($options['smtp_password'] ?? ''));
+			$authString = !empty($pass) ? $username . ':' . $pass : $username;
+	
+			if ($port === 25) {
+				// No SSL and No Verification 
+				return "smtp://$authString@$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
+			}
+	
+			return "smtp://$authString@$host:$port";
+		} else {
+			// No Verification
+			if ($port === 25) {
+				return "smtp://$host:$port?verify_peer=0&verify_peer_name=0&allow_self_signed=1";
+			}
+	
+			return "smtp://$host:$port";
+		}
+	}
 }


### PR DESCRIPTION
CWP fix if using local and FPM php so it does not trow the 503 error and cause it to fail, CWP restart FPM at creation of new account and cause the 503 error and script termination, so now it just push the commands and thinks it is fine,

Only Reset password ( user side ), Create,Cancel and Delete are working, everything else does not work at the moment
but atleast it can now be used to automatic deploy accounts

only tested on my own server with the following setup

CWP Pro / CLI php 8.2
Fossbilling / FPM PHP 8.2
Multi PHP setup ( FPM PHP 7.4 and 8.2 )

to explain it easy, it is a known problem of CWP in general
because it restart all services related to httpd ( apache / nginx ) and certainly the FPM processes, so they get killed off as soon cwp create a new account

The work around for this is to use the normal CLI PHP , but because of performance i still like to use the FPM PHP service

also fixed mail.php with english comments and spacing