### PR TITLE
Create a new onEveryEvent event

### DIFF
--- a/src/library/Box/EventDispatcher.php
+++ b/src/library/Box/EventDispatcher.php
@@ -40,6 +40,11 @@ class Box_EventDispatcher
             call_user_func($listener, $event);
         }
 
+        // Notify global listeners (onEveryEvent) too
+        foreach ($this->getListeners(Box_EventManager::GLOBAL_LISTENER_NAME) as $listener) {
+            call_user_func($listener, $event);
+        }
+
         return $event;
     }
 

--- a/src/library/Box/EventManager.php
+++ b/src/library/Box/EventManager.php
@@ -12,6 +12,8 @@ class Box_EventManager implements FOSSBilling\InjectionAwareInterface
 {
     protected ?Pimple\Container $di = null;
 
+    public const GLOBAL_LISTENER_NAME = 'onEveryEvent';
+
     public function setDi(Pimple\Container $di): void
     {
         $this->di = $di;
@@ -39,7 +41,10 @@ class Box_EventManager implements FOSSBilling\InjectionAwareInterface
         $e = new Box_Event($subject, $event, $params);
         $e->setDi($this->di);
         $disp = new Box_EventDispatcher();
+        
         $this->_connectDatabaseHooks($disp, $e->getName());
+        $this->_connectDatabaseHooks($disp, self::GLOBAL_LISTENER_NAME); // Also connect the global listeners (onEveryEvent)
+        
         $disp->notify($e);
 
         return $e->getReturnValue();


### PR DESCRIPTION
This PR adds support for global listeners (`onEveryEvent`) which are invoked whenever any event is dispatched.

I'm creating a Discord webhook notification module which would benefit from observing all dispatched events without registering methods individually for each event. This change provides a cleaner way to do that.

You just use it like a regular event.

```php
public static function onEveryEvent(\Box_Event $event): void
{
    /* (...) */

    // getName() Would return the original event name, e.g. onAfterClientOrderCreate
    $discord->notifyEvent($event->getName());
}
```