### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/themes/admin_default/esbuild.mjs
+++ b/src/themes/admin_default/esbuild.mjs
@@ -1,7 +1,7 @@
 import * as esbuild from 'esbuild';
 import { fileURLToPath } from 'url';
 import { dirname, resolve, join, basename } from 'path';
-import { readFile, readdir, copyFile, writeFile } from 'fs/promises';
+import { readFile, readdir, writeFile } from 'fs/promises';
 import { sassPlugin, postprocessCssFile } from '@fossbilling/frontend-build-utils/plugins';
 import { ensureDir, removeDirContents } from '@fossbilling/frontend-build-utils/helpers';
 import { purgeCssFile } from '@fossbilling/frontend-build-utils/purgecss-plugin.mjs';


### PR DESCRIPTION
To fix the problem, remove the unused `copyFile` named import from the `fs/promises` import statement. This keeps the used imports (`readFile`, `readdir`, `writeFile`) intact and does not change any runtime behavior, because `copyFile` was not referenced anywhere.

Concretely, in `src/themes/admin_default/esbuild.mjs`, update line 4 from:

```mjs
import { readFile, readdir, copyFile, writeFile } from 'fs/promises';
```

to:

```mjs
import { readFile, readdir, writeFile } from 'fs/promises';
```

No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._