### PR TITLE
Fix Renovate Config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "security:minimumReleaseAgeNpm",
     "schedule:daily",
     ":automergeBranch",
     ":automergeDigest",


### PR DESCRIPTION
Remove `security:minimumReleaseAgeNpm` config option as renamed from `npm:unpublishSafe` and Renovate hosted version not yet updated to 41.134.0.