### PR TITLE
Fix for code scanning alert no. 423: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-cs-fix.yml
+++ b/.github/workflows/auto-cs-fix.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 12 * * 2,4" # Runs once every Tuesday and Thursday
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   fix-cs:
     name: Rector & PHP-CS-Fixer


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/FOSSBilling/security/code-scanning/423](https://github.com/FOSSBilling/FOSSBilling/security/code-scanning/423)

Add an explicit `permissions` block to the workflow file so token scope is intentionally constrained.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), setting only what this workflow needs. A safe minimum based on the workflow behavior is:

- `contents: read` (for checkout/read access)
- `pull-requests: write` (workflow creates/updates PRs)

This change should be made in `.github/workflows/auto-cs-fix.yml` just after the `on:` block (before `jobs:`), without changing job steps or behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
