### PR TITLE
tomselect: Automatically grab the CSRF token from the API wrapper

### DIFF
--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -32,8 +32,7 @@
                                 placeholder="{{ 'Start typing the client name or ID'|trans }}"
                                 id="client_id"
                                 name="client_id"
-                                data-resturl="admin/client/get_pairs"
-                                data-csrf="{{ CSRFToken }}">
+                                data-resturl="admin/client/get_pairs">
                         {% if not request.client_id %}
                         {% else %}
                             {% set client = admin.client_get({ 'id': request.client_id }) %}
@@ -303,8 +302,7 @@
                                             placeholder="{{ 'Start typing the client name or ID'|trans }}"
                                             id="client_id"
                                             name="client_id"
-                                            data-resturl="admin/client/get_pairs"
-                                            data-csrf="{{ CSRFToken }}">
+                                            data-resturl="admin/client/get_pairs">
                                     </select>
                                 {% else %}
                                     {% set client = admin.client_get({ 'id': request.client_id }) %}

--- a/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_subscriptions.html.twig
@@ -106,8 +106,7 @@
                                         placeholder="{{ 'Start typing the client name or ID'|trans }}"
                                         id="client_id"
                                         name="client_id"
-                                        data-resturl="admin/client/get_pairs"
-                                        data-csrf="{{ CSRFToken }}">
+                                        data-resturl="admin/client/get_pairs">
                                 </select>
                             {% else %}
                                 {% set client = admin.client_get({ 'id': request.client_id }) %}

--- a/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
+++ b/src/modules/Massmailer/html_admin/mod_massmailer_index.html.twig
@@ -127,8 +127,7 @@
                                                 placeholder="{{ 'Start typing the client name or ID'|trans }}"
                                                 id="test_client_id"
                                                 name="test_client_id"
-                                                data-resturl="admin/client/get_pairs"
-                                                data-csrf="{{ CSRFToken }}">
+                                                data-resturl="admin/client/get_pairs">
                                         </select>
                                     {% else %}
                                         {% set test_client = admin.client_get({ 'id': request.test_client_id }) %}

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -282,7 +282,6 @@
                                             id="client_id"
                                             name="client_id"
                                             data-resturl="admin/client/get_pairs"
-                                            data-csrf="{{ CSRFToken }}"
                                             required aria-required="true">
                                     </select>
                                 {% else %}

--- a/src/modules/Support/html_admin/mod_support_canned_selector.html.twig
+++ b/src/modules/Support/html_admin/mod_support_canned_selector.html.twig
@@ -2,7 +2,6 @@
     name="canned_response"
     placeholder="Canned Responses"
     class="canned_ticket_response"
-    data-csrf="{{CSRFToken}}"
     data-resturl="admin/support/canned_get"
 >
     {% for ctitle, cat in admin.support_canned_pairs %}

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -299,8 +299,7 @@
                                         placeholder="{{ 'Start typing the client name or ID'|trans }}"
                                         id="client_id"
                                         name="client_id"
-                                        data-resturl="admin/client/get_pairs"
-                                        data-csrf="{{ CSRFToken }}">
+                                        data-resturl="admin/client/get_pairs">
                                 </select>
                             {% else %}
                                 {% set client = admin.client_get({ 'id': request.client_id }) %}

--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -58,14 +58,9 @@ document.addEventListener('DOMContentLoaded', () => {
       searchField: ["label", "value"],
       load: (query, callback) => {
         let items;
-        let restUrl = new URL(
-          bb.restUrl(autocompleteSelectorEl.dataset.resturl)
-        );
+        let restUrl = new URL(bb.restUrl(autocompleteSelectorEl.dataset.resturl));
         restUrl.searchParams.append("search", query);
-        restUrl.searchParams.append(
-          "CSRFToken",
-          autocompleteSelectorEl.dataset.csrf
-        );
+        restUrl.searchParams.append("CSRFToken", Tools.getCSRFToken());
         restUrl.searchParams.append("per_page", 5);
         fetch(restUrl)
           .then((response) => response.json())
@@ -106,10 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
         bb.restUrl(cannedResponseSelectorEl.dataset.resturl)
       );
       restUrl.searchParams.append('id', value);
-      restUrl.searchParams.append(
-        'CSRFToken',
-        cannedResponseSelectorEl.dataset.csrf,
-      );
+      restUrl.searchParams.append('CSRFToken', Tools.getCSRFToken());
       fetch(restUrl)
         .then((response) => response.json())
         .then((json) => {


### PR DESCRIPTION
Automatically grab the CSRF token from the API wrapper and attach it to Tom Select requests.

This removes the need to manually attach a `data-csrf` field.