### PR TITLE
Fix MySQL 8.0.22+ REGEXP charset conflict in patches 67 and 74

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -1504,7 +1504,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $expires = $this->computeInvoiceHashExpiration();
         $rows = $this->fetchAll(
             "SELECT id FROM invoice WHERE hash IS NOT NULL
-               AND (LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR BINARY hash NOT REGEXP '^[a-f0-9]+$')"
+               AND (LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CAST(hash AS BINARY) NOT REGEXP _binary'^[a-f0-9]+$')"
         );
         foreach ($rows as $row) {
             $this->executeSql(
@@ -1879,7 +1879,7 @@ class UpdatePatcher implements InjectionAwareInterface
         // Backfill hashes NULLed by the original revision of patch67.
         $expires = $this->computeInvoiceHashExpiration();
         $rows = $this->fetchAll(
-            "SELECT id FROM invoice WHERE hash IS NULL OR LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR BINARY hash NOT REGEXP '^[a-f0-9]+$'"
+            "SELECT id FROM invoice WHERE hash IS NULL OR LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CAST(hash AS BINARY) NOT REGEXP _binary'^[a-f0-9]+$'"
         );
         foreach ($rows as $row) {
             $this->executeSql(

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -1504,7 +1504,7 @@ class UpdatePatcher implements InjectionAwareInterface
         $expires = $this->computeInvoiceHashExpiration();
         $rows = $this->fetchAll(
             "SELECT id FROM invoice WHERE hash IS NOT NULL
-               AND (LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CAST(hash AS BINARY) NOT REGEXP _binary'^[a-f0-9]+$')"
+               AND (LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CONVERT(hash USING utf8mb4) COLLATE utf8mb4_bin NOT REGEXP '^[a-f0-9]+$')"
         );
         foreach ($rows as $row) {
             $this->executeSql(
@@ -1879,7 +1879,7 @@ class UpdatePatcher implements InjectionAwareInterface
         // Backfill hashes NULLed by the original revision of patch67.
         $expires = $this->computeInvoiceHashExpiration();
         $rows = $this->fetchAll(
-            "SELECT id FROM invoice WHERE hash IS NULL OR LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CAST(hash AS BINARY) NOT REGEXP _binary'^[a-f0-9]+$'"
+            "SELECT id FROM invoice WHERE hash IS NULL OR LENGTH(hash) < 30 OR LENGTH(hash) > 60 OR CONVERT(hash USING utf8mb4) COLLATE utf8mb4_bin NOT REGEXP '^[a-f0-9]+$'"
         );
         foreach ($rows as $row) {
             $this->executeSql(


### PR DESCRIPTION
MySQL 8.0.22+ changed the REGEXP implementation to use ICU internals, which rejects operands with mismatched character sets. Using `BINARY hash` (producing binary charset) alongside a pattern literal with the session charset (e.g. utf8mb3_general_ci) triggers:

  SQLSTATE[HY000]: General error: 3995 Character set 'binary' cannot be used in conjunction with 'utf8mb3_general_ci' in call to regexp_like.