### PR TITLE
Restore ADMIN_AREA guard in Theme\Service::getCurrentRouteTheme

### DIFF
--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -443,9 +443,10 @@ class Service implements InjectionAwareInterface
     {
         // Runtime check for admin area - uses index.php defined constant
         // @phpstan-ignore if.alwaysTrue
-        return $this->getCurrentAdminAreaTheme()['code'];
+        if (ADMIN_AREA) {
+            return $this->getCurrentAdminAreaTheme()['code'];
+        }
 
-        // @phpstan-ignore deadCode.unreachable
         return $this->getCurrentClientAreaTheme()->getName();
     }
 

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -442,7 +442,7 @@ class Service implements InjectionAwareInterface
     public function getCurrentRouteTheme(): string
     {
         // Runtime check for admin area - uses index.php defined constant.
-        // @phpstan-ignore if.alwaysTrue
+        // @phpstan-ignore if.alwaysTrue, booleanAnd.rightAlwaysTrue
         if (\defined('ADMIN_AREA') && ADMIN_AREA) {
             return $this->getCurrentAdminAreaTheme()['code'];
         }

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -443,8 +443,9 @@ class Service implements InjectionAwareInterface
     {
         // Runtime check for admin area - uses index.php defined constant
         // @phpstan-ignore if.alwaysTrue
-        if (ADMIN_AREA) {
+        if (\defined('ADMIN_AREA') && ADMIN_AREA) {
             return $this->getCurrentAdminAreaTheme()['code'];
+        }
         }
 
         return $this->getCurrentClientAreaTheme()->getName();

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -441,11 +441,10 @@ class Service implements InjectionAwareInterface
 
     public function getCurrentRouteTheme(): string
     {
-        // Runtime check for admin area - uses index.php defined constant
+        // Runtime check for admin area - uses index.php defined constant.
         // @phpstan-ignore if.alwaysTrue
         if (\defined('ADMIN_AREA') && ADMIN_AREA) {
             return $this->getCurrentAdminAreaTheme()['code'];
-        }
         }
 
         return $this->getCurrentClientAreaTheme()->getName();


### PR DESCRIPTION
### Motivation
- A previous change made `getCurrentRouteTheme()` always return the admin theme, making client-route theme resolution unreachable and causing incorrect theme selection for client routes.

### Description
- Reintroduced the runtime `ADMIN_AREA` check in `Box\Mod\Theme\Service::getCurrentRouteTheme()` so admin requests return `getCurrentAdminAreaTheme()['code']` and non-admin requests return `getCurrentClientAreaTheme()->getName()`.

### Testing
- Ran `php -l src/modules/Theme/Service.php` which reported no syntax errors; and
- Attempted to run the module unit test for the method via `composer test -- src/modules/Theme/tests/Unit/ServiceTest.php --filter getCurrentRouteTheme` but `pest` is not available in this environment so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211e9f0820832e904d96d60c640931)