### PR TITLE
Preserve < and > in ticket/KB messages by using Markdown-safe sanitization

### DIFF
--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -423,7 +423,7 @@ class Tools
      *
      * Use this only for content that is stored and rendered as HTML.
      * For Markdown content (e.g. ticket messages, KB articles), use sanitizeMarkdownContent() instead,
-     * since the HTML sanitizer incorrectly strips text that follows unrecognised tags like <foo>.
+     * since the HTML sanitizer incorrectly strips text that follows unrecognized tags like <foo>.
      *
      * @param string $content   The content to sanitize. If empty, returns an empty string.
      * @param bool   $allowHtml Whether to allow safe HTML tags (default: true for rich content)

--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -421,6 +421,10 @@ class Tools
      * Sanitize user content to prevent XSS attacks.
      * Uses Symfony's HTML Sanitizer component for robust protection.
      *
+     * Use this only for content that is stored and rendered as HTML.
+     * For Markdown content (e.g. ticket messages, KB articles), use sanitizeMarkdownContent() instead,
+     * since the HTML sanitizer incorrectly strips text that follows unrecognised tags like <foo>.
+     *
      * @param string $content   The content to sanitize. If empty, returns an empty string.
      * @param bool   $allowHtml Whether to allow safe HTML tags (default: true for rich content)
      *
@@ -451,6 +455,31 @@ class Tools
         $sanitizer = new \Symfony\Component\HtmlSanitizer\HtmlSanitizer($config);
 
         return trim($sanitizer->sanitize($content));
+    }
+
+    /**
+     * Sanitize Markdown content for storage.
+     *
+     * Unlike sanitizeContent(), this does NOT run an HTML sanitizer because the content is Markdown,
+     * not HTML. Running an HTML sanitizer on Markdown corrupts it: characters like < and > that users
+     * type as literal text get misinterpreted as unknown HTML elements and dropped together with all
+     * subsequent text.
+     *
+     * XSS protection for Markdown content is handled at render time by the markdown_to_html Twig
+     * filter, which is configured with html_input=escape so any raw HTML in the Markdown is safely
+     * escaped rather than executed.
+     *
+     * @param string $content the Markdown content to sanitize
+     *
+     * @return string Sanitized Markdown content safe for storage
+     */
+    public static function sanitizeMarkdownContent(string $content = ''): string
+    {
+        if (empty($content)) {
+            return '';
+        }
+
+        return trim(str_replace("\0", '', $content));
     }
 
     public static function validatePhoneCC(string|int $countryCode): int

