### PR TITLE
 Use fb_api_link instead of custom event listeners in Huraga

### DIFF
--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -800,7 +800,18 @@ const API = {
             );
           };
 
-          if (apiData.hasOwnProperty('modal') && apiData.modal.type === 'prompt') {
+          if (apiData.hasOwnProperty('modal') && typeof Modals === 'undefined') {
+            if (apiData.modal.type === 'prompt') {
+              const value = window.prompt(apiData.modal.label ?? apiData.modal.title ?? '', apiData.modal.value ?? '');
+              if (value) {
+                const p = {};
+                p[apiData.modal.key] = value;
+                handleApiRequest('GET', linkElement.getAttribute('href'), p);
+              }
+            } else if (window.confirm(apiData.modal.content || apiData.modal.title || 'Are you sure?')) {
+              handleApiRequest('GET', linkElement.getAttribute('href'));
+            }
+          } else if (apiData.hasOwnProperty('modal') && apiData.modal.type === 'prompt') {
             Modals.create({
               type: apiData.modal.type,
               title: apiData.modal.title,

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -800,7 +800,7 @@ const API = {
             );
           };
 
-          if (apiData.hasOwnProperty('modal') && typeof Modals === 'undefined') {
+          if (apiData.hasOwnProperty('modal') && (typeof Modals === 'undefined' || typeof Modals.create !== 'function')) {
             if (apiData.modal.type === 'prompt') {
               const value = window.prompt(apiData.modal.label ?? apiData.modal.title ?? '', apiData.modal.value ?? '');
               if (value) {

--- a/src/modules/Email/templates/client/mod_email_email.html.twig
+++ b/src/modules/Email/templates/client/mod_email_email.html.twig
@@ -24,7 +24,8 @@
                             <a class="btn btn-sm btn-outline-secondary email-resend" href="#" data-id="{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Resend'|trans }}">
                                 <svg class="icon"><use href="#arrows-exchange" /></svg>
                             </a>
-                            <a class="btn btn-sm btn-outline-danger border-start-0 email-delete" href="#" data-id="{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}">
+                            <a class="btn btn-sm btn-outline-danger border-start-0" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}"
+                               {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, message: 'Email deleted'|trans, redirect: 'email'|url}) }}>
                                 <svg class="icon"><use href="#trash" /></svg>
                             </a>
                         </div>
@@ -51,7 +52,6 @@
 <script>
     document.addEventListener("DOMContentLoaded", () => {
         const resendEmailBtn = document.querySelectorAll('.email-resend');
-        const deleteEmailBtn = document.querySelectorAll('.email-delete');
 
         resendEmailBtn.forEach((resendBtn) => {
             resendBtn.addEventListener('click', (e) => {
@@ -70,28 +70,6 @@
                         toggleLoader();
                     }
                 )
-            });
-        });
-
-        deleteEmailBtn.forEach((deleteBtn) => {
-            deleteBtn.addEventListener('click', (e) => {
-                e.preventDefault();
-                if (confirm('Are you sure?')) {
-                    toggleLoader();
-                    FOSSBilling.api.client.post('email/delete',
-                        {id: deleteBtn.dataset.id },
-                        () => {
-                            flashMessage({
-                                message: 'Email #'+ deleteBtn.dataset.id +' deleted',
-                                reload: '{{ 'email'|url }}'
-                            });
-                        },
-                        (res) => {
-                            FOSSBilling.message(`${res.message} (${res.code})`, 'error');
-                            toggleLoader();
-                        }
-                    )
-                }
             });
         });
 

--- a/src/modules/Email/templates/client/mod_email_email.html.twig
+++ b/src/modules/Email/templates/client/mod_email_email.html.twig
@@ -25,7 +25,7 @@
                                 <svg class="icon"><use href="#arrows-exchange" /></svg>
                             </a>
                             <a class="btn btn-sm btn-outline-danger border-start-0" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}"
-                               {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, message: 'Email deleted'|trans, redirect: 'email'|url}) }}>
+                               {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'email'|url}) }}>
                                 <svg class="icon"><use href="#trash" /></svg>
                             </a>
                         </div>

--- a/src/modules/Email/templates/client/mod_email_index.html.twig
+++ b/src/modules/Email/templates/client/mod_email_index.html.twig
@@ -61,7 +61,7 @@
                                                             <svg class="icon"><use href="#arrows-exchange" /></svg>
                                                         </a>
                                                         <a class="btn btn-sm btn-outline-danger border-start-0" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}"
-                                                           {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, message: 'Email deleted'|trans, redirect: 'email'|url}) }}>
+                                                           {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'email'|url}) }}>
                                                             <svg class="icon"><use href="#trash" /></svg>
                                                         </a>
                                                     </div>

