### PR TITLE
Harden CI against GHCR token exposure on PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
     name: 'PHP Build and Test (${{ matrix.php }})'
     permissions:
       contents: read
-      packages: write
     needs: [ spellcheck ]
     if: *normal_ci
     runs-on: ubuntu-latest
@@ -99,14 +98,6 @@ jobs:
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
 
-      - &login_ghcr
-        name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - &setup_buildx
         name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -117,8 +108,8 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             INSTALL_TRANSLATIONS=false
-          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:cache-ci-${{ matrix.php }}
-          cache-to: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:cache-ci-${{ matrix.php }},mode=max
+          cache-from: type=gha,scope=ci-${{ matrix.php }}
+          cache-to: type=gha,scope=ci-${{ matrix.php }},mode=max
           context: .
           load: true
           tags: |
@@ -149,13 +140,18 @@ jobs:
       contents: read
       packages: write
     needs: [ php-build-test ]
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled' && github.event.action != 'unlabeled' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id) || (github.event_name == 'push' && github.ref != 'refs/heads/main') }}
+    if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - *checkout_step
       - *lowercase_repo
-      - *login_ghcr
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - *setup_buildx
 
       - name: 'Build Release Artifact'


### PR DESCRIPTION
### Motivation
- Prevent untrusted pull-request-controlled code from accessing GHCR credentials or writing to shared GHCR cache scopes by removing package-write permissions and GHCR login from PR-running jobs.
- Maintain Docker layer caching and CI performance while eliminating the registry-credential exposure attack surface.

### Description
- Removed `packages: write` permission from the `php-build-test` job and eliminated the pre-test GHCR login from that job in `.github/workflows/ci.yml` so PR-executed scripts no longer run after a registry login.
- Switched the `php-build-test` build cache from GHCR registry caching to the GitHub Actions cache by changing `cache-from`/`cache-to` to `type=gha` with `scope=ci-${{ matrix.php }}` to preserve caching without registry credentials.
- Restricted the `preview-build` job condition so it only runs on non-`main` `push` events (removing fork PRs from that path) and inlined the GHCR login step there so only a push-only job performs registry login and cache writes.
- Kept preview artifact and preview-docker flows intact for push-only runs so release/preview functionality is preserved while preventing PRs from poisoning shared registry caches.

### Testing
- Reviewed the workflow diff for `.github/workflows/ci.yml` to verify that `php-build-test` no longer requests `packages: write` and no longer performs a GHCR login before running repository-controlled scripts, and that `preview-build` is push-only; verification succeeded.
- Performed a line-level inspection of the updated workflow to confirm `cache-*` entries were switched from `type=registry` to `type=gha` and that the GHCR login was moved into the push-only `preview-build` path; inspection succeeded.
- Attempted an automated YAML parse via Python `yaml.safe_load`, but PyYAML is not installed in this environment so the parser check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0666df64e8832e8a7bb446b6e7a976)