### PR TITLE
Fixed flags and Coloris being stripped from automated artifacts

### DIFF
--- a/src/themes/admin_default/esbuild.mjs
+++ b/src/themes/admin_default/esbuild.mjs
@@ -95,7 +95,7 @@ async function purgeCssFile(cssFilePath, themePath, enabled = false) {
       css: [{ raw: css, extension: 'css' }],
       safelist: {
         standard: [
-          /^fi-/, /^toast/, /^modal/, /^dropdown/, /^collapse/, /^alert/, /^spinner/,
+          /^fi-/, /^flag-country-/, /^clr-/, /^toast/, /^modal/, /^dropdown/, /^collapse/, /^alert/, /^spinner/,
           /^active$/, /^show$/, /^fade$/, /^nav-/, /^data-bs-/, /^btn-/, /^card-/,
           /^badge-/, /^form-/, /^text-/, /^bg-/, /^d-/, /^m-/, /^p-/, /^w-/, /^h-/,
           /^border-/, /^flex-/, /^justify-/, /^align-/, /^offcanvas-/, /^accordion-/, /^carousel-/,


### PR DESCRIPTION
Fixed an issue with PurgeCSS that stripped CSS classes belonging to Coloris and country flags. This made flags invisible and the color picker broken in automated preview/release builds.

<img width="515" height="503" alt="Screenshot 2026-03-05 at 13 16 17" src="https://github.com/user-attachments/assets/600a979d-fe8f-4e3d-8688-746c2711f4a4" />
