### PR TITLE
Fix fatal error when registering Doctrine PDO with debugbar collector

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -34,7 +34,7 @@ $connection = $di['em']->getConnection();
 $native = $connection->getNativeConnection();
 
 if ($native instanceof PDO) {
-    $pdoCollector->addConnection($native, 'Doctrine');
+    $pdoCollector->addConnection(new DebugBar\DataCollector\PDO\TraceablePDO($native), 'Doctrine');
 }
 
 $debugBar->addCollector($pdoCollector);


### PR DESCRIPTION
### Motivation
- The DebugBar `PDOCollector` was being passed Doctrine's native `PDO` instance directly, which causes a fatal `TypeError` because the collector expects a `TraceablePDO`, making the front controller unavailable on normal web requests.

### Description
- Wrap Doctrine's native PDO in `DebugBar\DataCollector\PDO\TraceablePDO` before calling `PDOCollector::addConnection()` in `src/index.php`, implemented as a single-line change to preserve existing debugbar behavior.

### Testing
- Ran `php -l src/index.php` to validate syntax and the change, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008fcddc94832ebaa97c3eeaf0369d)