### PR TITLE
Avoid emptying the cache during updates as it houses release ZIP

### DIFF
--- a/src/library/FOSSBilling/UpdateFinalization.php
+++ b/src/library/FOSSBilling/UpdateFinalization.php
@@ -276,7 +276,7 @@ class UpdateFinalization implements InjectionAwareInterface
         )));
 
         $config['maintenance_mode'] = $maintenanceMode;
-        Config::setConfig($config);
+        Config::setConfig($config, false);
     }
 
     private function restoreMaintenanceMode(array $state): void
@@ -284,7 +284,7 @@ class UpdateFinalization implements InjectionAwareInterface
         $config = Config::getConfig();
 
         $config['maintenance_mode'] = self::normalizeMaintenanceMode($state['maintenance_mode'] ?? []);
-        Config::setConfig($config);
+        Config::setConfig($config, false);
     }
 
     private function getFinalizationAllowedUrls(): array

--- a/tests-legacy/library/FOSSBilling/UpdateFinalizationTest.php
+++ b/tests-legacy/library/FOSSBilling/UpdateFinalizationTest.php
@@ -36,6 +36,7 @@ final class UpdateFinalizationTest extends PHPUnit\Framework\TestCase
         }
 
         $this->restoreOptionalFile($this->statePath, $this->originalState);
+        $this->filesystem->remove(Path::join(PATH_CACHE, 'downloaded-update.zip'));
         $this->filesystem->remove(Path::changeExtension(PATH_CONFIG, 'old.php'));
     }
 
@@ -49,6 +50,9 @@ final class UpdateFinalizationTest extends PHPUnit\Framework\TestCase
         ];
         Config::setConfig($config);
 
+        $cacheFile = Path::join(PATH_CACHE, 'downloaded-update.zip');
+        $this->filesystem->dumpFile($cacheFile, 'archive contents');
+
         $finalization = new UpdateFinalization();
         $state = $finalization->ensureCurrentVersionFinalization();
 
@@ -61,6 +65,7 @@ final class UpdateFinalizationTest extends PHPUnit\Framework\TestCase
         $updatedConfig = Config::getConfig();
         self::assertTrue($updatedConfig['maintenance_mode']['enabled']);
         self::assertContains(rtrim(ADMIN_PREFIX, '/') . '/system/update/finalize', $updatedConfig['maintenance_mode']['allowed_urls']);
+        self::assertFileExists($cacheFile);
     }
 
     public function testCompletingFinalizationRestoresMaintenanceAndWritesCompleteState(): void


### PR DESCRIPTION
Following #3639, make sure not to empty the cache during the update process as the release ZIP is stored in /data/cache.