### PR TITLE
Import Collapse component in Huraga

### DIFF
--- a/src/themes/huraga/assets/huraga.js
+++ b/src/themes/huraga/assets/huraga.js
@@ -1,8 +1,8 @@
-import { Tooltip, Toast, Modal } from 'bootstrap/dist/js/bootstrap.esm.js';
+import { Tooltip, Toast, Modal, Collapse } from 'bootstrap/dist/js/bootstrap.esm.js';
 import './js/utils';
 import { initAvatars } from './js/avatar.js';
 
-globalThis.bootstrap = { Tooltip, Toast, Modal };
+globalThis.bootstrap = { Tooltip, Toast, Modal, Collapse };
 
 document.addEventListener('DOMContentLoaded', () => {
   initAvatars();


### PR DESCRIPTION
Fixed error `can't access property "getOrCreateInstance", bootstrap.Collapse is undefined` while trying to checkout the cart in Huraga.