### PR TITLE
Display separate last name field in signup forms

### DIFF
--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_client.html.twig
@@ -61,33 +61,32 @@
                             </div>
 
                             <div class="row">
-                                <div class="form-floating col-md-7 mb-3">
-                                    <input class="form-control form-control-sm" type="text" name="first_name" id="first-name"
-                                           required="required"
-                                           value="{{ request.first_name }}"
-                                           placeholder="{{ 'First Name'|trans }}">
-                                    <label for="first-name" class="ms-2">{{ 'First Name'|trans }}</label>
-                                </div>
-                            </div>
+                                <div class="col-md-7">
+                                    <div class="row">
+                                        <div class="form-floating col-md-6 mb-3">
+                                            <input class="form-control form-control-sm" type="text" name="first_name" id="first-name"
+                                                   required="required"
+                                                   value="{{ request.first_name }}"
+                                                   placeholder="{{ 'First Name'|trans }}">
+                                            <label for="first-name" class="ms-2">{{ 'First Name'|trans }}</label>
+                                        </div>
 
-                            {% if 'last_name' in r %}
-                            <div class="row">
-                                <div class="form-floating col-md-7 mb-3">
-                                    <input class="form-control form-control-sm" type="text" name="last_name" id="last_name"
-                                           required="required"
-                                           value="{{ request.last_name }}"
-                                           placeholder="{{ 'Last Name'|trans }}">
-                                    <label for="last_name" class="ms-2">{{ 'Last Name'|trans }}</label>
+                                        <div class="form-floating col-md-6 mb-3">
+                                            <input class="form-control form-control-sm" type="text" name="last_name" id="last_name"
+                                                   value="{{ request.last_name }}"
+                                                   placeholder="{{ 'Last Name'|trans }}"{% if 'last_name' in r %} required="required"{% endif %}>
+                                            <label for="last_name" class="ms-2">{{ 'Last Name'|trans }}</label>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                            {% endif %}
 
                             {% if 'company' in r %}
                                 <div class="row">
                                     <div class="form-floating col-md-7 mb-3">
                                         <input class="form-control form-control-sm" type="text" name="company" id="company"
                                                required="required"
-                                               value="{{ request.last_name }}"
+                                               value="{{ request.company }}"
                                                placeholder="{{ 'Company'|trans }}">
                                         <label for="company" class="ms-2">{{ 'Company'|trans }}</label>
                                     </div>

--- a/src/modules/Page/templates/client/mod_page_signup.html.twig
+++ b/src/modules/Page/templates/client/mod_page_signup.html.twig
@@ -31,19 +31,19 @@
                         <form method="post" action="{{ 'client/create'|api_url(role: 'guest') }}" class="auth" {{ fb_api_form({redirect: '/'|url}) }}>
                             {% set r = guest.client_required %}
 
-                            <div class="mb-3">
-                                <label class="form-label" for="first-name">{{ 'First Name'|trans }}</label>
-                                <input class="form-control" id="first-name" type="text" name="first_name"
-                                       value="{{ request.first_name }}" required="required"/>
-                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label" for="first-name">{{ 'First Name'|trans }}</label>
+                                    <input class="form-control" id="first-name" type="text" name="first_name"
+                                           value="{{ request.first_name }}" required="required"/>
+                                </div>
 
-                            {% if 'last_name' in r %}
-                                <div class="mb-3">
+                                <div class="col-md-6 mb-3">
                                     <label class="form-label" for="last_name">{{ 'Last Name'|trans }}</label>
                                     <input class="form-control" id="last_name" type="text" name="last_name"
-                                           value="{{ request.last_name }}" required="required"/>
+                                           value="{{ request.last_name }}"{% if 'last_name' in r %} required="required"{% endif %}/>
                                 </div>
-                            {% endif %}
+                            </div>
 
                             <div class="mb-3">
                                 <label class="form-label" for="reg-email">{{ 'Email Address'|trans }}</label>

--- a/src/modules/System/templates/admin/mod_system_update_finalize.html.twig
+++ b/src/modules/System/templates/admin/mod_system_update_finalize.html.twig
@@ -32,13 +32,12 @@
                             </div>
                         </div>
                     {% else %}
-                        {% set targetVersion = state.target_version|default(FOSSBillingVersion) %}
                         {% if finalized %}
-                            <p>{{ 'FOSSBilling has successfully applied the patches for version %version%.'|trans({'%version%': targetVersion}) }}</p>
+                            <p>{{ 'FOSSBilling has successfully applied the patches for version %version%.'|trans({'%version%': FOSSBillingVersion}) }}</p>
                         {% elseif finalization.pending_patches is same as(null) or finalization.pending_patches is same as(0) %}
-                            <p>{{ 'You are updating your system to FOSSBilling %target_version%. The system needs to check and apply any pending update patches before you can proceed.'|trans({'%target_version%': targetVersion}) }}</p>
+                            <p>{{ 'You are updating your system to FOSSBilling %target_version%. The system needs to check and apply any pending update patches before you can proceed.'|trans({'%target_version%': FOSSBillingVersion}) }}</p>
                         {% else %}
-                            <p>{{ 'You are updating your system to FOSSBilling %target_version%. The system needs to run %count% update patches before you can proceed.'|trans({'%target_version%': targetVersion, '%count%': finalization.pending_patches}) }}</p>
+                            <p>{{ 'You are updating your system to FOSSBilling %target_version%. The system needs to run %count% update patches before you can proceed.'|trans({'%target_version%': FOSSBillingVersion, '%count%': finalization.pending_patches}) }}</p>
                         {% endif %}
 
                         {% if not finalized %}


### PR DESCRIPTION
Always display a separate last name field in signup forms. Previously it was only displayed if marked as a required field.

Fixes #3632.