### PR TITLE
Refactor IP retrieval method in Server.php

### DIFF
--- a/src/modules/Servicelicense/Server.php
+++ b/src/modules/Servicelicense/Server.php
@@ -49,24 +49,6 @@ class Server implements \FOSSBilling\InjectionAwareInterface
         return $_SERVER[$key] ?? $default;
     }
 
-    private function getIp($checkProxy = true)
-    {
-        $ip = null;
-        if ($checkProxy && $this->getServer('HTTP_CLIENT_IP') != null) {
-            $ip = $this->getServer('HTTP_CLIENT_IP');
-        } else {
-            if ($checkProxy && $this->getServer('HTTP_X_FORWARDED_FOR') != null) {
-                $ip = $this->getServer('HTTP_X_FORWARDED_FOR');
-            } else {
-                $ip = $this->getServer('REMOTE_ADDR');
-            }
-        }
-
-        $ips_arr = explode(',', $ip);
-
-        return trim($ips_arr[0]);
-    }
-
     public function process($data)
     {
         $data = is_array($data) ? $data : (json_decode($data ?? '', true) ?: []);
@@ -101,7 +83,7 @@ class Server implements \FOSSBilling\InjectionAwareInterface
             throw new \LogicException('Path key is not present in call', 1004);
         }
 
-        $ip = $this->getIp();
+        $ip = $this->di['request']->getClientIp();
         $host = $data['host'];
         $version = $data['version'];
         $path = $data['path'];

--- a/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/html_admin/mod_servicelicense_config.html.twig
@@ -2,7 +2,6 @@
 <div class="card-body">
     <h5>{{ 'License settings'|trans }}</h5>
     <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'License settings updated'|trans }}">
-        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Prefix'|trans }}:</label>
             <div class="col">
@@ -79,13 +78,13 @@
     <hr>
     <div>
         <h1>{{ 'License plugins'|trans }}</h1>
-        <p>{{ 'FOSSBilling gives you the ability to provide your own license generation script. Follow the instructions below to install new license plugin'|trans }}</p>
+        <p>{{ 'You can create your own license generation plugins for FOSSBilling. Follow these steps to add a new one:'|trans }}</p>
         <ul>
-            <li>{{ 'License plugin is PHP class "License_PluginName" with one method'|trans }} <strong>generate</strong></li>
-            <li>{{ 'Take a look at default plugin at'|trans }} <strong>src/modules/Servicelicense/Plugin/Simple.php</strong></li>
-            <li>{{ 'Create your plugin and place it to'|trans }} <strong>src/modules/Servicelicense/Plugin/PluginName.php</strong></li>
-            <li>{{ 'FOSSBilling will automatically detect new plugin'|trans }}</li>
-            <li>{{ 'Read'|trans }} <a href="https://fossbilling.org/docs" target="_blank">{{ 'FOSSBilling documentation'|trans }}</a> {{ 'for more information.'|trans }}</li>
+            <li>{{ 'A license plugin is a PHP class named'|trans }} <strong>License_PluginName</strong> {{ 'that must include a'|trans }} <code>generate</code> {{ 'method.'|trans }}</li>
+            <li>{{ 'See the default example plugin at'|trans }} <strong>/modules/Servicelicense/Plugin/Simple.php</strong></li>
+            <li>{{ 'Save your custom plugin in'|trans }} <strong>/modules/Servicelicense/Plugin/PluginName.php</strong></li>
+            <li>{{ 'FOSSBilling will automatically detect your new plugin.'|trans }}</li>
+            <li><a href="https://fossbilling.org/docs/product-types/license#custom-plugins" target="_blank">{{ 'Read the documentation'|trans }}</a> {{ 'for more details.'|trans }}</li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
This pull request makes several improvements and cleanups to the Service License module, focusing on simplifying IP address retrieval, improving plugin documentation, and minor UI adjustments. The most important changes are:

**Codebase Simplification & Security:**

* Removed the custom `getIp` method from `Server.php` and replaced its usage with the dependency-injected `$this->di['request']->getClientIp()`, ensuring more consistent and potentially more secure IP address retrieval. [[1]](diffhunk://#diff-165e71f1d234cfb9882d1bf8318ef4e1bc6e52cf25dbdfacb15c85be4a52132dL52-L69) [[2]](diffhunk://#diff-165e71f1d234cfb9882d1bf8318ef4e1bc6e52cf25dbdfacb15c85be4a52132dL104-R86)

**Documentation & Usability Improvements:**

* Updated the plugin instructions in `mod_servicelicense_config.html.twig` to clarify the process for creating custom license plugins, including improved wording, updated file paths, and a direct documentation link.

**UI/Template Adjustments:**

* Removed the hidden CSRF token input from the license settings form in `mod_servicelicense_config.html.twig`, possibly reflecting changes in how CSRF protection is handled.