### PR TITLE
Expand Stripe payment status mapping

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -190,8 +190,15 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
         $paymentStatus = match ($charge->status) {
             'succeeded' => 'processed',
+            'requires_action' => 'received',
+            'requires_payment_method' => 'received',
+            'requires_confirmation' => 'received',
+            'requires_capture' => 'received',
+            'processing' => 'received',
             'pending' => 'received',
+            'canceled' => 'error',
             'failed' => 'error',
+            default => 'received',
         };
 
         $tx->status = $paymentStatus;


### PR DESCRIPTION
Added additional Stripe charge statuses to the status mapping, ensuring more accurate transaction status handling for cases such as 'requires_action', 'requires_payment_method', 'requires_confirmation', 'requires_capture', 'processing', and 'canceled'.

Closes #2553.