### PR TITLE
Add a Discord banner to the admin area

### DIFF
--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -39,6 +39,28 @@
     {% endfor %}
 
 <div class="row row-deck row-cards">
+    <div class="col-12" id="discord-community-card">
+        <div class="card bg-azure-lt">
+            <div class="card-body d-flex flex-column flex-md-row align-items-md-center gap-3">
+                <div class="d-flex align-items-center gap-3 flex-fill">
+                    <span class="avatar bg-azure text-white">
+                        <svg class="icon" aria-hidden="true">
+                            <use href="#headset" />
+                        </svg>
+                    </span>
+                    <div>
+                        <h3 class="card-title mb-1">{{ 'Join the FOSSBilling community'|trans }}</h3>
+                        <p class="text-muted mb-0">{{ 'Get help from other users, follow development, suggest ideas, and discuss integrations with contributors.'|trans }}</p>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center gap-2 ms-md-auto">
+                    <a class="btn btn-primary" href="https://fossbilling.org/discord" target="_blank" rel="noopener noreferrer">{{ 'Join Discord'|trans }}</a>
+                    <button type="button" class="btn-close" data-dismiss-discord-community-card aria-label="{{ 'Dismiss'|trans }}"></button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     {% if admin.system_is_allowed({ 'mod': 'stats' }) %}
         {% set stats = admin.stats_get_summary %}
         {% set income = admin.stats_get_summary_income %}
@@ -432,6 +454,20 @@
 
 {% block js %}
     <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const card = document.getElementById('discord-community-card');
+
+            if (!card || localStorage.getItem('hideDiscordCommunityCard') === '1') {
+                card?.remove();
+                return;
+            }
+
+            card.querySelector('[data-dismiss-discord-community-card]')?.addEventListener('click', function() {
+                localStorage.setItem('hideDiscordCommunityCard', '1');
+                card.remove();
+            });
+        });
+
         document.addEventListener('click', async function(event) {
             const link = event.target.closest('[data-dashboard-section]');
             if (!link) {

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -39,7 +39,7 @@
     {% endfor %}
 
 <div class="row row-deck row-cards">
-    <div class="col-12" id="discord-community-card">
+    <div class="col-12 d-none" id="discord-community-card">
         <div class="card bg-azure-lt">
             <div class="card-body d-flex flex-column flex-md-row align-items-md-center gap-3">
                 <div class="d-flex align-items-center gap-3 flex-fill">
@@ -458,9 +458,10 @@
             const card = document.getElementById('discord-community-card');
 
             if (!card || localStorage.getItem('hideDiscordCommunityCard') === '1') {
-                card?.remove();
                 return;
             }
+
+            card.classList.remove('d-none');
 
             card.querySelector('[data-dismiss-discord-community-card]')?.addEventListener('click', function() {
                 localStorage.setItem('hideDiscordCommunityCard', '1');


### PR DESCRIPTION
Added a dismissable Discord banner to the admin area. Once you dismiss it, it's saved to the localStorage so it won't appear again.

<img width="1309" height="230" alt="image" src="https://github.com/user-attachments/assets/46236add-a726-4092-9863-cf8c4bf8913b" />