### PR TITLE
Harden license documentation links

### DIFF
--- a/src/modules/Servicelicense/templates/admin/mod_servicelicense_config.html.twig
+++ b/src/modules/Servicelicense/templates/admin/mod_servicelicense_config.html.twig
@@ -5,7 +5,7 @@
         <div class="mb-5">
             <div class="mb-3">
                 <h3 class="card-title mb-1">{{ 'License Settings'|trans }}</h3>
-                <p class="text-secondary mb-0">{{ 'Configure how license keys are generated for this product and which validation rules should apply to issued licenses.'|trans }} <a href="https://docs.fossbilling.org/admin-guide/product-types/license/" target="_blank">{{ 'Learn more'|trans }}</a></p>
+                <p class="text-secondary mb-0">{{ 'Configure how license keys are generated for this product and which validation rules should apply to issued licenses.'|trans }} <a href="https://docs.fossbilling.org/admin-guide/product-types/license/" target="_blank" rel="noopener noreferrer">{{ 'Learn more'|trans }}</a></p>
             </div>
             <div class="row g-3">
                 <div class="col-lg-4">
@@ -102,7 +102,7 @@
             <li>{{ 'See the default example plugin at'|trans }} <strong>/modules/Servicelicense/Plugin/Simple.php</strong></li>
             <li>{{ 'Save your custom plugin in'|trans }} <strong>/modules/Servicelicense/Plugin/PluginName.php</strong></li>
             <li>{{ 'FOSSBilling will automatically detect your new plugin.'|trans }}</li>
-            <li><a href="https://docs.fossbilling.org/admin-guide/product-types/license/#custom-license-plugins" target="_blank">{{ 'Read the documentation'|trans }}</a> {{ 'for more details.'|trans }}</li>
+            <li><a href="https://docs.fossbilling.org/admin-guide/product-types/license/#custom-license-plugins" target="_blank" rel="noopener noreferrer">{{ 'Read the documentation'|trans }}</a> {{ 'for more details.'|trans }}</li>
         </ul>
     </div>
 </div>

--- a/src/modules/Servicelicense/templates/admin/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/templates/admin/mod_servicelicense_manage.html.twig
@@ -3,7 +3,7 @@
 <div class="card-body overflow-auto">
     <div class="mb-3">
         <h3 class="card-title mb-1">{{ 'Details'|trans }}</h3>
-        <p class="text-secondary mb-0">{{ 'Review the current license, plugin, and recent validation activity for this order.'|trans }} <a href="https://docs.fossbilling.org/admin-guide/product-types/license/#validating-a-license" target="_blank">{{ 'Learn more'|trans }}</a></p>
+        <p class="text-secondary mb-0">{{ 'Review the current license, plugin, and recent validation activity for this order.'|trans }} <a href="https://docs.fossbilling.org/admin-guide/product-types/license/#validating-a-license" target="_blank" rel="noopener noreferrer">{{ 'Learn more'|trans }}</a></p>
     </div>
     <table class="table card-table table-vcenter table-striped text-nowrap">
         <tbody>


### PR DESCRIPTION
### Motivation

- External admin-area documentation links opened with `target="_blank"` but lacked an explicit `rel="noopener noreferrer"`, which can allow opener-based tabnabbing or leak referrer information in legacy browsers or embedded webviews.

### Description

- Add `rel="noopener noreferrer"` to the License Settings "Learn more" link in `src/modules/Servicelicense/templates/admin/mod_servicelicense_config.html.twig`.
- Add `rel="noopener noreferrer"` to the License Plugins documentation link in `src/modules/Servicelicense/templates/admin/mod_servicelicense_config.html.twig`.
- Add `rel="noopener noreferrer"` to the Details "Learn more" link in `src/modules/Servicelicense/templates/admin/mod_servicelicense_manage.html.twig`.

### Testing

- Ran a regex-based scan (`rg -n --pcre2 'target="_blank"(?![^>]*rel=)' src/modules/Servicelicense/templates/admin -g '*.twig'`) to ensure there are no `_blank` anchors missing a `rel` attribute, and it returned no matches (pass). 
- Ran a diff/whitespace check (`git diff --check`) to ensure no formatting issues were introduced (pass).
- Inspected the resulting template diffs to verify only the intended `rel` attribute additions were made (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad0a325f0832eacc69a16c555f491)