### PR TITLE
Fix CWP

### DIFF
--- a/src/library/Server/Manager/CWP.php
+++ b/src/library/Server/Manager/CWP.php
@@ -142,7 +142,7 @@ class Server_Manager_CWP extends Server_Manager
         }
 
         $new->setPackage($acc['account_info']['package_name']);
-        $new->setReseller($acc['account_info']['reseller']);
+        $new->setReseller($acc['account_info']['reseller'] ?? false);
 
         return $new;
     }


### PR DESCRIPTION
On our Discord the following error was brought to my attention when trying to provision accounts on CWP:

> Server_Account::setReseller(): Argument #1 ($reseller) must be of type bool, null given, called in /home/user1/billing.domain.com/library/Server/Manager/CWP.php on line 146 (9998)

This patch should resolve that issue for us, though I am unsure about why it randomly cropped up to begin with