### PR TITLE
Add 'Servicemembership' to cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -413,7 +413,8 @@
         "phpunit",
         "hcaptcha",
         "hCaptcha",
-        "LEMP"
+        "LEMP",
+        "Servicemembership"
     ],
     "ignorePaths": [
         "tests-legacy/**",


### PR DESCRIPTION
Updated cspell.json to include 'Servicemembership' in the list of recognized words to prevent false spelling errors.