### PR TITLE
Fix release notes workflow command

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -113,8 +113,6 @@ jobs:
             -f previous_tag_name="${previous_tag}" \
             --jq '.body' \
             > release-notes-context/github-generated-notes.md
-            --jq '.body' \
-            > release-notes-context/github-generated-notes.md
 
       - name: 'Generate GitHub Release Notes'
         if: ${{ inputs.release_notes == 'github' }}


### PR DESCRIPTION
### Motivation
- Remove a duplicated standalone `--jq`/redirection in `.github/workflows/create-release.yml` that made the runner attempt to execute `--jq` as a shell command and abort the release workflow when `release_notes` is `github` or `copilot`.

### Description
- Delete the extra `--jq '.body' > release-notes-context/github-generated-notes.md` lines so the `gh api "repos/${REPOSITORY}/releases/generate-notes"` call is a single valid command that writes once to `release-notes-context/github-generated-notes.md`.

### Testing
- Verified no duplicate standalone `--jq` redirection remains with a Python check (succeeded).
- Validated the workflow YAML parses using Ruby's `YAML` loader (succeeded).
- Ran `git diff --check` to ensure there are no formatting issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af6ac3d6c832ebdfd9bbeca92555a)