### PR TITLE
Partial revert of added strict types

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/index.php
+++ b/src/index.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/ipn.php
+++ b/src/ipn.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Api/Abstract.php
+++ b/src/library/Api/Abstract.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/Event.php
+++ b/src/library/Box/Event.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/Mod.php
+++ b/src/library/Box/Mod.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/Box/TwigLoader.php
+++ b/src/library/Box/TwigLoader.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/library/PdoSessionHandler.php
+++ b/src/library/PdoSessionHandler.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /*
  * This file is part of the Symfony package.
  *

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Formbuilder/Service.php
+++ b/src/modules/Formbuilder/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Massmailer/Service.php
+++ b/src/modules/Massmailer/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Page/Service.php
+++ b/src/modules/Page/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Product/Api/Admin.php
+++ b/src/modules/Product/Api/Admin.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Seo/Service.php
+++ b/src/modules/Seo/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Servicecustom/Service.php
+++ b/src/modules/Servicecustom/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Servicelicense/Service.php
+++ b/src/modules/Servicelicense/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Spamchecker/Service.php
+++ b/src/modules/Spamchecker/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Theme/Controller/Admin.php
+++ b/src/modules/Theme/Controller/Admin.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Theme/Model/Theme.php
+++ b/src/modules/Theme/Model/Theme.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
  * Copyright 2011-2021 BoxBilling, Inc.


### PR DESCRIPTION
This is a partial revert of the strict types added in #2836.
Specifically, I removed it from older code that frequently breaks with stricter typing added.

Confirmed broken by the changes were Serviceapikey and Servicehosting