### PR TITLE
fix(license): prevent request data from being overwritten when alread…

### DIFF
--- a/src/modules/Servicelicense/Server.php
+++ b/src/modules/Servicelicense/Server.php
@@ -51,7 +51,9 @@ class Server implements \FOSSBilling\InjectionAwareInterface
 
     public function process($data): array
     {
-        $data = is_array($data) ? $data : (json_decode($data ?? '', true) ?: []);
+        if (!is_array($data)) {
+            $data = json_decode($data ?? '', true);
+        }
 
         if (empty($data)) {
             throw new \LogicException('Invalid request. Parameters missing?', 1000);


### PR DESCRIPTION
…y array

The process() method incorrectly reset $data to an empty array when it was already an array. This caused valid API requests to fail with error code 1000 ("Invalid request. Parameters missing?").

Fix:
- Only decode JSON when $data is not an array
- Preserve original array payload

This restores proper parameter validation for license API calls.

#3269 