### PR TITLE
Remove unused batch-delete in staff login history

### DIFF
--- a/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
+++ b/src/modules/Staff/html_admin/mod_staff_login_history.html.twig
@@ -53,7 +53,6 @@
     </table>
 
     <div class="card-footer d-flex align-items-center justify-content-between">
-        {{ include('partial_batch_delete.html.twig', { 'action': 'admin/staff/batch_delete_logs' }) }}
         {{ include('partial_pagination.html.twig', { 'list': history, 'url': 'staff/logins' }) }}
     </div>
 </div>


### PR DESCRIPTION
Deleting staff login history lines via the admin UI isn't supported anymore.