### PR TITLE
Extend PurgeCSS safelist for Bootstrap utility classes

### DIFF
--- a/frontend-build-utils/purgecss-plugin.mjs
+++ b/frontend-build-utils/purgecss-plugin.mjs
@@ -41,6 +41,24 @@ export async function purgeCssFile(cssFilePath, themePath, enabled = false) {
           /^fade$/, // Fade transition
           /^nav-/, // Navigation classes
           /^data-bs-/, // Bootstrap data attributes
+          /^btn-/, // Button variants
+          /^card-/, // Cards
+          /^badge-/, // Badges
+          /^form-/, // Form controls
+          /^text-/, // Text utilities
+          /^bg-/, // Background utilities
+          /^d-/, // Display utilities
+          /^m-/, // Margin utilities
+          /^p-/, // Padding utilities
+          /^w-/, // Width utilities
+          /^h-/, // Height utilities
+          /^border-/, // Border utilities
+          /^flex-/, // Flex utilities
+          /^justify-/, // Justify utilities
+          /^align-/, // Align utilities
+          /^offcanvas-/, // Offcanvas components
+          /^accordion-/, // Accordion components
+          /^carousel-/, // Carousel components
         ],
         deep: [
           /tom-select/, // Tom Select plugin styles


### PR DESCRIPTION
Add 18 new safelist patterns for Bootstrap utility classes to prevent PurgeCSS from removing needed styles during build.