### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/themes/huraga/assets/huraga.js
+++ b/src/themes/huraga/assets/huraga.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.assign(reload);
       }
     }
-  }
+  };
   flashMessage({});
 
   /**


### PR DESCRIPTION
To fix the problem, the assignment statement defining `globalThis.flashMessage` should be explicitly terminated with a semicolon. This removes reliance on automatic semicolon insertion and matches the surrounding coding style.

Concretely, in `src/themes/huraga/assets/huraga.js`, locate the arrow function assigned to `globalThis.flashMessage`. At line 33, change the closing line of that function from just `}` to `};`. This keeps the function body and all logic identical while clearly ending the assignment statement. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._