### PR TITLE
Added tab-targeted redirects to API links and forms

### DIFF
--- a/src/modules/Client/templates/admin/mod_client_index.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_index.html.twig
@@ -343,7 +343,7 @@
                                     </svg>
                                 </a>
                                 <a class="btn btn-icon"
-                                    {{ fb_api_link({href: 'client/group_delete'|api_url(query: {'id': id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, reload: true}) }}>
+                                    {{ fb_api_link({href: 'client/group_delete'|api_url(query: {'id': id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'client#tab-groups'|url}) }}>
                                     <svg class="icon">
                                         <use xlink:href="#delete" />
                                     </svg>
@@ -362,7 +362,7 @@
 
             <div class="modal modal-blur fade" id="newGroupModal" tabindex="-1" aria-labelledby="newGroupModalLabel" aria-hidden="true">
                 <div class="modal-dialog modal-dialog-centered modal-sm">
-                    <form class="modal-content" method="post" action="{{ 'client/group_create'|api_url }}" {{ fb_api_form({ redirect: 'client'|url}) }}>
+                    <form class="modal-content" method="post" action="{{ 'client/group_create'|api_url }}" {{ fb_api_form({ redirect: 'client#tab-groups'|url}) }}>
                         <div class="modal-header">
                             <h3 class="modal-title" id="newGroupModalLabel">{{ 'Create New Group'|trans }}</h3>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
@@ -95,7 +95,7 @@
                                                 </svg>
                                             </a>
                                             <a class="btn btn-icon" href="{{ 'servicedomain/tld_delete'|api_url(query: { 'tld': tld.tld }) }}"
-                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, reload: true}) }}>
+                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'servicedomain#tab-tlds'|url}) }}>
                                                 <svg class="icon">
                                                     <use xlink:href="#delete" />
                                                 </svg>
@@ -137,7 +137,7 @@
                                             <a href='{{ "servicedomain/registrar/#{registrar.id}"|url }}'>{{ registrar.title }}</a>
                                         </td>
                                         <td>
-                                            <a class="btn btn-icon" href="{{ 'servicedomain/registrar_copy'|api_url(query: { 'id': registrar.id }) }}" title="{{ 'Copy'|trans }}" {{ fb_api_link({reload: true}) }}>
+                                            <a class="btn btn-icon" href="{{ 'servicedomain/registrar_copy'|api_url(query: { 'id': registrar.id }) }}" title="{{ 'Copy'|trans }}" {{ fb_api_link({redirect: 'servicedomain#tab-registrars'|url}) }}>
                                                 <svg class="icon">
                                                     <use xlink:href="#copy" />
                                                 </svg>
@@ -148,7 +148,7 @@
                                                 </svg>
                                             </a>
                                             <a class="btn btn-icon" href="{{ 'servicedomain/registrar_delete'|api_url(query: { 'id': registrar.id }) }}"
-                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, reload: true}) }}>
+                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'servicedomain#tab-registrars'|url}) }}>
                                                 <svg class="icon">
                                                     <use xlink:href="#delete" />
                                                 </svg>
@@ -211,7 +211,7 @@
 
         <div class="modal modal-blur fade" id="newTldModal" tabindex="-1" aria-labelledby="newTldModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down modal-xl">
-                <form class="modal-content fb-modal-form" method="post" action="{{ 'servicedomain/tld_create'|api_url }}" {{ fb_api_form({reload: true}) }}>
+                <form class="modal-content fb-modal-form" method="post" action="{{ 'servicedomain/tld_create'|api_url }}" {{ fb_api_form({redirect: 'servicedomain#tab-tlds'|url}) }}>
                     <div class="modal-header">
                         <h3 class="modal-title" id="newTldModalLabel">{{ 'Add New Top Level Domain'|trans }}</h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>

--- a/src/modules/Servicehosting/templates/admin/mod_servicehosting_index.html.twig
+++ b/src/modules/Servicehosting/templates/admin/mod_servicehosting_index.html.twig
@@ -144,7 +144,7 @@
                                             </a>
                                             <a class="btn btn-icon" href="{{ 'servicehosting/hp_delete'|api_url(query: { 'id': hp.id }) }}"
                                                 data-bs-toggle="tooltip" data-bs-placement="top" title="{{ 'Delete the Plan'|trans }}"
-                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'servicehosting'|url}) }}>
+                                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'servicehosting#tab-plans'|url}) }}>
                                                 <svg class="icon">
                                                     <use xlink:href="#delete" />
                                                 </svg>

