### PR TITLE
Fix regression bug while updating extensions

### DIFF
--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -197,12 +197,12 @@ class Admin extends \Api_Abstract
     /**
      * Completely remove extension from FOSSBilling.
      */
+    #[RequiredParams(['id' => 'Extension ID was not passed', 'type' => 'Extension type was not passed'])]
     public function uninstall($data): bool
     {
         $this->getDi()['mod_service']('Staff')->checkPermissionsAndThrowException('extension', 'uninstall_extensions');
 
-        $ext = $this->_getExtension($data);
-        $this->getDi()['events_manager']->fire(['event' => 'onBeforeAdminUninstallExtension', 'params' => ['id' => $ext->id]]);
+        $this->getDi()['events_manager']->fire(['event' => 'onBeforeAdminUninstallExtension', 'params' => ['type' => $data['type'], 'id' => $data['id']]]);
 
         $this->getService()->uninstall($data['type'], $data['id']);
 


### PR DESCRIPTION
Fixed a bug where uninstalling modules would never work because the uninstall endpoint is trying to do a lookup in the database extensions table.

A module needs to be deactivated to be able to be uninstalled. Deactivated modules are removed from the database, so the lookup fails with "Extension not found".

Removed the lookup. No reason to do it. It was probably introduced by accident.