### PR TITLE
Apply patch 44 to the default structure.sql

### DIFF
--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -1419,12 +1419,14 @@ CREATE TABLE `transaction` (
   `error_code` int(11) DEFAULT NULL,
   `validate_ipn` tinyint(1) DEFAULT '1',
   `ipn` text,
+  `ipn_hash` varchar(64) DEFAULT NULL,
   `output` text,
   `note` text,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `invoice_id_idx` (`invoice_id`)
+  KEY `invoice_id_idx` (`invoice_id`),
+  KEY `transaction_ipn_hash_idx` (`gateway_id`, `ipn_hash`(64))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
Applied [patch 44](https://github.com/FOSSBilling/FOSSBilling/commit/77c34394d6a5f7fe8d73e696bfc098c466d167a6#diff-e2bcd8068464c35c8dd3c10bd21f1606c42cb8431d590175917a27f92117232cR412-R418) to the default structure.sql, which was skipped by the update patcher for new installations as `last_patch` is set to 49.

Fixes error `"SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ipn_hash' in 'WHERE'"` during IPN processing.