### PR TITLE
Stop fetching network interface information at render time

### DIFF
--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -667,6 +667,8 @@ ZW=Zimbabwe
 
 {% block js %}
 <script>
+    const bindTo = "{{ constant('BIND_TO') }}";
+
     function updateExternalIP() {
         API.admin.get('system/env', { ip: true }, function (ip) {
             const el = document.getElementById('external-ip');
@@ -689,7 +691,7 @@ ZW=Zimbabwe
                 const opt = document.createElement('option');
                 opt.value = interface;
                 opt.textContent = interface;
-                if (interface === "{{ constant('BIND_TO') }}") {
+                if (interface === bindTo) {
                     opt.selected = true;
                 }
                 select.appendChild(opt);
@@ -697,7 +699,6 @@ ZW=Zimbabwe
 
             // Handle custom interface
             const custom = document.getElementById('custom_interface');
-            const bindTo = "{{ constant('BIND_TO') }}";
             if (bindTo !== "0" && !interfaces.includes(bindTo)) {
                 custom.value = bindTo;
             }

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -632,7 +632,7 @@ ZW=Zimbabwe
                     </div>
                     <div class="card-body">
                         <div class="alert alert-info" role="alert" id="external-ip">
-                            {{ "Checking external IP…"|trans }}
+                            {{ "Checking external IP..."|trans }}
                         </div>
 
                         <form class="api-form" method="post" action="{{ 'api/admin/system/set_interface_ip'|link }}" data-api-jsonp="onAfterInterfaceSet">
@@ -670,8 +670,12 @@ ZW=Zimbabwe
     const bindTo = "{{ constant('BIND_TO') }}";
 
     function updateExternalIP() {
+        const el = document.getElementById('external-ip');
+        // Always show a loading state first
+        el.innerText = `{{ "Checking external IP..."|trans }}`;
+        el.className = 'alert alert-info';
+    
         API.admin.get('system/env', { ip: true }, function (ip) {
-            const el = document.getElementById('external-ip');
             if (ip) {
                 el.innerText = `{{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }}` + ip;
                 el.className = 'alert alert-success';

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -25,8 +25,6 @@
 {% block content %}
     {% set new_params = admin.extension_config_get({ 'ext': 'mod_system' }) %}
     {% set params = admin.system_get_params %}
-    {% set environment = admin.system_env %}
-    {% set external_ip = admin.system_env({ 'ip': true }) %}
     <div class="card-tabs">
         <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item" role="presentation">
@@ -633,26 +631,17 @@ ZW=Zimbabwe
                         <h3 class="card-title">{{ 'Network interface'|trans }}</h3>
                     </div>
                     <div class="card-body">
-                        <div class="alert {% if external_ip %}alert-success{% else %}alert-danger{% endif %}" role="alert" id="external-ip">
-                            {% if external_ip %}
-                                {{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }} {{ external_ip }}
-                            {% else %}
-                                {{ 'The currently selected network interface does not appear to be able to reach the internet!'|trans }}
-                            {% endif %}
+                        <div class="alert alert-info" role="alert" id="external-ip">
+                            {{ "Checking external IP…"|trans }}
                         </div>
 
                         <form class="api-form" method="post" action="{{ 'api/admin/system/set_interface_ip'|link }}" data-api-jsonp="onAfterInterfaceSet">
-                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <p>{{ 'If your server has multiple network interfaces, you may select the default one for FOSSBilling to use when making requests here.'|trans }}</p>
-                            {% set interface_ips = admin.system_get_interface_ips %}
                             
                             <div class="col-12 col-lg-3">
-                                <label for="interface">{{"Select the default network interface:"|trans }}</label>
-                                <select class="form-select" aria-label="{{ 'Available network interfaces'|trans }}" name="interface" id="interface">
-                                    <option value="0" {% if constant('BIND_TO') == 0 %} selected {%endif%}>{{ 'None (Default PHP Behavior)'|trans }}</option>
-                                    {% for i, interface in interface_ips %}
-                                    <option value="{{ interface }}" {% if constant('BIND_TO') == interface %} selected {% endif %}>{{ interface }}</option>
-                                    {% endfor %}
+                                <label for="interface">{{ 'Select the default network interface:'|trans }}</label>
+                                <select class="form-select" name="interface" id="interface">
+                                    <option value="0">{{ 'None (Default PHP Behavior)'|trans }}</option>
                                 </select>
                             </div>
 
@@ -660,13 +649,11 @@ ZW=Zimbabwe
 
                             <div class="col-12 col-lg-3">
                                 <label for="custom_interface">{{'Enter a custom interface to use:'|trans }}</label>
-                                {% if constant('BIND_TO') not in interface_ips and constant('BIND_TO') != 0%}
-                                    <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface" value="{{ constant('BIND_TO') }}">
-                                {% else %}
-                                    <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface">
-                                {% endif %}
+                                <input class="form-control mt-1" type="text" name="custom_interface" id="custom_interface">
                             </div>
-                            <span class="text-muted">{{ "If the dropdown menu doesn't have the appropriate network interface, please enter the IP address or name (e.g., eth0) of the correct one above."|trans }}</span>
+                            <span class="text-muted">
+                                {{ "If the dropdown menu doesn't have the appropriate network interface, please enter the IP address or name (e.g., eth0) of the correct one above."|trans }}
+                            </span>
                             <br>
 
                             <input type="submit" class="btn btn-primary mt-1" value="{{ 'Update'|trans }}">
@@ -680,20 +667,54 @@ ZW=Zimbabwe
 
 {% block js %}
 <script>
-    function onAfterInterfaceSet(result) {
-        API.admin.post('system/env', {
-            ip: true,
-            CSRFToken: "{{ CSRFToken }}"
-        }, function (ip) {
-            FOSSBilling.message(`{{ 'Network interface updated.'|trans }}`);
-            if(ip){
-                document.getElementById('external-ip').innerText = `{{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }}` + ip;
-                document.getElementById('external-ip').className = 'alert alert-success';
+    function updateExternalIP() {
+        API.admin.get('system/env', { ip: true }, function (ip) {
+            const el = document.getElementById('external-ip');
+            if (ip) {
+                el.innerText = `{{ 'With the current settings, your FOSSBilling instance will have an external IP address of: '|trans }}` + ip;
+                el.className = 'alert alert-success';
             } else {
-                document.getElementById('external-ip').innerText = `{{ 'The currently selected network interface does not appear to be able to reach the internet!'|trans }}`;
-                document.getElementById('external-ip').className = 'alert alert-danger';
+                el.innerText = `{{ 'The currently selected network interface does not appear to be able to reach the internet!'|trans }}`;
+                el.className = 'alert alert-danger';
             }
         });
+    }
+
+    function loadInterfaceIPs() {
+        API.admin.get('system/get_interface_ips', {}, function (interfaces) {
+            const select = document.getElementById('interface');
+            select.innerHTML = `<option value="0">{{ 'None (Default PHP Behavior)'|trans }}</option>`;
+            
+            interfaces.forEach(interface => {
+                const opt = document.createElement('option');
+                opt.value = interface;
+                opt.textContent = interface;
+                if (interface === "{{ constant('BIND_TO') }}") {
+                    opt.selected = true;
+                }
+                select.appendChild(opt);
+            });
+
+            // Handle custom interface
+            const custom = document.getElementById('custom_interface');
+            const bindTo = "{{ constant('BIND_TO') }}";
+            if (bindTo !== "0" && !interfaces.includes(bindTo)) {
+                custom.value = bindTo;
+            }
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        const networkTab = document.querySelector('a[href="#network-interface"]');
+        networkTab.addEventListener("shown.bs.tab", function () {
+            updateExternalIP();
+            loadInterfaceIps();
+        });
+    });
+
+    function onAfterInterfaceSet(result) {
+        FOSSBilling.message(`{{ 'Network interface updated.'|trans }}`);
+        updateExternalIP();
     }
 </script>
 {% endblock %}

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -687,10 +687,13 @@ ZW=Zimbabwe
     }
 
     function loadInterfaceIPs() {
+        const select = document.getElementById('interface');
+        // Show loading state first
+        select.innerHTML = `<option disabled selected>{{ "Loading interfaces..."|trans }}</option>`;
+
         API.admin.get('system/get_interface_ips', {}, function (interfaces) {
-            const select = document.getElementById('interface');
             select.innerHTML = `<option value="0">{{ 'None (Default PHP Behavior)'|trans }}</option>`;
-            
+
             interfaces.forEach(interface => {
                 const opt = document.createElement('option');
                 opt.value = interface;

--- a/src/modules/System/html_admin/mod_system_settings.html.twig
+++ b/src/modules/System/html_admin/mod_system_settings.html.twig
@@ -708,7 +708,7 @@ ZW=Zimbabwe
         const networkTab = document.querySelector('a[href="#network-interface"]');
         networkTab.addEventListener("shown.bs.tab", function () {
             updateExternalIP();
-            loadInterfaceIps();
+            loadInterfaceIPs();
         });
     });
 


### PR DESCRIPTION
This PR improves the performance of the Network Interface tab by delaying slow API calls until the relevant tab is actually opened.

Instead of blocking the page during render, the required data is now fetched via JavaScript after the page has loaded. Existing behavior is preserved, only the timing of the API calls has changed.

The `system/get_interface_ips` request in particular can be very slow (sometimes taking even up to ~25 seconds). Previously, running it during render blocked the entire page from loading. With this change, the rest of the interface loads immediately.