### PR TITLE
Added new widget spots to the client area

### DIFF
--- a/src/modules/Order/templates/client/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/client/mod_order_manage.html.twig
@@ -20,6 +20,8 @@
 {% endblock %}
 
 {% block content %}
+    {{ render_widgets('client.order.manage.content.start', { 'order': order }) }}
+
     <div class="row">
         <div class="col-md-12">
             {# Order info #}
@@ -100,6 +102,7 @@
                         {% endif %}
                         </tbody>
                     </table>
+                    {{ render_widgets('client.order.manage.details.after', { 'order': order }) }}
                 </div>
                 <div class="card-footer">
                     {% if order.period and order.status != 'failed_renew' %}
@@ -112,13 +115,16 @@
                     {% if order.status == 'active' %}
                         <button class="btn btn-danger btn-sm" type="button" id="request-cancel" data-bs-toggle="modal" data-bs-target="#cancel-request-modal">{{ 'Request Cancellation'|trans }}</button>
                     {% endif %}
+                    {{ render_widgets('client.order.manage.actions.end', { 'order': order }) }}
                 </div>
             </div>
 
             {# Service management #}
             {% if guest.system_template_exists({ 'file': service_partial }) %}
                 {% set service = client.order_service({ 'id': order.id }) %}
+                {{ render_widgets('client.order.manage.service.before', { 'order': order, 'service': service }) }}
                 {{ include(service_partial, { 'order': order, 'service': service }) }}
+                {{ render_widgets('client.order.manage.service.after', { 'order': order, 'service': service }) }}
             {% endif %}
 
             {# Order addons #}

--- a/src/modules/Order/templates/client/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/client/mod_order_manage.html.twig
@@ -120,12 +120,13 @@
             </div>
 
             {# Service management #}
+            {% set service = null %}
+            {{ render_widgets('client.order.manage.service.before', { 'order': order, 'service': service }) }}
             {% if guest.system_template_exists({ 'file': service_partial }) %}
                 {% set service = client.order_service({ 'id': order.id }) %}
-                {{ render_widgets('client.order.manage.service.before', { 'order': order, 'service': service }) }}
                 {{ include(service_partial, { 'order': order, 'service': service }) }}
-                {{ render_widgets('client.order.manage.service.after', { 'order': order, 'service': service }) }}
             {% endif %}
+            {{ render_widgets('client.order.manage.service.after', { 'order': order, 'service': service }) }}
 
             {# Order addons #}
             {% if order.group_master == 1 and addons|length > 0 %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -143,8 +143,8 @@
                 </div>
             </div>
         </nav>
+        {{ render_widgets('client.theme.header.end') }}
     </header>
-    {{ render_widgets('client.theme.header.end') }}
     <div class="container">
         <div class="row">
         {% if client or not settings.hide_menu %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -60,8 +60,8 @@
     {% set logo_url =  company.logo_url %}
 {% endif %}
 <div class="container">
-    {{ render_widgets('client.theme.header.start') }}
     <header>
+        {{ render_widgets('client.theme.header.start') }}
         <nav class="navbar navbar-expand-md py-4">
             <div class="container-fluid">
                 {% if logo_url and settings.show_company_logo %}

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -28,6 +28,8 @@
 
 <body class="{% block body_class %}{% endblock %}">
 
+{{ render_widgets('client.theme.body.start') }}
+
 {% block body %}
 {% if not client and settings.require_login %}
     <script>
@@ -58,6 +60,7 @@
     {% set logo_url =  company.logo_url %}
 {% endif %}
 <div class="container">
+    {{ render_widgets('client.theme.header.start') }}
     <header>
         <nav class="navbar navbar-expand-md py-4">
             <div class="container-fluid">
@@ -141,6 +144,7 @@
             </div>
         </nav>
     </header>
+    {{ render_widgets('client.theme.header.end') }}
     <div class="container">
         <div class="row">
         {% if client or not settings.hide_menu %}
@@ -242,6 +246,7 @@
         {{ include('mod_cookieconsent_index.html.twig', ignore_missing: true) }}
     {% endif %}
 </div>
+{{ render_widgets('client.theme.body.end') }}
 {{ debug_bar_render() }}
 </body>
 </html>

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -24,8 +24,10 @@
     {% block js %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
+    {{ render_widgets('client.theme.body.start') }}
     {% block body %}{% endblock %}
     <div class="toast-container position-fixed bottom-0 end-0 p-3 toast-container-zindex" aria-live="polite" aria-atomic="true"></div>
     {{ include('partial_pending_messages.html.twig', ignore_missing: true) }}
+    {{ render_widgets('client.theme.body.end') }}
 </body>
 </html>


### PR DESCRIPTION
Added these new widget spots to the client area:
- `client.order.manage.content.start`
- `client.order.manage.details.after`
- `client.order.manage.actions.end`
- `client.order.manage.service.before`
- `client.order.manage.service.after`

- `client.theme.body.start`
- `client.theme.header.start`
- `client.theme.header.end`
- `client.theme.body.end`