### PR TITLE
Remove guest API system version endpoint

### DIFF
--- a/src/console.php
+++ b/src/console.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
+use FOSSBilling\Version;
 
 $di = include Path::join(PATH_ROOT, 'di.php');
 
@@ -29,7 +30,7 @@ $filesystem = new Filesystem();
 
 // Setting the application constraints
 $application->setName('FOSSBilling');
-$application->setVersion($di['mod_service']('system')->getVersion());
+$application->setVersion(Version::VERSION);
 
 $modules = $di['mod']('extension')->getCoreModules();
 

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -340,8 +340,7 @@ VALUES
 	(28,'funds_min_amount','10',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(29,'funds_max_amount','200',0,NULL,NULL,'2022-12-01 12:00:00','2022-12-01 12:00:00'),
 	(30,'company_favicon','themes/huraga/assets/build/favicon.ico',0,NULL,NULL,'2023-01-08 12:00:00','2023-01-08 12:00:00'),
-    (31,'hide_version_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00'),
-    (32,'hide_company_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
+    (31,'hide_company_public',1,0,NULL,NULL,'2023-07-31 12:00:00', '2023-07-31 12:00:00');
 
 /*!40000 ALTER TABLE `setting` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -421,9 +421,7 @@ class Client implements InjectionAwareInterface
         header('Cache-Control: no-cache, must-revalidate');
         header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
         header('Content-type: application/json; charset=utf-8');
-        if ($this->di['mod_service']('system')->shouldExposeVersion()) {
-            header('X-FOSSBilling-Version: ' . \FOSSBilling\Version::VERSION);
-        }
+
         if ($this->_requests_left !== null) {
             header('X-RateLimit-Span: ' . $this->_rate_span);
             header('X-RateLimit-Limit: ' . $this->_rate_limit);

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -22,18 +22,6 @@ use FOSSBilling\Validation\Api\RequiredParams;
 class Guest extends \Api_Abstract
 {
     /**
-     * Get FOSSBilling version.
-     *
-     * @return string
-     */
-    public function version()
-    {
-        $service = $this->getService();
-
-        return $service->shouldExposeVersion() ? $service->getVersion() : '';
-    }
-
-    /**
      * Returns company information.
      *
      * @return array

--- a/src/modules/System/Commands/Version.php
+++ b/src/modules/System/Commands/Version.php
@@ -38,7 +38,7 @@ class Version extends Command implements \FOSSBilling\InjectionAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln($this->di['mod_service']('system')->getVersion());
+        $output->writeln(\FOSSBilling\Version::VERSION);
 
         return Command::SUCCESS;
     }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -1006,18 +1006,6 @@ class Service
         return $this->di['db']->getAssoc($query);
     }
 
-    public function getVersion(): string
-    {
-        return Version::VERSION;
-    }
-
-    public function shouldExposeVersion(): bool
-    {
-        $hideVersionPublic = $this->getParamValue('hide_version_public');
-
-        return $this->di['auth']->isAdminLoggedIn() || !$hideVersionPublic;
-    }
-
     public function getPendingMessages()
     {
         $messages = $this->di['session']->get('pending_messages');
@@ -1080,7 +1068,6 @@ class Service
             'company_number',
             'company_vat_number',
             'company_account_number',
-            'hide_version_public',
             'hide_company_public',
             'company_signature',
         ];

--- a/src/modules/System/templates/admin/mod_system_settings.html.twig
+++ b/src/modules/System/templates/admin/mod_system_settings.html.twig
@@ -161,27 +161,6 @@
                             </div>
                             <div class="mb-3 row">
                                 <label class="form-label col-3 col-form-label">
-                                    {{ 'Disallow guest API to fetch FOSSBilling version' | trans }}
-                                    <br/>
-                                    <small class="text-muted">{{'Enabling this functionality may affect modules that depend on it.' | trans }}</small>
-                                </label>
-                                <div class="col">
-                                    <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showPublicYes" type="radio" name="hide_version_public" value="1" {% if params.hide_version_public == "1" %}checked{% endif %}>
-                                        <label class="form-check-label" for="radio_showPublicYes">
-                                            {{ 'Yes' | trans }}
-                                        </label>
-                                    </div>
-                                    <div class="form-check form-check-inline">
-                                        <input class="form-check-input" id="radio_showPublicNo" type="radio" name="hide_version_public" value="0" {% if params.hide_version_public == "0" %}checked{% endif %}>
-                                        <label class="form-check-label" for="radio_showPublicNo">
-                                            {{ 'No' | trans }}
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="mb-3 row">
-                                <label class="form-label col-3 col-form-label">
                                     {{ 'Hide some company information in the guest API' | trans }}
                                     <br/>
                                     <small class="text-muted">{{'Enabling this will hide some information from the "company" guest API endpoint such as the address, phone number, email, VAT number, and more.' | trans }}</small>

--- a/tests-legacy/modules/System/Api/GuestTest.php
+++ b/tests-legacy/modules/System/Api/GuestTest.php
@@ -23,42 +23,7 @@ final class GuestTest extends \BBTestCase
         $getDi = $this->api->getDi();
         $this->assertEquals($di, $getDi);
     }
-
-    public function testVersionShowPublicOn(): void
-    {
-        $serviceMock = $this->createMock(\Box\Mod\System\Service::class);
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('shouldExposeVersion')
-            ->willReturn(true);
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('getVersion')
-            ->willReturn(\FOSSBilling\Version::VERSION);
-
-        $di = $this->getDi();
-        $this->api->setDi($di);
-        $this->api->setService($serviceMock);
-        $result = $this->api->version();
-
-        $this->assertIsString($result);
-        $this->assertNotEmpty($result);
-    }
-
-    public function testVersionShowPublicOff(): void
-    {
-        $serviceMock = $this->createMock(\Box\Mod\System\Service::class);
-        $serviceMock->expects($this->atLeastOnce())
-            ->method('shouldExposeVersion')
-            ->willReturn(false);
-
-        $di = $this->getDi();
-        $this->api->setDi($di);
-        $this->api->setService($serviceMock);
-        $result = $this->api->version();
-
-        $this->assertIsString($result);
-        $this->assertEmpty($result);
-    }
-
+    
     public function testCompanyShowPublicOn(): void
     {
         $companyData = ['companyName' => 'TestCo'];

--- a/tests-legacy/modules/System/ServiceTest.php
+++ b/tests-legacy/modules/System/ServiceTest.php
@@ -327,13 +327,6 @@ final class ServiceTest extends \BBTestCase
         $this->assertIsArray($result);
     }
 
-    public function testGetVersion(): void
-    {
-        $result = $this->service->getVersion();
-        $this->assertIsString($result);
-        $this->assertEquals(\FOSSBilling\Version::VERSION, $result);
-    }
-
     public function testGetPendingMessages(): void
     {
         $di = $this->getDi();


### PR DESCRIPTION
Doesn't really need to exist. `\FOSSBilling\Version::VERSION` should be used internally.