### PR TITLE
Validate extension uninstall paths and harden core-module checks

### DIFF
--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -732,7 +732,7 @@ class Service implements InjectionAwareInterface
      *
      * @return string The filesystem path for the extension
      *
-     * @throws \FOSSBilling\Exception If the extension type is not supported
+     * @throws \FOSSBilling\InformationException If the extension type is not supported
      */
     public function getExtensionPath(string $type, string $id, bool $includeMessagesSubdir = false): string
     {

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -61,9 +61,9 @@ class Service implements InjectionAwareInterface
 
     public function isCoreModule(string $mod): bool
     {
-        $core = $this->di['mod']('extension')->getCoreModules();
+        $core = array_map('strtolower', $this->di['mod']('extension')->getCoreModules());
 
-        return in_array($mod, $core);
+        return in_array(strtolower($mod), $core, true);
     }
 
     public function isExtensionActive(string $type, string $id): bool
@@ -736,15 +736,50 @@ class Service implements InjectionAwareInterface
      */
     public function getExtensionPath(string $type, string $id, bool $includeMessagesSubdir = false): string
     {
-        return match ($type) {
-            \FOSSBilling\ExtensionManager::TYPE_MOD => Path::join(PATH_MODS, ucfirst($id)),
-            \FOSSBilling\ExtensionManager::TYPE_THEME => Path::join(PATH_THEMES, $id),
+        $this->assertValidExtensionIdentifier($id);
+
+        $basePath = $this->getExtensionBasePath($type);
+        $path = match ($type) {
+            \FOSSBilling\ExtensionManager::TYPE_MOD,
+            \FOSSBilling\ExtensionManager::TYPE_PG => Path::join($basePath, ucfirst($id)),
+            \FOSSBilling\ExtensionManager::TYPE_THEME => Path::join($basePath, $id),
             \FOSSBilling\ExtensionManager::TYPE_TRANSLATION => $includeMessagesSubdir
-                ? Path::join(PATH_LANGS, $id, 'LC_MESSAGES')
-                : Path::join(PATH_LANGS, $id),
-            \FOSSBilling\ExtensionManager::TYPE_PG => Path::join(PATH_LIBRARY, 'Payment', 'Adapter', ucfirst($id)),
+                ? Path::join($basePath, $id, 'LC_MESSAGES')
+                : Path::join($basePath, $id),
             default => throw new \FOSSBilling\InformationException('Extension type (:type) is not supported for automatic path determination.', [':type' => $type]),
         };
+
+        $this->assertPathWithinBasePath($path, $basePath);
+
+        return $path;
+    }
+
+    private function getExtensionBasePath(string $type): string
+    {
+        return match ($type) {
+            \FOSSBilling\ExtensionManager::TYPE_MOD => PATH_MODS,
+            \FOSSBilling\ExtensionManager::TYPE_THEME => PATH_THEMES,
+            \FOSSBilling\ExtensionManager::TYPE_TRANSLATION => PATH_LANGS,
+            \FOSSBilling\ExtensionManager::TYPE_PG => Path::join(PATH_LIBRARY, 'Payment', 'Adapter'),
+            default => throw new \FOSSBilling\InformationException('Extension type (:type) is not supported for automatic path determination.', [':type' => $type]),
+        };
+    }
+
+    private function assertValidExtensionIdentifier(string $id): void
+    {
+        if (preg_match('/\A[A-Za-z0-9_-]+\z/', $id) !== 1) {
+            throw new \FOSSBilling\InformationException('Extension ID contains invalid characters.');
+        }
+    }
+
+    private function assertPathWithinBasePath(string $path, string $basePath): void
+    {
+        $canonicalBasePath = rtrim(Path::canonicalize($basePath), '/');
+        $canonicalPath = Path::canonicalize($path);
+
+        if ($canonicalPath !== $canonicalBasePath && !str_starts_with($canonicalPath, $canonicalBasePath . '/')) {
+            throw new \FOSSBilling\InformationException('Extension path resolved outside the expected extension directory.');
+        }
     }
 
     private function _getSalt(): ?string

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -774,10 +774,10 @@ class Service implements InjectionAwareInterface
 
     private function assertPathWithinBasePath(string $path, string $basePath): void
     {
-        $canonicalBasePath = rtrim(Path::canonicalize($basePath), '/');
+        $canonicalBasePath = Path::canonicalize($basePath);
         $canonicalPath = Path::canonicalize($path);
 
-        if ($canonicalPath !== $canonicalBasePath && !str_starts_with($canonicalPath, $canonicalBasePath . '/')) {
+        if (!Path::isBasePath($canonicalBasePath, $canonicalPath)) {
             throw new \FOSSBilling\InformationException('Extension path resolved outside the expected extension directory.');
         }
     }

--- a/src/modules/Extension/tests/Unit/ServiceTest.php
+++ b/src/modules/Extension/tests/Unit/ServiceTest.php
@@ -51,6 +51,10 @@ test('isCoreModule checks if module is core module', function (): void {
     $result = $service->isCoreModule('extension');
     expect($result)->toBeBool();
     expect($result)->toBeTrue();
+
+    $result = $service->isCoreModule('Extension');
+    expect($result)->toBeBool();
+    expect($result)->toBeTrue();
 });
 
 test('isExtensionActive returns false when module not found', function (): void {
@@ -596,6 +600,18 @@ test('uninstall uninstalls an extension', function (): void {
     $result = $serviceMock->uninstall('mod', 'Branding');
     expect($result)->toBeTrue();
 });
+
+test('getExtensionPath rejects unsafe extension IDs', function (string $type, string $id): void {
+    $service = new Box\Mod\Extension\Service();
+
+    expect(fn (): string => $service->getExtensionPath($type, $id))
+        ->toThrow(FOSSBilling\InformationException::class, 'Extension ID contains invalid characters.');
+})->with([
+    [FOSSBilling\ExtensionManager::TYPE_MOD, '..'],
+    [FOSSBilling\ExtensionManager::TYPE_THEME, '../admin_default'],
+    [FOSSBilling\ExtensionManager::TYPE_TRANSLATION, '/tmp/language'],
+    [FOSSBilling\ExtensionManager::TYPE_PG, 'Paypal/../../Adapter'],
+]);
 
 test('downloadAndExtract throws exception when download URL is missing', function (): void {
     $service = new Box\Mod\Extension\Service();


### PR DESCRIPTION
### Motivation

- Prevent administrative uninstall from being abused to delete arbitrary filesystem paths by ensuring extension identifiers are validated and resolved paths remain inside expected extension directories.
- Prevent case-based bypasses of the core-module protection by making core-module detection case-insensitive.

### Description

- Make `isCoreModule()` compare module names case-insensitively to prevent casing bypasses when checking core modules. (src/modules/Extension/Service.php)
- Add input validation for extension IDs and enforce path containment before returning/using the filesystem path for an extension by introducing `getExtensionBasePath()`, `assertValidExtensionIdentifier()`, and `assertPathWithinBasePath()`, and update `getExtensionPath()` to use them. (src/modules/Extension/Service.php)
- Update unit tests to cover mixed-case core-module checks and unsafe extension ID inputs (traversal/absolute paths) that should be rejected. (src/modules/Extension/tests/Unit/ServiceTest.php)

### Testing

- Ran the module unit tests with `composer test -- src/modules/Extension/tests/Unit/ServiceTest.php`, which passed (`29 tests, 119 assertions`).
- Performed a PHP syntax check with `php -l` on the modified files and a dry-run PHP-CS-Fixer check with `./src/vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes src/modules/Extension/Service.php src/modules/Extension/tests/Unit/ServiceTest.php`, both completed without blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206935479c832ea4ebb47a51b838bd)