### PR TITLE
Fixed invalidateSessions()

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -292,7 +292,7 @@ class Admin extends \Api_Abstract
      * Change client password.
      */
     #[RequiredParams(['id' => 'ID required', 'password' => 'Password required', 'password_confirm' => 'Password confirmation required'])]
-    public function change_password($data): bool
+    public function change_password(array $data): bool
     {
         $this->di['mod_service']('Staff')->checkPermissionsAndThrowException('client', 'change_password');
 
@@ -309,7 +309,7 @@ class Admin extends \Api_Abstract
         $this->di['db']->store($client);
 
         $profileService = $this->di['mod_service']('profile');
-        $profileService->invalidateSessions('client', $data['id']);
+        $profileService->invalidateSessions('client', (int) $data['id']);
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminClientPasswordChange', 'params' => ['id' => $client->id, 'password' => $data['password']]]);
 

--- a/src/modules/Profile/Api/Admin.php
+++ b/src/modules/Profile/Api/Admin.php
@@ -132,7 +132,7 @@ class Admin extends \Api_Abstract
     public function destroy_sessions(array $data): bool
     {
         $data['type'] ??= null;
-        $data['id'] ??= null;
+        $data['id'] = ($data['id'] === null) ? null : (int) $data['id'];
 
         return $this->getService()->invalidateSessions($data['type'], $data['id']);
     }

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -598,7 +598,7 @@ class Service implements InjectionAwareInterface
         $this->di['db']->store($model);
 
         $profileService = $this->di['mod_service']('profile');
-        $profileService->invalidateSessions('admin', $model->id);
+        $profileService->invalidateSessions('admin', (int) $model->id);
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffPasswordChange', 'params' => ['id' => $model->id]]);
 


### PR DESCRIPTION
As $id is expected to be an int or null, basic typecasting to ensure correct type is being provided.