### PR TITLE
Fix duplicate custom page slug exception constructor arguments

### DIFF
--- a/src/modules/Custompages/Service.php
+++ b/src/modules/Custompages/Service.php
@@ -143,7 +143,7 @@ class Service
             [$slug, $id]
         )->fetchOne();
         if ($exists) {
-            throw new \FOSSBilling\Exception('You need to set unique slug.', 9999);
+            throw new \FOSSBilling\Exception('You need to set unique slug.', null, 9999);
         }
         $this->di['dbal']->executeStatement(
             'UPDATE custom_pages SET title = ?, description = ?, keywords = ?, content = ?, slug = ? WHERE id = ?',


### PR DESCRIPTION
### Motivation
- Prevent a PHP `TypeError` when updating a custom page with a duplicate slug by using the correct `FOSSBilling\Exception` constructor parameter order so the API error path remains intact.

### Description
- Change in `src/modules/Custompages/Service.php` to throw `new \FOSSBilling\Exception('You need to set unique slug.', null, 9999)` so the integer error code is passed as the third parameter instead of the second.

### Testing
- Ran a syntax check with `php -l src/modules/Custompages/Service.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15dc9e0474832e8594bbf93c568e22)