### PR TITLE
Fix browserslist lockfile regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.3.tgz",
-      "integrity": "sha512-fJuAi3QO096TeMRa/1Z/Z4xVxx2NVXFQc8aOX5huX0gA1V7NkIw+Qv1/Y16MatpJUeYs4mLXAsRs6RUp4sylIQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2367,18 +2367,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {


### PR DESCRIPTION
### Motivation
- The frontend build started failing because the `browserslist` 4.28.3 package installed a syntactically invalid `node.js` file which caused `npm run build` to throw a `SyntaxError`. 
- The goal is to restore a working frontend build while keeping other lockfile maintenance updates intact.

### Description
- Reverted the `node_modules/browserslist` resolution in `package-lock.json` from `4.28.3` back to `4.28.2`, updating the `version`, `resolved` URL and `integrity` fields. 
- Restored the `browserslist` dependency ranges to the values that match `4.28.2` for `baseline-browser-mapping`, `caniuse-lite`, `electron-to-chromium`, and `node-releases`, and removed the problematic extra funding entry introduced by the newer resolution. 
- Only `package-lock.json` was changed to address the regression; no source code or other configuration files were modified.

### Testing
- Ran `composer validate --strict` and it succeeded. 
- Ran `composer install --no-interaction --no-progress` and dependency installation completed successfully. 
- Ran `rm -rf node_modules && npm ci && npm run build` which completed the frontend build successfully after the lockfile revert. 
- Ran `composer test` which could not complete in this environment because the FOSSBilling configuration file is empty or invalid (test runner error), so full test-suite verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a395de7b998832e9b229528f3226f1f)