--- a/src/modules/Email/templates/client/mod_email_index.html.twig
+++ b/src/modules/Email/templates/client/mod_email_index.html.twig
@@ -60,7 +60,8 @@
                                                         <a class="btn btn-sm btn-outline-secondary email-resend" href="#" data-id="{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Resend'|trans }}">
                                                             <svg class="icon"><use href="#arrows-exchange" /></svg>
                                                         </a>
-                                                        <a class="btn btn-sm btn-outline-danger border-start-0 email-delete" href="#" data-id="{{ email.id }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}">
+                                                        <a class="btn btn-sm btn-outline-danger border-start-0" data-bs-toggle="tooltip" data-bs-title="{{ 'Delete'|trans }}"
+                                                           {{ fb_api_link({href: 'email/delete'|api_url(query: {id: email.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, message: 'Email deleted'|trans, redirect: 'email'|url}) }}>
                                                             <svg class="icon"><use href="#trash" /></svg>
                                                         </a>
                                                     </div>
@@ -100,7 +101,6 @@
         <script>
             document.addEventListener("DOMContentLoaded", () => {
                 const resendEmailBtn = document.querySelectorAll('.email-resend');
-                const deleteEmailBtn = document.querySelectorAll('.email-delete');
 
                 resendEmailBtn.forEach((resendBtn) => {
                     resendBtn.addEventListener('click', (e) => {
@@ -118,27 +118,6 @@
                                 toggleLoader();
                             }
                         )
-                    });
-                });
-
-                deleteEmailBtn.forEach((deleteBtn) => {
-                    deleteBtn.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        if (confirm('Are you sure?')) {
-                            toggleLoader();
-                            FOSSBilling.api.client.post('email/delete', { id: deleteBtn.dataset.id },
-                                () => {
-                                    flashMessage({
-                                        message: 'Email #'+ deleteBtn.dataset.id +' deleted',
-                                        reload: '{{ 'email'|url }}'
-                                    });
-                                },
-                                (res) => {
-                                    FOSSBilling.message(`${res.message} (${res.code})`, 'error');
-                                    toggleLoader();
-                                }
-                            )
-                        }
                     });
                 });
 

--- a/src/modules/Order/templates/client/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/client/mod_order_manage.html.twig
@@ -107,7 +107,8 @@
                 </div>
                 <div class="card-footer">
                     {% if order.period and order.status != 'failed_renew' %}
-                        <button class="btn btn-primary btn-sm" type="button" id="renewal-button">{{ 'Renew Now'|trans }}</button>
+                        <a class="btn btn-primary btn-sm"
+                           {{ fb_api_link({href: 'invoice/renewal_invoice'|api_url(query: {order_id: order.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans, content: 'This will generate new invoice. Are you sure you want to continue?'|trans}, redirect: 'invoice'|url}) }}>{{ 'Renew Now'|trans }}</a>
                     {% endif %}
                     {% if upgradables %}
                         <button class="btn btn-success btn-sm" type="button" id="request-upgrade" data-bs-toggle="modal" data-bs-target="#upgrade-request-modal">{{ 'Request Upgrade'|trans }}</button>
@@ -330,19 +331,6 @@
 
         });
 
-        const renewalButton = document.getElementById('renewal-button');
-        if (renewalButton) {
-            renewalButton.addEventListener('click', function (event) {
-                event.preventDefault();
-
-                if (confirm("This will generate new invoice. Are you sure you want to continue?")) {
-                    FOSSBilling.api.client.post('invoice/renewal_invoice', { order_id: {{ order.id }} },
-                        (result) => {
-                            window.location = "{{ 'invoice'|url }}" + '/' + result;
-                        });
-                }
-            });
-        }
     </script>
 {% endautoescape %}
 {% endblock %}

--- a/src/modules/Order/templates/client/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/client/mod_order_manage.html.twig
@@ -108,7 +108,8 @@
                 <div class="card-footer">
                     {% if order.period and order.status != 'failed_renew' %}
                         <a class="btn btn-primary btn-sm"
