### PR TITLE
Fix Huraga SVG sprite theme resolution

### DIFF
--- a/src/library/FOSSBilling/Twig/Extension/FOSSBillingExtension.php
+++ b/src/library/FOSSBilling/Twig/Extension/FOSSBillingExtension.php
@@ -128,7 +128,7 @@ class FOSSBillingExtension
     public function svgSprite(Environment $env): string
     {
         $globals = $env->getGlobals();
-        $themeCode = $globals['theme']['code'] ?? null;
+        $themeCode = $globals['current_theme'] ?? ($globals['theme']['code'] ?? null);
 
         if ($themeCode === null) {
             return '';

--- a/tests/Unit/FOSSBilling/Twig/Extension/FOSSBillingExtensionTest.php
+++ b/tests/Unit/FOSSBilling/Twig/Extension/FOSSBillingExtensionTest.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 
 use FOSSBilling\Twig\Extension\FOSSBillingExtension;
 use Pimple\Container;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 function makeFossBillingTwigExtension(?Container $di = null): FOSSBillingExtension
 {
@@ -21,6 +25,48 @@ function makeFossBillingTwigExtension(?Container $di = null): FOSSBillingExtensi
 
     return new FOSSBillingExtension($container);
 }
+
+test('svgSprite uses current_theme global for client environments', function (): void {
+    $extension = makeFossBillingTwigExtension();
+    $filesystem = new Filesystem();
+    $themeCode = 'test_current_theme_sprite';
+    $spriteDirectory = Path::join(PATH_THEMES, $themeCode, 'assets/build/symbol');
+    $spritePath = Path::join($spriteDirectory, 'icons-sprite.svg');
+    $sprite = '<svg><symbol id="icon-test"></symbol></svg>';
+
+    $filesystem->mkdir($spriteDirectory);
+    $filesystem->dumpFile($spritePath, $sprite);
+
+    try {
+        $env = new Environment(new ArrayLoader([]));
+        $env->addGlobal('current_theme', $themeCode);
+
+        expect($extension->svgSprite($env))->toBe($sprite);
+    } finally {
+        $filesystem->remove(Path::join(PATH_THEMES, $themeCode));
+    }
+});
+
+test('svgSprite still supports theme code global for admin environments', function (): void {
+    $extension = makeFossBillingTwigExtension();
+    $filesystem = new Filesystem();
+    $themeCode = 'test_theme_code_sprite';
+    $spriteDirectory = Path::join(PATH_THEMES, $themeCode, 'assets/build/symbol');
+    $spritePath = Path::join($spriteDirectory, 'icons-sprite.svg');
+    $sprite = '<svg><symbol id="icon-admin-test"></symbol></svg>';
+
+    $filesystem->mkdir($spriteDirectory);
+    $filesystem->dumpFile($spritePath, $sprite);
+
+    try {
+        $env = new Environment(new ArrayLoader([]));
+        $env->addGlobal('theme', ['code' => $themeCode]);
+
+        expect($extension->svgSprite($env))->toBe($sprite);
+    } finally {
+        $filesystem->remove(Path::join(PATH_THEMES, $themeCode));
+    }
+});
 
 test('publicAssetUrl returns full URL for an asset', function (): void {
     $extension = makeFossBillingTwigExtension();


### PR DESCRIPTION
### Motivation
- Client pages using the Huraga theme rendered blank inline `<use>` icons because `svg_sprite()` only read the admin `theme.code` global while client Twig environments expose `current_theme` instead. 

### Description
- Update `FOSSBillingExtension::svgSprite()` to resolve the theme code from the `current_theme` global first and fall back to `theme['code']` if needed. 
- Add two unit tests in `tests/Unit/FOSSBilling/Twig/Extension/FOSSBillingExtensionTest.php` to cover `current_theme` (client) and `theme['code']` (admin) sprite resolution. 
- Run formatting fixes with `php-cs-fixer` to keep code style consistent.

### Testing
- Ran `php -l src/library/FOSSBilling/Twig/Extension/FOSSBillingExtension.php` and `php -l tests/Unit/FOSSBilling/Twig/Extension/FOSSBillingExtensionTest.php` and both reported no syntax errors. 
- Ran `src/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes` on the modified files and applied style fixes successfully. 
- Attempted `composer test -- tests/Unit/FOSSBilling/Twig/Extension/FOSSBillingExtensionTest.php` but the test bootstrap aborted due to a missing/invalid local `src/config.php` causing the test run to fail before executing the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b589e56d4832e9753f8ac065056fb)