### PR TITLE
Replace Coloris with native `input type="color"`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1396,12 +1396,6 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
-    "node_modules/@melloware/coloris": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@melloware/coloris/-/coloris-0.25.0.tgz",
-      "integrity": "sha512-RBWVFLjWbup7GRkOXb9g3+ZtR9AevFtJinrRz2cYPLjZ3TCkNRGMWuNbmQWbZ5cF3VU7aQDZwUsYgIY/bGrh2g==",
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1584,9 +1578,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1608,9 +1599,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1632,9 +1620,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1656,9 +1641,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1680,9 +1662,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1683,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1924,9 +1900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1944,9 +1917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1964,9 +1934,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1984,9 +1951,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5636,7 +5600,6 @@
     },
     "src/themes/admin_default": {
       "dependencies": {
-        "@melloware/coloris": "^0.25.0",
         "@tabler/core": "^1.2.0",
         "chart.js": "^4.5.1",
         "flag-icons": "^7.2.3",

--- a/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
@@ -103,9 +103,13 @@
                                 <p class="text-secondary mb-4">{{ 'Adjust the color and opacity of the page overlay behind the popup.'|trans }}</p>
                                 <div class="row g-3">
                                     <div class="col-lg-4">
-                                        <label class="form-label" for="coloris-picker">{{ 'Color'|trans }}</label>
-                                                <input type="text" class="form-control" name="background_color"
-                                                       id="coloris-picker" value="{{ params.background_color|default('#000000') }}">
+                                        <label class="form-label" for="background_color">{{ 'Color'|trans }}</label>
+                                        <div class="input-group">
+                                            <input type="color" class="form-control form-control-color flex-grow-0" style="width: 4rem;" name="background_color"
+                                                   id="background_color" value="{{ params.background_color|default('#000000') }}">
+                                            <input type="text" class="form-control" id="background_color_hex"
+                                                   value="{{ params.background_color|default('#000000') }}" pattern="#[0-9a-fA-F]{6}" aria-label="{{ 'Hex color value'|trans }}">
+                                        </div>
                                     </div>
                                     <div class="col-lg-4">
                                         <label class="form-label" for="background_opacity">{{ 'Opacity'|trans }}</label>
@@ -285,7 +289,7 @@
                 const options = {
                     'width': document.getElementById('popup_width').value,
                     'theme_color': document.getElementById('theme_color').value,
-                    'background_color': document.getElementById('coloris-picker').value,
+                    'background_color': document.getElementById('background_color').value,
                     'background_opacity': document.getElementById('background_opacity').value,
                     'background_close': document.getElementById('background-close').checked ? 'on' : undefined,
                     'show_custom_form_values': document.getElementById('show-custom-form-values')?.checked ? 'on' : undefined,
@@ -332,6 +336,20 @@
                 show_link();
             });
 
+            const backgroundColor = document.getElementById('background_color');
+            const backgroundColorHex = document.getElementById('background_color_hex');
+
+            backgroundColor.addEventListener('input', function() {
+                backgroundColorHex.value = this.value;
+            });
+
+            backgroundColorHex.addEventListener('input', function() {
+                if (/^#[0-9a-fA-F]{6}$/.test(this.value)) {
+                    backgroundColor.value = this.value;
+                    show_link();
+                }
+            });
+
             document.querySelectorAll('input').forEach(function(input) {
                 input.addEventListener('input', function() {
                     changed = true;
@@ -339,7 +357,7 @@
                 });
             });
 
-            document.querySelectorAll('select, #background-color, input[type="radio"]').forEach(function(element) {
+            document.querySelectorAll('select, input[type="radio"]').forEach(function(element) {
                 element.addEventListener('change', function() {
                     changed = true;
                     show_link();

--- a/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
@@ -105,10 +105,8 @@
                                     <div class="col-lg-4">
                                         <label class="form-label" for="background_color">{{ 'Color'|trans }}</label>
                                         <div class="input-group">
-                                            <input type="color" class="form-control form-control-color flex-grow-0" style="width: 4rem;" name="background_color"
-                                                   id="background_color" value="{{ params.background_color|default('#000000') }}">
                                             <input type="text" class="form-control" id="background_color_hex"
-                                                   value="{{ params.background_color|default('#000000') }}" pattern="#[0-9a-fA-F]{6}" aria-label="{{ 'Hex color value'|trans }}">
+                                                   value="{{ params.background_color|default('#000000') }}" maxlength="7" autocomplete="off" spellcheck="false" inputmode="text" aria-label="{{ 'Hex color value'|trans }}">
                                         </div>
                                     </div>
                                     <div class="col-lg-4">

--- a/src/themes/admin_default/assets/css/vendor.css
+++ b/src/themes/admin_default/assets/css/vendor.css
@@ -5,4 +5,3 @@
 
 /* Admin theme-specific vendor dependencies */
 @import "sortable-tablesort/dist/sortable-base.css";
-@import "@melloware/coloris/dist/coloris.css";

--- a/src/themes/admin_default/assets/fossbilling.js
+++ b/src/themes/admin_default/assets/fossbilling.js
@@ -91,17 +91,6 @@ function loadAdminFeature(loader, name) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (document.querySelector('#coloris-picker')) {
-    loadAdminFeature(async () => {
-      const { coloris, init } = await import('@melloware/coloris');
-      init();
-      coloris({
-        el: '#coloris-picker',
-        alpha: false
-      });
-    }, 'Coloris');
-  }
-
   if (document.querySelector('.datepicker')) {
     loadAdminFeature(async () => {
       const { default: initDatepickers } = await import('./js/datepicker');

--- a/src/themes/admin_default/package.json
+++ b/src/themes/admin_default/package.json
@@ -5,7 +5,6 @@
     "dev": "node ./esbuild.mjs"
   },
   "dependencies": {
-    "@melloware/coloris": "^0.25.0",
     "@tabler/core": "^1.2.0",
     "chart.js": "^4.5.1",
     "flag-icons": "^7.2.3",


### PR DESCRIPTION
Replaced Coloris with already well-supported browser color picker. On an unrelated note we should decrease the width of these inputs.

Old:
<img width="876" height="374" alt="image" src="https://github.com/user-attachments/assets/40137112-5aef-4205-849c-d30e5f3d71a0" />

New:
<img width="865" height="374" alt="image" src="https://github.com/user-attachments/assets/0af0c880-f749-4902-8680-8bc46dd327a8" />