-                           {{ fb_api_link({href: 'invoice/renewal_invoice'|api_url(query: {order_id: order.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans, content: 'This will generate new invoice. Are you sure you want to continue?'|trans}, redirect: 'invoice'|url}) }}>{{ 'Renew Now'|trans }}</a>
+                           {{ fb_api_link({href: 'invoice/renewal_invoice'|api_url(query: {order_id: order.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans, content: 'This will generate new invoice. Are you sure you want to continue?'|trans}, callback: 'onRenewalInvoiceCreated'}) }}>{{ 'Renew Now'|trans }}</a>
+                        <script>window.onRenewalInvoiceCreated = (hash) => { window.location = "{{ 'invoice'|url }}/" + hash; };</script>
                     {% endif %}
                     {% if upgradables %}
                         <button class="btn btn-success btn-sm" type="button" id="request-upgrade" data-bs-toggle="modal" data-bs-target="#upgrade-request-modal">{{ 'Request Upgrade'|trans }}</button>

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
@@ -40,7 +40,12 @@
                                     {{ (item.total * cart_currency.conversion_rate)|format_currency(cart_currency.code) }}
                                 {% endif %}
                             </td>
-                            <td><button data-cart-item-id="{{ item.id }}" class="btn btn-dark btn-sm remove-cart-item" title="{{ 'Remove item'|trans }}"><svg class="icon"><use href="#x" /></svg></button></td>
+                            <td>
+                                <a class="btn btn-dark btn-sm" title="{{ 'Remove item'|trans }}"
+                                   {{ fb_api_link({href: 'cart/remove_item'|api_url(query: {id: item.id}, role: 'guest'), modal: {type: 'confirm', title: 'Are you sure?'|trans, content: 'Are you sure you want to remove this item from cart?'|trans}, reload: true}) }}>
+                                    <svg class="icon"><use href="#x" /></svg>
+                                </a>
+                            </td>
                         </tr>
 
                         {% if request.show_custom_form_values %}

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_js.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_js.html.twig
@@ -22,21 +22,6 @@
             });
         });
 
-        document.querySelectorAll('.remove-cart-item').forEach(function(button) {
-            button.addEventListener('click', function(event) {
-                event.preventDefault();
-
-                if (confirm("{{ 'Are you sure you want to remove this item from cart?'|trans }}")) {
-                    var item_id = this.getAttribute('data-cart-item-id');
-
-                    FOSSBilling.api.guest.post("cart/remove_item", { id: item_id },
-                        () => {
-                            FOSSBilling.message("{{ 'Item was removed from cart'|trans }}");
-                            window.location.reload();
-                        });
-                }
-            });
-        });
     });
 
     function onOrderCheckout(result){

--- a/src/modules/Serviceapikey/templates/client/mod_serviceapikey_manage.html.twig
+++ b/src/modules/Serviceapikey/templates/client/mod_serviceapikey_manage.html.twig
@@ -18,21 +18,8 @@
 
         <h4>{{ 'Reset API Key'|trans }}</h4>
         <div class="block">
-            <button class="btn btn-primary" type="button" id="license-apikey">{{ 'Reset'|trans }}</button>
+            <a class="btn btn-primary" {{ fb_api_link({href: 'serviceapikey/reset'|api_url(query: {order_id: order.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, reload: true}) }}>{{ 'Reset'|trans }}</a>
         </div>
     </div>
 </div>
-
-<script>
-    document.querySelector('#license-apikey').addEventListener('click', (event) => {
-        event.preventDefault();
-
-        if (confirm("{{ 'Are you sure?'|trans }}")) {
-            FOSSBilling.api.client.post('serviceapikey/reset', { order_id: {{ order.id }} },
-                (result) => {
-                    window.location.reload();
-                });
-        }
-    });
-</script>
 {% endif %}

--- a/src/modules/Servicelicense/templates/client/mod_servicelicense_manage.html.twig
+++ b/src/modules/Servicelicense/templates/client/mod_servicelicense_manage.html.twig
@@ -80,23 +80,10 @@
         <h2>{{ 'Reset License'|trans }}</h2>
         <p>{{ 'You can reset your license parameters if you have changed your server'|trans }}</p>
         <div class="block">
-            <p><button class="btn btn-primary" type="button" id="license-reset">{{ 'Reset'|trans }}</button></p>
+            <p>
+                <a class="btn btn-primary" {{ fb_api_link({href: 'servicelicense/reset'|api_url(query: {order_id: order.id}), modal: {type: 'confirm', title: 'Are you sure?'|trans}, message: 'License was reset'|trans}) }}>{{ 'Reset'|trans }}</a>
+            </p>
         </div>
     </div>
 </div>
-
-{% block js %}
-<script>
-    document.querySelector('#license-reset').addEventListener('click', (event) => {
-        event.preventDefault();
-
-        if (confirm("{{ 'Are you sure?'|trans }}")) {
-            FOSSBilling.api.client.post('servicelicense/reset', { order_id: {{ order.id }} },
-                (result) => {
-                    FOSSBilling.message("{{ 'License was reset'|trans }}");
-                });
-        }
-    });
-</script>
-{% endblock %}
 {% endif %}


### PR DESCRIPTION
* Use fb_api_link instead of custom event listeners in Huraga
* API.js: Fall back to `window.prompt` when Modals isn't present in the theme