### PR TITLE
Fix typo in class name for autocomplete template

### DIFF
--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const autocompleteTemplate = (item, escape) => {
     return `<div class="py-2 d-flex align-items-center text-body">
                 <span>${escape(item.label)}</span>
-                <small class="text-body-seconday ms-1 lh-1">#${escape(item.value)}</small>
+                <small class="text-body-secondary ms-1 lh-1">#${escape(item.value)}</small>
              </div>`;
   }
 


### PR DESCRIPTION
Corrected `text-body-seconday` to `text-body-secondary` spelling mistake in the autocomplete template introduced in #3203.