### PR TITLE
Fix Huraga pending flash message timing

### DIFF
--- a/src/themes/huraga/html/partial_pending_messages.html.twig
+++ b/src/themes/huraga/html/partial_pending_messages.html.twig
@@ -1,8 +1,10 @@
 {% set pending_messages = guest.system_get_pending_messages %}
 {% if pending_messages %}
 <script>
-    {% for message in pending_messages %}
-        FOSSBilling.message('{{message}}');
-    {% endfor %}
+    document.addEventListener('DOMContentLoaded', () => {
+        {% for message in pending_messages %}
+            FOSSBilling.message('{{ message|e('js') }}');
+        {% endfor %}
+    });
 </script>
 {% endif %}


### PR DESCRIPTION
### Motivation
- Pending flash messages were being emitted as a normal inline script before the Huraga module bundle (`huraga.js`) initialized `FOSSBilling.message`, which could throw and prevent flash messages from displaying on client pages.

### Description
- Update `src/themes/huraga/html/partial_pending_messages.html.twig` to wrap pending message calls in a `DOMContentLoaded` callback and escape message text with `|e('js')` so messages are displayed only after `FOSSBilling.message` is available.

### Testing
- Ran `npm run check-js-syntax` and `npm run build-huraga`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec1e76af4832eb604d320ae106d89)