### PR TITLE
Review fixes for #3808: null safety, LEFT JOIN, defaults, and test mock

### DIFF
--- a/src/library/FOSSBilling/Interfaces/ApiArrayInterface.php
+++ b/src/library/FOSSBilling/Interfaces/ApiArrayInterface.php
@@ -15,7 +15,13 @@ namespace FOSSBilling\Interfaces;
 interface ApiArrayInterface
 {
     /**
-     * Implementations may declare optional parameters for contextual API output.
+     * Convert the entity to an array suitable for API output.
+     *
+     * Implementations may declare additional optional parameters (e.g. an identity
+     * model) to tailor output based on who is calling. PHP allows implementations
+     * to extend the interface signature with optional parameters, so callers that
+     * know the concrete type may pass context; callers that only have the interface
+     * type should call with no arguments.
      */
     public function toApiArray(): array;
 }

--- a/src/modules/Support/Api/Admin.php
+++ b/src/modules/Support/Api/Admin.php
@@ -613,7 +613,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $qb = $repo->getSearchQueryBuilder($status, $search, $cat);
 
-        return $this->getDi()['pager']->paginateDoctrineQuery($qb, PaginationOptions::fromArray($data));
+        return $this->getDi()['pager']->paginateDoctrineQuery($qb, PaginationOptions::fromArray($data), $this->getIdentity());
     }
 
     /**

--- a/src/modules/Support/Api/Admin.php
+++ b/src/modules/Support/Api/Admin.php
@@ -18,9 +18,9 @@ namespace Box\Mod\Support\Api;
 
 use Box\Mod\Support\Entity\CannedResponse;
 use Box\Mod\Support\Entity\CannedResponseCategory;
+use Box\Mod\Support\Entity\Helpdesk;
 use Box\Mod\Support\Entity\KbArticle;
 use Box\Mod\Support\Entity\KbArticleCategory;
-use Box\Mod\Support\Entity\Helpdesk;
 use FOSSBilling\PaginationOptions;
 use FOSSBilling\Validation\Api\RequiredParams;
 
@@ -223,7 +223,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $qb = $repo->getSearchQueryBuilder($data);
 
-        return $this->getDi()['pager']->paginateDoctrineQuery($qb, PaginationOptions::fromArray($data), $this->identity);
+        return $this->getDi()['pager']->paginateDoctrineQuery($qb, PaginationOptions::fromArray($data), $this->getIdentity());
     }
 
     /**

--- a/src/modules/Support/Api/Guest.php
+++ b/src/modules/Support/Api/Guest.php
@@ -211,7 +211,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
      */
     public function kb_category_get_pairs(array $data): array
     {
-        $this->assertKbEnabled();
+        if (!$this->getService()->kbEnabled()) {
+            return [];
+        }
 
         return $this->getService()->getKbArticleCategoryRepository()->getPairs();
     }

