### PR TITLE
Fix missing client name in the activity list

### DIFF
--- a/src/modules/Activity/Service.php
+++ b/src/modules/Activity/Service.php
@@ -133,7 +133,7 @@ class Service implements InjectionAwareInterface
 
     public function getSearchQuery($data)
     {
-        $sql = 'SELECT m.*, a.id as staff_id, a.email as staff_email, a.name as staff_name, CONCAT(c.first_name, " ", c.last_name) as client_name, c.email as client_email
+        $sql = 'SELECT m.*, a.id as staff_id, a.email as staff_email, a.name as staff_name, CONCAT_WS(" ", c.first_name, c.last_name) as client_name, c.email as client_email
                 FROM activity_system as m
                 left join admin as a on a.id = m.admin_id
                 left join client as c on c.id = m.client_id';


### PR DESCRIPTION
CONCAT returns null if any of the concatenated values is null. This caused client_name to appear empty whenever a client had a missing first or last name.

This PR updates the query to use CONCAT_WS which just ignores the null value.

Before:
<img width="1302" height="132" alt="image" src="https://github.com/user-attachments/assets/ec701308-3444-4599-9cf5-cc291f83f62a" />

After:
<img width="1312" height="136" alt="image" src="https://github.com/user-attachments/assets/72b4ff7f-d16d-44d1-8739-9caa345544c5" />