### PR TITLE
Fix cache key generation for the extension directory

### DIFF
--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -158,7 +158,7 @@ class ExtensionManager implements InjectionAwareInterface
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
-        $key = 'extension-manager-' . md5($endpoint . serialize($params));
+        $key = 'extension-manager-' . hash('sha256', $endpoint . serialize($params));
 
         return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
             $item->expiresAfter(60 * 60);

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -158,7 +158,7 @@ class ExtensionManager implements InjectionAwareInterface
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
-        $key = $endpoint . serialize($params);
+        $key = 'extensionmanager-' . md5($endpoint . serialize($params));
 
         return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
             $item->expiresAfter(60 * 60);

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -158,7 +158,7 @@ class ExtensionManager implements InjectionAwareInterface
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
-        $key = 'extension-manager-' . hash('sha256', $endpoint . serialize($params));
+        $key = 'extension-manager-' . hash('xxh3', $endpoint . serialize($params));
 
         return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
             $item->expiresAfter(60 * 60);

--- a/src/library/FOSSBilling/ExtensionManager.php
+++ b/src/library/FOSSBilling/ExtensionManager.php
@@ -158,7 +158,7 @@ class ExtensionManager implements InjectionAwareInterface
     public function makeRequest(string $endpoint, array $params = []): array
     {
         $url = $this->_url . $endpoint;
-        $key = 'extensionmanager-' . md5($endpoint . serialize($params));
+        $key = 'extension-manager-' . md5($endpoint . serialize($params));
 
         return $this->di['cache']->get($key, function (ItemInterface $item) use ($url, $params) {
             $item->expiresAfter(60 * 60);

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -43,7 +43,9 @@ class Admin extends \Api_Abstract
 
         try {
             $list = $this->di['extension_manager']->getExtensionList($type);
-        } catch (\Exception) {
+        } catch (\Exception $e) {
+            $this->di['logger']->warn(sprintf('Failed to fetch extension list for type "%s": %s', $type ?? 'all', $e->getMessage()));
+
             $list = [];
         }
 

--- a/tests-legacy/modules/Extension/Api/AdminTest.php
+++ b/tests-legacy/modules/Extension/Api/AdminTest.php
@@ -73,6 +73,7 @@ class AdminTest extends \BBTestCase
 
         $di = new \Pimple\Container();
         $di['extension_manager'] = $extensionMock;
+        $di['logger'] = $this->getMockBuilder('Box_Log')->getMock();
 
         $this->api->setDi($di);
         $result = $this->api->get_latest($data);


### PR DESCRIPTION
Fix cache key generation in the ExtensionManager class to avoid reserved characters.

I don't know since when, but Symfony's caching won't allow characters like curly brackets.
(`Cache key "lista:0:{}" contains reserved characters "{}()/\@:".`)

The serialized parameters include `{` and `}`, which aren't allowed. I've instead replaced them with a SHA256 hash.

Also fixed a place where the exceptions were straight up ignored.

It has been broken for some time but the extension directory should now work again.

<img width="1295" height="524" alt="image" src="https://github.com/user-attachments/assets/fb27961c-470d-4a18-8dd6-f5d0bad65809" />
