### PR TITLE
Add Discord community button to admin header

### DIFF
--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -203,10 +203,9 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
    //===== Discord community popover (shown once) =====//
    const discordBtn = document.getElementById('discord-community-btn');
    if (discordBtn && !localStorage.getItem('fb-discord-popover-seen')) {
-     const popover = new bootstrap.Popover(discordBtn);
+     const popover = bootstrap.Popover.getOrCreateInstance(discordBtn);
      localStorage.setItem('fb-discord-popover-seen', '1');
      popover.show();
-     discordBtn.addEventListener('click', () => popover.hide(), { once: true });
      document.addEventListener('click', (e) => {
        if (!discordBtn.contains(e.target)) {
          popover.hide();

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -200,6 +200,20 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
      showTabById(nextTabId);
    });
 
+   //===== Discord community popover (shown once) =====//
+   const discordBtn = document.getElementById('discord-community-btn');
+   if (discordBtn && !localStorage.getItem('fb-discord-popover-seen')) {
+     const popover = new bootstrap.Popover(discordBtn);
+     localStorage.setItem('fb-discord-popover-seen', '1');
+     popover.show();
+     discordBtn.addEventListener('click', () => popover.hide(), { once: true });
+     document.addEventListener('click', (e) => {
+       if (!discordBtn.contains(e.target)) {
+         popover.hide();
+       }
+     }, { once: true });
+   }
+
    //===== Search filter toggle state =====//
    const syncSearchFilterToggleState = (toggle, panel) => {
      const targetSelector = toggle.getAttribute('data-bs-target');

--- a/src/themes/admin_default/assets/js/fossbilling.js
+++ b/src/themes/admin_default/assets/js/fossbilling.js
@@ -202,7 +202,17 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
 
    //===== Discord community popover (shown once) =====//
    const discordBtn = document.getElementById('discord-community-btn');
-   if (discordBtn && !localStorage.getItem('fb-discord-popover-seen')) {
+   const isDiscordBtnVisible = () => {
+     if (!discordBtn) {
+       return false;
+     }
+
+     const style = window.getComputedStyle(discordBtn);
+
+     return style.visibility !== 'hidden' && style.display !== 'none' && discordBtn.getClientRects().length > 0;
+   };
+
+   if (discordBtn && !localStorage.getItem('fb-discord-popover-seen') && isDiscordBtnVisible()) {
      const popover = bootstrap.Popover.getOrCreateInstance(discordBtn);
      localStorage.setItem('fb-discord-popover-seen', '1');
      popover.show();

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -193,6 +193,7 @@
                                             <a class="dropdown-item" href="https://docs.fossbilling.org/" target="_blank" rel="noopener">{{ 'Documentation'|trans }}</a>
                                             <a class="dropdown-item" href="https://github.com/FOSSBilling/FOSSBilling" target="_blank" rel="noopener">GitHub</a>
                                             <a class="dropdown-item" href="https://github.com/FOSSBilling/FOSSBilling/issues" target="_blank" rel="noopener">{{ 'Report a Bug'|trans }}</a>
+                                            <a class="dropdown-item" href="https://fossbilling.org/discord" target="_blank" rel="noopener">{{ 'Discord Community'|trans }}</a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -77,6 +77,20 @@
                                  <use href="#brand-github" />
                               </svg>
                            </a>
+                           <a href="https://fossbilling.org/discord"
+                              class="btn px-3"
+                              id="discord-community-btn"
+                              target="_blank"
+                              rel="noreferrer"
+                              title="{{ 'Discord Community'|trans }}"
+                              data-bs-toggle="popover"
+                              data-bs-trigger="manual"
+                              data-bs-placement="bottom"
+                              data-bs-content="{{ 'Join our Discord community for support and discussion!'|trans }}">
+                              <svg class="icon m-0">
+                                 <use href="#brand-discord" />
+                              </svg>
+                           </a>
                            <a href="https://github.com/sponsors/FOSSBilling" class="btn px-3" target="_blank" rel="noreferrer" title="{{ 'Sponsor'|trans }}">
                               <svg class="icon m-0 text-pink">
                                  <use href="#heart" />

--- a/src/themes/admin_default/html/layout_default.html.twig
+++ b/src/themes/admin_default/html/layout_default.html.twig
@@ -82,7 +82,7 @@
                               id="discord-community-btn"
                               target="_blank"
                               rel="noreferrer"
-                              title="{{ 'Discord Community'|trans }}"
+                              title="{{ 'Discord'|trans }}"
                               data-bs-toggle="popover"
                               data-bs-trigger="manual"
                               data-bs-placement="bottom"
@@ -193,7 +193,7 @@
                                             <a class="dropdown-item" href="https://docs.fossbilling.org/" target="_blank" rel="noopener">{{ 'Documentation'|trans }}</a>
                                             <a class="dropdown-item" href="https://github.com/FOSSBilling/FOSSBilling" target="_blank" rel="noopener">GitHub</a>
                                             <a class="dropdown-item" href="https://github.com/FOSSBilling/FOSSBilling/issues" target="_blank" rel="noopener">{{ 'Report a Bug'|trans }}</a>
-                                            <a class="dropdown-item" href="https://fossbilling.org/discord" target="_blank" rel="noopener">{{ 'Discord Community'|trans }}</a>
+                                            <a class="dropdown-item" href="https://fossbilling.org/discord" target="_blank" rel="noopener">{{ 'Discord'|trans }}</a>
                                         </div>
                                     </div>
                                 </div>

--- a/src/themes/admin_default/icon-manifest.json
+++ b/src/themes/admin_default/icon-manifest.json
@@ -7,6 +7,7 @@
     "arrow-left",
     "arrow-up",
     "brand-github",
+    "brand-discord",
     "calendar",
     "check",
     "chevron-down",


### PR DESCRIPTION
Adds a compact Discord icon button to the admin navbar between the existing GitHub and Sponsor icon buttons, linking to https://fossbilling.org/discord.

On the **first page load only**, a  popover callout appears below the button to draw attention to it. The seen state is written to `localStorage` immediately on show, so the callout never reappears regardless of whether the user explicitly dismisses it. After that the button sits quietly in the header as a permanent, unobtrusive link.

This is an alternative to #3817, which added a full-width dismissible banner.

Example:

<img width="1150" height="161" alt="Discord Button and Popover" src="https://github.com/user-attachments/assets/742bc376-467e-4531-8149-5594a392ff5d"/></br>

*Edit: also adds Discord to the Help menu*:

<img width="208" height="212" alt="Screenshot 2026-06-29 at 19 13 28" src="https://github.com/user-attachments/assets/df10bd19-111d-4922-a8c9-b351dfd9892e" />

Closes #3817.