### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/themes/admin_default/assets/js/tomselect.js
+++ b/src/themes/admin_default/assets/js/tomselect.js
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <span>${escape(item.label)}</span>
                 <small class="text-body-secondary ms-1 lh-1">#${escape(item.value)}</small>
              </div>`;
-  }
+  };
 
   const autocompleteSelectorEls = document.querySelectorAll('.autocomplete-selector');
   if (autocompleteSelectorEls.length > 0) {


### PR DESCRIPTION
To fix this, terminate the `const autocompleteTemplate = ...` function expression with an explicit semicolon (`};`) instead of relying on ASI.

Best single change (no functional change):
- In `src/themes/admin_default/assets/js/tomselect.js`, at the end of the `autocompleteTemplate` definition (line 54 in the snippet), change the closing `}` to `};`.

No imports, new methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._