### PR TITLE
Fix obsolete sessions persisting past regeneration grace period

### DIFF
--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -217,13 +217,6 @@ class Session implements InjectionAwareInterface
 
             return;
         }
-
-        // Do not regenerate the ID for obsolete sessions that are still within
-        // the grace period. Emitting a fresh session cookie from an older,
-        // unauthenticated request can overwrite a newer authenticated cookie
-        // if the responses race.
-        // Keep obsolete metadata until the grace period expires so this session
-        // can still be invalidated and have authentication cleared.
     }
 
     private function rotateSessionId(): void

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -222,7 +222,8 @@ class Session implements InjectionAwareInterface
         // the grace period. Emitting a fresh session cookie from an older,
         // unauthenticated request can overwrite a newer authenticated cookie
         // if the responses race.
-        unset($_SESSION[self::OBSOLETE_FLAG], $_SESSION[self::OBSOLETE_EXPIRES_AT]);
+        // Keep obsolete metadata until the grace period expires so this session
+        // can still be invalidated and have authentication cleared.
     }
 
     private function rotateSessionId(): void


### PR DESCRIPTION
### Motivation
- Prevent an obsolete session accessed during the regeneration grace period from having its obsolete metadata cleared and thereby surviving as an authenticated session beyond the intended grace window.

### Description
- Stop clearing the obsolete markers inside `Session::handleObsoleteSession()` so the old session remains marked until expiry, with the change localized to `src/library/FOSSBilling/Session.php`.

### Testing
- Ran `php -l src/library/FOSSBilling/Session.php` and the file lint check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084d1546ec832ea6cf496898406a7b)