--- a/src/modules/Support/Entity/KbArticle.php
+++ b/src/modules/Support/Entity/KbArticle.php
@@ -62,9 +62,6 @@ class KbArticle implements ApiArrayInterface, TimestampInterface
     public function toApiArray(\Model_Admin|\Model_Client|\Model_Guest|null $identity = null, bool $includeContent = false, bool $includeViews = true): array
     {
         $category = $this->category;
-        if (!$category instanceof KbArticleCategory) {
-            throw new \FOSSBilling\Exception('Knowledge Base category not found');
-        }
 
         $data = [
             'id' => $this->id,
@@ -74,11 +71,11 @@ class KbArticle implements ApiArrayInterface, TimestampInterface
             'created_at' => $this->createdAt?->format('Y-m-d H:i:s'),
             'status' => $this->status,
             'updated_at' => $this->updatedAt?->format('Y-m-d H:i:s'),
-            'category' => [
+            'category' => $category instanceof KbArticleCategory ? [
                 'id' => $category->getId(),
                 'slug' => $category->getSlug(),
                 'title' => $category->getTitle(),
-            ],
+            ] : null,
         ];
 
         if (!$includeViews) {

--- a/src/modules/Support/Entity/KbArticleCategory.php
+++ b/src/modules/Support/Entity/KbArticleCategory.php
@@ -93,7 +93,7 @@ class KbArticleCategory implements ApiArrayInterface, TimestampInterface
     }
 
     #[ORM\PreUpdate]
-    public function updateTimestamp(): void
+    public function onPreUpdate(): void
     {
         $this->updatedAt = new \DateTime();
     }

--- a/src/modules/Support/Repository/KbArticleCategoryRepository.php
+++ b/src/modules/Support/Repository/KbArticleCategoryRepository.php
@@ -21,14 +21,19 @@ class KbArticleCategoryRepository extends EntityRepository
     public function getSearchQueryBuilder(array $data): QueryBuilder
     {
         $qb = $this->createQueryBuilder('c')
-            ->leftJoin('c.articles', 'a')
-            ->addSelect('a')
             ->distinct()
             ->orderBy('c.title', 'ASC');
 
+        // Use a WITH condition on the JOIN so the status filter does not turn the
+        // LEFT JOIN into an implicit INNER JOIN — categories with no active articles
+        // must still appear in the results.
         if (!empty($data['article_status'])) {
-            $qb->andWhere('a.status = :status')
+            $qb->leftJoin('c.articles', 'a', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.status = :status')
+                ->addSelect('a')
                 ->setParameter('status', $data['article_status']);
+        } else {
+            $qb->leftJoin('c.articles', 'a')
+                ->addSelect('a');
         }
 
         if (isset($data['q']) && trim((string) $data['q']) !== '') {

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -510,7 +510,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         $helpdesk = $this->getHelpdeskRepository()->find((int) $model->support_helpdesk_id);
         if (!$helpdesk instanceof Helpdesk) {
-            throw new \FOSSBilling\Exception('Helpdesk invalid');
+            return false;
         }
 
         return $helpdesk->canReopen();
@@ -1265,7 +1265,14 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     private function sendAutoresponderCannedReply(\Model_SupportTicket $ticket, $cannedId): void
     {
         try {
-            $canned = $this->getCannedResponseRepository()->find((int) $cannedId)?->toApiArray() ?? [];
+            $cannedResponse = $this->getCannedResponseRepository()->find((int) $cannedId);
+            if (!$cannedResponse instanceof CannedResponse) {
+                $this->di['logger']->warning('Autoresponder: canned response #%s not found, skipping reply for ticket #%s', $cannedId, $ticket->id);
+
+                return;
+            }
+
+            $canned = $cannedResponse->toApiArray();
             $staffService = $this->di['mod_service']('staff');
             $admin = $staffService->getCronAdmin();
 
@@ -1492,7 +1499,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $extensionService = $this->di['mod_service']('extension');
         $config = $extensionService->getConfig('mod_support');
 
-        return Tools::normalizeBoolean($config['kb_enable'] ?? true, true);
+        return Tools::normalizeBoolean($config['kb_enable'] ?? false, false);
     }
 
     public function kbArticleViewsEnabled(): bool

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -14,14 +14,14 @@ namespace Box\Mod\Support;
 
 use Box\Mod\Support\Entity\CannedResponse;
 use Box\Mod\Support\Entity\CannedResponseCategory;
+use Box\Mod\Support\Entity\Helpdesk;
 use Box\Mod\Support\Entity\KbArticle;
 use Box\Mod\Support\Entity\KbArticleCategory;
-use Box\Mod\Support\Entity\Helpdesk;
 use Box\Mod\Support\Repository\CannedResponseCategoryRepository;
 use Box\Mod\Support\Repository\CannedResponseRepository;
+use Box\Mod\Support\Repository\HelpdeskRepository;
 use Box\Mod\Support\Repository\KbArticleCategoryRepository;
 use Box\Mod\Support\Repository\KbArticleRepository;
-use Box\Mod\Support\Repository\HelpdeskRepository;
 use FOSSBilling\InformationException;
 use FOSSBilling\Tools;
 
@@ -897,31 +897,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $data;
     }
 
-    public function helpdeskGetSearchQuery(array $data): array
-    {
-        $query = 'SELECT * FROM support_helpdesk';
-
-        $search = $data['search'] ?? null;
-
-        $where = [];
-        $bindings = [];
-
-        if ($search) {
-            $search = '%' . $search . '%';
-            $where[] = '(name LIKE :name OR email LIKE :email OR signature LIKE :signature)';
-            $bindings[':name'] = $search;
-            $bindings[':email'] = $search;
-            $bindings[':signature'] = $search;
-        }
-
-        if (!empty($where)) {
-            $query = $query . ' WHERE ' . implode(' AND ', $where);
-        }
-        $query .= ' ORDER BY id DESC';
-
-        return [$query, $bindings];
-    }
-
     public function helpdeskRm(Helpdesk $model): bool
     {
         $id = $model->getId();
@@ -1135,7 +1110,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $helpdesk = isset($data['support_helpdesk_id'])
             ? $this->getHelpdeskRepository()->find((int) $data['support_helpdesk_id'])
             : $this->getHelpdeskRepository()->getDefault();
-        
+
         if (!$helpdesk instanceof Helpdesk) {
             throw new \FOSSBilling\Exception('Helpdesk invalid');
         }

--- a/src/modules/Support/templates/admin/mod_support_kb_index.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_kb_index.html.twig
@@ -123,13 +123,13 @@
                                                 <a href='{{ "support/kb/article/#{post.id}"|url }}'>{{ post.title }}</a>
                                             </td>
                                             <td>
-                                                <a href='{{ "support/kb/category/#{post.category.id}"|url }}'>{{ post.category.title }}</a>
+                                                {% if post.category %}<a href='{{ "support/kb/category/#{post.category.id}"|url }}'>{{ post.category.title }}</a>{% else %}<span class="text-muted">—</span>{% endif %}
                                             </td>
                                             <td>{{ mf.status_badge(post.status, 'post') }}</td>
                                             <td class="text-center">{{ post.views }}</td>
                                             <td class="text-muted">{% if post.updated_at %}{{ '%time% ago'|trans({ '%time%': post.updated_at|timeago }) }}{% else %}-{% endif %}</td>
                                             <td>
-                                                {% if post.status == 'active' %}
+                                                {% if post.status == 'active' and post.category %}
                                                 <a class="btn btn-icon" href='{{ "support/kb/#{post.category.slug}/#{post.slug}"|url(area: 'client') }}' target="_blank"
                                                     data-bs-toggle="tooltip" data-bs-title="{{ 'View'|trans }}">
                                                     <svg class="icon">

--- a/src/modules/Support/templates/admin/mod_support_settings.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_settings.html.twig
@@ -110,7 +110,7 @@
                         <div class="card-body border-top">
                             <h4 class="card-title mb-2">{{ 'Knowledge Base'|trans }}</h4>
                             <p class="text-secondary mb-3">{{ 'Control whether the knowledge base is visible to clients and available throughout the support area.'|trans }}</p>
-                            {% set kb_enabled = params.kb_enable is not defined or params.kb_enable is same as(true) or params.kb_enable in [1, '1', 'true', 'on', 'yes'] %}
+                            {% set kb_enabled = params.kb_enable is same as(true) or params.kb_enable in [1, '1', 'true', 'on', 'yes'] %}
                             <label class="form-check form-switch form-switch-2">
                                 <input name="kb_enable" type="hidden" value="false">
                                 <input class="form-check-input" name="kb_enable" type="checkbox" value="true" {% if kb_enabled %} checked="checked"{% endif %}>

--- a/src/modules/Support/templates/client/mod_support_kb_article.html.twig
+++ b/src/modules/Support/templates/client/mod_support_kb_article.html.twig
@@ -9,14 +9,16 @@
 <li class="breadcrumb-item">
     <a href="{{ 'support/kb'|url }}">{{ 'Knowledge Base'|trans }}</a>
 </li>
+{% if article.category %}
 <li class="breadcrumb-item">
     <a href='{{ "support/kb/#{article.category.slug}"|url }}'>{{ article.category.title }}</a>
 </li>
+{% endif %}
 <li class="breadcrumb-item active" aria-current="page">{{ article.title }}</li>
 {% endblock %}
 
 {% block content %}
-{% set related_articles = guest.support_kb_article_get_list({ 'kb_article_category_id': article.category.id, 'per_page': 6 }).list|filter(related_article => related_article.id != article.id)|slice(0, 5) %}
+{% set related_articles = article.category ? guest.support_kb_article_get_list({ 'kb_article_category_id': article.category.id, 'per_page': 6 }).list|filter(related_article => related_article.id != article.id)|slice(0, 5) : [] %}
 <div class="row g-4 justify-content-center">
     <article class="col-lg-9">
         <div class="mb-4">
@@ -51,7 +53,9 @@
 
         <div class="d-flex flex-wrap gap-2 mb-4">
             <a href="{{ 'support/kb'|url }}" class="btn btn-outline-secondary">{{ 'Browse all articles'|trans }}</a>
+            {% if article.category %}
             <a href='{{ "support/kb/#{article.category.slug}"|url }}' class="btn btn-outline-secondary">{{ 'More in this category'|trans }}</a>
+            {% endif %}
         </div>
     </article>
 
@@ -59,8 +63,10 @@
         <div class="position-sticky" style="top: 1rem;">
             <div class="card mb-4">
                 <div class="card-body">
+                    {% if article.category %}
                     <div class="text-muted small mb-1">{{ 'Category'|trans }}</div>
                     <a class="h5 d-block mb-3 text-decoration-none" href='{{ "support/kb/#{article.category.slug}"|url }}'>{{ article.category.title }}</a>
+                    {% endif %}
                     <a class="btn btn-outline-secondary btn-sm w-100" href="{{ 'support/kb'|url }}">{{ 'Knowledge Base'|trans }}</a>
                 </div>
             </div>
@@ -72,7 +78,7 @@
                 <div class="list-group list-group-flush">
                     {% if related_articles %}
                         {% for related_article in related_articles %}
-                            <a class="list-group-item list-group-item-action" href='{{ "support/kb/#{related_article.category.slug}/#{related_article.slug}"|url }}'>{{ related_article.title }}</a>
+                            <a class="list-group-item list-group-item-action" href='{{ related_article.category ? "support/kb/#{related_article.category.slug}/#{related_article.slug}"|url : "support/kb"|url }}'>{{ related_article.title }}</a>
                         {% endfor %}
                     {% else %}
                         <div class="list-group-item text-muted">{{ 'No related articles yet.'|trans }}</div>

--- a/src/modules/Support/templates/client/mod_support_kb_suggestions.html.twig
+++ b/src/modules/Support/templates/client/mod_support_kb_suggestions.html.twig
@@ -37,6 +37,9 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         articles.forEach((article) => {
+            if (!article.category) {
+                return;
+            }
             const link = document.createElement('a');
             link.className = 'list-group-item list-group-item-action px-0 bg-transparent';
             link.href = `{{ 'support/kb'|url }}/${encodeURIComponent(article.category.slug)}/${encodeURIComponent(article.slug)}`;

--- a/src/modules/Support/templates/client/mod_support_kb_suggestions.html.twig
+++ b/src/modules/Support/templates/client/mod_support_kb_suggestions.html.twig
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function () {
         articles.forEach((article) => {
             const link = document.createElement('a');
             link.className = 'list-group-item list-group-item-action px-0 bg-transparent';
-            link.href = `{{ 'support/kb'|url }}/${article.category.slug}/${article.slug}`;
+            link.href = `{{ 'support/kb'|url }}/${encodeURIComponent(article.category.slug)}/${encodeURIComponent(article.slug)}`;
             link.target = '_blank';
             link.rel = 'noopener';
             link.textContent = article.title;

--- a/src/modules/Support/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Support/tests/Unit/Api/AdminTest.php
@@ -1025,7 +1025,7 @@ test('kb article get list', function (): void {
     $pager = Mockery::mock(FOSSBilling\Pagination::class);
     $pager->shouldReceive('paginateDoctrineQuery')
         ->once()
-        ->with($qb, Mockery::type(FOSSBilling\PaginationOptions::class))
+        ->with($qb, Mockery::type(FOSSBilling\PaginationOptions::class), null)
         ->andReturn(['list' => []]);
     $di['pager'] = $pager;
     $adminApi->setDi($di);

--- a/src/modules/Support/tests/Unit/ServiceTest.php
+++ b/src/modules/Support/tests/Unit/ServiceTest.php
@@ -1076,25 +1076,6 @@ test('canned category update', function (): void {
  * Helpdesk Tests
  */
 
-test('helpdesk get search query', function (): void {
-    $service = new Service();
-
-    $data = [
-        'search' => 'SearchQuery',
-    ];
-    [$query, $bindings] = $service->helpdeskGetSearchQuery($data);
-
-    $expectedBindings = [
-        ':name' => '%SearchQuery%',
-        ':email' => '%SearchQuery%',
-        ':signature' => '%SearchQuery%',
-    ];
-
-    expect($query)->toBeString();
-    expect($bindings)->toBeArray();
-    expect($bindings)->toEqual($expectedBindings);
-});
-
 test('helpdesk rm', function (): void {
     $service = new Service();
     $repo = Mockery::mock(HelpdeskRepository::class);


### PR DESCRIPTION
Follow-up fixes for #3808, targeting `feat/kb-doctrine` directly.

## Changes

### Bug fixes
- **`Service.php`**: `kbEnabled()` defaulted to `true` — changed to `false` so KB is opt-in, not opt-out on new installs that haven't set the config key
- **`Service.php`**: `canBeReopened()` threw an exception when the helpdesk was missing — now returns `false` gracefully
- **`Service.php`**: `sendAutoresponderCannedReply()` threw when the canned response ID wasn't found — now logs a warning and returns cleanly
- **`KbArticleCategoryRepository.php`**: Article status filter was applied in a `WHERE` clause on a `LEFT JOIN`, which turned it into an implicit `INNER JOIN` (categories with no active articles were excluded) — moved the filter to a `JOIN … WITH` condition
- **`KbArticle.php`**: `toApiArray()` threw when `$category` was `null` — now returns `'category' => null` instead
- **`Admin.php`**: `helpdesk_get_list()` used `$this->identity` directly instead of `$this->getIdentity()`
- **`Admin.php`**: `kb_article_get_list()` was missing the identity argument in `paginateDoctrineQuery()`
- **`Guest.php`**: `kb_category_get_pairs()` threw `InformationException` when KB was disabled — now returns `[]`

### Null safety in templates
- **`mod_support_kb_article.html.twig`**: Multiple guards for `article.category` being null (breadcrumb, related articles query, sidebar, buttons)
- **`mod_support_kb_suggestions.html.twig`**: JS skips articles with no category; slugs wrapped in `encodeURIComponent()`
- **`mod_support_kb_index.html.twig`**: Null guards on `post.category` in category cell and View button condition

### Dead code removal
- **`Service.php`**: Removed dead `helpdeskGetSearchQuery()` method (replaced by Doctrine repository)
- **`ServiceTest.php`**: Removed corresponding dead test

### Test fix
- **`AdminTest.php`**: Updated `kb article get list` mock to expect the third `null` identity argument now passed to `paginateDoctrineQuery()`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGXKsZEYCkpimH8Q29kY9K)_