### PR TITLE
Replace `ctype_alnum` with `preg_match`

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -255,7 +255,7 @@ class Service implements InjectionAwareInterface
         $mods = [];
         $handle = opendir(PATH_MODS);
         while ($name = readdir($handle)) {
-            if ($name && ctype_alnum($name)) {
+            if ($name && preg_match('/^[a-zA-Z0-9]+$/', $name)) {
                 $m = $name;
                 $mod = $this->di['mod']($m);
                 if ($mod->isCore()) {


### PR DESCRIPTION
Replace `ctype_alnum` with `preg_match` to work around intermittent PHPStan CI error. 

Local benchmarking didn't suggest any notable performance concerns with the change.