### PR TITLE
Fix honeypot checkbox false-state rendering

### DIFF
--- a/src/modules/Antispam/templates/admin/mod_antispam_settings.html.twig
+++ b/src/modules/Antispam/templates/admin/mod_antispam_settings.html.twig
@@ -160,7 +160,7 @@ value="{{ params.captcha_recaptcha_privatekey }}">
 <div class="col-md-6 pt-2 ps-0">
 <label class="form-check form-check-single form-switch ps-0">
 <input id="honeypot_enabled" class="form-check-input" name="honeypot_enabled" type="checkbox"
-{% if params.honeypot_enabled|default(true) %} checked="checked" {% endif %}>
+{% if params.honeypot_enabled is defined ? params.honeypot_enabled : true %} checked="checked" {% endif %}>
 </label>
 </div>
 </div>


### PR DESCRIPTION
### Motivation
- The Antispam admin template used `params.honeypot_enabled|default(true)`, which treats an explicit boolean `false` as empty and causes the honeypot checkbox to render checked, misrepresenting the stored configuration and risking an unintended overwrite when saving.

### Description
- Replace `params.honeypot_enabled|default(true)` with `params.honeypot_enabled is defined ? params.honeypot_enabled : true` in `src/modules/Antispam/templates/admin/mod_antispam_settings.html.twig` so that only missing values default to `true` while explicit `false` is preserved.

### Testing
- Verified the updated template with `sed -n '140,190p'`, inspected the change via `git diff`, and committed the fix with `git commit`, and all checks completed successfully; no automated unit tests were changed or run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0923c90318832eb7f949ee578dbde2)