### PR TITLE
Prevent deleting a registrar assigned to one or more TLDs

### DIFF
--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -630,7 +630,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $data['transfer_code'] = $model->transfer_code;
 
             $tldRegistrar = $this->di['db']->load('TldRegistrar', $model->tld_registrar_id);
-            $data['registrar'] = $tldRegistrar->name;
+            $data['registrar'] = $tldRegistrar instanceof \Model_TldRegistrar ? $tldRegistrar->name : null;
         }
 
         return $data;
@@ -900,7 +900,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
             $result['registrar'] = [
                 'id' => $model->tld_registrar_id,
-                'title' => $tldRegistrar->name,
+                'title' => $tldRegistrar instanceof \Model_TldRegistrar ? $tldRegistrar->name : null,
             ];
         }
 
@@ -1061,6 +1061,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         if ($count > 0) {
             throw new \FOSSBilling\InformationException('Registrar is used by :count: domains', [':count:' => $count], 707);
+        }
+
+        $tlds = $this->di['db']->find('Tld', 'tld_registrar_id = :registrar_id', [':registrar_id' => $model->id]);
+        $count = \FOSSBilling\Tools::safeCount($tlds);
+
+        if ($count > 0) {
+            throw new \FOSSBilling\InformationException('Registrar is used by :count: TLDs', [':count:' => $count], 707);
         }
 
         $name = $model->name;

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
@@ -86,7 +86,11 @@
                                             {{ 'Active:'|trans }} {% if tld.active %}{{ 'Yes'|trans }}{% else %}{{ 'No'|trans }}{% endif %}
                                         </td>
                                         <td>
-                                            <a href='{{ "servicedomain/registrar/#{tld.registrar.id}"|url }}'>{{ tld.registrar.title }}</a>
+                                            {% if tld.registrar.title %}
+                                                <a href='{{ "servicedomain/registrar/#{tld.registrar.id}"|url }}'>{{ tld.registrar.title }}</a>
+                                            {% else %}
+                                                <span class="text-danger">{{ 'Registrar missing'|trans }}</span>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             <a class="btn btn-icon" href='{{ "servicedomain/id/#{tld.id}"|url }}'>

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
@@ -13,8 +13,11 @@
                 </svg>
             </a>
         </li>
-        <li>
+        <li class="breadcrumb-item">
             <a href="{{ 'servicedomain'|url }}">{{ 'Domain Management'|trans }}</a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{{ 'servicedomain'|url }}">{{ 'TLDs'|trans }}</a>
         </li>
         <li class="breadcrumb-item active" aria-current="page">{{ tld.tld }}</li>
     </ol>

--- a/tests-legacy/modules/Servicedomain/ServiceTest.php
+++ b/tests-legacy/modules/Servicedomain/ServiceTest.php
@@ -1523,6 +1523,35 @@ final class ServiceTest extends \BBTestCase
         $this->assertArrayNotHasKey('registrar', $result);
     }
 
+    public function testTldToApiArrayHandlesMissingRegistrar(): void
+    {
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->atLeastOnce())
+            ->method('load')
+            ->willReturn(null);
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $this->service->setDi($di);
+
+        $model = new \Model_Tld();
+        $model->loadBean(new \DummyBean());
+        $model->tld = '.com';
+        $model->price_registration = 1;
+        $model->price_renew = 1;
+        $model->price_transfer = 1;
+        $model->active = 1;
+        $model->allow_register = 1;
+        $model->allow_transfer = 1;
+        $model->min_years = 2;
+        $model->tld_registrar_id = 1;
+
+        $result = $this->service->tldToApiArray($model, new \Model_Admin());
+
+        $this->assertSame(1, $result['registrar']['id']);
+        $this->assertNull($result['registrar']['title']);
+    }
+
     public function testTldFindOneByTld(): void
     {
         $tldModel = new \Model_Tld();
@@ -1728,6 +1757,30 @@ final class ServiceTest extends \BBTestCase
         $dbMock->expects($this->atLeastOnce())
             ->method('find')
             ->willReturn([$serviceDomainModel]);
+        $dbMock->expects($this->never())
+            ->method('trash')
+            ->willReturn(null);
+
+        $di = $this->getDi();
+        $di['db'] = $dbMock;
+        $this->service->setDi($di);
+
+        $model = new \Model_TldRegistrar();
+        $model->loadBean(new \DummyBean());
+        $model->id = 1;
+
+        $this->expectException(\FOSSBilling\Exception::class);
+        $this->service->registrarRm($model);
+    }
+
+    public function testRegistrarRmHasTldsException(): void
+    {
+        $tldModel = new \Model_Tld();
+        $tldModel->loadBean(new \DummyBean());
+        $dbMock = $this->createMock('\Box_Database');
+        $dbMock->expects($this->exactly(2))
+            ->method('find')
+            ->willReturnOnConsecutiveCalls([], [$tldModel]);
         $dbMock->expects($this->never())
             ->method('trash')
             ->willReturn(null);


### PR DESCRIPTION
- Prevent deleting a registrar that is assigned to one or more TLDs
- Fixed a warning that was emitted if the TLD is referenced to a missing or deleted registrar