### PR TITLE
Restore correct JSON and array handling for Servicelicense

### DIFF
--- a/src/modules/Servicelicense/Server.php
+++ b/src/modules/Servicelicense/Server.php
@@ -69,7 +69,7 @@ class Server implements \FOSSBilling\InjectionAwareInterface
 
     public function process($data)
     {
-        $data = (!is_array($data)) ? json_decode($data ?? '', true) : [];
+        $data = is_array($data) ? $data : (json_decode($data, true) ?: []);
 
         if (empty($data)) {
             throw new \LogicException('Invalid request. Parameters missing?', 1000);

--- a/src/modules/Servicelicense/Server.php
+++ b/src/modules/Servicelicense/Server.php
@@ -69,7 +69,7 @@ class Server implements \FOSSBilling\InjectionAwareInterface
 
     public function process($data)
     {
-        $data = is_array($data) ? $data : (json_decode($data, true) ?: []);
+        $data = is_array($data) ? $data : (json_decode($data ?? '', true) ?: []);
 
         if (empty($data)) {
             throw new \LogicException('Invalid request. Parameters missing?', 1000);


### PR DESCRIPTION
Fixed a bug that appeared with v0.7.2. Servicelicense should now work correctly.

A previous refactor replaced the JSON decode logic with a broken one-liner. This caused two issues:
- Arrays were overwritten with empty arrays instead of preserved.
- Invalid JSON or null input returned `null` instead of `[]`.

This commit restores the intended behavior using a correct one-liner. Now:
- Arrays are preserved.
- Valid JSON strings are decoded into arrays.
- Invalid JSON or null input falls back to an empty array.