### PR TITLE
Fix Twig markdown on example text

### DIFF
--- a/src/library/Box/TwigExtensions.php
+++ b/src/library/Box/TwigExtensions.php
@@ -383,7 +383,7 @@ class Box_TwigExtensions extends AbstractExtension implements InjectionAwareInte
 
     public function twig_markdown_filter(Twig\Environment $env, $value)
     {
-        return $this->di['parse_markdown']($value);
+        return $this->di['parse_markdown']((string) $value);
     }
 
     public function twig_truncate_filter(Twig\Environment $env, $value, $length = 30, $preserve = false, $separator = '...')


### PR DESCRIPTION
When attempting to render the example markdown in email settings, an error is raised.
`An exception has been thrown during the rendering of a template ("{closure}(): Argument #1 ($content) must be of type ?string, Twig\Markup given`

Twig\Markup contains __toString() so casting to string resolves the issue.