### PR TITLE
Prevent client override of free subdomain base domain

### DIFF
--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -1128,6 +1128,10 @@ class Service implements InjectionAwareInterface
 
         $data = array_merge($c, $data);
 
+        if (($data['domain']['action'] ?? null) === 'subdomain' && array_key_exists('subdomain_base_domain', $c)) {
+            $data['subdomain_base_domain'] = $c['subdomain_base_domain'];
+        }
+
         if (isset($data['domain']['action'])) {
             $this->validateDomainAction($data, $c);
         }

--- a/tests-legacy/modules/Servicehosting/ServiceTest.php
+++ b/tests-legacy/modules/Servicehosting/ServiceTest.php
@@ -111,6 +111,32 @@ final class ServiceTest extends \BBTestCase
         $this->assertSame('.example.com', $result['tld']);
     }
 
+    public function testPrependOrderConfigUsesConfiguredFreeSubdomainBaseDomain(): void
+    {
+        $product = new \Model_Product();
+        $product->loadBean(new \DummyBean());
+        $product->config = json_encode([
+            'server_id' => 1,
+            'hosting_plan_id' => 2,
+            'allow_subdomain' => true,
+            'subdomain_base_domain' => 'example.com',
+        ]);
+
+        $this->service->setDi($this->getDi());
+
+        $result = $this->service->prependOrderConfig($product, [
+            'subdomain_base_domain' => 'attacker.example',
+            'domain' => [
+                'action' => 'subdomain',
+                'subdomain_sld' => 'customer',
+            ],
+        ]);
+
+        $this->assertSame('example.com', $result['subdomain_base_domain']);
+        $this->assertSame('customer', $result['sld']);
+        $this->assertSame('.example.com', $result['tld']);
+    }
+
     public function testPrependOrderConfigRequiresFreeSubdomainName(): void
     {
         $product = new \Model_Product();


### PR DESCRIPTION
### Motivation
- A client-supplied `subdomain_base_domain` could override the product configuration during order processing, allowing customers to provision subdomains on arbitrary domains instead of the product's configured base domain. 
- The change ensures that free-subdomain orders are bound to the product's configured `subdomain_base_domain` to preserve product-level restrictions and prevent abuse.

### Description
- When merging product config and order data in `prependOrderConfig()` the code now forces the effective `subdomain_base_domain` to the product-configured value for `subdomain` actions, preventing client override; see `src/modules/Servicehosting/Service.php`. 
- Added a regression unit test that supplies a client `subdomain_base_domain` and asserts the product-configured base domain is used instead; see `tests-legacy/modules/Servicehosting/ServiceTest.php`. 
- No other behaviour or domain flows were changed; subdomain validation and domain tuple construction still occur as before but use the enforced base domain.

### Testing
- Syntax checks with `php -l` on `src/modules/Servicehosting/Service.php` and the new test file completed without errors. 
- Ran the legacy module test subset with `APP_ENV=test src/vendor/bin/phpunit --filter ServiceTest tests-legacy/modules/Servicehosting/ServiceTest.php` and the test suite executed successfully including the new regression test. 
- Ran PHP CS Fixer in dry-run mode with `src/vendor/bin/php-cs-fixer --dry-run --diff --config=.php-cs-fixer.dist.php` and there were no auto-fix issues introduced by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad5962794832eb2c19cf574c5dd39)