--- a/src/modules/Staff/templates/admin/mod_staff_settings.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_settings.html.twig
@@ -233,7 +233,7 @@
                                     </a>
                                     <a class="btn btn-icon" href="{{ 'staff/group_delete'|api_url(query: { 'id': group.id }) }}"
                                         data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}"
-                                        {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'extension/settings/staff'|url}) }}>
+                                        {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'extension/settings/staff#tab-groups'|url}) }}>
                                         <svg class="icon">
                                             <use xlink:href="#delete"/>
                                         </svg>
@@ -305,7 +305,7 @@
 
     <div class="modal fade" id="newStaffGroupModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
-            <form method="post" action="{{ 'staff/group_create'|api_url }}" class="modal-content" {{ fb_api_form({redirect: 'extension/settings/staff'|url}) }}>
+            <form method="post" action="{{ 'staff/group_create'|api_url }}" class="modal-content" {{ fb_api_form({redirect: 'extension/settings/staff#tab-groups'|url}) }}>
                 <div class="modal-header">
                     <h5 class="modal-title">{{ 'New Group'|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>

--- a/src/modules/Support/templates/admin/mod_support_canned_category.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_canned_category.html.twig
@@ -28,7 +28,7 @@
 
 {% block content %}
 <div class="card">
-    <form method="post" action="{{ 'support/canned_category_update'|api_url }}" {{ fb_api_form({ redirect: 'support/canned-responses'|url }) }}>
+    <form method="post" action="{{ 'support/canned_category_update'|api_url }}" {{ fb_api_form({ redirect: 'support/canned-responses#tab-categories'|url }) }}>
         {% embed 'partial_admin_form_card.html.twig' with {
             title: 'Canned Category'|trans,
             subtitle: category.title,

--- a/src/modules/Support/templates/admin/mod_support_canned_responses.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_canned_responses.html.twig
@@ -170,7 +170,7 @@
                                 </svg>
                             </a>
                             <a class="btn btn-icon" href="{{ 'support/canned_category_delete'|api_url(query: { 'id': cat_id }) }}"
-                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'support/canned-responses'|url}) }}>
+                                {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'support/canned-responses#tab-categories'|url}) }}>
                                 <svg class="icon">
                                     <use xlink:href="#delete" />
                                 </svg>
@@ -231,7 +231,7 @@
 
         <div class="modal modal-blur fade" id="newCannedCategoryModal" tabindex="-1" aria-labelledby="newCannedCategoryModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered">
-                <form class="modal-content" method="post" action="{{ 'support/canned_category_create'|api_url }}" {{ fb_api_form({redirect: 'support/canned-responses'|url}) }}>
+                <form class="modal-content" method="post" action="{{ 'support/canned_category_create'|api_url }}" {{ fb_api_form({redirect: 'support/canned-responses#tab-categories'|url}) }}>
                     <div class="modal-header">
                         <h3 class="modal-title" id="newCannedCategoryModalLabel">{{ 'Create New Category'|trans }}</h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>

--- a/src/modules/Support/templates/admin/mod_support_kb_index.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_kb_index.html.twig
@@ -173,7 +173,7 @@
                                                 </svg>
                                             </a>
                                             <a class="btn btn-icon" href="{{ 'support/kb_category_delete'|api_url(query: { 'id': cat_id }) }}"
-                                                {{ fb_api_link({ message: 'Are you sure?'|trans, modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'support/kb'|url }) }}>
+                                                {{ fb_api_link({ message: 'Are you sure?'|trans, modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'support/kb#tab-categories'|url }) }}>
                                                 <svg class="icon">
                                                     <use xlink:href="#delete" />
                                                 </svg>
@@ -247,7 +247,7 @@
 
         <div class="modal modal-blur fade" id="newKbCategoryModal" tabindex="-1" aria-labelledby="newKbCategoryModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down">
-                <form class="modal-content fb-modal-form" method="post" action="{{ 'support/kb_category_create'|api_url }}" {{ fb_api_form({ reload: true }) }}>
+                <form class="modal-content fb-modal-form" method="post" action="{{ 'support/kb_category_create'|api_url }}" {{ fb_api_form({ redirect: 'support/kb#tab-categories'|url }) }}>
                     <div class="modal-header">
                         <h3 class="modal-title" id="newKbCategoryModalLabel">{{ 'Create New Category'|trans }}</h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>


### PR DESCRIPTION
Following #3648, added more tab-specific redirects to improve user experience