### PR TITLE
Fix undefined birthday access in admin client update

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -247,7 +247,7 @@ class Admin extends \Api_Abstract
             $this->di['validator']->isBirthdayValid($data['birthday']);
         }
 
-        if($data['birthday'] === ""){
+        if (($data['birthday'] ?? null) === '') {
             unset($data['birthday']);
         }
 


### PR DESCRIPTION
### Motivation
- Avoid a potential PHP warning when `birthday` is omitted in the admin client update payload while preserving the existing behavior of unsetting empty birthday values.

### Description
- Replace the unguarded check `if($data['birthday'] === "")` with a null-coalescing guard `if (($data['birthday'] ?? null) === '')` in `src/modules/Client/Api/Admin.php` so the optional `birthday` key is read safely.

### Testing
- Ran `php -l src/modules/Client/Api/Admin.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0657c41f70832ebc31aaefe6e8e71c)