### PR TITLE
Fix CSS purging paths

### DIFF
--- a/src/themes/huraga/esbuild.mjs
+++ b/src/themes/huraga/esbuild.mjs
@@ -85,7 +85,7 @@ async function build() {
     });
 
     await postprocessCssFile(join(cssDir, 'huraga.css'), isProduction);
-    await purgeCssFile(join(cssDir, 'huraga.css'), __dirname, isProduction);
+    await purgeCssFile(join(cssDir, 'huraga.css'), __dirname, isProduction, true);
 
     // Build vendor CSS
     await esbuild.build({
@@ -105,7 +105,7 @@ async function build() {
       logLevel: 'info'
     });
 
-    await purgeCssFile(join(cssDir, 'vendor.css'), __dirname, isProduction);
+    await purgeCssFile(join(cssDir, 'vendor.css'), __dirname, isProduction, true);
 
     // Build markdown CSS
     await esbuild.build({


### PR DESCRIPTION
This PR resolves #3192 by updating the purge CSS function to accept a toggle which will switch between scanning the admin and client template directories since not all templates are found under the theme path itself