### PR TITLE
Switch CSRF to cookie-based double-submit pattern

### DIFF
--- a/src/di.php
+++ b/src/di.php
@@ -304,18 +304,26 @@ $di['twig'] = $di->factory(function () use ($di) {
         $_GET['ajax'] = true;
     }
 
-    // CSRF token
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-        $token = hash('md5', $_COOKIE['PHPSESSID'] ?? '');
-    } else {
-        $token = hash('md5', session_id());
+    // CSRF token - cookie-based double-submit pattern.
+    $session = $di['session'];
+    $csrfToken = $session->get('csrf_token');
+    if (empty($csrfToken)) {
+        $csrfToken = bin2hex(random_bytes(32));
+        $session->set('csrf_token', $csrfToken);
+    }
+    setcookie('csrf_token', $csrfToken, [
+        'expires' => 0,
+        'path' => '/',
+        'samesite' => 'Strict',
+        'secure' => isset($_SERVER['HTTPS']),
+    ]);
+
+    $redirectUri = $session->get('redirect_uri');
+    if (!empty($redirectUri)) {
+        $twig->addGlobal('redirect_uri', $redirectUri);
     }
 
-    if (!empty($_SESSION['redirect_uri'])) {
-        $twig->addGlobal('redirect_uri', $_SESSION['redirect_uri']);
-    }
-
-    $twig->addGlobal('CSRFToken', $token);
+    $twig->addGlobal('CSRFToken', $csrfToken);
     $twig->addGlobal('request', $_GET);
     $twig->addGlobal('guest', $di['api_guest']);
     $twig->addGlobal('FOSSBillingVersion', FOSSBilling\Version::VERSION);

--- a/src/library/Api/API.js
+++ b/src/library/Api/API.js
@@ -45,15 +45,11 @@ const Tools = {
   },
 
   /**
-   * @returns {string} The CSRF token.
-   * @throws {Error} If the CSRF token meta tag is not found.
+   * @returns {string|null} The CSRF token from cookie, or null if not found.
    */
   getCSRFToken: function () {
-    const metaElement = document.querySelector('meta[name="csrf-token"]');
-    if (!metaElement) {
-      throw new Error('CSRF token meta tag not found');
-    }
-    return metaElement.getAttribute('content');
+    const match = document.cookie.match(/csrf_token=([^;]*)/);
+    return match ? decodeURIComponent(match[1]) : null;
   },
 
   /**
@@ -358,6 +354,7 @@ const API = {
 
     const headers = {
       'Accept': 'application/json',
+      'X-CSRF-Token': Tools.getCSRFToken() || '',
     };
     if (body && !isFormData) {
       headers['Content-Type'] = 'application/json';

--- a/src/modules/Client/html_admin/mod_client_index.html.twig
+++ b/src/modules/Client/html_admin/mod_client_index.html.twig
@@ -12,7 +12,6 @@
         <div class="card-body">
             <h5>{{ 'Filter clients'|trans }}</h5>
             <form method="get">
-                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Client ID'|trans }}</label>
                     <div class="col">

--- a/src/modules/Currency/html_admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/html_admin/mod_currency_settings.html.twig
@@ -256,7 +256,6 @@
 
                 <div class="tab-pane fade" id="tab-converter" role="tabpanel">
                     <form method="post" action="">
-                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="card-body">
                             <div class="input-group">
                                 <span class="input-group-text">{{ guest.currency_get.code }}</span>

--- a/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
+++ b/src/modules/Custompages/html_admin/mod_custompages_index.html.twig
@@ -27,7 +27,6 @@
                         {% include "partial_batch_delete.html.twig" with {'action' : 'custompages/batch_delete'} %}
                         <div class="ms-auto text-muted">
                             <form method="get">
-                                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}">
                                 <input type="hidden" name="_url" value="{{request._url}}">
                                 <div class="input-group">
                                     <input type="text" class="form-control" placeholder="Search…" name="search">

--- a/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_transactions.html.twig
@@ -12,7 +12,7 @@
     <div class="card-body">
         <h5>{{ 'Filter transactions'|trans }}</h5>
         <form method="get">
-            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
+
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">

--- a/src/modules/Order/html_admin/mod_order_index.html.twig
+++ b/src/modules/Order/html_admin/mod_order_index.html.twig
@@ -12,7 +12,6 @@
     <div class="card-body">
         <h5>{{ 'Filter orders'|trans }}</h5>
         <form method="get">
-            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <div class="form-group mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'ID'|trans }}</label>
                 <div class="col">
@@ -273,7 +272,6 @@
             <div class="tab-pane fade" id="tab-new" role="tabpanel" aria-labelledby="new-tab">
                 <div class="card-body">
                     <form method="post" action="{{ 'order/new'|alink }}">
-                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="form-group mb-3 row">
                             <label class="form-label col-3 col-form-label" for="client_id">{{ 'Client'|trans }}</label>
                             <div class="col">

--- a/src/modules/Order/html_client/mod_order_manage.html.twig
+++ b/src/modules/Order/html_client/mod_order_manage.html.twig
@@ -174,7 +174,6 @@
                         </div>
                         <form action="" method="post" id="cancel-request-form" class="request-cancellation">
                             <div class="modal-body">
-                                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                                 <input type="hidden" name="rel_type" value="order">
                                 <input type="hidden" name="rel_id" value="{{ order.id }}">
                                 <input type="hidden" name="rel_task" value="cancel">
@@ -208,7 +207,6 @@
                         </div>
                         <form action="" method="post" id="open-ticket-form" class="open-ticket">
                             <div class="modal-body">
-                                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                                 <input type="hidden" name="rel_type" value="order">
                                 <input type="hidden" name="rel_id" value="{{ order.id }}">
                                 <div class="mb-3">
@@ -241,7 +239,6 @@
                         </div>
                         <form action="" method="post" id="upgrade-request-form" class="request-upgrade">
                             <div class="modal-body">
-                                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                                 <input type="hidden" name="rel_type" value="order">
                                 <input type="hidden" name="rel_id" value="{{ order.id }}">
                                 <input type="hidden" name="rel_task" value="upgrade">

--- a/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/html_admin/mod_orderbutton_settings.html.twig
@@ -182,7 +182,6 @@
         </div>
         <form class="">
             <div class="card-body">
-                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="row mb-3">
                     <div class="col">
                         <div class="row align-items-center">

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_config.html.twig
@@ -21,7 +21,6 @@
         </div>
     <div class="row mb-3">
         <form method="post" action="{{ 'api/admin/servicedownloadable/upload'|link }}" enctype="multipart/form-data" id="upload-form">
-            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             {% if product.config.filename  %}
             <div class="mb-3 row">
                 <label class="form-label col-3 col-form-label">{{ 'Currently uploaded file'|trans }}:</label>

--- a/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
+++ b/src/modules/Servicedownloadable/html_admin/mod_servicedownloadable_manage.html.twig
@@ -23,7 +23,6 @@
     <p class="text-muted">{{ 'Use this function to update existing order file. Client will be able to download new file from client area'|trans }}</p>
 
     <form method="post" action="{{ 'api/admin/servicedownloadable/upload'|link }}" enctype="multipart/form-data" id="upload-form">
-        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Upload new file'|trans }}:</label>
             <div class="col">

--- a/src/modules/Support/html_admin/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_admin/mod_support_tickets.html.twig
@@ -29,7 +29,6 @@
         <div class="card-body">
             <h5>{{ 'Filter Support Tickets'|trans }}</h5>
             <form method="get">
-                <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                 <div class="form-group mb-3 row">
                     <label class="form-label col-3 col-form-label">{{ 'Client ID'|trans }}</label>
                     <div class="col">

--- a/src/modules/Support/html_client/mod_support_kb_index.html.twig
+++ b/src/modules/Support/html_client/mod_support_kb_index.html.twig
@@ -31,7 +31,6 @@
                             <span class="small text-muted">{{ 'Explore our knowledge base categories and their associated articles below.'|trans }}</span>
                         </div>
                         <form method="get" action="" class="form-inline">
-                            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                             <input name="_url" type="hidden" value="/support/kb">
                             <div class="input-group">
                                 <input class="form-control" name="q" type="text" value="{{ request.q }}" placeholder="{{ 'What are you looking for?'|trans }}">

--- a/src/modules/Support/html_client/mod_support_ticket.html.twig
+++ b/src/modules/Support/html_client/mod_support_ticket.html.twig
@@ -133,7 +133,6 @@
                         <div class="card mt-3" id="reply-to">
                             <div class="card-body">
                                 <form id="ticket-reply-form">
-                                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                                     <input type="hidden" name="id" value="{{ ticket.id }}">
                                     <textarea name="content" cols="5" rows="10" class="editor-textarea form-control" required="required"
                                               id="ticket-reply-text"></textarea>

--- a/src/modules/Support/html_client/mod_support_tickets.html.twig
+++ b/src/modules/Support/html_client/mod_support_tickets.html.twig
@@ -83,7 +83,6 @@
             </div>
             <form action="" method="post" id="ticket-submit" class="form" style="background: none">
                 <div class="modal-body">
-                    <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                     <div class="form-group">
                     </div>
                     <div class="mb-3">

--- a/src/modules/Theme/html_admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/html_admin/mod_theme_preset.html.twig
@@ -68,7 +68,6 @@
                 <div class="card-body">
                     <h3 class="card-title">{{ 'Config for'|trans }} {{ current_preset }} {{ 'preset'|trans }}</h3>
                     <div class="" id="theme-settings">
-                        <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         <div class="accordion" id="preset-config">
                             {{ include(template_from_string(settings_html)) }}
                         </div>

--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -74,15 +74,17 @@ document.addEventListener('DOMContentLoaded', () => {
             const restUrl = new URL(Tools.getBaseURL(autocompleteSelectorEl.dataset.resturl));
             restUrl.searchParams.append("search", query);
 
-            // Add CSRF token if available
-            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
-            if (csrfToken) {
-              restUrl.searchParams.append("CSRFToken", csrfToken);
-            }
+            // Add CSRF token from cookie
+            const csrfTokenMatch = document.cookie.match(/csrf_token=([^;]+)/);
+            const csrfToken = csrfTokenMatch ? csrfTokenMatch[1] : null;
 
             restUrl.searchParams.append("per_page", 5);
 
-            fetch(restUrl)
+            fetch(restUrl, {
+              headers: {
+                'X-CSRF-Token': csrfToken || '',
+              }
+            })
               .then((response) => {
                 if (!response.ok) throw new Error('Network response was not ok');
                 return response.json();
@@ -151,12 +153,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         finalUrl.searchParams.append('id', value);
 
-        const csrfToken = getCSRFToken();
-        if (csrfToken) {
-          finalUrl.searchParams.append('CSRFToken', csrfToken);
-        }
+        const csrfTokenMatch = document.cookie.match(/csrf_token=([^;]+)/);
+        const csrfToken = csrfTokenMatch ? csrfTokenMatch[1] : null;
 
-        fetch(finalUrl)
+        fetch(finalUrl, {
+          headers: {
+            'X-CSRF-Token': csrfToken || '',
+          }
+        })
           .then((response) => {
             if (!response.ok) throw new Error('Network response was not ok');
             return response.json();

--- a/src/themes/admin_default/assets/js/utils.js
+++ b/src/themes/admin_default/assets/js/utils.js
@@ -9,11 +9,12 @@
  */
 
 /**
- * Get CSRF token from meta tag
+ * Get CSRF token from cookie
  * @returns {string|null} CSRF token or null if not found
  */
 export function getCSRFToken() {
-  return document.querySelector('meta[name="csrf-token"]')?.content || null;
+  const match = document.cookie.match(/csrf_token=([^;]+)/);
+  return match ? match[1] : null;
 }
 
 /**

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -11,7 +11,6 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="csrf-token" content="{{ CSRFToken }}">
 
     <link rel="shortcut icon" href="{{ company.favicon_url }}">
 

--- a/src/themes/admin_default/html/layout_login.html.twig
+++ b/src/themes/admin_default/html/layout_login.html.twig
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="csrf-token" content="{{ CSRFToken }}">
 
     <link rel="shortcut icon" href="{{ guest.system_company.favicon_url }}">
 

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -158,7 +158,6 @@
 <div style="position: relative;">
     <div class="dataTables_filter">
         <form method="get" action="">
-            <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             <input type="hidden" name="_url" value="{{request._url}}"/>
             <label>{{ 'Search:'|trans }} <input type="text" name="search" placeholder="{{ 'Enter search text...'|trans }}" value="{{ request.search }}"><div class="srch"></div></label>
         </form>

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -4,8 +4,6 @@
     <meta charset="utf-8">
     <title>{{ settings.meta_title_prefix }} {% block meta_title %}{% endblock %} {{ settings.meta_title_suffix }}</title>
 
-    <meta name="csrf-token" content="{{ CSRFToken }}">
-
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="keywords" content="{{ settings.meta_keywords }}">
     <meta name="robots" content="{{ settings.meta_robots }}">

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -4,8 +4,6 @@
     <meta charset="utf-8">
     <title>{{ settings.meta_title_prefix }} {% block meta_title %}{% endblock %} {{ settings.meta_title_suffix }}</title>
 
-    <meta name="csrf-token" content="{{ CSRFToken }}">
-
     <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="keywords" content="{{ settings.meta_keywords }}">
     <meta name="robots" content="{{ settings.meta_robots }}">


### PR DESCRIPTION
Implement major overhaul of the CSRF token handling mechanism throughout the application. System now uses a cookie-based double-submit pattern for CSRF protection, replacing previous session/meta tag approach.