### PR TITLE
Harden create-release workflow against shell injection

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,9 +38,17 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: 'Validate Release Inputs'
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ inputs.target_ref }}
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "Release version must be valid SemVer without a leading v."
+            exit 1
+          fi
+
+          if [[ ! "${TARGET_REF}" =~ ^[A-Za-z0-9._/-]+$ ]] || ! git check-ref-format --branch "${TARGET_REF}" >/dev/null 2>&1; then
+            echo "Target ref must be a valid branch name containing only letters, numbers, dots, underscores, slashes, or hyphens."
             exit 1
           fi
 
@@ -70,40 +78,47 @@ jobs:
 
       - name: 'Create Release Archive'
         id: archive
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
           mkdir -p ../dist
-          zip -qr "../dist/FOSSBilling-${{ inputs.version }}.zip" .
+          zip -qr "../dist/FOSSBilling-${RELEASE_VERSION}.zip" .
         working-directory: ./release-tree
 
       - name: 'Create or Update GitHub Release'
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          IS_DRAFT: ${{ inputs.draft }}
+          IS_PRERELEASE: ${{ inputs.prerelease }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          asset="./dist/FOSSBilling-${{ inputs.version }}.zip"
+          asset="./dist/FOSSBilling-${RELEASE_VERSION}.zip"
 
-          if gh release view "${{ inputs.version }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            gh release upload "${{ inputs.version }}" "${asset}" \
-              --repo "${{ github.repository }}" \
+          if gh release view "${RELEASE_VERSION}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_VERSION}" "${asset}" \
+              --repo "${REPOSITORY}" \
               --clobber
             echo "operation=updated" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           release_args=(
-            "${{ inputs.version }}"
+            "${RELEASE_VERSION}"
             "${asset}"
-            --repo "${{ github.repository }}"
-            --title "${{ inputs.version }}"
-            --target "${{ inputs.target_ref }}"
+            --repo "${REPOSITORY}"
+            --title "${RELEASE_VERSION}"
+            --target "${TARGET_REF}"
             --generate-notes
           )
 
-          if [[ "${{ inputs.draft }}" == "true" ]]; then
+          if [[ "${IS_DRAFT}" == "true" ]]; then
             release_args+=(--draft)
           fi
 
-          if [[ "${{ inputs.prerelease }}" == "true" ]]; then
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
             release_args+=(--prerelease)
           fi
 


### PR DESCRIPTION
### Motivation
- Close a command-injection vector in `.github/workflows/create-release.yml` where `workflow_dispatch` inputs were interpolated directly into bash `run` blocks while `contents: write` and `GH_TOKEN` were available. 
- Ensure manually-triggered release inputs are validated and cannot be used to execute arbitrary commands in the runner. 

### Description
- Stop direct interpolation of `${{ inputs.* }}` inside `run` scripts and instead pass `version`, `target_ref`, `draft`, and `prerelease` through step `env` variables and reference those shell variables (e.g. `RELEASE_VERSION`, `TARGET_REF`).
- Add explicit validation for `RELEASE_VERSION` (SemVer regex) and `TARGET_REF` (safe character allowlist plus `git check-ref-format --branch`) in the `Validate Release Inputs` step to reject malformed or malicious refs prior to checkout or release actions.
- Update the archive creation and `gh` release commands to use the validated env-backed variables when constructing filenames and `release_args` so no attacker-controlled input is evaluated by the shell while `GH_TOKEN` is present.
- Preserve existing workflow behavior and outputs while removing unsafe interpolation points.

### Testing
- Verified the unsafe `${{ inputs.* }}` occurrences inside `run` blocks were replaced by env-backed variable references using `git diff -- .github/workflows/create-release.yml` and confirmed the intended changes; the check succeeded.
- Inspected the updated workflow file contents with `nl -ba .github/workflows/create-release.yml | sed -n '34,150p'` to confirm the new `env` assignments and validation logic are present; the inspection succeeded.
- Committed the hardened workflow with `git commit` and confirmed the repository contains the updated workflow file; the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a87854c4832ebf3f3208070e98d1)