### PR TITLE
Fixed console file finder

### DIFF
--- a/src/console.php
+++ b/src/console.php
@@ -4,7 +4,6 @@
 declare(strict_types=1);
 /**
  * Copyright 2022-2025 FOSSBilling
- * Copyright 2011-2021 BoxBilling, Inc.
  * SPDX-License-Identifier: Apache-2.0.
  *
  * @copyright FOSSBilling (https://www.fossbilling.org)


### PR DESCRIPTION
The old one errored out:

You've received a generic error message: <code>The &quot;C:/(...)/src/modules/Activity/Commands&quot; directory does not exist.