### PR TITLE
Fix: Cast support ticket count to int to prevent checkout crash

### DIFF
--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -446,7 +446,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             ':status2' => \Model_SupportTicket::ONHOLD,
         ];
 
-        return (int)$this->di['db']->getCell($query, $bindings);
+        return (int) $this->di['db']->getCell($query, $bindings);
     }
 
     public function checkIfTaskAlreadyExists(\Model_Client $client, int $rel_id, string $rel_type, string $rel_task): bool

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -446,7 +446,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             ':status2' => \Model_SupportTicket::ONHOLD,
         ];
 
-        return $this->di['db']->getCell($query, $bindings);
+        return (int)$this->di['db']->getCell($query, $bindings);
     }
 
     public function checkIfTaskAlreadyExists(\Model_Client $client, int $rel_id, string $rel_type, string $rel_task): bool


### PR DESCRIPTION
Fixes a fatal TypeError during the checkout process where PHP expects an int but the database driver returns a string. Wrapping the database response in (int) ensures strict-type compliance on PHP 8+.

Error encountered: Return value must be of type int, string returned
<img width="1126" height="182" alt="image" src="https://github.com/user-attachments/assets/e41660c1-66ff-47a3-968e-6ac23c9bdf76" />
