### PR TITLE
Better module manifest descriptions

### DIFF
--- a/src/modules/Activity/manifest.json
+++ b/src/modules/Activity/manifest.json
@@ -2,7 +2,7 @@
   "id": "activity",
   "type": "mod",
   "name": "Activity",
-  "description": "FOSSBilling core module",
+  "description": "Tracks and displays system activity logs for staff, clients, orders, invoices, and other administrative events.",
   "version": "1.0.0",
   "icon_url": "icon.svg"
 }

--- a/src/modules/Client/manifest.json
+++ b/src/modules/Client/manifest.json
@@ -2,7 +2,7 @@
   "id": "client",
   "type": "mod",
   "name": "Client",
-  "description": "FOSSBilling core module",
+  "description": "Manages client accounts, profiles, authentication settings, and client-facing account preferences.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Cron/manifest.json
+++ b/src/modules/Cron/manifest.json
@@ -2,7 +2,7 @@
   "id": "cron",
   "type": "mod",
   "name": "Scheduled Tasks",
-  "description": "FOSSBilling core module",
+  "description": "Configures scheduled task execution and automation used for recurring system maintenance.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Currency/manifest.json
+++ b/src/modules/Currency/manifest.json
@@ -3,6 +3,6 @@
   "type": "mod",
   "name": "Currency",
   "icon_url": "icon.svg",
-  "description": "FOSSBilling core module",
+  "description": "Manages currencies, exchange rates, formatting, and default billing currency settings.",
   "version": "1.0.0"
 }

--- a/src/modules/Email/manifest.json
+++ b/src/modules/Email/manifest.json
@@ -3,6 +3,6 @@
   "type": "mod",
   "name": "Email",
   "icon_url": "icon.svg",
-  "description": "FOSSBilling core module",
+  "description": "Configures outgoing mail delivery, email queue processing, and message logging for system notifications.",
   "version": "1.0.0"
 }

--- a/src/modules/Invoice/manifest.json
+++ b/src/modules/Invoice/manifest.json
@@ -2,7 +2,7 @@
   "id": "invoice",
   "type": "mod",
   "name": "Invoices",
-  "description": "FOSSBilling core module",
+  "description": "Controls invoice numbering, tax behavior, payment gateways, and billing document preferences.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Order/manifest.json
+++ b/src/modules/Order/manifest.json
@@ -2,7 +2,7 @@
   "id": "order",
   "type": "mod",
   "name": "Orders",
-  "description": "FOSSBilling core module",
+  "description": "Configures ordering behavior, fraud checks, order activation, and checkout-related preferences.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Redirect/manifest.json
+++ b/src/modules/Redirect/manifest.json
@@ -2,7 +2,7 @@
   "id": "redirect",
   "type": "mod",
   "name": "Redirect",
-  "description": "Manage redirects",
+  "description": "Creates and manages URL redirects within FOSSBilling.",
   "icon_url": "icon.svg",
   "author": "FOSSBilling",
   "author_url": "https://www.fossbilling.org",

--- a/src/modules/Staff/manifest.json
+++ b/src/modules/Staff/manifest.json
@@ -2,7 +2,7 @@
   "id": "staff",
   "type": "mod",
   "name": "Staff",
-  "description": "FOSSBilling core module",
+  "description": "Manages staff accounts, roles, permissions, authentication, and administrative access settings.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Support/manifest.json
+++ b/src/modules/Support/manifest.json
@@ -2,7 +2,7 @@
   "id": "support",
   "type": "mod",
   "name": "Support",
-  "description": "FOSSBilling core module",
+  "description": "Provides support ticket departments, helpdesk settings, knowledge base controls, and client support tools.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/System/manifest.json
+++ b/src/modules/System/manifest.json
@@ -2,7 +2,7 @@
   "id": "system",
   "type": "mod",
   "name": "System",
-  "description": "FOSSBilling core module",
+  "description": "Configures global system behavior including localization, company details, caching and other settings.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }

--- a/src/modules/Theme/manifest.json
+++ b/src/modules/Theme/manifest.json
@@ -2,7 +2,7 @@
   "id": "theme",
   "type": "mod",
   "name": "Theme",
-  "description": "FOSSBilling core module",
+  "description": "Manages active admin and client themes, theme presets, and appearance-related configuration.",
   "icon_url": "icon.svg",
   "version": "1.0.0"
 }


### PR DESCRIPTION
Added better module manifest descriptions instead of "FOSSBilling core module" as these show up in the admin area settings page.