### PR TITLE
Update Renovate Config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices",
     "schedule:daily",
+    "npm:unpublishSafe",
     ":automergeBranch",
     ":automergeDigest",
     ":automergeLinters",


### PR DESCRIPTION
Add `npm:unpublishSafe` to avoid potential issues with pinned packages. 

Note: this has been renamed to `security:minimumReleaseAgeNpm` in a newer version of Renovate. This *should* be handled by Renovate once that version hits the GitHub app version.