### PR TITLE
Add PSR-3 styled logger method names to Box_Log

### DIFF
--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -11,14 +11,18 @@ declare(strict_types=1);
  */
 
 /**
- * @method void emerg(string $message)
+ * @method void emergency(string $message)
  * @method void alert(string $message)
- * @method void crit(string $message)
- * @method void err(string $message)
- * @method void warn(string $message)
+ * @method void critical(string $message)
+ * @method void error(string $message)
+ * @method void warning(string $message)
  * @method void notice(string $message)
  * @method void info(string $message)
  * @method void debug(string $message)
+ * @method void emerg(string $message) Legacy alias for emergency()
+ * @method void crit(string $message) Legacy alias for critical()
+ * @method void err(string $message) Legacy alias for error()
+ * @method void warn(string $message) Legacy alias for warning()
  */
 class Box_Log implements FOSSBilling\InjectionAwareInterface
 {
@@ -32,14 +36,21 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
     final public const int DEBUG = 7; // Debug: debug messages
 
     protected array $_priorities = [
-        self::EMERG => 'EMERG',
+        self::EMERG => 'EMERGENCY',
         self::ALERT => 'ALERT',
-        self::CRIT => 'CRIT',
-        self::ERR => 'ERR',
-        self::WARN => 'WARN',
+        self::CRIT => 'CRITICAL',
+        self::ERR => 'ERROR',
+        self::WARN => 'WARNING',
         self::NOTICE => 'NOTICE',
         self::INFO => 'INFO',
         self::DEBUG => 'DEBUG',
+    ];
+
+    private const array PRIORITY_ALIASES = [
+        'EMERG' => 'EMERGENCY',
+        'CRIT' => 'CRITICAL',
+        'ERR' => 'ERROR',
+        'WARN' => 'WARNING',
     ];
 
     protected ?Pimple\Container $di = null;
@@ -88,8 +99,9 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
     public function __call($method, $params): void
     {
         $priority = strtoupper((string) $method);
+        $priority = self::PRIORITY_ALIASES[$priority] ?? $priority;
         $params = $this->maskParams($params);
-        if (($priority = array_search($priority, $this->_priorities)) !== false) {
+        if (($priority = array_search($priority, $this->_priorities, true)) !== false) {
             switch (FOSSBilling\Tools::safeCount($params)) {
                 case 0:
                     throw new FOSSBilling\Exception('Missing log message');

--- a/src/library/Box/Log.php
+++ b/src/library/Box/Log.php
@@ -72,9 +72,9 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
         return $this->di;
     }
 
-    private function maskParams(array|string $params, int $depthLimit = 15): array|string
+    private function maskParams(mixed $params, int $depthLimit = 15): mixed
     {
-        if (is_string($params)) {
+        if (!is_array($params)) {
             return $params;
         }
 
@@ -83,10 +83,10 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
         }
 
         foreach ($params as $key => $value) {
-            if (is_array($value)) {
-                $params[$key] = $this->maskParams($value, $depthLimit - 1);
-            } elseif (in_array(strtolower((string) $key), $this->_maskedKeys)) {
+            if (in_array(strtolower((string) $key), $this->_maskedKeys)) {
                 $params[$key] = '********';
+            } elseif (is_array($value)) {
+                $params[$key] = $this->maskParams($value, $depthLimit - 1);
             }
         }
 
@@ -100,7 +100,6 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
     {
         $priority = strtoupper((string) $method);
         $priority = self::PRIORITY_ALIASES[$priority] ?? $priority;
-        $params = $this->maskParams($params);
         if (($priority = array_search($priority, $this->_priorities, true)) !== false) {
             switch (FOSSBilling\Tools::safeCount($params)) {
                 case 0:
@@ -111,6 +110,8 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
                     break;
                 default:
                     $message = array_shift($params);
+                    $params = $this->maskParams($params);
+
                     $message = vsprintf($message, array_values($params));
                     if (!$message) {
                         throw new LogicException('Number of placeholders does not match number of variables');
@@ -130,12 +131,12 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
     public function log($message, $priority, array|string|null $extras = null): void
     {
         // sanity checks
-        if (empty($this->_writers)) {
-            return;
-        }
-
         if (!isset($this->_priorities[$priority])) {
             throw new FOSSBilling\Exception('Bad log priority');
+        }
+
+        if (empty($this->_writers)) {
+            return;
         }
 
         if ($this->_min_priority && $priority > $this->_min_priority) {
@@ -143,6 +144,7 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
         }
 
         $event = $this->_packEvent($message, $priority);
+        $extras = $this->maskParams($extras);
 
         // Check to see if any extra information was passed
         if (!empty($extras)) {
@@ -150,7 +152,9 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
             if (is_array($extras)) {
                 foreach ($extras as $key => $value) {
                     if (is_string($key)) {
-                        $event[$key] = $value;
+                        if (!array_key_exists($key, $event)) {
+                            $event[$key] = $value;
+                        }
                     } else {
                         $info[] = $value;
                     }
@@ -170,7 +174,11 @@ class Box_Log implements FOSSBilling\InjectionAwareInterface
 
         // send to each writer
         foreach ($this->_writers as $writer) {
-            $writer->write($event, $this->_channel);
+            try {
+                $writer->write($event, $this->_channel);
+            } catch (Throwable $e) {
+                error_log($e->getMessage());
+            }
         }
     }
 

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -1243,9 +1243,7 @@ class UpdatePatcher implements InjectionAwareInterface
             $needsSave = false;
             foreach ($fields as $field) {
                 if (isset($config[$field]) && is_string($config[$field]) && preg_match('/\b(function|include|import|extends|range|max|min|dump|system|guest\.|admin\.|client\.)\b/i', $config[$field])) {
-                    $this->di['logger']->setChannel('update')->warning('Custom payment adapter template for gateway ID {id} contained incompatible Twig syntax and has been cleared. Please re-create it with compatible syntax.', [
-                        'id' => $gateway['id'],
-                    ]);
+                    $this->di['logger']->setChannel('update')->warning('Custom payment adapter template for gateway ID %s contained incompatible Twig syntax and has been cleared. Please re-create it with compatible syntax.', $gateway['id']);
                     unset($config[$field]);
                     $needsSave = true;
                 }

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -336,7 +336,7 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
             ]);
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception("HttpClientException: {$error->getMessage()}.");
-            $this->getLog()->err($e->getMessage());
+            $this->getLog()->error($e->getMessage());
 
             throw $e;
         }

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -139,7 +139,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
             }
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception("HttpClientException: {$error->getMessage()}.");
-            $this->getLog()->err($e->getMessage());
+            $this->getLog()->error($e->getMessage());
 
             throw $e;
         }

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -684,7 +684,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $this->getLog()->info('API RESULT: ' . $result->getContent(false));
         } catch (HttpExceptionInterface $error) {
             $e = new Registrar_Exception("HttpClientException: {$error->getMessage()}.");
-            $this->getLog()->err($e->getMessage());
+            $this->getLog()->error($e->getMessage());
 
             throw $e;
         }

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -750,7 +750,7 @@ class Server_Manager_Directadmin extends Server_Manager
         } catch (TransportExceptionInterface|HttpExceptionInterface $error) {
             // If there is an error while sending the request, throw an exception
             $exception = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
-            $this->getLog()->err($exception->getMessage());
+            $this->getLog()->error($exception->getMessage());
 
             throw $exception;
         }
@@ -771,7 +771,7 @@ class Server_Manager_Directadmin extends Server_Manager
         // If the response contains an error, log the error and throw an exception
         if (isset($response['error']) && $response['error'] == 1) {
             $placeholders = [':action:' => $command, ':type:' => 'DirectAdmin'];
-            $this->getLog()->err('Failed to ' . $command . ' on the DirectAdmin server: ' . $response['text'] . ': ' . $response['details']);
+            $this->getLog()->error('Failed to ' . $command . ' on the DirectAdmin server: ' . $response['text'] . ': ' . $response['details']);
 
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -98,11 +98,11 @@ class Server_Manager_Whm extends Server_Manager
                 if (isset($response->data->url)) {
                     return $response->data->url;
                 }
-                $this->getLog()->err('Unexpected API response: ' . print_r($response, true));
+                $this->getLog()->error('Unexpected API response: ' . print_r($response, true));
 
                 return 'https://' . $this->_config['host'] . '/cpanel';
             } catch (Server_Exception $e) {
-                $this->getLog()->err("Failed to get login URL: {$e->getMessage()}.");
+                $this->getLog()->error("Failed to get login URL: {$e->getMessage()}.");
 
                 return 'https://' . $this->_config['host'] . '/cpanel';
             }
@@ -136,11 +136,11 @@ class Server_Manager_Whm extends Server_Manager
                 if (isset($response->data->url)) {
                     return $response->data->url;
                 }
-                $this->getLog()->err('Unexpected API response: ' . print_r($response, true));
+                $this->getLog()->error('Unexpected API response: ' . print_r($response, true));
 
                 return 'https://' . $this->_config['host'] . '/whm';
             } catch (Server_Exception $e) {
-                $this->getLog()->err("Failed to get login URL: {$e->getMessage()}.");
+                $this->getLog()->error("Failed to get login URL: {$e->getMessage()}.");
 
                 return 'https://' . $this->_config['host'] . '/whm';
             }
@@ -608,7 +608,7 @@ class Server_Manager_Whm extends Server_Manager
             ]);
         } catch (HttpExceptionInterface $error) {
             $e = new Server_Exception('HttpClientException: :error', [':error' => $error->getMessage()]);
-            $this->getLog()->err($e->getMessage());
+            $this->getLog()->error($e->getMessage());
 
             throw $e;
         }
@@ -620,7 +620,7 @@ class Server_Manager_Whm extends Server_Manager
         // Check the response for errors and throw a Server_Exception if any are found
         if (!is_object($json)) {
             $msg = sprintf('Function call "%s" response is invalid, body: %s', $action, $body);
-            $this->getLog()->crit($msg);
+            $this->getLog()->critical($msg);
 
             $placeholders = [':action:' => $action, ':type:' => 'cPanel'];
 
@@ -628,28 +628,28 @@ class Server_Manager_Whm extends Server_Manager
         }
 
         if (isset($json->cpanelresult->error)) {
-            $this->getLog()->crit(sprintf('WHM server response error calling action %s: "%s"', $action, $json->cpanelresult->error));
+            $this->getLog()->critical(sprintf('WHM server response error calling action %s: "%s"', $action, $json->cpanelresult->error));
             $placeholders = ['action' => $action, 'type' => 'cPanel'];
 
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
         if (isset($json->data->result) && $json->data->result == '0') {
-            $this->getLog()->crit(sprintf('WHM server response error calling action %s: "%s"', $action, $json->data->reason));
+            $this->getLog()->critical(sprintf('WHM server response error calling action %s: "%s"', $action, $json->data->reason));
             $placeholders = [':action:' => $action, ':type:' => 'cPanel'];
 
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
         if (isset($json->result) && is_array($json->result) && $json->result[0]->status == 0) {
-            $this->getLog()->crit(sprintf('WHM server response error calling action %s: "%s"', $action, $json->result[0]->statusmsg));
+            $this->getLog()->critical(sprintf('WHM server response error calling action %s: "%s"', $action, $json->result[0]->statusmsg));
             $placeholders = [':action:' => $action, ':type:' => 'cPanel'];
 
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);
         }
 
         if (isset($json->status) && $json->status != '1') {
-            $this->getLog()->crit(sprintf('WHM server response error calling action %s: "%s"', $action, $json->statusmsg));
+            $this->getLog()->critical(sprintf('WHM server response error calling action %s: "%s"', $action, $json->statusmsg));
             $placeholders = [':action:' => $action, ':type:' => 'cPanel'];
 
             throw new Server_Exception('Failed to :action: on the :type: server, check the error logs for further details', $placeholders);

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -998,11 +998,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             try {
                 $this->di['db']->trash($queue);
             } catch (\Exception $e) {
-                $this->di['logger']->setChannel('email')->err($e->getMessage());
+                $this->di['logger']->setChannel('email')->error($e->getMessage());
             }
         } catch (\Exception $e) {
             $message = $e->getMessage();
-            $this->di['logger']->setChannel('email')->err($e->getMessage());
+            $this->di['logger']->setChannel('email')->error($e->getMessage());
 
             if ($queue->priority) {
                 --$queue->priority;

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -52,7 +52,7 @@ class Admin extends \Api_Abstract
         try {
             $list = $this->di['extension_manager']->getExtensionList($type);
         } catch (\Exception $e) {
-            $this->di['logger']->warn(sprintf('Failed to fetch extension list for type "%s": %s', $type ?? 'all', $e->getMessage()));
+            $this->di['logger']->warning(sprintf('Failed to fetch extension list for type "%s": %s', $type ?? 'all', $e->getMessage()));
 
             $list = [];
         }

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -513,7 +513,7 @@ class Service implements InjectionAwareInterface
                 $this->filesystem->remove($path);
                 $this->di['logger']->info('Removed extension files for "%s" from %s', $id, $path);
             } catch (IOException $e) {
-                $this->di['logger']->warn('Failed to remove extension files for "%s": %s', $id, $e->getMessage());
+                $this->di['logger']->warning('Failed to remove extension files for "%s": %s', $id, $e->getMessage());
 
                 throw new \FOSSBilling\Exception('Failed to remove extension files. Please check file permissions and try again or manually remove the files from :path', [':path' => $path]);
             }

--- a/src/modules/Invoice/ServiceTransaction.php
+++ b/src/modules/Invoice/ServiceTransaction.php
@@ -186,7 +186,7 @@ class ServiceTransaction implements InjectionAwareInterface
             $supported = in_array('ipn_hash', $columns, true) && in_array('transaction_ipn_hash_idx', $indexes, true);
         } catch (\Throwable $e) {
             if (isset($this->di['logger'])) {
-                $this->di['logger']->warn('Could not determine whether transaction.ipn_hash exists; disabling IPN hash dedupe: %s', $e->getMessage());
+                $this->di['logger']->warning('Could not determine whether transaction.ipn_hash exists; disabling IPN hash dedupe: %s', $e->getMessage());
             }
 
             return false;

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -469,7 +469,7 @@ class Service implements InjectionAwareInterface
             $data['meta'] = $meta[$order['id']] ?? [];
             $data['active_tickets'] = $activeTickets[$order['id']] ?? 0;
             if (!isset($clients[$clientId])) {
-                $this->di['logger']->err('Missing client for order ' . $order['id']);
+                $this->di['logger']->error('Missing client for order ' . $order['id']);
                 $data['client'] = [];
             } else {
                 $data['client'] = $clients[$clientId];

--- a/src/modules/Servicedownloadable/Service.php
+++ b/src/modules/Servicedownloadable/Service.php
@@ -124,7 +124,7 @@ class Service implements InjectionAwareInterface
         }
 
         if (!$this->isAllowedMimeType($mimeType, $allowedTypes['mime_types']) && $this->di->offsetExists('logger')) {
-            $this->di['logger']->warn(
+            $this->di['logger']->warning(
                 'Accepting downloadable upload %s with unexpected MIME type %s because the extension %s is allowed',
                 $file->getClientOriginalName(),
                 $mimeType,

--- a/src/modules/Support/Controller/Admin.php
+++ b/src/modules/Support/Controller/Admin.php
@@ -124,7 +124,7 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
                 }
             }
         } catch (\Exception $e) {
-            $this->di['logger']->err($e->getMessage());
+            $this->di['logger']->error($e->getMessage());
         }
 
         return $app->render('mod_support_ticket', ['ticket' => $ticket, 'canned_delay_message' => $cdm, 'request_message' => $messageid]);

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -78,7 +78,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -100,7 +100,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -122,7 +122,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -144,7 +144,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -166,7 +166,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -189,7 +189,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -212,7 +212,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -235,7 +235,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $email['ticket'] = $ticketArr;
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
-            $di['logger']->err($exc->getMessage());
+            $di['logger']->error($exc->getMessage());
         }
     }
 
@@ -716,7 +716,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $data['helpdesk'] = $helpdesk ? $this->helpdeskToApiArray($helpdesk, $identity) : null;
 
             if (!isset($clients[$ticket['client_id']])) {
-                $this->di['logger']->err('Missing client for ticket ' . $ticket['id']);
+                $this->di['logger']->error('Missing client for ticket ' . $ticket['id']);
                 $data['client'] = [];
             } else {
                 $data['client'] = $clients[$ticket['client_id']];
@@ -780,7 +780,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         if ($client instanceof \Model_Client) {
             return $this->clientToTicketApiArray($client, $identity);
         }
-        $this->di['logger']->err('Missing client for ticket ' . $ticket->id);
+        $this->di['logger']->error('Missing client for ticket ' . $ticket->id);
 
         return [];
     }
@@ -1226,7 +1226,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
                 $this->ticketReply($ticket, $admin, $canned['content']);
             }
         } catch (\Exception $e) {
-            $this->di['logger']->err($e->getMessage());
+            $this->di['logger']->error($e->getMessage());
         }
     }
 

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -258,7 +258,7 @@ class Service implements InjectionAwareInterface
             ['settings' => $settings],
             'Theme settings template',
             function (\Twig\Sandbox\SecurityError $e) use ($theme): void {
-                $this->di['logger']->setChannel('security')->warn('Theme settings template sandbox violation', [
+                $this->di['logger']->setChannel('security')->warning('Theme settings template sandbox violation', [
                     'theme' => $theme->getName(),
                     'error' => $e->getMessage(),
                 ]);

--- a/src/modules/Widgets/Service.php
+++ b/src/modules/Widgets/Service.php
@@ -96,7 +96,7 @@ class Service implements InjectionAwareInterface
                 }
             } catch (\Throwable $e) {
                 // Log the error but continue with other modules
-                $this->di['logger']->err("Error loading widgets from module '{$modName}': " . $e->getMessage());
+                $this->di['logger']->error("Error loading widgets from module '{$modName}': " . $e->getMessage());
             }
         }
 

--- a/tests-legacy/modules/Servicedownloadable/ServiceTest.php
+++ b/tests-legacy/modules/Servicedownloadable/ServiceTest.php
@@ -375,7 +375,7 @@ final class ServiceTest extends \BBTestCase
             {
             }
 
-            public function warn(...$args): void
+            public function warning(...$args): void
             {
             }
         };

--- a/tests-legacy/modules/Theme/ServiceTest.php
+++ b/tests-legacy/modules/Theme/ServiceTest.php
@@ -452,7 +452,7 @@ final class ServiceTest extends \BBTestCase
                 return $this;
             }
 
-            public function warn(string $message, array $context = []): void
+            public function warning(string $message, array $context = []): void
             {
             }
         };


### PR DESCRIPTION
Switched to PSR-3 compatible logger method names and kept the old ones as aliases.

We should still rewrite the Box_Log class under \FOSSBilling\. Until then, I've added these as we use `warning()` in some places of the codebase which is unsupported by Box_Log and was throwing exceptions.