### PR TITLE
Update API endpoints to fossbilling.net domain

### DIFF
--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -94,7 +94,7 @@ class Update implements InjectionAwareInterface
             $item->expiresAfter(3600);
 
             $httpClient = HttpClient::create(['bindto' => BIND_TO]);
-            $response = $httpClient->request('GET', "https://api.fossbilling.org/versions/build_changelog/{$end}");
+            $response = $httpClient->request('GET', "https://api.fossbilling.net/versions/v1/build_changelog/{$end}");
             $result = $response->toArray();
 
             return $result['result'];
@@ -143,7 +143,7 @@ class Update implements InjectionAwareInterface
                 $item->expiresAfter(3600);
 
                 try {
-                    $releaseInfoUrl = 'https://api.fossbilling.org/versions/latest';
+                    $releaseInfoUrl = 'https://api.fossbilling.net/versions/v1/latest';
                     $httpClient = HttpClient::create(['bindto' => BIND_TO]);
                     $response = $httpClient->request('GET', $releaseInfoUrl);
                     $releaseInfo = $response->toArray()['result'];


### PR DESCRIPTION
Changed API URLs in Update.php from fossbilling.org to fossbilling.net to reflect the updated endpoint locations for version and changelog retrieval.

Added a stats UI/endpoint to duplicate similar functionality in api.fossbilling.org for @BelleNottelling 🙂 : https://api.fossbilling.net/stats/v1. 

Edit: api.fossbilling.org is currently set to redirect to api.fossbilling.net equivalent endpoints.