### PR TITLE
Replace gravatar with libravatar

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -280,7 +280,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
      * 
      * @param string $email The user's email address.
      * @param int $size 
-     * @return string 
+     * @return string The URL for the profile picture
      */
     public function twig_gravatar_filter(string $email, $size = 20): string
     {
@@ -291,7 +291,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
         $url = 'https://seccdn.libravatar.org/avatar/';
         $url .= md5(strtolower(trim((string) $email)));
 
-        return $url . "?s=$size";
+        return $url . "?s=$size&d=identicon";
     }
 
     public function twig_autolink_filter($text): ?string


### PR DESCRIPTION
This acts as a direct in-line replacement of gravatar with libravatar for no other purpose than to get avatars loading in some shape or form.

Not intended to be a permanent solution, but it works "for now"
<img width="543" height="298" alt="image" src="https://github.com/user-attachments/assets/842823b4-50ee-45a3-ae78-e7b9bdb936fc" />
