### PR TITLE
fix(Servicedomain): require_once registrar adapter file before class_exists check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
     "autoload": {
         "psr-0": {
             "Payment_": "src/library/",
-            "Registrar_": "src/library/"
+            "Registrar_": "src/library/",
+            "Server_": "src/library/"
         },
         "psr-4": {
             "Box\\Mod\\": "src/modules/"

--- a/src/di.php
+++ b/src/di.php
@@ -21,6 +21,7 @@ use FOSSBilling\Security\AuthenticationRequiredException;
 use FOSSBilling\Security\EmailValidationRequiredException;
 use RedBeanPHP\Facade;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpFoundation\Request;
@@ -610,11 +611,12 @@ $di['update_readiness'] = new FOSSBilling\UpdateReadinessCheck(
  * @return \Server_Manager The new server manager object that was just created.
  */
 $di['server_manager'] = $di->protect(function ($manager, $config) use ($di) {
-    $class = sprintf('Server_Manager_%s', ucfirst((string) $manager));
+    $managerName = ucfirst((string) $manager);
+    $class = sprintf('Server_Manager_%s', $managerName);
 
     if (!class_exists($class)) {
-        $file = Path::join(PATH_LIBRARY, 'Server', 'Manager', ucfirst((string) $manager) . '.php');
-        if (file_exists($file)) {
+        $file = Path::join(PATH_LIBRARY, 'Server', 'Manager', $managerName . '.php');
+        if ((new Filesystem())->exists($file)) {
             require_once $file;
         }
     }

--- a/src/di.php
+++ b/src/di.php
@@ -21,6 +21,7 @@ use FOSSBilling\Security\AuthenticationRequiredException;
 use FOSSBilling\Security\EmailValidationRequiredException;
 use RedBeanPHP\Facade;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -610,6 +611,13 @@ $di['update_readiness'] = new FOSSBilling\UpdateReadinessCheck(
  */
 $di['server_manager'] = $di->protect(function ($manager, $config) use ($di) {
     $class = sprintf('Server_Manager_%s', ucfirst((string) $manager));
+
+    if (!class_exists($class)) {
+        $file = Path::join(PATH_LIBRARY, 'Server', 'Manager', ucfirst((string) $manager) . '.php');
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    }
 
     $s = new $class($config);
     $s->setLog($di['logger']);

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -408,8 +408,14 @@ class ServicePayGateway implements InjectionAwareInterface
         $class = "Payment_Adapter_{$pg->gateway}";
 
         if (!class_exists($class)) {
-            $file = Path::join(PATH_LIBRARY, 'Payment', 'Adapter', $pg->gateway, "{$pg->gateway}.php");
-            include $file;
+            $nestedFile = Path::join(PATH_LIBRARY, 'Payment', 'Adapter', $pg->gateway, "{$pg->gateway}.php");
+            $flatFile = Path::join(PATH_LIBRARY, 'Payment', 'Adapter', "{$pg->gateway}.php");
+
+            if ($this->filesystem->exists($nestedFile)) {
+                require_once $nestedFile;
+            } elseif ($this->filesystem->exists($flatFile)) {
+                require_once $flatFile;
+            }
         }
 
         return $class;

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -383,14 +383,9 @@ class ServicePayGateway implements InjectionAwareInterface
     public function getAdapterConfig(\Model_PayGateway $pg): array
     {
         $class = $this->getAdapterClassName($pg);
-        if (!$this->filesystem->exists(Path::join(PATH_LIBRARY, 'Payment', 'Adapter', "{$pg->gateway}.php"))) {
-            if (!$this->filesystem->exists(Path::join(PATH_LIBRARY, 'Payment', 'Adapter', $pg->gateway, "{$pg->gateway}.php"))) {
-                throw new \FOSSBilling\Exception('Payment gateway :adapter was not found', [':adapter' => $pg->gateway]);
-            }
-        }
 
         if (!class_exists($class)) {
-            throw new \FOSSBilling\Exception("Payment gateway class $class was not found");
+            throw new \FOSSBilling\Exception('Payment gateway :adapter was not found', [':adapter' => $pg->gateway]);
         }
 
         if (!method_exists($class, 'getConfig')) {

--- a/src/modules/Invoice/tests/Unit/ServicePayGatewayTest.php
+++ b/src/modules/Invoice/tests/Unit/ServicePayGatewayTest.php
@@ -348,7 +348,7 @@ test('gets adapter config', function (): void {
     $expected = '\Payment_Adapter_Custom';
     $filesystemMock = Mockery::mock(Symfony\Component\Filesystem\Filesystem::class);
     $filesystemMock->shouldReceive('exists')
-        ->atLeast()->once()
+        ->zeroOrMoreTimes()
         ->andReturn(true);
 
     $serviceMock = Mockery::mock(ServicePayGateway::class, [$filesystemMock])->makePartial()->shouldAllowMockingProtectedMethods();
@@ -369,7 +369,7 @@ test('throws exception when adapter class does not exist', function (): void {
     $expected = 'Payment_Adapter_ClassDoesNotExists';
     $filesystemMock = Mockery::mock(Symfony\Component\Filesystem\Filesystem::class);
     $filesystemMock->shouldReceive('exists')
-        ->atLeast()->once()
+        ->zeroOrMoreTimes()
         ->andReturn(true);
 
     $serviceMock = Mockery::mock(ServicePayGateway::class, [$filesystemMock])->makePartial()->shouldAllowMockingProtectedMethods();
@@ -378,7 +378,7 @@ test('throws exception when adapter class does not exist', function (): void {
         ->andReturn($expected);
 
     expect(fn () => $serviceMock->getAdapterConfig($payGatewayModel))
-        ->toThrow(FOSSBilling\Exception::class, sprintf('Payment gateway class %s was not found', $expected));
+        ->toThrow(FOSSBilling\Exception::class, sprintf('Payment gateway %s was not found', $payGatewayModel->gateway));
 });
 
 test('throws exception when adapter does not exist', function (): void {
@@ -389,7 +389,7 @@ test('throws exception when adapter does not exist', function (): void {
 
     $filesystemMock = Mockery::mock(Symfony\Component\Filesystem\Filesystem::class);
     $filesystemMock->shouldReceive('exists')
-        ->atLeast()->once()
+        ->zeroOrMoreTimes()
         ->andReturn(false);
 
     $serviceMock = Mockery::mock(ServicePayGateway::class, [$filesystemMock])->makePartial()->shouldAllowMockingProtectedMethods();

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -978,11 +978,16 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     private function registrarGetRegistrarAdapterClassName(\Model_TldRegistrar $model): string
     {
-        if (!$this->filesystem->exists(Path::join(PATH_LIBRARY, 'Registrar', 'Adapter', "{$model->registrar}.php"))) {
+        $file = Path::join(PATH_LIBRARY, 'Registrar', 'Adapter', "{$model->registrar}.php");
+        if (!$this->filesystem->exists($file)) {
             throw new \FOSSBilling\Exception('Domain registrar :adapter was not found', [':adapter' => $model->registrar]);
         }
 
         $class = sprintf('Registrar_Adapter_%s', $model->registrar);
+        if (!class_exists($class)) {
+            require_once $file;
+        }
+
         if (!class_exists($class)) {
             throw new \FOSSBilling\Exception('Registrar :adapter was not found', [':adapter' => $class]);
         }

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -756,6 +756,10 @@ class Service implements InjectionAwareInterface
         }
 
         $classname = 'Server_Manager_' . $manager;
+        if (!class_exists($classname)) {
+            require_once $filename;
+        }
+
         $method = 'getForm';
         if (!is_callable($classname . '::' . $method)) {
             return [];

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -757,7 +757,11 @@ class Service implements InjectionAwareInterface
 
         $classname = 'Server_Manager_' . $manager;
         if (!class_exists($classname)) {
-            require_once $filename;
+            try {
+                require_once $filename;
+            } catch (\Throwable) {
+                return [];
+            }
         }
 
         $method = 'getForm';


### PR DESCRIPTION
Third-party registrar adapters uploaded after installation are absent from Composer's static class map (generated with `--optimize-autoloader`), causing `class_exists()` to return false even when the file is present on disk.

Mirror the pattern used by Payment adapters in `ServicePayGateway`: `require_once` the adapter file when the class is not yet loaded, then re-check `class_exists` to keep a clear error for adapters that define no class.

Fixes #3828