### PR TITLE
Remove opcache extension installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN apt-get update \
   && docker-php-ext-install -j$(nproc) gd \
   && docker-php-ext-configure intl \
   && docker-php-ext-install -j$(nproc) intl \
-  && docker-php-ext-configure opcache \
-  && docker-php-ext-install -j$(nproc) opcache \
   && docker-php-ext-configure pdo_mysql \
   && docker-php-ext-install -j$(nproc) pdo_mysql \
   && apt-get clean \


### PR DESCRIPTION
The steps to configure and install the opcache PHP extension have been removed from the Dockerfile. This is due to opcache being enabled by default in PHP 8.5.