### PR TITLE
Restored activation and settings buttons for extensions

### DIFF
--- a/src/modules/Extension/html_admin/mod_extension_index.html.twig
+++ b/src/modules/Extension/html_admin/mod_extension_index.html.twig
@@ -88,8 +88,17 @@
                                             {% endif %}
                                         {% endif %}
                                     </td>
-                                    {% if ext.type == 'mod' and ext.status != 'installed' %}
                                     <td>
+                                        {% if ext.type == 'mod' and ext.status != 'installed' %}
+                                            <a class="btn btn-icon"
+                                                href="{{ 'api/admin/extension/activate'|link({ 'type': ext.type, 'id': ext.id }) }}"
+                                                {{ fb_api_link({modal: { type: 'confirm', title: 'Are you sure?'|trans, button: 'Activate'|trans}, callback: 'onAfterModuleActivated'}) }}
+                                                data-bs-toggle="tooltip" data-bs-title="{{ 'Activate'|trans }}">
+                                                <svg class="icon">
+                                                    <use xlink:href="#play" />
+                                                </svg>
+                                            </a>
+                                        {% endif %}
                                         {% if ext.has_settings %}
                                             <a class="btn btn-icon" href="{{ 'extension/settings'|alink }}/{{ ext.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Settings'|trans }}">
                                                 <svg class="icon">
@@ -98,7 +107,6 @@
                                             </a>
                                         {% endif %}
                                     </td>
-                                    {% endif %}
                                 </tr>
                             {% else %}
                                 <tr>


### PR DESCRIPTION
Restored the activation and settings buttons for extensions removed by accident in #2725.

<img width="1317" height="620" alt="image" src="https://github.com/user-attachments/assets/ba348cea-c9a9-47e6-b18e-247a311666f2" />

<img width="1317" height="614" alt="image" src="https://github.com/user-attachments/assets/715c2af0-ba37-41e1-bcfb-c81de39054bd" />
