### PR TITLE
Don't display service-specific partial for inactive orders

### DIFF
--- a/src/modules/Order/templates/client/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/client/mod_order_manage.html.twig
@@ -122,7 +122,7 @@
             {# Service management #}
             {% set service = null %}
             {{ render_widgets('client.order.manage.service.before', { 'order': order, 'service': service }) }}
-            {% if guest.system_template_exists({ 'file': service_partial }) %}
+            {% if order.status == 'active' and guest.system_template_exists({ 'file': service_partial }) %}
                 {% set service = client.order_service({ 'id': order.id }) %}
                 {{ include(service_partial, { 'order': order, 'service': service }) }}
             {% endif %}


### PR DESCRIPTION
- Prevent inactive orders from trying to load service management partial that's accessible for active orders only.
- Avoid "Order is not active" rendering failures after checkout redirects to the order management page before the order is activated.

Fixes #3641.