### PR TITLE
Fixed invisible company logo in staff auth pages

### DIFF
--- a/src/modules/Staff/templates/admin/mod_staff_login.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_login.html.twig
@@ -2,13 +2,16 @@
 
 {% block meta_title %}{{ 'Login'|trans }}{% endblock %}
 
+{% set company = guest.system_company %}
+
 {% block content %}
 
 <div class="page page-center">
     <div class="container-tight py-4">
         <div class="text-center mb-4">
-            <a href="{{ '/'|url(area: 'client') }}" class="navbar-brand">
-                <img src="{{ guest.system_company.logo_url }}" height="75" alt="{{ guest.system_company.name }}">
+            <a href="{{ '/'|url(area: 'client') }}">
+                <img class="hide-theme-light" src="{{ company.logo_url_dark }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
+                <img class="hide-theme-dark" src="{{ company.logo_url }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
             </a>
         </div>
         <div class="card card-md">

--- a/src/modules/Staff/templates/admin/mod_staff_password_reset.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_password_reset.html.twig
@@ -9,8 +9,9 @@
 <div class="page page-center">
     <div class="container-tight py-4">
         <div class="text-center mb-4">
-            <a href="{{ '/'|url(area: 'client') }}" class="navbar-brand">
-                <img src="{{ guest.system_company.logo_url }}" height="75" alt="{{ guest.system_company.name }}">
+            <a href="{{ '/'|url(area: 'client') }}">
+                <img class="hide-theme-light" src="{{ company.logo_url_dark }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
+                <img class="hide-theme-dark" src="{{ company.logo_url }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
             </a>
         </div>
         <div class="card card-md">

--- a/src/modules/Staff/templates/admin/mod_staff_password_reset.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_password_reset.html.twig
@@ -4,6 +4,8 @@
 
 {% block meta_title %}{{ 'Reset your password'|trans }}{% endblock %}
 
+{% set company = guest.system_company %}
+
 {% block content %}
 
 <div class="page page-center">

--- a/src/modules/Staff/templates/admin/mod_staff_password_update.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_password_update.html.twig
@@ -2,6 +2,8 @@
 
 {% block meta_title %}{{ 'Reset your password'|trans }}{% endblock %}
 
+{% set company = guest.system_company %}
+
 {% block content %}
 
 <div class="page page-center">

--- a/src/modules/Staff/templates/admin/mod_staff_password_update.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_password_update.html.twig
@@ -7,8 +7,9 @@
 <div class="page page-center">
     <div class="container-tight py-4">
         <div class="text-center mb-4">
-            <a href="{{ '/'|url(area: 'client') }}" class="navbar-brand">
-                <img src="{{ guest.system_company.logo_url }}" height="75" alt="{{ guest.system_company.name }}">
+            <a href="{{ '/'|url(area: 'client') }}">
+                <img class="hide-theme-light" src="{{ company.logo_url_dark }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
+                <img class="hide-theme-dark" src="{{ company.logo_url }}" style="height: 60px; width: auto;" alt="{{ company.name }}">
             </a>
         </div>
         <div class="card card-md">


### PR DESCRIPTION
Fixed company logo rendering in staff authentication pages. Previously they were overridden with a CSS rule that prevented them from rendering.