### PR TITLE
Fix missing directory separator in _loadTheme

### DIFF
--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -364,8 +364,7 @@ class Service implements InjectionAwareInterface
         }
         $list = array_unique($list);
         foreach ($list as $mod) {
-            $p = Path::join(PATH_MODS, ucfirst($mod));
-            $p .= $client ? 'html_client' : 'html_admin';
+            $p = Path::join(PATH_MODS, ucfirst($mod), $client ? 'html_client' : 'html_admin');
             if ($this->filesystem->exists($p)) {
                 $paths[] = $p;
             }


### PR DESCRIPTION
In this commit 315f9f3, the filesystem api was migrated.
But we forgot to add trailing slash in the end.

Which made the `paths` in `theme` missing modules paths.
The previus code was searching for (notice the missing slash):
` /var/www/html/modules/Servicehostinghtml_admin/mod_servicehosting_config.html.twig`

I fixed it by adding the template folder to the `Path::join` which will add slash, and now the modules paths will resolve correctly.