### PR TITLE
Prevent admin from blocking own IP

### DIFF
--- a/src/modules/Antispam/Api/Admin.php
+++ b/src/modules/Antispam/Api/Admin.php
@@ -68,6 +68,10 @@ class Admin extends \Api_Abstract
             throw new \FOSSBilling\InformationException(':ip is already blocked.', [':ip' => $ip]);
         }
 
+        if ((string) $this->di['request']->getClientIp() === $ip) {
+            throw new \FOSSBilling\InformationException('You cannot block :ip as it is the IP you are making requests from.', [':ip' => $ip]);
+        }
+
         $blocked_ips[] = $ip;
         $blocked_ips_string = implode(PHP_EOL, $blocked_ips);
 


### PR DESCRIPTION
As the tin says. Should prevent people from accidentally locking themselves out
<img width="435" height="161" alt="image" src="https://github.com/user-attachments/assets/568cfc4f-0f8c-4390-9cac-50e17f4f8088" />
