### PR TITLE
Refactor admin "mark as paid" Invoice functionality to be more robust

### DIFF
--- a/src/library/Box/Database.php
+++ b/src/library/Box/Database.php
@@ -54,6 +54,20 @@ class Box_Database implements InjectionAwareInterface
         return $this->orm->store($bean);
     }
 
+    public function transaction(callable $callback)
+    {
+        if (!is_object($this->orm) || !method_exists($this->orm, 'getDatabaseAdapter')) {
+            return $callback();
+        }
+
+        $adapter = $this->orm->getDatabaseAdapter();
+        if ($adapter === null) {
+            return $callback();
+        }
+
+        return RedBeanPHP\Util\Transaction::transaction($adapter, $callback);
+    }
+
     public function getAll($sql, $values = [])
     {
         return $this->orm->getAll($sql, $values);

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -64,41 +64,9 @@ class Admin extends \Api_Abstract
      */
     public function mark_as_paid($data)
     {
-        $execute = false;
-        if (isset($data['execute']) && $data['execute']) {
-            $execute = true;
-        }
         $invoice = $this->_getInvoice($data);
-        $gateway_id = ['id' => $invoice->gateway_id];
 
-        if (!$gateway_id['id']) {
-            throw new InformationException('You must set the payment gateway in the invoice manage tab before marking it as paid.');
-        }
-
-        $payGateway = $this->gateway_get($gateway_id);
-        $charge = false;
-
-        // Check if the payment type is "Custom Payment", Add the transaction and process it.
-        if (($payGateway['code'] ?? null) == 'Custom' && ($payGateway['enabled'] ?? 0) == 1) {
-            // create transaction
-            $transactionService = $this->di['mod_service']('Invoice', 'Transaction');
-            $newtx = $transactionService->create([
-                'invoice_id' => $invoice->id,
-                'gateway_id' => $invoice->gateway_id,
-                'currency' => $invoice->currency,
-                'status' => 'received',
-                'source' => 'admin',
-                'txn_id' => $data['transactionId'],
-            ]);
-
-            try {
-                return $transactionService->processTransaction($newtx);
-            } catch (\Exception $e) {
-                $this->di['logger']->info("Error processing transaction: {$e->getMessage()}.");
-            }
-        }
-
-        return $this->getService()->markAsPaid($invoice, $charge, $execute);
+        return $this->getService()->markAsPaidByAdmin($invoice, $data);
     }
 
     /**

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -55,12 +55,12 @@ class Admin extends \Api_Abstract
     /**
      * Sets invoice status to paid. This method differs from invoice update method
      * in a way that it sends notification to Events system, so emails are sent.
-     * Also this will try to automatically apply payment if clients balance is
-     * available.
      *
      * @optional bool $execute - execute related tasks on invoice items. Default false.
+     * @optional int $gateway_id - Payment gateway to associate with the invoice
+     * @optional string $transactionId - Custom transaction ID to use when the selected gateway is Custom
      *
-     * @return array
+     * @return bool
      */
     public function mark_as_paid($data)
     {

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -503,7 +503,7 @@ class Service implements InjectionAwareInterface
             return true;
         }
 
-        $execute = (bool) ($data['execute'] ?? false);
+        $execute = \Tools::normalizeBoolean($data['execute'] ?? false);
         $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
         $transactionId = isset($data['transactionId']) ? trim((string) $data['transactionId']) : null;
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -501,6 +501,7 @@ class Service implements InjectionAwareInterface
     {
         $execute = (bool) ($data['execute'] ?? false);
         $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
+        $transactionId = isset($data['transactionId']) ? trim((string) $data['transactionId']) : null;
 
         if ((int) $payGateway->id !== (int) $invoice->gateway_id) {
             $invoice->gateway_id = (int) $payGateway->id;
@@ -516,7 +517,7 @@ class Service implements InjectionAwareInterface
                 'currency' => $invoice->currency,
                 'status' => 'received',
                 'source' => 'admin',
-                'txn_id' => $data['transactionId'] ?? null,
+                'txn_id' => $transactionId,
             ]);
 
             return $transactionService->processTransaction($newtx);

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -497,6 +497,52 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
+    public function markAsPaidByAdmin(\Model_Invoice $invoice, array $data = []): bool
+    {
+        $execute = (bool) ($data['execute'] ?? false);
+        $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
+
+        if ((int) $payGateway->id !== (int) $invoice->gateway_id) {
+            $invoice->gateway_id = (int) $payGateway->id;
+            $invoice->updated_at = date('Y-m-d H:i:s');
+            $this->di['db']->store($invoice);
+        }
+
+        if (($payGateway->gateway ?? null) === 'Custom' && (int) ($payGateway->enabled ?? 0) === 1) {
+            $transactionService = $this->di['mod_service']('Invoice', 'Transaction');
+            $newtx = $transactionService->create([
+                'invoice_id' => $invoice->id,
+                'gateway_id' => $invoice->gateway_id,
+                'currency' => $invoice->currency,
+                'status' => 'received',
+                'source' => 'admin',
+                'txn_id' => $data['transactionId'] ?? null,
+            ]);
+
+            return $transactionService->processTransaction($newtx);
+        }
+
+        return $this->markAsPaid($invoice, false, $execute);
+    }
+
+    public function validateAdminMarkAsPaidRequest(array $data, ?\Model_Invoice $invoice = null): \Model_PayGateway
+    {
+        $gatewayId = isset($data['gateway_id']) && !empty($data['gateway_id']) ? (int) $data['gateway_id'] : (int) ($invoice->gateway_id ?? 0);
+        if ($gatewayId <= 0) {
+            throw new InformationException('Payment gateway is required when marking an invoice as paid.');
+        }
+
+        $payGateway = $this->di['db']->getExistingModelById('PayGateway', $gatewayId, 'Payment gateway not found');
+        if (($payGateway->gateway ?? null) === 'Custom' && (int) ($payGateway->enabled ?? 0) === 1) {
+            $transactionId = trim((string) ($data['transactionId'] ?? ''));
+            if ($transactionId === '') {
+                throw new InformationException('Transaction ID is required when using the Custom payment gateway.');
+            }
+        }
+
+        return $payGateway;
+    }
+
     /**
      * Finds all paid invoices associated with a given client order.
      *
@@ -513,6 +559,24 @@ class Service implements InjectionAwareInterface
         ];
 
         return $this->di['db']->find('Invoice', 'id IN (SELECT invoice_id FROM invoice_item WHERE rel_id = :rel_id) AND status = :status', $bindings);
+    }
+
+    public function findInvoiceForOrder(\Model_ClientOrder $order): ?\Model_Invoice
+    {
+        $item = $this->di['db']->findOne(
+            'InvoiceItem',
+            'type = :type AND rel_id = :rel_id ORDER BY id DESC',
+            [
+                ':type' => \Model_InvoiceItem::TYPE_ORDER,
+                ':rel_id' => $order->id,
+            ]
+        );
+
+        if (!$item instanceof \Model_InvoiceItem || empty($item->invoice_id)) {
+            return null;
+        }
+
+        return $this->di['db']->getExistingModelById('Invoice', $item->invoice_id, 'Invoice not found');
     }
 
     public function getNextInvoiceNumber()

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -499,6 +499,10 @@ class Service implements InjectionAwareInterface
 
     public function markAsPaidByAdmin(\Model_Invoice $invoice, array $data = []): bool
     {
+        if ($invoice->status == \Model_Invoice::STATUS_PAID) {
+            return true;
+        }
+
         $execute = (bool) ($data['execute'] ?? false);
         $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
         $transactionId = isset($data['transactionId']) ? trim((string) $data['transactionId']) : null;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -499,7 +499,7 @@ class Service implements InjectionAwareInterface
 
     public function markAsPaidByAdmin(\Model_Invoice $invoice, array $data = []): bool
     {
-        if ($invoice->status == \Model_Invoice::STATUS_PAID) {
+        if ($invoice->status === \Model_Invoice::STATUS_PAID) {
             return true;
         }
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -503,7 +503,7 @@ class Service implements InjectionAwareInterface
             return true;
         }
 
-        $execute = \Tools::normalizeBoolean($data['execute'] ?? false);
+        $execute = \FOSSBilling\Tools::normalizeBoolean($data['execute'] ?? false);
         $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
         $transactionId = isset($data['transactionId']) ? trim((string) $data['transactionId']) : null;
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -567,24 +567,6 @@ class Service implements InjectionAwareInterface
         return $this->di['db']->find('Invoice', 'id IN (SELECT invoice_id FROM invoice_item WHERE rel_id = :rel_id) AND status = :status', $bindings);
     }
 
-    public function findInvoiceForOrder(\Model_ClientOrder $order): ?\Model_Invoice
-    {
-        $item = $this->di['db']->findOne(
-            'InvoiceItem',
-            'type = :type AND rel_id = :rel_id ORDER BY id DESC',
-            [
-                ':type' => \Model_InvoiceItem::TYPE_ORDER,
-                ':rel_id' => $order->id,
-            ]
-        );
-
-        if (!$item instanceof \Model_InvoiceItem || empty($item->invoice_id)) {
-            return null;
-        }
-
-        return $this->di['db']->getExistingModelById('Invoice', $item->invoice_id, 'Invoice not found');
-    }
-
     public function getNextInvoiceNumber()
     {
         $systemService = $this->di['mod_service']('system');

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -17,6 +17,7 @@ use Dompdf\Dompdf;
 use FOSSBilling\Environment;
 use FOSSBilling\InformationException;
 use FOSSBilling\InjectionAwareInterface;
+use FOSSBilling\Tools;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\HeaderUtils;
@@ -503,7 +504,7 @@ class Service implements InjectionAwareInterface
             return true;
         }
 
-        $execute = \Tools::normalizeBoolean($data['execute'] ?? false);
+        $execute = Tools::normalizeBoolean($data['execute'] ?? false);
         $payGateway = $this->validateAdminMarkAsPaidRequest($data, $invoice);
         $transactionId = isset($data['transactionId']) ? trim((string) $data['transactionId']) : null;
 

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -122,6 +122,12 @@ class Admin extends \Api_Abstract
                 $orderId,
                 $e->getMessage()
             ));
+
+            throw new \FOSSBilling\InformationException(sprintf(
+                'Order %d was created, but marking its invoice as paid failed: %s',
+                $orderId,
+                $e->getMessage()
+            ));
         }
 
         return $orderId;

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -76,7 +76,7 @@ class Admin extends \Api_Abstract
      * @optional string $created_at - date when order was created. Default: now
      * @optional string $updated_at - date when order was updated. Default: now
      *
-     * @return array
+     * @return int
      */
     #[RequiredParams([
         'client_id' => 'Client ID was not passed',

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -85,7 +85,6 @@ class Admin extends \Api_Abstract
     public function create($data)
     {
         $markInvoicePaid = Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
-        // Normalize back into $data to ensure consistent value throughout the flow
         $data['mark_invoice_paid'] = $markInvoicePaid;
 
         if ($markInvoicePaid) {

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -70,6 +70,9 @@ class Admin extends \Api_Abstract
      * @optional string $title - Order title. If not passed, product title is used
      * @optional bool $activate - activate immediately
      * @optional string $invoice_option - Options: "no-invoice", "issue-invoice"; Default: no-invoice
+     * @optional bool $mark_invoice_paid - Mark the generated invoice as paid after the order is created
+     * @optional int $gateway_id - Payment gateway to associate with the invoice when mark_invoice_paid is used
+     * @optional string $transactionId - Custom transaction ID to use when the selected gateway is Custom
      * @optional string $created_at - date when order was created. Default: now
      * @optional string $updated_at - date when order was updated. Default: now
      *
@@ -81,10 +84,39 @@ class Admin extends \Api_Abstract
     ])]
     public function create($data)
     {
+        $markInvoicePaid = Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
+
+        if ($markInvoicePaid) {
+            $staffService = $this->di['mod_service']('Staff');
+            $staffService->checkPermissionsAndThrowException('invoice');
+
+            if (($data['invoice_option'] ?? 'no-invoice') !== 'issue-invoice') {
+                throw new \FOSSBilling\InformationException('Marking an invoice as paid requires the order to issue an invoice.');
+            }
+
+            $this->di['mod_service']('Invoice')->validateAdminMarkAsPaidRequest($data);
+        }
+
         $client = $this->di['db']->getExistingModelById('Client', $data['client_id'], 'Client not found');
         $product = $this->di['db']->getExistingModelById('Product', $data['product_id'], 'Product not found');
 
-        return $this->getService()->createOrder($client, $product, $data);
+        $orderId = $this->getService()->createOrder($client, $product, $data);
+
+        if (!$markInvoicePaid) {
+            return $orderId;
+        }
+
+        $order = $this->di['db']->getExistingModelById('ClientOrder', $orderId, 'Order not found');
+        $invoiceService = $this->di['mod_service']('Invoice');
+        $invoice = $invoiceService->findInvoiceForOrder($order);
+
+        if (!$invoice instanceof \Model_Invoice) {
+            throw new \FOSSBilling\InformationException('No invoice was generated for this order.');
+        }
+
+        $invoiceService->markAsPaidByAdmin($invoice, $data);
+
+        return $orderId;
     }
 
     /**

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -85,6 +85,8 @@ class Admin extends \Api_Abstract
     public function create($data)
     {
         $markInvoicePaid = Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
+        // Normalize back into $data to ensure consistent value throughout the flow
+        $data['mark_invoice_paid'] = $markInvoicePaid;
 
         if ($markInvoicePaid) {
             $staffService = $this->di['mod_service']('Staff');

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -100,37 +100,7 @@ class Admin extends \Api_Abstract
         $client = $this->di['db']->getExistingModelById('Client', $data['client_id'], 'Client not found');
         $product = $this->di['db']->getExistingModelById('Product', $data['product_id'], 'Product not found');
 
-        $orderId = $this->getService()->createOrder($client, $product, $data);
-
-        if (!$markInvoicePaid) {
-            return $orderId;
-        }
-
-        try {
-            $order = $this->di['db']->getExistingModelById('ClientOrder', $orderId, 'Order not found');
-            $invoiceService = $this->di['mod_service']('Invoice');
-            $invoice = $invoiceService->findInvoiceForOrder($order);
-
-            if (!$invoice instanceof \Model_Invoice) {
-                throw new \FOSSBilling\InformationException('No invoice was generated for this order.');
-            }
-
-            $invoiceService->markAsPaidByAdmin($invoice, $data);
-        } catch (\Throwable $e) {
-            error_log(sprintf(
-                'Order %d was created, but marking its invoice as paid failed: %s',
-                $orderId,
-                $e->getMessage()
-            ));
-
-            throw new \FOSSBilling\InformationException(sprintf(
-                'Order %d was created, but marking its invoice as paid failed: %s',
-                $orderId,
-                $e->getMessage()
-            ));
-        }
-
-        return $orderId;
+        return $this->getService()->createOrder($client, $product, $data);
     }
 
     /**

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -106,15 +106,23 @@ class Admin extends \Api_Abstract
             return $orderId;
         }
 
-        $order = $this->di['db']->getExistingModelById('ClientOrder', $orderId, 'Order not found');
-        $invoiceService = $this->di['mod_service']('Invoice');
-        $invoice = $invoiceService->findInvoiceForOrder($order);
+        try {
+            $order = $this->di['db']->getExistingModelById('ClientOrder', $orderId, 'Order not found');
+            $invoiceService = $this->di['mod_service']('Invoice');
+            $invoice = $invoiceService->findInvoiceForOrder($order);
 
-        if (!$invoice instanceof \Model_Invoice) {
-            throw new \FOSSBilling\InformationException('No invoice was generated for this order.');
+            if (!$invoice instanceof \Model_Invoice) {
+                throw new \FOSSBilling\InformationException('No invoice was generated for this order.');
+            }
+
+            $invoiceService->markAsPaidByAdmin($invoice, $data);
+        } catch (\Throwable $e) {
+            error_log(sprintf(
+                'Order %d was created, but marking its invoice as paid failed: %s',
+                $orderId,
+                $e->getMessage()
+            ));
         }
-
-        $invoiceService->markAsPaidByAdmin($invoice, $data);
 
         return $orderId;
     }

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -772,7 +772,10 @@ class Service implements InjectionAwareInterface
 
                 $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
 
-                if (!empty($data['mark_invoice_paid'])) {
+                $markInvoicePaid = isset($data['mark_invoice_paid'])
+                    && filter_var($data['mark_invoice_paid'], FILTER_VALIDATE_BOOLEAN);
+
+                if ($markInvoicePaid) {
                     $invoiceService->markAsPaidByAdmin($invoice, $data);
                 }
             }

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -764,10 +764,6 @@ class Service implements InjectionAwareInterface
 
             $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
 
-            // mark invoice as paid on creation
-            if (!empty($data['mark_invoice_paid']) && $invoice instanceof \Model_Invoice) {
-                $invoiceService->markAsPaid($invoice);
-            }
         }
 
         // activate immediately on creation

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -684,7 +684,7 @@ class Service implements InjectionAwareInterface
             $generatedOrderTitle = null;
         }
 
-        $id = \RedBeanPHP\R::transaction(function () use (
+        $id = $this->di['db']->transaction(function () use (
             $client,
             $config,
             $currency,

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -684,9 +684,7 @@ class Service implements InjectionAwareInterface
             $generatedOrderTitle = null;
         }
 
-        // Store invoice ID and mark-paid flag for post-transaction processing
-        // These are captured before the transaction to ensure they use the original request data
-        $invoiceId = null;
+        $invoice = null;
         $markInvoicePaid = \FOSSBilling\Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
 
         $id = $this->di['db']->transaction(function () use (
@@ -701,7 +699,7 @@ class Service implements InjectionAwareInterface
             $period,
             $product,
             $qty,
-            &$invoiceId
+            &$invoice
         ) {
             $order = $this->di['db']->dispense('ClientOrder');
             $order->client_id = $client->id;
@@ -775,23 +773,27 @@ class Service implements InjectionAwareInterface
             if ($invoiceOption == 'issue-invoice' && $order->price > 0) {
                 $invoiceService = $this->di['mod_service']('invoice');
                 $invoice = $invoiceService->generateForOrder($order);
-                // Store invoice ID for post-transaction processing
-                $invoiceId = $invoice->id;
             }
 
             return $id;
         });
 
-        // Process invoice operations outside transaction to avoid inconsistent side effects
-        // if transaction rolls back (events can trigger emails and other non-rollbackable actions)
-        if ($invoiceId !== null) {
+        if ($invoice instanceof \Model_Invoice) {
             $invoiceService = $this->di['mod_service']('invoice');
-            $invoice = $this->di['db']->getExistingModelById('Invoice', $invoiceId, 'Invoice not found');
+            try {
+                $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
 
-            $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
+                if ($markInvoicePaid) {
+                    $invoiceService->markAsPaidByAdmin($invoice, $data);
+                }
+            } catch (\Exception $e) {
+                error_log($e->getMessage());
 
-            if ($markInvoicePaid) {
-                $invoiceService->markAsPaidByAdmin($invoice, $data);
+                try {
+                    $invoiceService->addNote($invoice, 'Order was created, but invoice follow-up failed: ' . $e->getMessage());
+                } catch (\Exception $noteException) {
+                    error_log($noteException->getMessage());
+                }
             }
         }
 

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -772,8 +772,7 @@ class Service implements InjectionAwareInterface
 
                 $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
 
-                $markInvoicePaid = isset($data['mark_invoice_paid'])
-                    && filter_var($data['mark_invoice_paid'], FILTER_VALIDATE_BOOLEAN);
+                $markInvoicePaid = \FOSSBilling\Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
 
                 if ($markInvoicePaid) {
                     $invoiceService->markAsPaidByAdmin($invoice, $data);

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -684,87 +684,107 @@ class Service implements InjectionAwareInterface
             $generatedOrderTitle = null;
         }
 
-        $order = $this->di['db']->dispense('ClientOrder');
-        $order->client_id = $client->id;
-        $order->product_id = $product->id;
-        $order->form_id = $product->form_id;
-        $order->group_id = ($parent_order) ? $parent_order->group_id : uniqid();
-        $order->group_master = ($parent_order) ? 0 : 1;
-        $order->title = $generatedOrderTitle ?? $data['title'] ?? $product->title;
-        $order->currency = $currency->getCode();
-        $order->service_type = $product->type;
-        $order->unit = $product->unit;
-        $order->status = \Model_ClientOrder::STATUS_PENDING_SETUP;
-        $order->config = json_encode($config);
-        $order->invoice_option = $invoiceOption;
+        $id = \RedBeanPHP\R::transaction(function () use (
+            $client,
+            $config,
+            $currency,
+            $currencyRepository,
+            $data,
+            $generatedOrderTitle,
+            $invoiceOption,
+            $parent_order,
+            $period,
+            $product,
+            $qty
+        ) {
+            $order = $this->di['db']->dispense('ClientOrder');
+            $order->client_id = $client->id;
+            $order->product_id = $product->id;
+            $order->form_id = $product->form_id;
+            $order->group_id = ($parent_order) ? $parent_order->group_id : uniqid();
+            $order->group_master = ($parent_order) ? 0 : 1;
+            $order->title = $generatedOrderTitle ?? $data['title'] ?? $product->title;
+            $order->currency = $currency->getCode();
+            $order->service_type = $product->type;
+            $order->unit = $product->unit;
+            $order->status = \Model_ClientOrder::STATUS_PENDING_SETUP;
+            $order->config = json_encode($config);
+            $order->invoice_option = $invoiceOption;
 
-        if ($period) {
-            $bp = $this->di['period']($data['period']);
-            $order->period = $bp->getCode();
-        }
-
-        $line = null;
-        if (!isset($data['price']) || $product->type === \Model_Product::DOMAIN) {
-            $product->setDi($this->di);
-            $repo = $product->getTable();
-            $line = $repo->getOrderLineConfig($product, array_merge($config, ['quantity' => $qty]));
-            $order->quantity = $line['quantity'];
-        } else {
-            $order->quantity = $qty;
-        }
-
-        if (isset($data['price'])) {
-            $order->price = $data['price'];
-        } else {
-            $rate = $currencyRepository->getRateByCode($currency->getCode());
-            if ($rate === null) {
-                throw new \FOSSBilling\Exception("Currency rate for '{$currency->getCode()}' is not configured");
+            if ($period) {
+                $bp = $this->di['period']($data['period']);
+                $order->period = $bp->getCode();
             }
-            $order->price = $line['price'] * $rate;
-        }
 
-        $order->notes = $data['notes'] ?? $order->notes;
-        if (isset($data['created_at'])) {
-            $order->created_at = date('Y-m-d H:i:s', strtotime($data['created_at']));
-        } else {
-            $order->created_at = date('Y-m-d H:i:s');
-        }
+            $line = null;
+            if (!isset($data['price']) || $product->type === \Model_Product::DOMAIN) {
+                $product->setDi($this->di);
+                $repo = $product->getTable();
+                $line = $repo->getOrderLineConfig($product, array_merge($config, ['quantity' => $qty]));
+                $order->quantity = $line['quantity'];
+            } else {
+                $order->quantity = $qty;
+            }
 
-        if (isset($data['updated_at'])) {
-            $order->updated_at = date('Y-m-d H:i:s', strtotime($data['updated_at']));
-        } else {
-            $order->updated_at = date('Y-m-d H:i:s');
-        }
-
-        $id = $this->di['db']->store($order);
-
-        if (isset($data['meta']) && is_array($data['meta'])) {
-            foreach ($data['meta'] as $k => $v) {
-                $mm = $this->di['db']->findOne('client_order_meta', 'client_order_id = :id AND name = :n', [':id' => $order->id, ':n' => $k]);
-                if (!$mm) {
-                    $mm = $this->di['db']->dispense('ClientOrderMeta');
-                    $mm->client_order_id = $id;
-                    $mm->name = $k;
-                    $mm->created_at = date('Y-m-d H:i:s');
+            if (isset($data['price'])) {
+                $order->price = $data['price'];
+            } else {
+                $rate = $currencyRepository->getRateByCode($currency->getCode());
+                if ($rate === null) {
+                    throw new \FOSSBilling\Exception("Currency rate for '{$currency->getCode()}' is not configured");
                 }
-                $mm->value = $v;
-                $mm->updated_at = date('Y-m-d H:i:s');
-                $this->di['db']->store($mm);
+                $order->price = $line['price'] * $rate;
             }
-        }
+
+            $order->notes = $data['notes'] ?? $order->notes;
+            if (isset($data['created_at'])) {
+                $order->created_at = date('Y-m-d H:i:s', strtotime($data['created_at']));
+            } else {
+                $order->created_at = date('Y-m-d H:i:s');
+            }
+
+            if (isset($data['updated_at'])) {
+                $order->updated_at = date('Y-m-d H:i:s', strtotime($data['updated_at']));
+            } else {
+                $order->updated_at = date('Y-m-d H:i:s');
+            }
+
+            $id = $this->di['db']->store($order);
+
+            if (isset($data['meta']) && is_array($data['meta'])) {
+                foreach ($data['meta'] as $k => $v) {
+                    $mm = $this->di['db']->findOne('client_order_meta', 'client_order_id = :id AND name = :n', [':id' => $order->id, ':n' => $k]);
+                    if (!$mm) {
+                        $mm = $this->di['db']->dispense('ClientOrderMeta');
+                        $mm->client_order_id = $id;
+                        $mm->name = $k;
+                        $mm->created_at = date('Y-m-d H:i:s');
+                    }
+                    $mm->value = $v;
+                    $mm->updated_at = date('Y-m-d H:i:s');
+                    $this->di['db']->store($mm);
+                }
+            }
+
+            if ($invoiceOption == 'issue-invoice' && $order->price > 0) {
+                $invoiceService = $this->di['mod_service']('invoice');
+                $invoice = $invoiceService->generateForOrder($order);
+
+                $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
+
+                if (!empty($data['mark_invoice_paid'])) {
+                    $invoiceService->markAsPaidByAdmin($invoice, $data);
+                }
+            }
+
+            return $id;
+        });
+
+        $order = $this->di['db']->getExistingModelById('ClientOrder', $id, 'Order not found');
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminOrderCreate', 'params' => ['id' => $order->id], 'subject' => $product->type]);
 
         $this->di['logger']->info('Created order #%s', $id);
-
-        // invoice options
-        if ($invoiceOption == 'issue-invoice' && $order->price > 0) {
-            $invoiceService = $this->di['mod_service']('invoice');
-            $invoice = $invoiceService->generateForOrder($order);
-
-            $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
-
-        }
 
         // activate immediately on creation
         if ($activate) {

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -684,6 +684,10 @@ class Service implements InjectionAwareInterface
             $generatedOrderTitle = null;
         }
 
+        // Store invoice ID for post-transaction processing
+        $invoiceId = null;
+        $markInvoicePaid = \FOSSBilling\Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
+
         $id = $this->di['db']->transaction(function () use (
             $client,
             $config,
@@ -695,7 +699,8 @@ class Service implements InjectionAwareInterface
             $parent_order,
             $period,
             $product,
-            $qty
+            $qty,
+            &$invoiceId
         ) {
             $order = $this->di['db']->dispense('ClientOrder');
             $order->client_id = $client->id;
@@ -769,18 +774,25 @@ class Service implements InjectionAwareInterface
             if ($invoiceOption == 'issue-invoice' && $order->price > 0) {
                 $invoiceService = $this->di['mod_service']('invoice');
                 $invoice = $invoiceService->generateForOrder($order);
-
-                $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
-
-                $markInvoicePaid = \FOSSBilling\Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
-
-                if ($markInvoicePaid) {
-                    $invoiceService->markAsPaidByAdmin($invoice, $data);
-                }
+                // Store invoice ID for post-transaction processing
+                $invoiceId = $invoice->id;
             }
 
             return $id;
         });
+
+        // Process invoice operations outside transaction to avoid inconsistent side effects
+        // if transaction rolls back (events can trigger emails and other non-rollbackable actions)
+        if ($invoiceId !== null) {
+            $invoiceService = $this->di['mod_service']('invoice');
+            $invoice = $this->di['db']->getExistingModelById('Invoice', $invoiceId, 'Invoice not found');
+
+            $invoiceService->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
+
+            if ($markInvoicePaid) {
+                $invoiceService->markAsPaidByAdmin($invoice, $data);
+            }
+        }
 
         $order = $this->di['db']->getExistingModelById('ClientOrder', $id, 'Order not found');
 

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -684,7 +684,8 @@ class Service implements InjectionAwareInterface
             $generatedOrderTitle = null;
         }
 
-        // Store invoice ID for post-transaction processing
+        // Store invoice ID and mark-paid flag for post-transaction processing
+        // These are captured before the transaction to ensure they use the original request data
         $invoiceId = null;
         $markInvoicePaid = \FOSSBilling\Tools::normalizeBoolean($data['mark_invoice_paid'] ?? false);
 

--- a/src/modules/Order/templates/admin/mod_order_new.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_new.html.twig
@@ -67,6 +67,35 @@
                 {{ include(product_order) }}
             {% endif %}
 
+            {% if has_permission('invoice') %}
+            <div id="mark-invoice-paid-options" class="d-none">
+                <div class="mb-3 row">
+                    <label class="form-label col-3 col-form-label">{{ 'Mark Invoice as Paid'|trans }}</label>
+                    <div class="col">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="mark_invoice_paid" name="mark_invoice_paid" value="1">
+                            <label class="form-check-label" for="mark_invoice_paid">{{ 'Confirm that the first invoice has already been paid by the client'|trans }}.</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="mark-invoice-paid-fields" class="d-none">
+                    <div class="mb-3 row">
+                        <label class="form-label col-3 col-form-label" for="gateway_id">{{ 'Payment Gateway'|trans }}</label>
+                        <div class="col">
+                            {{ mf.selectbox('gateway_id', admin.invoice_gateway_get_pairs, request.gateway_id, 0, 'Select payment gateway'|trans) }}
+                            <small class="form-hint">{{ 'Required when marking the invoice as paid during order creation.'|trans }}</small>
+                        </div>
+                    </div>
+                    <div class="mb-3 row">
+                        <label class="form-label col-3 col-form-label" for="transaction-id">{{ 'Transaction ID'|trans }}</label>
+                        <div class="col">
+                            <input class="form-control" type="text" name="transactionId" id="transaction-id" value="{{ request.transactionId }}">
+                            <small class="form-hint">{{ 'Required when using the Custom payment gateway.'|trans }}</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
 
             <input type="hidden" name="client_id" value="{{ client.id }}">
             <input type="hidden" name="product_id" value="{{ product.id }}">
@@ -83,6 +112,38 @@
     }
 
     const periodEl = document.getElementById('period');
+    const invoiceOptionEl = document.querySelector('[name="invoice_option"]');
+    const markInvoicePaidOptionsEl = document.getElementById('mark-invoice-paid-options');
+    const markInvoicePaidEl = document.getElementById('mark_invoice_paid');
+    const markInvoicePaidFieldsEl = document.getElementById('mark-invoice-paid-fields');
+    const gatewayEl = document.querySelector('[name="gateway_id"]');
+    const transactionIdEl = document.getElementById('transaction-id');
+
+    function syncMarkInvoicePaidControls() {
+        if (!markInvoicePaidOptionsEl || !invoiceOptionEl) {
+            return;
+        }
+
+        const invoiceIsIssued = invoiceOptionEl.value === 'issue-invoice';
+        markInvoicePaidOptionsEl.classList.toggle('d-none', !invoiceIsIssued);
+
+        if (!invoiceIsIssued && markInvoicePaidEl) {
+            markInvoicePaidEl.checked = false;
+        }
+
+        const markInvoicePaid = invoiceIsIssued && !!(markInvoicePaidEl && markInvoicePaidEl.checked);
+        if (markInvoicePaidFieldsEl) {
+            markInvoicePaidFieldsEl.classList.toggle('d-none', !markInvoicePaid);
+        }
+        if (gatewayEl) {
+            gatewayEl.required = markInvoicePaid;
+            gatewayEl.disabled = !markInvoicePaid;
+        }
+        if (transactionIdEl) {
+            transactionIdEl.disabled = !markInvoicePaid;
+        }
+    }
+
     if (periodEl) {
         periodEl.addEventListener('change', function() {
             const optionSelected = this.options[this.selectedIndex];
@@ -109,6 +170,14 @@
         });
     }
 
+    if (invoiceOptionEl) {
+        invoiceOptionEl.addEventListener('change', syncMarkInvoicePaidControls);
+    }
+
+    if (markInvoicePaidEl) {
+        markInvoicePaidEl.addEventListener('change', syncMarkInvoicePaidControls);
+    }
+
     // Parse URL parameters for pre-filling form values
     document.addEventListener('DOMContentLoaded', function() {
         const urlParams = new URLSearchParams(window.location.search);
@@ -127,6 +196,8 @@
                 }
             }
         }
+
+        syncMarkInvoicePaidControls();
     });
 </script>
 {% endblock %}

--- a/src/modules/Order/templates/admin/mod_order_new.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_new.html.twig
@@ -67,15 +67,6 @@
                 {{ include(product_order) }}
             {% endif %}
 
-            <div class="mb-3 row">
-                <label class="form-label col-3 col-form-label">{{ 'Mark Invoice as Paid'|trans }}</label>
-                <div class="col">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="mark_invoice_paid" name="mark_invoice_paid" value="1">
-                        <label class="form-check-label" for="mark_invoice_paid">{{ 'Confirm that the first invoice has already been paid by the client'|trans }}.</label>
-                    </div>
-                </div>
-            </div>
 
             <input type="hidden" name="client_id" value="{{ client.id }}">
             <input type="hidden" name="product_id" value="{{ product.id }}">

--- a/src/modules/Order/templates/admin/mod_order_new.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_new.html.twig
@@ -178,6 +178,9 @@
         markInvoicePaidEl.addEventListener('change', syncMarkInvoicePaidControls);
     }
 
+    // Initialize state immediately for AJAX-rendered contexts (DOMContentLoaded may not fire)
+    syncMarkInvoicePaidControls();
+
     // Parse URL parameters for pre-filling form values
     document.addEventListener('DOMContentLoaded', function() {
         const urlParams = new URLSearchParams(window.location.search);
@@ -197,6 +200,7 @@
             }
         }
 
+        // Re-sync state after URL parameters are processed
         syncMarkInvoicePaidControls();
     });
 </script>

--- a/tests-legacy/modules/Invoice/Api/AdminTest.php
+++ b/tests-legacy/modules/Invoice/Api/AdminTest.php
@@ -81,7 +81,7 @@ final class AdminTest extends \BBTestCase
 
         $serviceMock = $this->createMock(\Box\Mod\Invoice\Service::class);
         $serviceMock->expects($this->atLeastOnce())
-            ->method('markAsPaid')
+            ->method('markAsPaidByAdmin')
             ->willReturn(true);
 
         $model = new \Model_Invoice();
@@ -101,72 +101,6 @@ final class AdminTest extends \BBTestCase
 
         $result = $this->api->mark_as_paid($data);
         $this->assertTrue($result);
-    }
-
-    public function testMarkAsPaidCreatesTrustedCustomTransaction(): void
-    {
-        $data = [
-            'id' => 42,
-            'transactionId' => 'manual-txn-1',
-        ];
-
-        $invoice = new \Model_Invoice();
-        $invoice->loadBean(new \DummyBean());
-        $invoice->id = 42;
-        $invoice->gateway_id = 5;
-        $invoice->currency = 'USD';
-
-        $gatewayModel = new \Model_PayGateway();
-        $gatewayModel->loadBean(new \DummyBean());
-
-        $dbMock = $this->createMock('\Box_Database');
-        $dbMock->method('getExistingModelById')
-            ->willReturnCallback(fn (string $model, int $id): \Model_Invoice|\Model_PayGateway => match ([$model, $id]) {
-                ['Invoice', 42] => $invoice,
-                ['PayGateway', 5] => $gatewayModel,
-                default => throw new \RuntimeException('Unexpected lookup'),
-            });
-
-        $payGatewayServiceMock = $this->createMock(\Box\Mod\Invoice\ServicePayGateway::class);
-        $payGatewayServiceMock->expects($this->once())
-            ->method('toApiArray')
-            ->with($gatewayModel, true, $this->isInstanceOf(\Model_Admin::class))
-            ->willReturn([
-                'code' => 'Custom',
-                'enabled' => 1,
-            ]);
-
-        $transactionServiceMock = $this->createMock(\Box\Mod\Invoice\ServiceTransaction::class);
-        $transactionServiceMock->expects($this->once())
-            ->method('create')
-            ->with($this->callback(function (array $payload) use ($invoice): bool {
-                $this->assertSame($invoice->id, $payload['invoice_id']);
-                $this->assertSame($invoice->gateway_id, $payload['gateway_id']);
-                $this->assertSame($invoice->currency, $payload['currency']);
-                $this->assertSame('received', $payload['status']);
-                $this->assertSame('admin', $payload['source']);
-                $this->assertSame('manual-txn-1', $payload['txn_id']);
-
-                return true;
-            }))
-            ->willReturn(99);
-        $transactionServiceMock->expects($this->once())
-            ->method('processTransaction')
-            ->with(99)
-            ->willReturn(true);
-
-        $di = $this->getDi();
-        $di['db'] = $dbMock;
-        $di['mod_service'] = $di->protect(fn (string $name, string $sub = ''): \PHPUnit\Framework\MockObject\MockObject => match ([$name, $sub]) {
-            ['Invoice', 'PayGateway'] => $payGatewayServiceMock,
-            ['Invoice', 'Transaction'] => $transactionServiceMock,
-            default => throw new \RuntimeException('Unexpected service request'),
-        });
-
-        $this->api->setDi($di);
-        $this->api->setIdentity(new \Model_Admin());
-
-        $this->assertTrue($this->api->mark_as_paid($data));
     }
 
     public function testPrepare(): void

--- a/tests-legacy/modules/Invoice/ServiceTest.php
+++ b/tests-legacy/modules/Invoice/ServiceTest.php
@@ -709,7 +709,7 @@ final class ServiceTest extends \BBTestCase
         $serviceMock->setDi($di);
 
         $this->assertTrue($serviceMock->markAsPaidByAdmin($invoiceModel, [
-            'transactionId' => 'manual-txn-1',
+            'transactionId' => '  manual-txn-1  ',
         ]));
     }
 

--- a/tests-legacy/modules/Invoice/ServiceTest.php
+++ b/tests-legacy/modules/Invoice/ServiceTest.php
@@ -751,6 +751,37 @@ final class ServiceTest extends \BBTestCase
         $serviceMock->markAsPaidByAdmin($invoiceModel, []);
     }
 
+    public function testMarkAsPaidByAdminReturnsEarlyForAlreadyPaidInvoice(): void
+    {
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new \DummyBean());
+        $invoiceModel->id = 42;
+        $invoiceModel->status = \Model_Invoice::STATUS_PAID;
+        $invoiceModel->gateway_id = 5;
+
+        $serviceMock = $this->getMockBuilder(Service::class)
+            ->onlyMethods(['markAsPaid'])
+            ->getMock();
+        $serviceMock->expects($this->never())
+            ->method('markAsPaid');
+
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->never())
+            ->method('getExistingModelById');
+        $dbMock->expects($this->never())
+            ->method('store');
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+
+        $serviceMock->setDi($di);
+
+        $this->assertTrue($serviceMock->markAsPaidByAdmin($invoiceModel, [
+            'gateway_id' => 5,
+        ]));
+    }
+
     public function testPrepareInvoiceCurrencyWasNotDefined(): void
     {
         $serviceMock = $this->getMockBuilder(Service::class)

--- a/tests-legacy/modules/Invoice/ServiceTest.php
+++ b/tests-legacy/modules/Invoice/ServiceTest.php
@@ -664,6 +664,7 @@ final class ServiceTest extends \BBTestCase
 
         $gatewayModel = new \Model_PayGateway();
         $gatewayModel->loadBean(new \DummyBean());
+        $gatewayModel->id = 5;
         $gatewayModel->gateway = 'Custom';
         $gatewayModel->enabled = 1;
 
@@ -711,6 +712,7 @@ final class ServiceTest extends \BBTestCase
         $this->assertTrue($serviceMock->markAsPaidByAdmin($invoiceModel, [
             'transactionId' => '  manual-txn-1  ',
         ]));
+        $this->assertSame(5, $invoiceModel->gateway_id);
     }
 
     public function testMarkAsPaidByAdminRequiresTransactionIdForCustomGateway(): void

--- a/tests-legacy/modules/Invoice/ServiceTest.php
+++ b/tests-legacy/modules/Invoice/ServiceTest.php
@@ -610,6 +610,145 @@ final class ServiceTest extends \BBTestCase
         $serviceMock->countIncome($invoiceModel);
     }
 
+    public function testMarkAsPaidByAdminUsesGatewayOverrideAndDoesNotChargeBalance(): void
+    {
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new \DummyBean());
+        $invoiceModel->gateway_id = null;
+
+        $gatewayModel = new \Model_PayGateway();
+        $gatewayModel->loadBean(new \DummyBean());
+        $gatewayModel->id = 7;
+        $gatewayModel->gateway = 'PayPal';
+        $gatewayModel->enabled = 1;
+
+        $serviceMock = $this->getMockBuilder(Service::class)
+            ->onlyMethods(['markAsPaid'])
+            ->getMock();
+        $serviceMock->expects($this->once())
+            ->method('markAsPaid')
+            ->with($invoiceModel, false, true)
+            ->willReturn(true);
+
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('store')
+            ->with($invoiceModel);
+        $dbMock->expects($this->once())
+            ->method('getExistingModelById')
+            ->with('PayGateway', 7, 'Payment gateway not found')
+            ->willReturn($gatewayModel);
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+
+        $serviceMock->setDi($di);
+
+        $result = $serviceMock->markAsPaidByAdmin($invoiceModel, [
+            'gateway_id' => 7,
+            'execute' => true,
+        ]);
+
+        $this->assertTrue($result);
+        $this->assertSame(7, $invoiceModel->gateway_id);
+    }
+
+    public function testMarkAsPaidByAdminProcessesTrustedCustomTransaction(): void
+    {
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new \DummyBean());
+        $invoiceModel->id = 42;
+        $invoiceModel->gateway_id = 5;
+        $invoiceModel->currency = 'USD';
+
+        $gatewayModel = new \Model_PayGateway();
+        $gatewayModel->loadBean(new \DummyBean());
+        $gatewayModel->gateway = 'Custom';
+        $gatewayModel->enabled = 1;
+
+        $transactionServiceMock = $this->createMock(ServiceTransaction::class);
+        $transactionServiceMock->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function (array $payload) use ($invoiceModel): bool {
+                $this->assertSame($invoiceModel->id, $payload['invoice_id']);
+                $this->assertSame($invoiceModel->gateway_id, $payload['gateway_id']);
+                $this->assertSame($invoiceModel->currency, $payload['currency']);
+                $this->assertSame('received', $payload['status']);
+                $this->assertSame('admin', $payload['source']);
+                $this->assertSame('manual-txn-1', $payload['txn_id']);
+
+                return true;
+            }))
+            ->willReturn(99);
+        $transactionServiceMock->expects($this->once())
+            ->method('processTransaction')
+            ->with(99)
+            ->willReturn(true);
+
+        $serviceMock = $this->getMockBuilder(Service::class)
+            ->onlyMethods(['markAsPaid'])
+            ->getMock();
+        $serviceMock->expects($this->never())
+            ->method('markAsPaid');
+
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('getExistingModelById')
+            ->with('PayGateway', 5, 'Payment gateway not found')
+            ->willReturn($gatewayModel);
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+        $di['mod_service'] = $di->protect(fn (string $serviceName, string $sub = '') => match ([$serviceName, $sub]) {
+            ['Invoice', 'Transaction'] => $transactionServiceMock,
+            default => throw new \RuntimeException('Unexpected service request'),
+        });
+
+        $serviceMock->setDi($di);
+
+        $this->assertTrue($serviceMock->markAsPaidByAdmin($invoiceModel, [
+            'transactionId' => 'manual-txn-1',
+        ]));
+    }
+
+    public function testMarkAsPaidByAdminRequiresTransactionIdForCustomGateway(): void
+    {
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new \DummyBean());
+        $invoiceModel->gateway_id = 5;
+
+        $gatewayModel = new \Model_PayGateway();
+        $gatewayModel->loadBean(new \DummyBean());
+        $gatewayModel->gateway = 'Custom';
+        $gatewayModel->enabled = 1;
+
+        $serviceMock = $this->getMockBuilder(Service::class)
+            ->onlyMethods(['markAsPaid'])
+            ->getMock();
+        $serviceMock->expects($this->never())
+            ->method('markAsPaid');
+
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('getExistingModelById')
+            ->with('PayGateway', 5, 'Payment gateway not found')
+            ->willReturn($gatewayModel);
+        $dbMock->expects($this->never())
+            ->method('store');
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $di['logger'] = new \Box_Log();
+
+        $serviceMock->setDi($di);
+
+        $this->expectException(\FOSSBilling\InformationException::class);
+        $this->expectExceptionMessage('Transaction ID is required when using the Custom payment gateway.');
+        $serviceMock->markAsPaidByAdmin($invoiceModel, []);
+    }
+
     public function testPrepareInvoiceCurrencyWasNotDefined(): void
     {
         $serviceMock = $this->getMockBuilder(Service::class)

--- a/tests-legacy/modules/Order/Api/Api_AdminTest.php
+++ b/tests-legacy/modules/Order/Api/Api_AdminTest.php
@@ -138,7 +138,7 @@ final class Api_AdminTest extends BBTestCase
                 $this->callback(function (array $data): bool {
                     return $data['gateway_id'] === 5
                         && $data['invoice_option'] === 'issue-invoice'
-                        && $data['mark_invoice_paid'] === 1;
+                        && $data['mark_invoice_paid'] === true;
                 })
             )
             ->willReturn(55);
@@ -156,7 +156,7 @@ final class Api_AdminTest extends BBTestCase
             ->with($this->callback(function (array $data): bool {
                 return $data['gateway_id'] === 5
                     && $data['invoice_option'] === 'issue-invoice'
-                    && $data['mark_invoice_paid'] === 1;
+                    && $data['mark_invoice_paid'] === true;
             }))
             ->willReturn(new Model_PayGateway());
 

--- a/tests-legacy/modules/Order/Api/Api_AdminTest.php
+++ b/tests-legacy/modules/Order/Api/Api_AdminTest.php
@@ -132,6 +132,15 @@ final class Api_AdminTest extends BBTestCase
         $serviceMock = $this->getMockBuilder(Box\Mod\Order\Service::class)
             ->onlyMethods(['createOrder'])->getMock();
         $serviceMock->expects($this->once())->method('createOrder')
+            ->with(
+                $this->isInstanceOf(Model_Client::class),
+                $this->isInstanceOf(Model_Product::class),
+                $this->callback(function (array $data): bool {
+                    return $data['gateway_id'] === 5
+                        && $data['invoice_option'] === 'issue-invoice'
+                        && $data['mark_invoice_paid'] === 1;
+                })
+            )
             ->willReturn(55);
 
         $staffServiceMock = $this->createMock(\Box\Mod\Staff\Service::class);
@@ -139,15 +148,8 @@ final class Api_AdminTest extends BBTestCase
             ->method('checkPermissionsAndThrowException')
             ->with('invoice');
 
-        $invoiceModel = new \Model_Invoice();
-        $invoiceModel->loadBean(new DummyBean());
-
-        $orderModel = new Model_ClientOrder();
-        $orderModel->loadBean(new DummyBean());
-        $orderModel->id = 55;
-
         $invoiceServiceMock = $this->getMockBuilder(Box\Mod\Invoice\Service::class)
-            ->onlyMethods(['validateAdminMarkAsPaidRequest', 'findInvoiceForOrder', 'markAsPaidByAdmin'])
+            ->onlyMethods(['validateAdminMarkAsPaidRequest'])
             ->getMock();
         $invoiceServiceMock->expects($this->once())
             ->method('validateAdminMarkAsPaidRequest')
@@ -157,18 +159,6 @@ final class Api_AdminTest extends BBTestCase
                     && $data['mark_invoice_paid'] === 1;
             }))
             ->willReturn(new Model_PayGateway());
-        $invoiceServiceMock->expects($this->once())
-            ->method('findInvoiceForOrder')
-            ->with($orderModel)
-            ->willReturn($invoiceModel);
-        $invoiceServiceMock->expects($this->once())
-            ->method('markAsPaidByAdmin')
-            ->with($invoiceModel, $this->callback(function (array $data): bool {
-                return $data['gateway_id'] === 5
-                    && $data['invoice_option'] === 'issue-invoice'
-                    && $data['mark_invoice_paid'] === 1;
-            }))
-            ->willReturn(true);
 
         $clientModel = new Model_Client();
         $clientModel->loadBean(new DummyBean());
@@ -176,9 +166,9 @@ final class Api_AdminTest extends BBTestCase
         $productModel->loadBean(new DummyBean());
 
         $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
-        $dbMock->expects($this->exactly(3))
+        $dbMock->expects($this->exactly(2))
             ->method('getExistingModelById')
-            ->willReturn($clientModel, $productModel, $orderModel);
+            ->willReturn($clientModel, $productModel);
 
         $di = $this->getDi();
         $di['db'] = $dbMock;

--- a/tests-legacy/modules/Order/Api/Api_AdminTest.php
+++ b/tests-legacy/modules/Order/Api/Api_AdminTest.php
@@ -96,6 +96,151 @@ final class Api_AdminTest extends BBTestCase
         $this->assertIsInt($result);
     }
 
+    public function testCreateWithMarkInvoicePaidRequiresInvoicePermission(): void
+    {
+        $serviceMock = $this->getMockBuilder(Box\Mod\Order\Service::class)
+            ->onlyMethods(['createOrder'])->getMock();
+        $serviceMock->expects($this->never())->method('createOrder');
+
+        $staffServiceMock = $this->createMock(\Box\Mod\Staff\Service::class);
+        $staffServiceMock->expects($this->once())
+            ->method('checkPermissionsAndThrowException')
+            ->with('invoice')
+            ->willThrowException(new \FOSSBilling\InformationException('Denied', [], 403));
+
+        $di = $this->getDi();
+        $di['mod_service'] = $di->protect(fn (string $serviceName) => match ($serviceName) {
+            'Staff' => $staffServiceMock,
+            default => throw new \RuntimeException('Unexpected service request'),
+        });
+
+        $this->api->setDi($di);
+        $this->api->setService($serviceMock);
+
+        $this->expectException(\FOSSBilling\InformationException::class);
+        $this->api->create([
+            'client_id' => 1,
+            'product_id' => 1,
+            'invoice_option' => 'issue-invoice',
+            'mark_invoice_paid' => 1,
+            'gateway_id' => 5,
+        ]);
+    }
+
+    public function testCreateWithMarkInvoicePaidUsesInvoiceService(): void
+    {
+        $serviceMock = $this->getMockBuilder(Box\Mod\Order\Service::class)
+            ->onlyMethods(['createOrder'])->getMock();
+        $serviceMock->expects($this->once())->method('createOrder')
+            ->willReturn(55);
+
+        $staffServiceMock = $this->createMock(\Box\Mod\Staff\Service::class);
+        $staffServiceMock->expects($this->once())
+            ->method('checkPermissionsAndThrowException')
+            ->with('invoice');
+
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new DummyBean());
+
+        $orderModel = new Model_ClientOrder();
+        $orderModel->loadBean(new DummyBean());
+        $orderModel->id = 55;
+
+        $invoiceServiceMock = $this->getMockBuilder(Box\Mod\Invoice\Service::class)
+            ->onlyMethods(['validateAdminMarkAsPaidRequest', 'findInvoiceForOrder', 'markAsPaidByAdmin'])
+            ->getMock();
+        $invoiceServiceMock->expects($this->once())
+            ->method('validateAdminMarkAsPaidRequest')
+            ->with($this->callback(function (array $data): bool {
+                return $data['gateway_id'] === 5
+                    && $data['invoice_option'] === 'issue-invoice'
+                    && $data['mark_invoice_paid'] === 1;
+            }))
+            ->willReturn(new Model_PayGateway());
+        $invoiceServiceMock->expects($this->once())
+            ->method('findInvoiceForOrder')
+            ->with($orderModel)
+            ->willReturn($invoiceModel);
+        $invoiceServiceMock->expects($this->once())
+            ->method('markAsPaidByAdmin')
+            ->with($invoiceModel, $this->callback(function (array $data): bool {
+                return $data['gateway_id'] === 5
+                    && $data['invoice_option'] === 'issue-invoice'
+                    && $data['mark_invoice_paid'] === 1;
+            }))
+            ->willReturn(true);
+
+        $clientModel = new Model_Client();
+        $clientModel->loadBean(new DummyBean());
+        $productModel = new Model_Product();
+        $productModel->loadBean(new DummyBean());
+
+        $dbMock = $this->getMockBuilder('\Box_Database')->disableOriginalConstructor()->getMock();
+        $dbMock->expects($this->exactly(3))
+            ->method('getExistingModelById')
+            ->willReturn($clientModel, $productModel, $orderModel);
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn (string $serviceName) => match ($serviceName) {
+            'Staff' => $staffServiceMock,
+            'Invoice' => $invoiceServiceMock,
+            default => throw new \RuntimeException('Unexpected service request'),
+        });
+
+        $this->api->setDi($di);
+        $this->api->setService($serviceMock);
+
+        $result = $this->api->create([
+            'client_id' => 1,
+            'product_id' => 1,
+            'invoice_option' => 'issue-invoice',
+            'mark_invoice_paid' => 1,
+            'gateway_id' => 5,
+        ]);
+
+        $this->assertSame(55, $result);
+    }
+
+    public function testCreateWithMarkInvoicePaidRejectsInvalidInvoicePaymentPayloadBeforeOrderCreation(): void
+    {
+        $serviceMock = $this->getMockBuilder(Box\Mod\Order\Service::class)
+            ->onlyMethods(['createOrder'])->getMock();
+        $serviceMock->expects($this->never())->method('createOrder');
+
+        $staffServiceMock = $this->createMock(\Box\Mod\Staff\Service::class);
+        $staffServiceMock->expects($this->once())
+            ->method('checkPermissionsAndThrowException')
+            ->with('invoice');
+
+        $invoiceServiceMock = $this->getMockBuilder(Box\Mod\Invoice\Service::class)
+            ->onlyMethods(['validateAdminMarkAsPaidRequest'])
+            ->getMock();
+        $invoiceServiceMock->expects($this->once())
+            ->method('validateAdminMarkAsPaidRequest')
+            ->willThrowException(new \FOSSBilling\InformationException('Transaction ID is required when using the Custom payment gateway.'));
+
+        $di = $this->getDi();
+        $di['mod_service'] = $di->protect(fn (string $serviceName) => match ($serviceName) {
+            'Staff' => $staffServiceMock,
+            'Invoice' => $invoiceServiceMock,
+            default => throw new \RuntimeException('Unexpected service request'),
+        });
+
+        $this->api->setDi($di);
+        $this->api->setService($serviceMock);
+
+        $this->expectException(\FOSSBilling\InformationException::class);
+        $this->expectExceptionMessage('Transaction ID is required when using the Custom payment gateway.');
+        $this->api->create([
+            'client_id' => 1,
+            'product_id' => 1,
+            'invoice_option' => 'issue-invoice',
+            'mark_invoice_paid' => 1,
+            'gateway_id' => 5,
+        ]);
+    }
+
     public function testUpdate(): void
     {
         $order = new Model_ClientOrder();

--- a/tests-legacy/modules/Order/ServiceTest.php
+++ b/tests-legacy/modules/Order/ServiceTest.php
@@ -1668,6 +1668,134 @@ final class ServiceTest extends \BBTestCase
         $this->assertEquals(42, $clientOrderModel->form_id, 'Order form_id should be set from product');
     }
 
+    public function testCreateOrderReturnsSuccessWhenInvoiceFollowUpFails(): void
+    {
+        $modelClient = new \Model_Client();
+        $modelClient->loadBean(new \DummyBean());
+        $modelClient->currency = 'USD';
+
+        $modelProduct = new \Model_Product();
+        $modelProduct->loadBean(new \DummyBean());
+        $modelProduct->id = 1;
+        $modelProduct->type = 'custom';
+
+        $currencyModel = $this->getMockBuilder(\Box\Mod\Currency\Entity\Currency::class)->disableOriginalConstructor()->getMock();
+        $currencyRepositoryMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Repository\CurrencyRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $currencyRepositoryMock->expects($this->atLeastOnce())
+            ->method('findOneByCode')
+            ->willReturn($currencyModel);
+
+        $currencyServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Currency\Service::class)
+            ->onlyMethods(['getCurrencyRepository'])
+            ->getMock();
+        $currencyServiceMock->expects($this->atLeastOnce())
+            ->method('getCurrencyRepository')
+            ->willReturn($currencyRepositoryMock);
+
+        $cartServiceMock = $this->getMockBuilder('\\' . \Box\Mod\Cart\Service::class)->getMock();
+        $cartServiceMock->expects($this->atLeastOnce())
+            ->method('isStockAvailable')
+            ->with($modelProduct)
+            ->willReturn(true);
+
+        $eventMock = $this->createMock('\Box_EventManager');
+        $eventMock->expects($this->atLeastOnce())
+            ->method('fire');
+
+        $productServiceMock = $this->getMockBuilder(\Box\Mod\Servicecustom\Service::class)->getMock();
+
+        $clientOrderModel = new \Model_ClientOrder();
+        $clientOrderModel->loadBean(new \DummyBean());
+
+        $invoiceModel = new \Model_Invoice();
+        $invoiceModel->loadBean(new \DummyBean());
+        $invoiceModel->id = 10;
+
+        $invoiceServiceMock = $this->getMockBuilder(\Box\Mod\Invoice\Service::class)
+            ->onlyMethods(['generateForOrder', 'approveInvoice', 'markAsPaidByAdmin', 'addNote'])
+            ->getMock();
+        $invoiceServiceMock->expects($this->once())
+            ->method('generateForOrder')
+            ->with($clientOrderModel)
+            ->willReturn($invoiceModel);
+        $invoiceServiceMock->expects($this->once())
+            ->method('approveInvoice')
+            ->with($invoiceModel, ['id' => $invoiceModel->id, 'use_credits' => true])
+            ->willReturn(true);
+        $invoiceServiceMock->expects($this->once())
+            ->method('markAsPaidByAdmin')
+            ->with($invoiceModel, $this->callback(function (array $data): bool {
+                return $data['invoice_option'] === 'issue-invoice'
+                    && $data['mark_invoice_paid'] === true
+                    && $data['gateway_id'] === 7;
+            }))
+            ->willThrowException(new \Exception('Payment follow-up failed'));
+        $invoiceServiceMock->expects($this->once())
+            ->method('addNote')
+            ->with(
+                $invoiceModel,
+                $this->callback(fn (string $note): bool => str_contains($note, 'Order was created, but invoice follow-up failed: Payment follow-up failed'))
+            )
+            ->willReturn(true);
+
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('transaction')
+            ->willReturnCallback(fn (callable $callback) => $callback());
+        $dbMock->expects($this->atLeastOnce())
+            ->method('dispense')
+            ->with('ClientOrder')
+            ->willReturn($clientOrderModel);
+        $newId = 1;
+        $dbMock->expects($this->atLeastOnce())
+            ->method('store')
+            ->with($clientOrderModel)
+            ->willReturn($newId);
+        $dbMock->expects($this->atLeastOnce())
+            ->method('getExistingModelById')
+            ->with('ClientOrder', $newId, 'Order not found')
+            ->willReturn($clientOrderModel);
+
+        $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
+        $periodMock->expects($this->atLeastOnce())
+            ->method('getCode')
+            ->willReturn('1Y');
+
+        $di = $this->getDi();
+        $di['mod_service'] = $di->protect(function ($serviceName) use ($cartServiceMock, $currencyServiceMock, $invoiceServiceMock, $productServiceMock) {
+            if ($serviceName == 'currency') {
+                return $currencyServiceMock;
+            }
+            if ($serviceName == 'cart') {
+                return $cartServiceMock;
+            }
+            if ($serviceName == 'invoice') {
+                return $invoiceServiceMock;
+            }
+            if ($serviceName == 'servicecustom') {
+                return $productServiceMock;
+            }
+        });
+        $di['events_manager'] = $eventMock;
+        $di['db'] = $dbMock;
+        $di['period'] = $di->protect(fn (): \PHPUnit\Framework\MockObject\MockObject => $periodMock);
+        $di['logger'] = new \Box_Log();
+
+        $this->service->setDi($di);
+
+        $result = $this->service->createOrder($modelClient, $modelProduct, [
+            'period' => '1Y',
+            'price' => '10',
+            'invoice_option' => 'issue-invoice',
+            'mark_invoice_paid' => true,
+            'gateway_id' => 7,
+        ]);
+
+        $this->assertSame($newId, $result);
+    }
+
     public function testGetMasterOrderForClient(): void
     {
         $clientModel = new \Model_Client();

--- a/tests-legacy/modules/Order/ServiceTest.php
+++ b/tests-legacy/modules/Order/ServiceTest.php
@@ -1538,6 +1538,9 @@ final class ServiceTest extends \BBTestCase
         $clientOrderModel->loadBean(new \DummyBean());
 
         $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('transaction')
+            ->willReturnCallback(fn (callable $callback) => $callback());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
             ->with('ClientOrder')
@@ -1547,6 +1550,10 @@ final class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($clientOrderModel)
             ->willReturn($newId);
+        $dbMock->expects($this->atLeastOnce())
+            ->method('getExistingModelById')
+            ->with('ClientOrder', $newId, 'Order not found')
+            ->willReturn($clientOrderModel);
 
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
         $periodMock->expects($this->atLeastOnce())
@@ -1616,6 +1623,9 @@ final class ServiceTest extends \BBTestCase
         $clientOrderModel->loadBean(new \DummyBean());
 
         $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->once())
+            ->method('transaction')
+            ->willReturnCallback(fn (callable $callback) => $callback());
         $dbMock->expects($this->atLeastOnce())
             ->method('dispense')
             ->with('ClientOrder')
@@ -1625,6 +1635,10 @@ final class ServiceTest extends \BBTestCase
             ->method('store')
             ->with($clientOrderModel)
             ->willReturn($newId);
+        $dbMock->expects($this->atLeastOnce())
+            ->method('getExistingModelById')
+            ->with('ClientOrder', $newId, 'Order not found')
+            ->willReturn($clientOrderModel);
 
         $periodMock = $this->getMockBuilder('\Box_Period')->disableOriginalConstructor()->getMock();
         $periodMock->expects($this->atLeastOnce())


### PR DESCRIPTION
Introduce a more robust and flexible approach for marking invoices as paid by admins, particularly when creating new orders. 

The changes centralise and validate the logic for marking invoices as paid, especially handling the "Custom" payment gateway and related transaction IDs. Additionally, the admin order creation UI and backend now support marking the generated invoice as paid in a controlled, permission-checked manner.