### PR TITLE
Fix PDF Unicode, tab persistence, invoice numbering

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -193,7 +193,7 @@ class Service implements InjectionAwareInterface
         $result['nr'] = $row['nr'];
         $result['client_id'] = $invoice->client_id;
 
-        $nr = (is_numeric($result['nr'])) ? $result['nr'] : $result['id'];
+        $nr = is_numeric($row['nr']) ? intval($row['nr']) : $result['id'];
         $result['serie_nr'] = $result['serie'] . sprintf('%0' . $invoice_number_padding . 's', $nr);
 
         $result['hash'] = $row['hash'];
@@ -1336,7 +1336,6 @@ class Service implements InjectionAwareInterface
         $pdf->setPaper($document_format, 'portrait');
         $options = $pdf->getOptions();
         $options->setChroot($_SERVER['DOCUMENT_ROOT']);
-        $options->setDefaultFont('DejaVu Sans');
 
         $sellerLines = 0;
         $buyerLines = 0;

--- a/src/modules/Product/html_admin/mod_product_manage.html.twig
+++ b/src/modules/Product/html_admin/mod_product_manage.html.twig
@@ -345,6 +345,26 @@
                 btn.setAttribute('href', "{{ 'extension/settings/formbuilder'|alink }}");
             }
         }
+
+        const urlHash = window.location.hash;
+        if (urlHash && urlHash.startsWith('#tab-')) {
+            const tabId = urlHash.substring(5);
+            const tabEl = document.querySelector(`[data-bs-target="#tab-${tabId}"]`);
+            if (tabEl) {
+                const tab = new bootstrap.Tab(tabEl);
+                tab.show();
+            }
+        }
+
+        document.querySelectorAll('.nav-tabs .nav-link').forEach(tabEl => {
+            tabEl.addEventListener('shown.bs.tab', function(e) {
+                const targetId = e.target.getAttribute('data-bs-target');
+                if (targetId && targetId.startsWith('#tab-')) {
+                    const tabName = targetId.substring(5);
+                    history.replaceState(null, null, '#' + tabName);
+                }
+            });
+        });
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

This PR addresses three GitHub issues with minimal, focused changes:

### Fix #3157 - Thai/Asian Languages not recognized in PDF
- **File:** `src/modules/Invoice/Service.php`
- **Change:** Removed `setDefaultFont('DejaVu Sans')` from PDF generation
- **Reason:** DejaVu Sans lacks proper Unicode support for Thai, CJK, and other non-Latin scripts. Removing this allows dompdf to use its internal font handling which supports a wider range of characters.

### Fix #2618 - Invoice number format mismatch
- **File:** `src/modules/Invoice/Service.php`
- **Change:** Ensured `nr` is always stored as an integer using `intval()`
- **Reason:** The client template was applying 5-digit padding, but if `nr` was already stored as a string with leading zeros (e.g., "00014"), double-padding could occur resulting in formats like 2025030000014 instead of 2025030014.

### Fix #2835 - Stay on page after configuration changes
- **File:** `src/modules/Product/html_admin/mod_product_manage.html.twig`
- **Change:** Added JavaScript to persist the active tab via URL hash
- **Reason:** After submitting product configuration changes, users were redirected back to the General Settings tab instead of staying on their current tab (Configuration, Addons, etc.).

## Testing
- PHP syntax verified: No errors
- Code follows existing project conventions