### PR TITLE
Replace jQuery with vanilla JS in `PayPalEmail` adapter

### DIFF
--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -269,11 +269,11 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements FOS
         if (isset($this->config['auto_redirect']) && $this->config['auto_redirect']) {
             $form .= sprintf('<h2>%s</h2>', __trans('Redirecting to PayPal.com'));
             $form .= "<script>
-                        document.addEventListener('DOMContentLoaded', function() {
-                            document.getElementById('payment_button').style.display = 'none';
-                            document.forms['payment_form'].submit();
-                        });
-                     </script>";
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('payment_button').style.display = 'none';
+    document.forms['payment_form'].submit();
+});
+</script>";
         }
 
         return $form;


### PR DESCRIPTION
Remove jQuery dependency for auto-redirect functionality by using `document.addEventListener('DOMContentLoaded', ...)` instead of `.ready()`.