### PR TITLE
Implement email template preview modal

### DIFF
--- a/src/modules/Email/html_admin/mod_email_template.html.twig
+++ b/src/modules/Email/html_admin/mod_email_template.html.twig
@@ -8,7 +8,7 @@
         <li class="breadcrumb-item">
             <a href="{{ '/'|alink }}">
                 <svg class="icon">
-                    <use xlink:href="#home" />
+                    <use xlink:href="#home"/>
                 </svg>
             </a>
         </li>
@@ -23,11 +23,49 @@
 {% endblock %}
 
 {% block content %}
-{# {% if template.vars|length == 0 %}
+    {# {% if template.vars|length == 0 %}
 <div class="nNote nInformation hideit first">
     <p><strong>{{ 'INFORMATION'|trans }}: </strong>{{ 'This email template is deprecated'|trans }}</p>
 </div>
 {% endif %} #}
+
+    {# Preview Modal Dialog #}
+    <div class="modal-overlay" id="preview-modal"
+         style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.5); z-index: 1050; justify-content: center; align-items: center; padding: 20px;">
+        <div class="preview-dialog"
+             style="background: white; border-radius: 8px; width: 100%; max-width: 900px; max-height: 90vh; display: flex; flex-direction: column; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);">
+            <div class="dialog-header"
+                 style="padding: 20px 24px; border-bottom: 1px solid #dee2e6; display: flex; justify-content: space-between; align-items: center;">
+                <h3 style="font-size: 18px; font-weight: 600; color: #212529; margin: 0;">{{ 'Email Template Preview'|trans }}</h3>
+                <button class="close-button" id="close-modal-btn"
+                        style="background: none; border: none; font-size: 24px; color: #6c757d; cursor: pointer; padding: 0; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 4px;">
+                    &times;
+                </button>
+            </div>
+            <div class="dialog-body" style="flex: 1; overflow-y: auto; padding: 24px;">
+                <div class="preview-section" style="margin-bottom: 24px;">
+                    <div class="preview-label"
+                         style="font-size: 12px; font-weight: 600; text-transform: uppercase; color: #6c757d; margin-bottom: 8px; letter-spacing: 0.5px;">{{ 'Subject'|trans }}</div>
+                    <div class="subject-preview" id="modal-subject-preview"
+                         style="background: white; border: 1px dashed #adb5bd; border-radius: 4px; padding: 16px; overflow: auto; min-height: 50px;"></div>
+                </div>
+                <div class="preview-section">
+                    <div class="preview-label"
+                         style="font-size: 12px; font-weight: 600; text-transform: uppercase; color: #6c757d; margin-bottom: 8px; letter-spacing: 0.5px;">{{ 'Message Content'|trans }}</div>
+                    <div class="content-preview-wrapper"
+                         style="background: white; border: 1px dashed #adb5bd; border-radius: 4px; overflow: hidden;">
+                        <iframe class="content-preview" id="modal-content-iframe"
+                                style="width: 100%; min-height: 400px; border: none; display: block;"></iframe>
+                    </div>
+                </div>
+            </div>
+            <div class="dialog-footer"
+                 style="padding: 16px 24px; border-top: 1px solid #dee2e6; display: flex; justify-content: flex-end; gap: 12px;">
+                <button class="btn btn-secondary" id="close-modal-footer-btn">{{ 'Close'|trans }}</button>
+            </div>
+        </div>
+    </div>
+
     <div class="card-tabs">
         <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item" role="presentation">
@@ -46,7 +84,8 @@
         <div class="card">
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="tab-template" role="tabpanel">
-                    <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
+                    <form method="post" action="admin/email/template_update" class="api-form"
+                          data-api-msg="{{ 'Template updated'|trans }}">
                         <input type="hidden" name="id" value="{{ template.id }}">
                         <div class="card-body">
                             <h3 class="card-title">{{ 'Manage email template'|trans }}</h3>
@@ -54,25 +93,21 @@
                             <div class="mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Email subject'|trans }}</label>
                                 <div class="col-md-7">
-                                    <input class="form-control" type="text" name="subject" value="{{ template.subject }}" id="email-subject" required>
+                                    <input class="form-control" type="text" name="subject"
+                                           value="{{ template.subject }}" id="email-subject" required>
                                 </div>
                             </div>
                             <div class="mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Email message'|trans }}</label>
                                 <div class="col-md-7">
-                                    <textarea class="form-control" name="content" id="email-template" rows="10" required>{{ template.content }}</textarea>
+                                    <textarea class="form-control" name="content" id="email-template" rows="10"
+                                              required>{{ template.content }}</textarea>
                                 </div>
-                            </div>
-
-
-                            <div class="mt-3" id="preview" style="display: none;">
-                                <div class="p-3 esubject mb-3" style="background: white; border: 1px dashed grey; overflow: auto;"></div>
-                                <div class="p-3 econtent" style="background: white; border: 1px dashed grey; overflow: auto;"></div>
                             </div>
                         </div>
                         <div class="card-footer d-flex justify-content-between">
                             <a class="btn btn-danger api-link"
-                               href="{{ 'api/admin/email/template_reset'|link({'code' : template.action_code })}}"
+                               href="{{ 'api/admin/email/template_reset'|link({'code' : template.action_code }) }}"
                                data-api-confirm="{{ 'Are you sure?'|trans }}"
                                data-api-confirm-btn="{{ 'Reset'|trans }}"
                                data-api-type="danger"
@@ -81,11 +116,11 @@
                             </a>
                             <div class="text-end">
                                 <button class="btn btn-secondary" id="preview-button"
-                                    {% if template.vars|length == 0 %}
+                                        {% if template.vars|length == 0 %}
                                 disabled
-                                    {% endif %}>
+                                        {% endif %}>
                                     <svg class="icon">
-                                        <use xlink:href="#eye" />
+                                        <use xlink:href="#eye"/>
                                     </svg>
                                     {{ 'Preview'|trans }}
                                 </button>
@@ -96,7 +131,8 @@
                 </div>
 
                 <div class="tab-pane fade" id="tab-manage" role="tabpanel">
-                    <form method="post" action="admin/email/template_update" class="api-form" data-api-msg="{{ 'Template updated'|trans }}">
+                    <form method="post" action="admin/email/template_update" class="api-form"
+                          data-api-msg="{{ 'Template updated'|trans }}">
                         <input type="hidden" name="id" value="{{ template.id }}">
                         <div class="card-body">
                             <h3 class="card-title">{{ 'Template settings'|trans }}</h3>
@@ -106,11 +142,13 @@
                                 <label class="col-md-3 form-label">{{ 'Enabled'|trans }}</label>
                                 <div class="col-md-6">
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radioEnabledYes" type="radio" name="enabled" value="1"{% if template.enabled %} checked{% endif %}>
+                                        <input class="form-check-input" id="radioEnabledYes" type="radio" name="enabled"
+                                               value="1"{% if template.enabled %} checked{% endif %}>
                                         <label class="form-check-label" for="radioEnabledYes">{{ 'Yes'|trans }}</label>
                                     </div>
                                     <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radioEnabledNo" type="radio" name="enabled" value="0"{% if not template.enabled %} checked{% endif %}>
+                                        <input class="form-check-input" id="radioEnabledNo" type="radio" name="enabled"
+                                               value="0"{% if not template.enabled %} checked{% endif %}>
                                         <label class="form-check-label" for="radioEnabledNo">{{ 'No'|trans }}</label>
                                     </div>
                                 </div>
@@ -118,7 +156,8 @@
                             <div class="mb-3 row">
                                 <label class="col-md-3 col-form-label">{{ 'Category'|trans }}</label>
                                 <div class="col-md-6">
-                                    <input class="form-control" type="text" name="category" value="{{ template.category }}" required placeholder="General">
+                                    <input class="form-control" type="text" name="category"
+                                           value="{{ template.category }}" required placeholder="General">
                                 </div>
                             </div>
                         </div>
@@ -150,12 +189,14 @@
                                             {% for subsubkey,subsubvalue in var %}
                                                 {% if subsubvalue is not iterable %}
                                                     <tr>
-                                                        <td>{{ '{{' }} {{ k }}.{{ subkey }}.{{ subsubkey }}{{ '}}' }}</td>
+                                                        <td>{{ '{{' }} {{ k }}.{{ subkey }}
+                                                            .{{ subsubkey }}{{ '}}' }}</td>
                                                         <td>{{ subsubvalue }}</td>
                                                     </tr>
                                                 {% else %}
                                                     <tr>
-                                                        <td>{{ '{{' }} {{ k }}.{{ subkey }}.{{ subsubkey }}{{ '}}' }}</td>
+                                                        <td>{{ '{{' }} {{ k }}.{{ subkey }}
+                                                            .{{ subsubkey }}{{ '}}' }}</td>
                                                         <td>Array [ ]</td>
                                                     </tr>
                                                 {% endif %}
@@ -175,7 +216,8 @@
                                 {% endif %}
                             {% else %}
                                 <tr>
-                                    <td class="text-muted" colspan="2">{{ 'This template has no known parameters, you may need to take an action to trigger its sending before they become known.'|trans }}</td>
+                                    <td class="text-muted"
+                                        colspan="2">{{ 'This template has no known parameters, you may need to take an action to trigger its sending before they become known.'|trans }}</td>
                                 </tr>
                             {% endfor %}
                             </tbody>
@@ -189,7 +231,8 @@
                         <p class="card-subtitle">{{ 'Email template playground. Use this tool to try rendering email templates.'|trans }}</p>
 
                         <div class="mb-3">
-                    <textarea class="form-control" rows="20">{% autoescape false %}{% apply markdown %}
+                    <textarea class="form-control" id="email-sample-template"
+                              rows="20">{% autoescape false %}{% apply markdown %}
                             This is an example of markdown syntax in email template
 
                             *Italic text*
@@ -218,17 +261,16 @@
                             {# Comments in email templates. This text is not visible #}
                             {# Uncomment the line below to see what is the output #}
 
-                            {#<pre>{% debug stats %}</pre>#}
+                            {# <pre>{% debug stats %}</pre> #}
                         {% endapply %}{% endautoescape %}</textarea>
                         </div>
 
                         <button class="btn btn-secondary epb">
                             <svg class="icon">
-                                <use xlink:href="#eye" />
+                                <use xlink:href="#eye"/>
                             </svg>
                             {{ 'Preview'|trans }}
                         </button>
-                        <div class="mt-3 p-3 example-preview" style="border: 1px dashed grey; overflow: auto; display: none;"></div>
                     </div>
                 </div>
             </div>
@@ -237,34 +279,93 @@
 {% endblock %}
 
 {% block js %}
-<script>
-$(function() {
-    $('.epb').on('click', function() {
-        var r = $(this).siblings('.example-preview');
-        var params = { _tpl: $(this).siblings('textarea').val(), id: '{{ template.id }}', CSRFToken: "{{ CSRFToken }}" };
+    <script>
+        $( function () {
+            // Modal functionality
+            const modal = document.getElementById( 'preview-modal' );
+            const closeModalBtn = document.getElementById( 'close-modal-btn' );
+            const closeModalFooterBtn = document.getElementById( 'close-modal-footer-btn' );
 
-        bb.post('admin/email/template_render', params, function(result) {
-            r.html(result).show();
-        });
-    });
+            function openModal() {
+                modal.style.display = 'flex';
+            }
 
-    $('#preview-button').on('click', function() {
-        var params = { _tpl: $('#email-template').val(), id: '{{ template.id }}', CSRFToken: "{{ CSRFToken }}" };
+            function closeModal() {
+                modal.style.display = 'none';
+            }
 
-        bb.post('admin/email/template_render', params, function(result) {
-            $('#preview').show();
-            $('#preview .econtent').html(result);
-        });
+            function show_preview( content ) {
+                // Render content in modal iframe
+                const iframe = document.getElementById( 'modal-content-iframe' );
+                const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
-        var params = { _tpl: $('#email-subject').val(), id: '{{ template.id }}', CSRFToken: "{{ CSRFToken }}" };
+                iframeDoc.open();
+                iframeDoc.write( '<!DOCTYPE html><html><head><meta charset="UTF-8"><style>body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; padding: 16px; margin: 0; background: white; }</style></head><body>' + content + '</body></html>' );
+                iframeDoc.close();
 
-        bb.post('admin/email/template_render', params, function(result) {
-            $('#preview').show();
-            $('#preview .esubject').html(result);
-        });
+                // Open modal
+                openModal();
+            }
 
-        return false;
-    });
-});
-</script>
+            closeModalBtn.addEventListener( 'click', closeModal );
+            closeModalFooterBtn.addEventListener( 'click', closeModal );
+
+            // Close on overlay click
+            modal.addEventListener( 'click', function ( e ) {
+                if ( e.target === modal ) {
+                    closeModal();
+                }
+            } );
+
+            // Close on ESC key
+            document.addEventListener( 'keydown', function ( e ) {
+                if ( e.key === 'Escape' && modal.style.display === 'flex' ) {
+                    closeModal();
+                }
+            } );
+
+            $( '.epb' ).on( 'click', function () {
+                var params = {
+                    _tpl: $( '#email-sample-template' ).val(),
+                    id: '{{ template.id }}',
+                    CSRFToken: "{{ CSRFToken }}"
+                };
+
+                // Render in modal
+                bb.post( 'admin/email/template_render', params, function ( result ) {
+
+                    // Clear subject (examples don't have subjects)
+                    $( '#modal-subject-preview' ).html( '<em style="color: #6c757d;">{{ 'No subject for example preview'|trans }}</em>' );
+
+                    show_preview( result );
+                } );
+            } );
+
+            $( '#preview-button' ).on( 'click', function () {
+                var subjectParams = {
+                    _tpl: $( '#email-subject' ).val(),
+                    id: '{{ template.id }}',
+                    CSRFToken: "{{ CSRFToken }}"
+                };
+
+                var contentParams = {
+                    _tpl: $( '#email-template' ).val(),
+                    id: '{{ template.id }}',
+                    CSRFToken: "{{ CSRFToken }}"
+                };
+
+                // Render subject in modal
+                bb.post( 'admin/email/template_render', subjectParams, function ( result ) {
+                    $( '#modal-subject-preview' ).html( result );
+                } );
+
+                // Render content in modal iframe
+                bb.post( 'admin/email/template_render', contentParams, function ( result ) {
+                    show_preview( result );
+                } );
+
+                return false;
+            } );
+        } );
+    </script>
 {% endblock %}


### PR DESCRIPTION
Added a preview modal dialog for email templates, using a iframe ensures that any HTML/CSS in the email template (which often has its own inline styles) won't interfere with the dialog or underlying admin page styling, keeping everything clean and isolated...
<img width="1302" height="872" alt="2025-11-16_20h13_03" src="https://github.com/user-attachments/assets/29998739-ade6-40b0-8ed0-b131e03dab1f" />
