### PR TITLE
Add parentheses to SQL `WHERE` clauses for correct logic

### DIFF
--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -154,11 +154,11 @@ class Service implements InjectionAwareInterface
         // smartSearch
         if ($search) {
             if (is_numeric($search)) {
-                $where[] = 'c.id = :cid or c.aid = :caid';
+                $where[] = '(c.id = :cid OR c.aid = :caid)';
                 $params[':cid'] = $search;
                 $params[':caid'] = $search;
             } else {
-                $where[] = "c.company LIKE :s_company OR c.first_name LIKE :s_first_time OR c.last_name LIKE :s_last_name OR c.email LIKE :s_email OR CONCAT(c.first_name,  ' ', c.last_name ) LIKE  :full_name";
+                $where[] = "(c.company LIKE :s_company OR c.first_name LIKE :s_first_time OR c.last_name LIKE :s_last_name OR c.email LIKE :s_email OR CONCAT(c.first_name,  ' ', c.last_name ) LIKE  :full_name)";
                 $search = '%' . $search . '%';
                 $params[':s_company'] = $search;
                 $params[':s_first_time'] = $search;
@@ -281,7 +281,7 @@ class Service implements InjectionAwareInterface
         $where = [];
         $params = [];
         if ($search) {
-            $where[] = 'c.first_name LIKE :first_name OR c.last_name LIKE :last_name OR c.id LIKE :id';
+            $where[] = '(c.first_name LIKE :first_name OR c.last_name LIKE :last_name OR c.id LIKE :id)';
             $params[':first_name'] = '%' . $search . '%';
             $params[':last_name'] = '%' . $search . '%';
             $params[':id'] = $search;

--- a/src/modules/Custompages/Service.php
+++ b/src/modules/Custompages/Service.php
@@ -43,7 +43,7 @@ class Service
         $filter = [];
         $sql = 'SELECT * FROM custom_pages WHERE 1';
         if ($search) {
-            $sql .= ' AND title LIKE :q OR content LIKE :q';
+            $sql .= ' AND (title LIKE :q OR content LIKE :q)';
             $filter[':q'] = "%$search%";
         }
         $sql .= ' ORDER BY id DESC';

--- a/src/modules/Invoice/ServiceSubscription.php
+++ b/src/modules/Invoice/ServiceSubscription.php
@@ -163,7 +163,7 @@ class ServiceSubscription implements InjectionAwareInterface
         }
 
         if ($search) {
-            $sql .= ' AND sid = :sid OR id = :mid ';
+            $sql .= ' AND (sid = :sid OR id = :mid) ';
             $params[':sid'] = $search;
             $params[':mid'] = $search;
         }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -743,7 +743,7 @@ class Service implements InjectionAwareInterface
         $where = [];
         $params = [];
         if ($search) {
-            $where[] = ' a.name LIKE :name OR a.id LIKE :id OR a.email LIKE :email ';
+            $where[] = '(a.name LIKE :name OR a.id LIKE :id OR a.email LIKE :email)';
             $params['name'] = "%$search%";
             $params['id'] = "%$search%";
             $params['email'] = "%$search%";

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -1069,7 +1069,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
                 $bindings[':p_ticket_id'] = $search;
             } else {
                 $search = '%' . $search . '%';
-                $where[] = 'sptm.content LIKE :p_message_content OR spt.subject LIKE :p_ticket_subject';
+                $where[] = '(sptm.content LIKE :p_message_content OR spt.subject LIKE :p_ticket_subject)';
                 $bindings[':p_message_content'] = $search;
                 $bindings[':p_ticket_subject'] = $search;
             }
@@ -1352,7 +1352,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         if ($search) {
             $search = '%' . $search . '%';
-            $where[] = 'title LIKE :title OR content LIKE :content';
+            $where[] = '(title LIKE :title OR content LIKE :content)';
             $bindings[':title'] = $search;
             $bindings[':content'] = $search;
         }

--- a/tests-legacy/modules/Client/ServiceTest.php
+++ b/tests-legacy/modules/Client/ServiceTest.php
@@ -238,7 +238,7 @@ final class ServiceTest extends \BBTestCase
             ],
             [
                 ['search' => '2'],
-                'c.id = :cid or c.aid = :caid',
+                '(c.id = :cid OR c.aid = :caid)',
                 [':cid' => '2', ':caid' => '2'],
             ],
             [


### PR DESCRIPTION
Wrapped `OR` conditions in SQL `WHERE` clauses with parentheses across multiple service classes to ensure correct logical grouping and prevent operator precedence issues during search queries.