### PR TITLE
Prevent add funds invoices from being auto-paid with credits

### DIFF
--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -126,9 +126,12 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements FOS
                         throw new Payment_Exception('Cannot process duplicate IPN');
                     }
                     $api_admin->client_balance_add_funds($bd);
-                    if ($tx['invoice_id']) {
+                    // Skip payment for deposit invoices - funds were already added above
+                    $invoiceService = $this->di['mod_service']('Invoice');
+                    $invoiceDbModel = $this->di['db']->load('Invoice', $tx['invoice_id']);
+                    if ($tx['invoice_id'] && !$invoiceService->isInvoiceTypeDeposit($invoiceDbModel)) {
                         $api_admin->invoice_pay_with_credits(['id' => $tx['invoice_id']]);
-                    } else {
+                    } elseif (!$tx['invoice_id']) {
                         $api_admin->invoice_batch_pay_with_credits(['client_id' => $client_id]);
                     }
                 }

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -176,9 +176,10 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                 $clientService->addFunds($client, $bd['amount'], $bd['description'], $bd);
 
                 // Now pay the invoice / batch pay if there's no invoice associated with the transaction
-                if ($tx->invoice_id) {
+                // Skip payment for deposit invoices - funds were already added above
+                if ($tx->invoice_id && !$invoiceService->isInvoiceTypeDeposit($invoice)) {
                     $invoiceService->payInvoiceWithCredits($invoice);
-                } else {
+                } elseif (!$tx->invoice_id) {
                     $invoiceService->doBatchPayWithCredits(['client_id' => $client->id]);
                 }
             }


### PR DESCRIPTION
Added a check using the existing `isInvoiceTypeDeposit()` method to skip credit payment for deposit invoices, since funds were already added directly. This is consistent with how the `ClientBalance` payment adapter already handles this case.

Closes #2988.