### PR TITLE
Switch to per-service `HttpClient` for external IP

### DIFF
--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -331,7 +331,12 @@ class Tools
                     return $ip;
                 }
             } catch (\Exception $e) {
-                error_log($e->getMessage());
+                error_log(sprintf(
+                    'Error fetching external IP from "%s" (%s): %s',
+                    $service,
+                    get_class($e),
+                    $e->getMessage()
+                ));
             }
         }
 


### PR DESCRIPTION
Revert `getExternalIP()` back to foreach loop that explicitly tries each service, as `RetryableHttpClient` doesn't properly retry on timeout errors with multiple base URLs.