### PR TITLE
Add module-level company logo partial fallback

### DIFF
--- a/src/modules/Page/templates/client/partial_company_logo.html.twig
+++ b/src/modules/Page/templates/client/partial_company_logo.html.twig
@@ -1,0 +1,18 @@
+{% set logo_url = logo_url|default(null) %}
+{% set link_url = link_url|default('/'|url) %}
+{% set link_class = link_class|default('') %}
+{% set link_rel = link_rel|default(null) %}
+{% set image_class = image_class|default('') %}
+{% set image_height = image_height|default('45px') %}
+{% set show_mobile_name = show_mobile_name|default(false) %}
+
+<a{% if link_class %} class="{{ link_class }}"{% endif %} href="{{ link_url }}"{% if link_target is defined %} target="{{ link_target }}"{% endif %}{% if link_rel %} rel="{{ link_rel }}"{% endif %}>
+    {% if logo_url %}
+        <img{% if image_class %} class="{{ image_class }}"{% endif %} src="{{ logo_url }}" alt="{{ company.name }}" height="{{ image_height }}" title="{{ company.name }}">
+        {% if show_mobile_name %}
+            <span class="d-sm-none">{{ company.name }}</span>
+        {% endif %}
+    {% else %}
+        <span>{{ company.name }}</span>
+    {% endif %}
+</a>


### PR DESCRIPTION
### Motivation
- Prevent `TemplateNotFound` errors on module client pages when a custom client theme reuses the Page module templates but does not provide Huraga's theme-only `partial_company_logo.html.twig`, so login/password pages continue to render.

### Description
- Add `src/modules/Page/templates/client/partial_company_logo.html.twig` as a module-level fallback that preserves the same configurable logo/link markup and include parameters (`logo_url`, `link_url`, `link_target`, `link_rel`, `image_class`, `image_height`, `show_mobile_name`).

### Testing
- Attempted to lint the new template with `twig-lint`, but the check could not run because project dependencies were not installed (`src/vendor/autoload.php` was unavailable), so no automated template linting completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb8f55698832e948d322b188324f1)