### PR TITLE
Restore Currency module manage_settings permission

### DIFF
--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -81,6 +81,7 @@ class Service implements InjectionAwareInterface
                 'display_name' => __trans('Update Currency Rates'),
                 'description' => __trans('Allows the staff member to refresh all currency conversion rates.'),
             ],
+            'manage_settings' => [],
         ];
     }
 


### PR DESCRIPTION
### Motivation
- Fix an authorization regression where the Currency module no longer advertised a `manage_settings` permission, allowing staff with only general module access to read and modify sensitive exchange-rate provider configuration and API keys via the generic extension config APIs.

### Description
- Reintroduced the `manage_settings` permission marker in `src/modules/Currency/Service.php::getModulePermissions()` so `Extension\Service::hasManagePermission()` enforces the dedicated settings check for `mod_currency`.

### Testing
- Ran a syntax check with `php -l src/modules/Currency/Service.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15de897944832ebc097da07deb0d18)