### PR TITLE
Reject non-scalar select/radio config values

### DIFF
--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1402,7 +1402,7 @@ class Service implements InjectionAwareInterface
             $options = $field['options'] ?? [];
             if (!empty($options)) {
                 if ($field['type'] === 'select' || $field['type'] === 'radio') {
-                    if ($value !== null && $value !== '' && !array_key_exists($value, $options) && !in_array($value, $options, true)) {
+                    if ($value !== null && $value !== '' && (!is_scalar($value) || (!array_key_exists($value, $options) && !in_array($value, $options, true)))) {
                         throw new \FOSSBilling\Exception('Invalid value for field ":field"', [':field' => $field['label']], 4893);
                     }
                 } elseif ($field['type'] === 'checkbox') {

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1402,7 +1402,15 @@ class Service implements InjectionAwareInterface
             $options = $field['options'] ?? [];
             if (!empty($options)) {
                 if ($field['type'] === 'select' || $field['type'] === 'radio') {
-                    if ($value !== null && $value !== '' && (!is_scalar($value) || (!array_key_exists($value, $options) && !in_array($value, $options, true)))) {
+                    if ($value === null || $value === '') {
+                        continue;
+                    }
+
+                    if (!is_scalar($value)) {
+                        throw new \FOSSBilling\Exception('Invalid value for field ":field"', [':field' => $field['label']], 4893);
+                    }
+
+                    if (!array_key_exists($value, $options) && !in_array($value, $options, true)) {
                         throw new \FOSSBilling\Exception('Invalid value for field ":field"', [':field' => $field['label']], 4893);
                     }
                 } elseif ($field['type'] === 'checkbox') {

--- a/tests-legacy/modules/Order/ServiceTest.php
+++ b/tests-legacy/modules/Order/ServiceTest.php
@@ -2304,6 +2304,38 @@ final class ServiceTest extends \BBTestCase
         $this->service->updateOrderConfig($order, ['plan' => 'enterprise']);
     }
 
+    public function testUpdateOrderConfigSelectRejectsArrayValue(): void
+    {
+        $this->expectException(\FOSSBilling\Exception::class);
+        $this->expectExceptionCode(4893);
+
+        $form = [
+            'fields' => [
+                ['name' => 'plan', 'label' => 'Plan', 'type' => 'select', 'required' => false, 'options' => ['basic' => 'Basic', 'pro' => 'Pro']],
+            ],
+        ];
+
+        $formbuilderServiceMock = $this->createMock(\Box\Mod\Formbuilder\Service::class);
+        $formbuilderServiceMock->expects($this->once())
+            ->method('getForm')
+            ->willReturn($form);
+
+        $di = $this->getDi();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($formbuilderServiceMock) {
+            if ($serviceName === 'formbuilder') {
+                return $formbuilderServiceMock;
+            }
+        });
+
+        $this->service->setDi($di);
+
+        $order = new \Model_ClientOrder();
+        $order->loadBean(new \DummyBean());
+        $order->form_id = 11;
+
+        $this->service->updateOrderConfig($order, ['plan' => ['pro']]);
+    }
+
     public function testUpdateOrderConfigInvalidRadioOption(): void
     {
         $this->expectException(\FOSSBilling\Exception::class);


### PR DESCRIPTION
### Motivation
- A crafted nested admin parameter (e.g. `config[plan][]=x`) could make a select/radio value an array and trigger a `TypeError` when passed to `array_key_exists()`, converting a handled validation failure into an uncaught request-level 500. 
- The API controller only catches `Exception`, so the `TypeError` was not converted into a normal JSON API error. 
- The change prevents accidental engine-level crashes while preserving the existing validation semantics.

### Description
- Added a scalar check to `validateConfigAgainstForm()` in `src/modules/Order/Service.php` so `select`/`radio` values are rejected if not a scalar before calling `array_key_exists()` or `in_array()`. 
- Implemented the condition as `!is_scalar($value) || (!array_key_exists($value, $options) && !in_array($value, $options, true))` to keep prior behavior for valid scalar values. 
- Added a regression unit test `testUpdateOrderConfigSelectRejectsArrayValue()` to `tests-legacy/modules/Order/ServiceTest.php` that submits an array for a select field and expects `FOSSBilling\Exception` with code `4893`. 
- Modified files: `src/modules/Order/Service.php` and `tests-legacy/modules/Order/ServiceTest.php`.

### Testing
- Added unit test `testUpdateOrderConfigSelectRejectsArrayValue()` to assert array input for a select field is handled as a validation error (expects exception code `4893`).
- Ran a targeted PHPUnit invocation (`./src/vendor/bin/phpunit ...`) in this environment but it failed because the PHPUnit binary is not present (`./src/vendor/bin/phpunit: No such file or directory`).
- Static inspection and local test harnesses were used to verify the scalar check prevents `array_key_exists()` from receiving an array and avoids the `TypeError` crash.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008f95ceb8832e90992a4b91acbc72)