### PR TITLE
Fix/checkout before login

### DIFF
--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -1,4 +1,4 @@
-{% set cart = guest.cart_get%}
+{% set cart = guest.cart_get %}
 <div class="accordion-item">
     <h2 class="accordion-header">
         <button class="accordion-button {% if not request.checkout %}collapsed{%endif%}" type="button" data-bs-toggle="collapse" data-bs-target="#checkout" aria-expanded="false" aria-controls="checkout">
@@ -191,7 +191,7 @@
                                                 </label>
                                             </div>
                                         {% endif %}
-                                        <button class="btn btn-primary btn-large" type="submit">{{ 'Checkout'|trans }}</button>
+                                        <button id="checkoutButton" class="btn btn-primary btn-large" type="submit" {% if not client %} disabled {% endif %}>{{ 'Checkout'|trans }}</button>
                                     </div>
                                 </div>
                             </fieldset>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_checkout.html.twig
@@ -191,7 +191,8 @@
                                                 </label>
                                             </div>
                                         {% endif %}
-                                        <button id="checkoutButton" class="btn btn-primary btn-large" type="submit" {% if not client %} disabled {% endif %}>{{ 'Checkout'|trans }}</button>
+                                        <button id="checkoutButton" class="btn btn-primary btn-large" type="submit" {% if not client %} hidden="true" {% endif %}>{{ 'Checkout'|trans }}</button>
+                                        <p id="loginMessage" {% if client %} hidden="true" {% endif %}>{{ 'You must first login / create an account before you can checkout.'|trans }}</p>
                                     </div>
                                 </div>
                             </fieldset>

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
@@ -109,7 +109,8 @@
         FOSSBilling.message("{{ 'You logged in successfully'|trans }}");
         let registerEl = document.getElementById('register');
         new bootstrap.Collapse('#register').hide();
-        document.querySelector("#checkoutButton").disabled = false;
+        document.querySelector("#checkoutButton").hidden = false;
+        document.querySelector("#loginMessage").hidden = true;
         setTimeout(() => {
             registerEl.parentElement.remove();
             new bootstrap.Collapse('#checkout').show();
@@ -129,7 +130,8 @@
                 FOSSBilling.message("{{ 'You logged in successfully'|trans }}");
                 let registerEl = document.getElementById('register');
                 new bootstrap.Collapse('#register').hide();
-                document.querySelector("#checkoutButton").disabled = false;
+                document.querySelector("#checkoutButton").hidden = false;
+                document.querySelector("#loginMessage").hidden = true;
                 setTimeout(() => {
                     registerEl.parentElement.remove();
                     new bootstrap.Collapse('#checkout').show();

--- a/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
+++ b/src/modules/Orderbutton/html_client/mod_orderbutton_index.html.twig
@@ -109,6 +109,7 @@
         FOSSBilling.message("{{ 'You logged in successfully'|trans }}");
         let registerEl = document.getElementById('register');
         new bootstrap.Collapse('#register').hide();
+        document.querySelector("#checkoutButton").disabled = false;
         setTimeout(() => {
             registerEl.parentElement.remove();
             new bootstrap.Collapse('#checkout').show();
@@ -128,6 +129,7 @@
                 FOSSBilling.message("{{ 'You logged in successfully'|trans }}");
                 let registerEl = document.getElementById('register');
                 new bootstrap.Collapse('#register').hide();
+                document.querySelector("#checkoutButton").disabled = false;
                 setTimeout(() => {
                     registerEl.parentElement.remove();
                     new bootstrap.Collapse('#checkout').show();


### PR DESCRIPTION
Replaces the checkout button with a message informing the user that they need to login or register.
Once they do so, the message is hidden and the checkout button comes back.

Closes #2873

<img width="1067" height="804" alt="image" src="https://github.com/user-attachments/assets/d95cc4a8-b513-45fd-9f6d-2b5bb964610d" />
