### PR TITLE
🔒 Validate downloadable stored filenames

### DIFF
--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -326,7 +326,7 @@ class Service implements InjectionAwareInterface
 
     private function removeStoredFileIfOrphaned(string $storedFilename): void
     {
-        if (!$this->isStoredFilenameReferenced($storedFilename) && $this->isValidStoredFilename($storedFilename)) {
+        if ($this->isValidStoredFilename($storedFilename) && !$this->isStoredFilenameReferenced($storedFilename)) {
             $filePath = $this->getStoredFilePath($storedFilename);
             if ($this->filesystem->exists($filePath)) {
                 $this->filesystem->remove($filePath);

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -152,7 +152,7 @@ class Service implements InjectionAwareInterface
         $this->di['validator']->checkRequiredParamsForArray($required, $config);
 
         $data['filename'] = $config['filename'];
-        $data[self::STORED_FILENAME_CONFIG_KEY] = $config[self::STORED_FILENAME_CONFIG_KEY];
+        $data[self::STORED_FILENAME_CONFIG_KEY] = $this->validateStoredFilename($config[self::STORED_FILENAME_CONFIG_KEY]);
 
         return array_merge($config, $data);
     }
@@ -164,6 +164,7 @@ class Service implements InjectionAwareInterface
             self::STORED_FILENAME_CONFIG_KEY => 'Stored filename is missing in product config',
         ];
         $this->di['validator']->checkRequiredParamsForArray($required, $data);
+        $data[self::STORED_FILENAME_CONFIG_KEY] = $this->validateStoredFilename($data[self::STORED_FILENAME_CONFIG_KEY]);
     }
 
     /**
@@ -253,18 +254,32 @@ class Service implements InjectionAwareInterface
         ];
 
         if ($identity instanceof \Model_Admin) {
-            $result['path'] = Path::join(PATH_UPLOADS, $model->stored_filename);
+            $result['path'] = $this->getStoredFilePath($model->stored_filename);
             $result['downloads'] = $model->downloads;
         }
 
         return $result;
     }
 
+    private function validateStoredFilename(mixed $storedFilename): string
+    {
+        if (!is_string($storedFilename) || preg_match('/\A[a-f0-9]{64}\z/', $storedFilename) !== 1) {
+            throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
+        }
+
+        return $storedFilename;
+    }
+
+    private function getStoredFilePath(mixed $storedFilename): string
+    {
+        return Path::join(PATH_UPLOADS, $this->validateStoredFilename($storedFilename));
+    }
+
     private function generateStoredFilename(): string
     {
         do {
             $storedFilename = bin2hex(random_bytes(32));
-            $filePath = Path::join(PATH_UPLOADS, $storedFilename);
+            $filePath = $this->getStoredFilePath($storedFilename);
         } while ($this->filesystem->exists($filePath));
 
         return $storedFilename;
@@ -304,10 +319,15 @@ class Service implements InjectionAwareInterface
         return $count > 0;
     }
 
+    private function isValidStoredFilename(mixed $storedFilename): bool
+    {
+        return is_string($storedFilename) && preg_match('/\A[a-f0-9]{64}\z/', $storedFilename) === 1;
+    }
+
     private function removeStoredFileIfOrphaned(string $storedFilename): void
     {
-        if (!$this->isStoredFilenameReferenced($storedFilename)) {
-            $filePath = Path::join(PATH_UPLOADS, $storedFilename);
+        if (!$this->isStoredFilenameReferenced($storedFilename) && $this->isValidStoredFilename($storedFilename)) {
+            $filePath = $this->getStoredFilePath($storedFilename);
             if ($this->filesystem->exists($filePath)) {
                 $this->filesystem->remove($filePath);
             }
@@ -420,6 +440,8 @@ class Service implements InjectionAwareInterface
             }
         }
 
+        $storedFilename = $this->validateStoredFilename($storedFilename);
+
         $serviceDownloadable->filename = $fileName;
         $serviceDownloadable->stored_filename = $storedFilename;
         $serviceDownloadable->updated_at = date('Y-m-d H:i:s');
@@ -463,7 +485,7 @@ class Service implements InjectionAwareInterface
             throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
         }
 
-        $filePath = Path::join(PATH_UPLOADS, $storedFilename);
+        $filePath = $this->getStoredFilePath($storedFilename);
         if (!$this->filesystem->exists($filePath)) {
             throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
         }
@@ -514,7 +536,7 @@ class Service implements InjectionAwareInterface
         }
 
         $fileName = $config['filename'];
-        $filePath = Path::join(PATH_UPLOADS, $config[self::STORED_FILENAME_CONFIG_KEY]);
+        $filePath = $this->getStoredFilePath($config[self::STORED_FILENAME_CONFIG_KEY]);
 
         if (!$this->filesystem->exists($filePath)) {
             throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -264,7 +264,7 @@ class Service implements InjectionAwareInterface
     private function validateStoredFilename(mixed $storedFilename): string
     {
         if (!is_string($storedFilename) || preg_match('/\A[a-f0-9]{64}\z/', $storedFilename) !== 1) {
-            throw new \FOSSBilling\Exception('File cannot be downloaded at the moment. Please contact support.', null, 404);
+            throw new \FOSSBilling\Exception('File is not available at the moment. Please contact support.', null, 404);
         }
 
         return $storedFilename;

--- a/tests-legacy/modules/Servicedownloadable/ServiceTest.php
+++ b/tests-legacy/modules/Servicedownloadable/ServiceTest.php
@@ -20,7 +20,7 @@ final class ServiceTest extends \BBTestCase
     {
         $productModel = new \Model_Product();
         $productModel->loadBean(new \DummyBean());
-        $productModel->config = '{"filename" : "temp/asdcxTest.txt", "stored_filename": "stored-temp-file"}';
+        $productModel->config = '{"filename" : "temp/asdcxTest.txt", "stored_filename": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}';
 
         $data = [];
 
@@ -36,11 +36,29 @@ final class ServiceTest extends \BBTestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testAttachOrderConfigRejectsInvalidStoredFilename(): void
+    {
+        $productModel = new \Model_Product();
+        $productModel->loadBean(new \DummyBean());
+        $productModel->config = '{"filename" : "download.txt", "stored_filename": "../config.php"}';
+
+        $validatorMock = $this->createMock(\FOSSBilling\Validate::class);
+
+        $di = $this->getDi();
+        $di['validator'] = $validatorMock;
+        $this->service->setDi($di);
+
+        $this->expectException(\FOSSBilling\Exception::class);
+
+        $data = [];
+        $this->service->attachOrderConfig($productModel, $data);
+    }
+
     public function testActionCreate(): void
     {
         $clientOrderModel = new \Model_ClientOrder();
         $clientOrderModel->loadBean(new \DummyBean());
-        $clientOrderModel->config = '{"filename" : "temp/asdcxTest.txt", "stored_filename": "stored-temp-file"}';
+        $clientOrderModel->config = '{"filename" : "temp/asdcxTest.txt", "stored_filename": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}';
 
         $model = new \Model_ServiceDownloadable();
         $model->loadBean(new \DummyBean());
@@ -62,7 +80,25 @@ final class ServiceTest extends \BBTestCase
         $this->service->setDi($di);
         $result = $this->service->action_create($clientOrderModel);
         $this->assertInstanceOf('\Model_ServiceDownloadable', $result);
-        $this->assertSame('stored-temp-file', $result->stored_filename);
+        $this->assertSame('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $result->stored_filename);
+    }
+
+    public function testActionCreateRejectsInvalidStoredFilename(): void
+    {
+        $clientOrderModel = new \Model_ClientOrder();
+        $clientOrderModel->loadBean(new \DummyBean());
+        $clientOrderModel->config = '{"filename" : "download.txt", "stored_filename": "../config.php"}';
+
+        $validatorMock = $this->createMock(\FOSSBilling\Validate::class);
+
+        $di = $this->getDi();
+        $di['validator'] = $validatorMock;
+
+        $this->service->setDi($di);
+
+        $this->expectException(\FOSSBilling\Exception::class);
+
+        $this->service->action_create($clientOrderModel);
     }
 
     public function testActionDelete(): void
@@ -258,6 +294,56 @@ final class ServiceTest extends \BBTestCase
         $this->service->sendProductFile($product);
     }
 
+    public function testSendProductFileRejectsTraversalStoredFilename(): void
+    {
+        $di = $this->createUploadDi();
+        $this->service->setDi($di);
+
+        $product = $this->createProductModel('{"filename": "download.txt", "stored_filename": "../config.php"}');
+
+        $this->expectException(\FOSSBilling\Exception::class);
+
+        $this->service->sendProductFile($product);
+    }
+
+    public function testSendFileRejectsTraversalStoredFilename(): void
+    {
+        $di = $this->createUploadDi();
+        $this->service->setDi($di);
+
+        $serviceDownloadable = new \Model_ServiceDownloadable();
+        $serviceDownloadable->loadBean(new \DummyBean());
+        $serviceDownloadable->filename = 'download.txt';
+        $serviceDownloadable->stored_filename = '../config.php';
+
+        $this->expectException(\FOSSBilling\Exception::class);
+
+        $this->service->sendFile($serviceDownloadable);
+    }
+
+    public function testReplacingProductFileDoesNotDeleteInvalidOldStoredFilenameOutsideUploads(): void
+    {
+        $di = $this->createUploadDi();
+        $this->service->setDi($di);
+
+        $outsidePath = \Symfony\Component\Filesystem\Path::join(dirname(PATH_UPLOADS), 'downloadable-secret.txt');
+        file_put_contents($outsidePath, 'SECRET');
+
+        $product = $this->createProductModel(json_encode([
+            'filename' => 'old.txt',
+            'stored_filename' => '../downloadable-secret.txt',
+        ]));
+
+        try {
+            $this->uploadFile($di, $product, 'download.txt', 'NEW_CONTENT');
+
+            $this->assertFileExists($outsidePath);
+            $this->assertSame('SECRET', file_get_contents($outsidePath));
+        } finally {
+            @unlink($outsidePath);
+        }
+    }
+
     private function invokeValidateFileUpload(\Symfony\Component\HttpFoundation\File\UploadedFile $file): void
     {
         $reflection = new \ReflectionMethod(Service::class, 'validateFileUpload');
@@ -271,6 +357,11 @@ final class ServiceTest extends \BBTestCase
             public function store($model): int
             {
                 return 1;
+            }
+
+            public function getCell(string $query, array $bindings = []): int
+            {
+                return 0;
             }
         };
         $di['logger'] = new class {


### PR DESCRIPTION
### Motivation
- Prevent path traversal and arbitrary file disclosure caused by using unvalidated `stored_filename` values from product/order config when constructing filesystem paths or deleting orphaned files.
- Ensure only the internally generated 64-character hex storage keys are accepted as storage identifiers to preserve the uploads directory boundary.

### Description
- Add `validateStoredFilename()` and `getStoredFilePath()` helpers and use them when copying `stored_filename` from product/order config and when exposing or reading file paths to ensure the stored filename matches the expected 64-character lowercase hex token (see `src/modules/Servicedownloadable/Service.php`).
- Harden orphan cleanup by checking `isValidStoredFilename()` before attempting to remove files and avoid deleting files outside `PATH_UPLOADS` when a malicious or legacy value is present.
- Validate `stored_filename` in `attachOrderConfig()`, `validateOrderData()`, `updateProductFile()` and reuse the validated path in `sendFile()` and `sendProductFile()` to prevent traversal on reads.
- Add regression unit tests covering rejection of traversal-style `stored_filename` values, successful handling of valid generated tokens, and ensuring replacement does not delete files outside uploads (see `tests-legacy/modules/Servicedownloadable/ServiceTest.php`).

### Testing
- Ran syntax checks with `php -l` on `src/modules/Servicedownloadable/Service.php` and `tests-legacy/modules/Servicedownloadable/ServiceTest.php`, both passed.
- Installed project dependencies with `composer install` and ran PHP CS Fixer via `src/vendor/bin/php-cs-fixer fix` on the modified files, which completed successfully.
- Attempted unit test run via `composer test -- --filter 'Box\\Mod\\Servicedownloadable\\ServiceTest'` but PHPUnit bootstrap failed in this environment because the repository `src/config.php` is empty/invalid, preventing automated test execution here; added/updated tests are included and their files pass static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae03d9bc8832eb8d646905ea04357)