### PR TITLE
Fix duplicate `updateContacts()` call in Client API

### DIFF
--- a/src/modules/Servicedomain/Api/Client.php
+++ b/src/modules/Servicedomain/Api/Client.php
@@ -46,8 +46,6 @@ class Client extends \Api_Abstract
     {
         $s = $this->_getService($data);
 
-        $this->getService()->updateContacts($s, $data);
-
         return $this->getService()->updateContacts($s, $data);
     }
 


### PR DESCRIPTION
Fixes the duplicate `updateContacts()` call bug reported in issue #3137.