### PR TITLE
Automatically log clients in after successful registration

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Box\Mod\Client\Api;
 
 use FOSSBilling\Security\RandomizedTimeFloor;
+use FOSSBilling\Tools;
 use FOSSBilling\Validation\Api\RequiredParams;
 
 class Guest extends \Api_Abstract
@@ -24,7 +25,6 @@ class Guest extends \Api_Abstract
     /**
      * Client signup action.
      *
-     * @optional bool $auto_login - Auto login client after signup
      * @optional string $last_name - last name
      * @optional string $aid - Alternative id. Usually used by import tools.
      * @optional string $gender - Gender - values: male|female|nonbinary|other
@@ -87,7 +87,7 @@ class Guest extends \Api_Abstract
             $service->sendEmailConfirmationForClient($client);
         }
 
-        if ($data['auto_login'] ?? 0) {
+        if (Tools::normalizeBoolean($config['auto_login_after_signup'] ?? true, true)) {
             try {
                 $this->login(['email' => $client->email, 'password' => $data['password']]);
             } catch (\Exception $e) {

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -90,7 +90,7 @@ class Guest extends \Api_Abstract
         if (Tools::normalizeBoolean($config['auto_login_after_signup'] ?? true, true)) {
             try {
                 $this->login(['email' => $client->email, 'password' => $data['password']]);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 error_log($e->getMessage());
             }
         }

--- a/src/modules/Client/templates/admin/mod_client_settings.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_settings.html.twig
@@ -23,6 +23,7 @@
 {% block content %}
     {% set params = admin.extension_config_get({ 'ext': 'mod_client' }) %}
     {% set required_fields = params.required|default([]) %}
+    {% set auto_login_after_signup = params.auto_login_after_signup is not defined or params.auto_login_after_signup == true %}
     <div class="card">
         <div class="card-header">
             <div>
@@ -65,6 +66,12 @@
                                                     <span class="form-check-label">{{ 'Require Email Confirmation'|trans }}</span>
                                                 </label>
                                                 <small class="form-hint">{{ 'After enabling this feature, existing users who have not yet confirmed their email addresses will also need to do so.'|trans }}</small>
+                                                <input type="hidden" name="auto_login_after_signup" value="0">
+                                                <label class="form-check form-switch form-switch-2">
+                                                    <input class="form-check-input" name="auto_login_after_signup" value="1" type="checkbox" {% if auto_login_after_signup %}checked="checked"{% endif %}>
+                                                    <span class="form-check-label">{{ 'Auto Login After Signup'|trans }}</span>
+                                                </label>
+                                                <small class="form-hint">{{ 'Automatically log clients in after successful registration.'|trans }}</small>
                                                 <label class="form-check form-switch form-switch-2">
                                                     <input class="form-check-input" name="disable_change_email" type="checkbox" {% if params.disable_change_email %}checked="checked"{% endif %}>
                                                     <span class="form-check-label">{{ 'Disable Email Change'|trans }}</span>


### PR DESCRIPTION
Added an option to the client settings that makes clients automatically login upon successful registration.

Previously there was an `auto_login` parameter that could be passed by signup forms, which was unused and replaced with an admin-side toggle.