### PR TITLE
Bug: Servicehosting API returning wrong order data

### DIFF
--- a/src/modules/Servicehosting/Api/Admin.php
+++ b/src/modules/Servicehosting/Api/Admin.php
@@ -178,7 +178,7 @@ class Admin extends \Api_Abstract
             $bean->import($account);
             $model = $bean->box();
 
-            $order = $this->di['db']->findOne('ClientOrder', 'service_id = :service_id', [':service_id' => $model->id]);
+            $order = $this->di['db']->findOne('ClientOrder', 'service_type = "hosting" AND service_id = :service_id', [':service_id' => $model->id]);
 
             $result['list'][$key] = $this->getService()->toHostingAccountApiArray($model, true, $this->getIdentity());
 


### PR DESCRIPTION
This bug was happening when orders of different product types had the same ID in their respective `service_*` table. It now only looks for hosting orders, so no collision.

We also need to improve and clarify how products/orders/services are stored in the database. Products/services should have one specific ID unique to themselves.