--- a/src/modules/Support/Api/Admin.php
+++ b/src/modules/Support/Api/Admin.php
@@ -115,8 +115,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     {
         $this->checkPermissions('support', 'manage_tickets');
 
-        // Sanitize content to prevent XSS attacks
-        $data['content'] = \FOSSBilling\Tools::sanitizeContent($data['content'], true);
+        $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']);
 
         $ticket = $this->getDi()['db']->getExistingModelById('SupportTicket', $data['id'], 'Ticket not found');
 
@@ -153,8 +152,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     {
         $this->checkPermissions('support', 'manage_tickets');
 
-        // Sanitize content to prevent XSS attacks
-        $data['content'] = \FOSSBilling\Tools::sanitizeContent($data['content'], true);
+        $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']);
 
         $client = $this->getDi()['db']->getExistingModelById('Client', $data['client_id'], 'Client not found');
         $helpdesk = $this->getDi()['db']->getExistingModelById('SupportHelpdesk', $data['support_helpdesk_id'], 'Helpdesk invalid');
@@ -581,10 +579,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('support', 'manage_kb');
 
         $articleCategoryId = (int) $data['kb_article_category_id'];
-        // Sanitize title and content to prevent XSS attacks
         $title = \FOSSBilling\Tools::sanitizeContent($data['title'], false);
         $status = $data['status'] ?? \Model_SupportKbArticle::DRAFT;
-        $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeContent($data['content'], true) : null;
+        $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']) : null;
 
         return $this->getService()->kbCreateArticle($articleCategoryId, $title, $status, $content);
     }
@@ -605,11 +602,10 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('support', 'manage_kb');
 
         $articleCategoryId = isset($data['kb_article_category_id']) ? (int) $data['kb_article_category_id'] : null;
-        // Sanitize title and content to prevent XSS attacks
         $title = isset($data['title']) ? \FOSSBilling\Tools::sanitizeContent($data['title'], false) : null;
         $slug = $data['slug'] ?? null;
         $status = $data['status'] ?? null;
-        $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeContent($data['content'], true) : null;
+        $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']) : null;
         $views = isset($data['views']) ? (int) $data['views'] : null;
 
         return $this->getService()->kbUpdateArticle((int) $data['id'], $articleCategoryId, $title, $slug, $status, $content, $views);

--- a/src/modules/Support/Api/Client.php
+++ b/src/modules/Support/Api/Client.php
@@ -82,8 +82,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
     ])]
     public function ticket_create(array $data): int
     {
-        // Sanitize content to prevent XSS attacks
-        $data['content'] = \FOSSBilling\Tools::sanitizeContent($data['content'], true);
+        $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']);
 
         $helpdesk = $this->getDi()['db']->getExistingModelById('SupportHelpdesk', $data['support_helpdesk_id'], 'Helpdesk invalid');
 
@@ -98,8 +97,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
     #[RequiredParams(['id' => 'Ticket ID was not passed', 'content' => 'Ticket content required'])]
     public function ticket_reply(array $data): bool
     {
-        // Sanitize content to prevent XSS attacks
-        $data['content'] = \FOSSBilling\Tools::sanitizeContent($data['content'], true);
+        $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']);
 
         $client = $this->getIdentity();
 

--- a/src/modules/Support/Api/Guest.php
+++ b/src/modules/Support/Api/Guest.php
@@ -38,8 +38,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         $data['email'] = $this->getDi()['tools']->validateAndSanitizeEmail($data['email']);
         $this->getDi()['rate_limiter']->consumeOrThrow('guest_ticket_create', (string) $this->getIp());
 
-        // Sanitize message to prevent XSS attacks
-        $data['content'] = \FOSSBilling\Tools::sanitizeContent($content, true);
+        $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($content);
 
         return $this->getService()->ticketCreateForGuest($data);
     }
@@ -82,8 +81,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             throw new \FOSSBilling\InformationException('Message cannot be empty');
         }
 
-        // Sanitize message to prevent XSS attacks
-        $message = \FOSSBilling\Tools::sanitizeContent($message, true);
+        $message = \FOSSBilling\Tools::sanitizeMarkdownContent($message);
 
         return $this->getService()->ticketReply($guestTicket, new \Model_Guest(), $message);
     }

--- a/src/modules/Support/templates/admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_ticket.html.twig
@@ -145,7 +145,9 @@
                                     <span class="ms-auto text-muted">{{ message.created_at|format_datetime }}</span>
                                 </div>
                                 <div class="card-body" style="display:{{ loop.last or loop.index + 1 == ticket.messages|length ? 'block' : 'none' }};">
-                                    {{ (message.content ?? '')|markdown_to_html }}
+                                    <article class="markdown-body bg-transparent text-reset">
+                                        {{ (message.content ?? '')|markdown_to_html }}
+                                    </article>
                                 </div>
                             </div>
                             {% endfor %}
@@ -408,4 +410,7 @@
 </script>
 {% endblock %}
 
-{% block head %}{{ wysiwyg('.editor-textarea') }}{% endblock %}
+{% block head %}
+    {{ 'css/markdown.css' | public_asset_url | stylesheet_tag }}
+    {{ wysiwyg('.editor-textarea') }}
+{% endblock %}

