### PR TITLE
Fix search query logic in Support service

### DIFF
--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -1544,7 +1544,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
 
         if ($search) {
-            $sql .= ' AND title LIKE :q OR content LIKE :q';
+            $sql .= ' AND (title LIKE :q OR content LIKE :q)';
             $filter[':q'] = "%$search%";
         }
 


### PR DESCRIPTION
Wraps the title and content `LIKE` conditions in parentheses to ensure correct SQL operator precedence when filtering support entries by search term.