### PR TITLE
Refresh config OPcache when preserving cache

### DIFF
--- a/src/library/FOSSBilling/Config.php
+++ b/src/library/FOSSBilling/Config.php
@@ -113,18 +113,15 @@ class Config
             throw new Exception('An error occurred when writing the updated configuration file.');
         }
 
-        if ($clearCache) {
-            // If opcache is installed and enabled, invalidate the cache for the config file
-            if (function_exists('opcache_invalidate') && function_exists('opcache_compile_file')) {
-                try {
-                    $filesystem->touch(PATH_CACHE);
-                } catch (\Exception) {
-                    // Silently ignore if touch fails
-                }
-                @opcache_invalidate(PATH_CONFIG, true);
-                @opcache_compile_file(PATH_CONFIG);
-            }
+        // If opcache is installed and enabled, always invalidate the cache for the config file.
+        // This must happen even when the FOSSBilling cache directory is preserved, otherwise
+        // runtimes with delayed or disabled timestamp validation can keep reading stale config values.
+        if (function_exists('opcache_invalidate') && function_exists('opcache_compile_file')) {
+            @opcache_invalidate(PATH_CONFIG, true);
+            @opcache_compile_file(PATH_CONFIG);
+        }
 
+        if ($clearCache) {
             try {
                 $filesystem->remove(PATH_CACHE);
                 $filesystem->mkdir(PATH_CACHE, 0o755);

--- a/tests-legacy/library/FOSSBilling/FOSSBilling_ConfigTest.php
+++ b/tests-legacy/library/FOSSBilling/FOSSBilling_ConfigTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 #[Group('Core')]
 final class FOSSBilling_ConfigTest extends PHPUnit\Framework\TestCase
@@ -64,6 +66,29 @@ final class FOSSBilling_ConfigTest extends PHPUnit\Framework\TestCase
         } finally {
             @unlink($filePath);
             unset($GLOBALS['config_injection_test']);
+        }
+    }
+
+    public function testSetConfigWithoutCacheClearRefreshesConfigReadsAndPreservesCacheFiles(): void
+    {
+        $filesystem = new Filesystem();
+        $cacheFile = Path::join(PATH_CACHE, 'config-cache-preservation-test.txt');
+        $filesystem->dumpFile($cacheFile, 'preserve me');
+
+        try {
+            $config = FOSSBilling\Config::getConfig();
+            $config['maintenance_mode'] = [
+                'enabled' => true,
+                'allowed_urls' => [],
+                'allowed_ips' => [],
+            ];
+
+            FOSSBilling\Config::setConfig($config, false);
+
+            $this->assertFileExists($cacheFile);
+            $this->assertTrue(FOSSBilling\Config::getProperty('maintenance_mode.enabled', false));
+        } finally {
+            $filesystem->remove($cacheFile);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Writing `config.php` while preserving the FOSSBilling cache directory previously skipped OPcache invalidation when called with `$clearCache = false`, which can leave runtimes reading a stale `maintenance_mode` value and allow public/client traffic during update finalization.

### Description
- Always invalidate and recompile `PATH_CONFIG` in OPcache after writing the updated configuration file in `Config::setConfig()`, regardless of the `$clearCache` flag, to ensure new config values are immediately visible to request handlers. (`src/library/FOSSBilling/Config.php`)
- Keep deletion/recreation of the FOSSBilling cache directory gated by the existing `$clearCache` parameter so cache preservation behavior is unchanged. (`src/library/FOSSBilling/Config.php`)
- Add a regression test that exercises `Config::setConfig($config, false)` to verify the cache file is preserved and that subsequent config reads reflect the updated `maintenance_mode` state. (`tests-legacy/library/FOSSBilling/FOSSBilling_ConfigTest.php`)

### Testing
- Ran the legacy PHPUnit suites for the modified tests with `cp src/config-sample.php src/config.php && ./src/vendor/bin/phpunit tests-legacy/library/FOSSBilling/FOSSBilling_ConfigTest.php tests-legacy/library/FOSSBilling/UpdateFinalizationTest.php` and all tests passed (`OK (10 tests, 28 assertions)`).
- Performed syntax checks with `php -l` on the changed files with no errors. 
- Ran a PHP-CS-Fixer dry-run using `./src/vendor/bin/php-cs-fixer --dry-run --diff --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes` and received no actionable fix errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a9cdf6ac0832e9cefc3f93ee15dfc)