### PR TITLE
Fix installer re-entry in non-production environments

### DIFF
--- a/.github/scripts/run-docker-live-tests.sh
+++ b/.github/scripts/run-docker-live-tests.sh
@@ -76,7 +76,7 @@ done
 
 docker run --rm --network "${network}" "${image}" curl -fsS "http://${app_container}/install/" >/dev/null
 
-docker exec "${app_container}" sh -c 'rm -f /var/www/html/config.php /workspace/src/config.php /workspace/config.php'
+docker exec "${app_container}" rm -f /var/www/html/config.php
 
 docker run --rm \
   --network "${network}" \

--- a/.github/scripts/run-docker-live-tests.sh
+++ b/.github/scripts/run-docker-live-tests.sh
@@ -67,6 +67,8 @@ docker run --detach \
   --env APP_ENV=test \
   "${image}" >/dev/null
 
+docker exec "${app_container}" rm -f /var/www/html/config.php
+
 for _ in {1..60}; do
   if docker run --rm --network "${network}" "${image}" curl -fsS "http://${app_container}/install/" >/dev/null; then
     break
@@ -75,8 +77,6 @@ for _ in {1..60}; do
 done
 
 docker run --rm --network "${network}" "${image}" curl -fsS "http://${app_container}/install/" >/dev/null
-
-docker exec "${app_container}" rm -f /var/www/html/config.php
 
 docker run --rm \
   --network "${network}" \

--- a/.github/scripts/run-docker-live-tests.sh
+++ b/.github/scripts/run-docker-live-tests.sh
@@ -76,6 +76,8 @@ done
 
 docker run --rm --network "${network}" "${image}" curl -fsS "http://${app_container}/install/" >/dev/null
 
+docker exec "${app_container}" sh -c 'rm -f /var/www/html/config.php /workspace/src/config.php /workspace/config.php'
+
 docker run --rm \
   --network "${network}" \
   --env APP_ENV=test \

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -109,11 +109,9 @@ final class FOSSBilling_Installer
         require_once 'session.php';
         $this->session = new Session();
         $this->filesystem = new Filesystem();
-        $this->isDebug = !Environment::isProduction();
-
-        if (!$this->isDebug && $this->filesystem->exists(PATH_CONFIG)) {
+        if ($this->filesystem->exists(PATH_CONFIG)) {
             $config = require PATH_CONFIG;
-            $this->isDebug = $config['debug_and_monitoring']['debug'] || !Environment::isProduction();
+            $this->isDebug = (bool) ($config['debug_and_monitoring']['debug'] ?? false);
         }
 
         $action = $this->request->query->get('a', 'index');

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -111,7 +111,9 @@ final class FOSSBilling_Installer
         $this->filesystem = new Filesystem();
         if ($this->filesystem->exists(PATH_CONFIG)) {
             $config = require PATH_CONFIG;
-            $this->isDebug = (bool) ($config['debug_and_monitoring']['debug'] ?? false);
+            if (is_array($config)) {
+                $this->isDebug = (bool) ($config['debug_and_monitoring']['debug'] ?? false);
+            }
         }
 
         $action = $this->request->query->get('a', 'index');

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -387,7 +387,7 @@ class Service
         }
 
         $install = Path::join(PATH_ROOT, 'install');
-        if (!Environment::isDevelopment() && $this->filesystem->exists($install)) {
+        if ($this->filesystem->exists($install)) {
             $msgs['danger'][] = [
                 'text' => sprintf('Install module "%s" still exists. Please remove it for security reasons.', $install),
             ];


### PR DESCRIPTION
### Motivation
- Prevent already-installed non-production instances from bypassing the installer guard and allowing unauthenticated reinstallation/config overwrite by ensuring debug mode is not implicitly enabled for fresh dev/test environments before a persisted `config.php` exists.

### Description
- Stop forcing debug for all non-production environments by removing the default `!Environment::isProduction()` assignment and instead set `isDebug` only from an existing `PATH_CONFIG` value in `src/install/install.php` (`$this->isDebug = (bool) ($config['debug_and_monitoring']['debug'] ?? false);`).
- Restore the install-module security warning in `src/modules/System/Service.php` so the presence of the `install` directory is reported regardless of `APP_ENV` (remove the `!Environment::isDevelopment()` conditional that previously suppressed the message).

### Testing
- Ran `php -l src/install/install.php` and `php -l src/modules/System/Service.php`, both returned "No syntax errors detected".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0096b8cfd4832e8a74a4f2edf67990)