### PR TITLE
Fix VAT validation in Client API Guest (fixes #3253)

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -16,6 +16,8 @@
 namespace Box\Mod\Client\Api;
 
 use FOSSBilling\Validation\Api\RequiredParams;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 
 class Guest extends \Api_Abstract
 {
@@ -238,8 +240,8 @@ class Guest extends \Api_Abstract
     }
 
     /**
-     * Check if given vat number is valid EU country VAT number
-     * This method uses http://isvat.appspot.com/ method to validate VAT.
+     * Check if given vat number is valid EU country VAT number.
+     * Uses the EU VIES REST API to validate VAT numbers.
      *
      * @return bool true if VAT is valid, false if not
      */
@@ -249,9 +251,17 @@ class Guest extends \Api_Abstract
         $cc = $data['country'];
         $vatnum = $data['vat'];
 
-        // @todo add new service provider https://vatlayer.com/ check
-        //         $url    = 'http://isvat.appspot.com/' . rawurlencode($cc) . '/' . rawurlencode($vatnum) . '/';
-        return true;
+        $url = 'https://ec.europa.eu/taxation_customs/vies/rest-api/ms/' . rawurlencode($cc) . '/vat/' . rawurlencode($vatnum);
+
+        try {
+            $client = HttpClient::create(['bindto' => BIND_TO]);
+            $response = $client->request('GET', $url);
+            $content = $response->toArray();
+
+            return (bool) ($content['isValid'] ?? false);
+        } catch (ExceptionInterface $e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Summary
Fixes Issue#3253. The is_vat() method in src/modules/Client/Api/Guest.php was a stub that always returned true, so no real VAT validation was performed.

The Problem (old implementation):
Accepted country and vat parameters.
Always returned true, no matter what was entered.
Had validation logic commented out (the old isvat.appspot.com URL).
Result: Invalid VAT numbers (e.g., "INVALID123", "000000000") were accepted, potentially affecting tax compliance and data quality in systems that collect VAT.

The Fix
The method now validates VAT numbers using the EU VIES REST API (European Commission’s official VAT validation service):
Calls https://ec.europa.eu/taxation_customs/vies/rest-api/ms/{country}/vat/{vat_number} with the submitted country and VAT number.
Reads the isValid field from the JSON response.
Returns true only when the API reports the VAT as valid; otherwise, returns false.
On network or API errors, returns false so that we do not accept VAT numbers when validation cannot be performed.