### PR TITLE
Fix for Missing variable declaration

### DIFF
--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -31,7 +31,7 @@ FormData.prototype.serializeObject = function () {
     }
     // reformat input[] fields to arrays
     for (const pair of this.entries()) {
-        key = pair[0];
+        let key = pair[0];
         if (key.endsWith('[]')) {
             key = key.slice(0, -2);
             if (!obj[key]) {


### PR DESCRIPTION
To fix the problem, the variable `key` on line 34 should be explicitly declared with the `let` keyword to make it local to the block where it is used. This prevents accidental pollution of the global scope and helps ensure maintainability and predictability. The change should be made directly on line 34 in src/library/Api/API.js, replacing `key = pair[0];` with `let key = pair[0];`. No imports or additional changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._