### PR TITLE
Fixes for admin theme `esbuild.mjs` code quality findings

### DIFF
--- a/src/themes/admin_default/esbuild.mjs
+++ b/src/themes/admin_default/esbuild.mjs
@@ -112,7 +112,7 @@ async function build() {
       bundle: true,
       outfile: resolve(__dirname, 'assets/build/css/fossbilling.css'),
       plugins: [sassPlugin(nodeModulesDir, isProduction)],
-      loader: loader: sharedLoaders,
+      loader: sharedLoaders,
       minify: isProduction,
       sourcemap: !isProduction,
       logLevel: 'info'
@@ -125,7 +125,7 @@ async function build() {
       entryPoints: [resolve(__dirname, 'assets/css/vendor.css')],
       bundle: true,
       outfile: resolve(__dirname, 'assets/build/css/vendor.css'),
-      loader: loader: sharedLoaders,
+      loader: sharedLoaders,
       minify: isProduction,
       sourcemap: !isProduction,
       logLevel: 'info'
@@ -139,7 +139,7 @@ async function build() {
       outfile: resolve(__dirname, 'assets/build/js/fossbilling.js'),
       platform: 'browser',
       target: 'es2018',
-      loader: loader: sharedLoaders,
+      loader: sharedLoaders,
       define: {
         'process.env.NODE_ENV': isProduction ? '"production"' : '"development"'
       },


### PR DESCRIPTION
Apply several code quality fixes:

- The variable name 'f' is too short and ambiguous. Consider using 'file' or 'filename' for better readability.
- The error in cleanBuild is caught but not handled or logged. Consider logging the error or adding a comment explaining why it's silently ignored.
- The loader configuration is duplicated three times (lines 105-111, 124-130, 144-150). Consider extracting this into a shared constant to reduce code duplication.