--- a/src/modules/Support/templates/client/mod_support_kb_article.html.twig
+++ b/src/modules/Support/templates/client/mod_support_kb_article.html.twig
@@ -5,6 +5,7 @@
 {% block meta_description %}{{ (article.content ?? '')|markdown_to_html|striptags|trim|truncate(160) }}{% endblock %}
 
 {% block body_class %}kb-article{% endblock %}
+{% block head %}{{ 'css/markdown.css' | public_asset_url | stylesheet_tag }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item">
     <a href="{{ 'support/kb'|url }}">{{ 'Knowledge Base'|trans }}</a>
@@ -26,9 +27,9 @@
                 </div>
             </div>
             <div class="card-body">
-                <div class="list-group ms-2">
+                <article class="markdown-body bg-transparent text-reset">
                     {{ (article.content ?? '')|markdown_to_html }}
-                </div>
+                </article>
             </div>
             <div class="card-footer">
                 <a href="{{ 'support/kb'|url }}" class="btn btn-primary btn-sm" type="button">{{ 'Go Back'|trans }}</a>

--- a/tests/Unit/FOSSBilling/ToolsTest.php
+++ b/tests/Unit/FOSSBilling/ToolsTest.php
@@ -113,3 +113,42 @@ test('sanitize content preserves text content', function (): void {
     expect($result)->not->toContain('<');
     expect($result)->not->toContain('>');
 });
+
+test('sanitize markdown content preserves angle brackets as literal text', function (): void {
+    $input = 'Hello <World> this text must not disappear';
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent($input);
+    expect($result)->toBe('Hello <World> this text must not disappear');
+});
+
+test('sanitize markdown content preserves comparison operators', function (): void {
+    $input = 'Value must be 1 < x < 10 and y > 0';
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent($input);
+    expect($result)->toBe('Value must be 1 < x < 10 and y > 0');
+});
+
+test('sanitize markdown content removes null bytes', function (): void {
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent("Hello\0World");
+    expect($result)->not->toContain("\0");
+    expect($result)->toBe('HelloWorld');
+});
+
+test('sanitize markdown content returns empty string for empty input', function (): void {
+    expect(FOSSBilling\Tools::sanitizeMarkdownContent(''))->toBe('');
+});
+
+test('sanitize markdown content trims surrounding whitespace', function (): void {
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent("  Hello World  \n");
+    expect($result)->toBe('Hello World');
+});
+
+test('sanitize markdown content preserves markdown bold syntax', function (): void {
+    $input = 'This is **bold** and _italic_ text';
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent($input);
+    expect($result)->toBe($input);
+});
+
+test('sanitize markdown content preserves markdown inline code', function (): void {
+    $input = 'Use `git clone` or `<tag>` syntax';
+    $result = FOSSBilling\Tools::sanitizeMarkdownContent($input);
+    expect($result)->toBe($input);
+});


### PR DESCRIPTION
The WYSIWYG editor (CKEditor) uses the Markdown plugin, so ticket replies and KB article bodies are stored as Markdown, not HTML. Calling the Symfony HTML Sanitizer on Markdown content silently corrupts it: when a user types text containing an unknown tag-like string such as `<World>`, the sanitizer treats it as an unknown HTML element, drops it, and because there is no closing tag also drops everything that follows, causing the rest of the message to disappear.

Fix by introducing `Tools::sanitizeMarkdownContent()`, which only strips null bytes and trims whitespace. XSS protection is already provided at render time by the `|markdown_to_html` Twig filter, whose underlying
CommonMark converter is configured with `html_input: escape`; any raw HTML inside the stored Markdown is therefore escaped before it reaches the browser.

Affected endpoints (all now use the new helper):
- Admin: ticket_reply, ticket_create, kb_article_create, kb_article_update
- Client: ticket_create, ticket_reply
- Guest: ticket_create, ticket_reply

Fixes #3827