### PR TITLE
Code quality: replace error_log with logger, fix Stripe search escaping, and several small cleanups

### DIFF
--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -800,43 +800,45 @@ const API = {
             );
           };
 
-          if (apiData.hasOwnProperty('modal') && (typeof Modals === 'undefined' || typeof Modals.create !== 'function')) {
-            if (apiData.modal.type === 'prompt') {
-              const value = window.prompt(apiData.modal.label ?? apiData.modal.title ?? '', apiData.modal.value ?? '');
-              if (value) {
-                const p = {};
-                p[apiData.modal.key] = value;
-                handleApiRequest('GET', linkElement.getAttribute('href'), p);
-              }
-            } else if (window.confirm(apiData.modal.content || apiData.modal.title || 'Are you sure?')) {
-              handleApiRequest('GET', linkElement.getAttribute('href'));
-            }
-          } else if (apiData.hasOwnProperty('modal') && apiData.modal.type === 'prompt') {
-            Modals.create({
-              type: apiData.modal.type,
-              title: apiData.modal.title,
-              label: apiData.modal.label ?? 'Label',
-              value: apiData.modal.value ?? '',
-              promptConfirmCallback: (value) => {
+          if (apiData.hasOwnProperty('modal')) {
+            if (typeof Modals === 'undefined' || typeof Modals.create !== 'function') {
+              if (apiData.modal.type === 'prompt') {
+                const value = window.prompt(apiData.modal.label ?? apiData.modal.title ?? '', apiData.modal.value ?? '');
                 if (value) {
                   const p = {};
-                  const name = apiData.modal.key;
-                  p[name] = value;
+                  p[apiData.modal.key] = value;
                   handleApiRequest('GET', linkElement.getAttribute('href'), p);
                 }
-              },
-            });
-          } else if (apiData.hasOwnProperty('modal')) {
-            Modals.create({
-              type: (apiData.modal.type === 'confirm') ? 'small-confirm' : apiData.modal.type,
-              title: apiData.modal.title,
-              content: apiData.modal.content ?? '',
-              confirmButton: apiData.modal.button ?? 'Confirm',
-              confirmButtonColor: apiData.modal.buttonColor ?? 'primary',
-              confirmCallback: () => {
+              } else if (window.confirm(apiData.modal.content || apiData.modal.title || 'Are you sure?')) {
                 handleApiRequest('GET', linkElement.getAttribute('href'));
-              },
-            });
+              }
+            } else if (apiData.modal.type === 'prompt') {
+              Modals.create({
+                type: apiData.modal.type,
+                title: apiData.modal.title,
+                label: apiData.modal.label ?? 'Label',
+                value: apiData.modal.value ?? '',
+                promptConfirmCallback: (value) => {
+                  if (value) {
+                    const p = {};
+                    const name = apiData.modal.key;
+                    p[name] = value;
+                    handleApiRequest('GET', linkElement.getAttribute('href'), p);
+                  }
+                },
+              });
+            } else {
+              Modals.create({
+                type: (apiData.modal.type === 'confirm') ? 'small-confirm' : apiData.modal.type,
+                title: apiData.modal.title,
+                content: apiData.modal.content ?? '',
+                confirmButton: apiData.modal.button ?? 'Confirm',
+                confirmButtonColor: apiData.modal.buttonColor ?? 'primary',
+                confirmCallback: () => {
+                  handleApiRequest('GET', linkElement.getAttribute('href'));
+                },
+              });
+            }
           } else {
             handleApiRequest('GET', linkElement.getAttribute('href'));
           }

--- a/frontend/tools/check-icons.mjs
+++ b/frontend/tools/check-icons.mjs
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
-import { dirname, join, relative, resolve } from 'path';
-import { readdirSync, statSync } from 'fs';
+import { dirname, extname, join, relative, resolve } from 'path';
+import { readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -47,7 +47,7 @@ function walkFiles(dir) {
       continue;
     }
 
-    if ([...sourceExtensions].some((extension) => entry.name.endsWith(extension))) {
+    if (sourceExtensions.has(extname(entry.name))) {
       files.push(path);
     }
   }
@@ -83,7 +83,7 @@ async function getDynamicNavigationIcons() {
   const icons = new Set();
 
   for (const file of walkFiles(resolve(rootDir, 'src/modules'))) {
-    if (!file.endsWith('/Controller/Admin.php') || !statSync(file).isFile()) {
+    if (!file.endsWith('/Controller/Admin.php')) {
       continue;
     }
 

--- a/src/library/FOSSBilling/Api/Dispatcher.php
+++ b/src/library/FOSSBilling/Api/Dispatcher.php
@@ -43,7 +43,7 @@ final class Dispatcher implements InjectionAwareInterface
             throw new Exception('Method :method must contain underscore', [':method' => $method], 710);
         }
 
-        $role = str_replace('model_', '', strtolower($identity::class));
+        $role = Identity::typeFromObject($identity);
         $parts = explode('_', $method);
         $mod = strtolower($parts[0]);
         unset($parts[0]);

--- a/src/library/FOSSBilling/Api/Identity.php
+++ b/src/library/FOSSBilling/Api/Identity.php
@@ -18,7 +18,12 @@ final readonly class Identity
 
     public function __construct(private object $identity)
     {
-        $this->type = str_replace('model_', '', strtolower($identity::class));
+        $this->type = self::typeFromObject($identity);
+    }
+
+    public static function typeFromObject(object $identity): string
+    {
+        return str_replace('model_', '', strtolower($identity::class));
     }
 
     public function getIdentity(): object

--- a/src/library/FOSSBilling/Api/Proxy.php
+++ b/src/library/FOSSBilling/Api/Proxy.php
@@ -19,10 +19,11 @@ final class Proxy implements InjectionAwareInterface
 {
     protected string $type;
     protected ?Container $di = null;
+    private ?Dispatcher $dispatcher = null;
 
     public function __construct(protected object $identity)
     {
-        $this->type = str_replace('model_', '', strtolower($identity::class));
+        $this->type = Identity::typeFromObject($identity);
     }
 
     public function setDi(Container $di): void
@@ -52,6 +53,10 @@ final class Proxy implements InjectionAwareInterface
 
     private function getDispatcher(): Dispatcher
     {
+        if ($this->dispatcher !== null) {
+            return $this->dispatcher;
+        }
+
         if ($this->di === null || !$this->di->offsetExists('api_dispatcher')) {
             throw new \LogicException('API proxy requires the api_dispatcher service');
         }
@@ -61,6 +66,6 @@ final class Proxy implements InjectionAwareInterface
             throw new \LogicException('API dispatcher service must resolve to a FOSSBilling\Api\Dispatcher instance');
         }
 
-        return $dispatcher;
+        return $this->dispatcher = $dispatcher;
     }
 }

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -1602,8 +1602,7 @@ class UpdatePatcher implements InjectionAwareInterface
             Path::join(PATH_CACHE, 'fallbackClassMap.php') => 'unlink',
         ]);
 
-        $schemaManager = $this->di['dbal']->createSchemaManager();
-        if (!$schemaManager->tablesExist(['promo_redemption'])) {
+        if (!$this->tableExists('promo_redemption')) {
             $this->executeSql(
                 "CREATE TABLE `promo_redemption` (
                     `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1631,6 +1630,7 @@ class UpdatePatcher implements InjectionAwareInterface
             );
         }
 
+        $schemaManager = $this->di['dbal']->createSchemaManager();
         $table = $schemaManager->introspectTable('promo_redemption');
         $columns = [];
 
@@ -1927,7 +1927,7 @@ class UpdatePatcher implements InjectionAwareInterface
                     ['value' => $documentNr, 'id' => $clientId]
                 );
             } else {
-                error_log(sprintf('patch75: client #%d has no free custom field slot; unmigrated document_nr was "%s".', $clientId, $documentNr));
+                $this->di['logger']->setChannel('update')->warning('patch75: client #%d has no free custom field slot; unmigrated document_nr was "%s".', $clientId, $documentNr);
             }
         }
 

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -1066,14 +1066,18 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         return null;
     }
 
+    private function escapeStripeSearchValue(string $value): string
+    {
+        return str_replace(['\\', '\''], ['\\\\', '\\\''], $value);
+    }
+
     private function getOrCreateCustomer(Model_Invoice $invoice): Stripe\Customer
     {
         $validatedEmail = filter_var($invoice->buyer_email, FILTER_VALIDATE_EMAIL);
 
         if ($validatedEmail !== false) {
-            $escapedEmail = str_replace(['\\', '\''], ['\\\\', '\\\''], $validatedEmail);
             $customers = $this->stripe->customers->search([
-                'query' => "email:'" . $escapedEmail . "'",
+                'query' => "email:'" . $this->escapeStripeSearchValue($validatedEmail) . "'",
                 'limit' => 1,
             ]);
         } else {
@@ -1129,9 +1133,8 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
         $productName = $invoiceItems[0]['title'];
 
-        $escapedProductName = str_replace("'", "\\'", $productName);
         $products = $this->stripe->products->search([
-            'query' => "name:'{$escapedProductName}'",
+            'query' => "name:'" . $this->escapeStripeSearchValue($productName) . "'",
             'limit' => 1,
         ]);
 

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -720,7 +720,7 @@ class Service implements InjectionAwareInterface
                             $orderService->activateOrder($order);
                         }
                     } catch (\Exception $e) {
-                        error_log($e->getMessage());
+                        $this->di['logger']->error('Order activation failed after checkout: %s', $e->getMessage());
                         $status = 'error';
                         $notes = "Order could not be activated after checkout due to error: {$e->getMessage()}.";
                         $orderService->orderStatusAdd($order, $status, $notes);

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -936,7 +936,7 @@ class Service implements InjectionAwareInterface
 
             $addon = $this->getAddonById($id);
             if (!$addon instanceof Product) {
-                error_log('Addon not found by id ' . $id);
+                $this->di['logger']->warning('Addon not found by id %s', $id);
 
                 continue;
             }


### PR DESCRIPTION
## Summary

Code-quality cleanup pass over the last ~100 commits. No behaviour changes — each item below either removes silent log-swallowing, fixes a latent bug, or reduces duplication.

### Logging (`error_log` → structured logger)

- **`Cart/Service.php`** — order-activation failures after checkout were silently sent to the PHP system log. They now go through `$this->di['logger']->error()` and appear in the admin activity log.
- **`Product/Service.php`** — "addon not found by id" warnings similarly routed to the structured logger.
- **`UpdatePatcher.php` (patch75)** — the "no free custom field slot" warning during the `document_nr` migration now uses `$this->di['logger']->setChannel('update')->warning()`, consistent with every other warning in the same file.

### UpdatePatcher: use the existing `tableExists()` helper (patch72)

patch72 called `$schemaManager->tablesExist(['promo_redemption'])` directly instead of the private `$this->tableExists()` helper added in the same diff. The `$schemaManager` instance is now created once, right before it is first needed for schema introspection, rather than before the table-existence check.

### Stripe: consistent search-value escaping

`getOrCreateCustomer` escaped both `\` and `'`; `getOrCreateProduct` escaped only `'`. A product name containing a backslash would produce a malformed Stripe search query. Both methods now call a shared private `escapeStripeSearchValue()`.

### `frontend/core/api.js`: deduplicate `hasOwnProperty('modal')` check

The three-branch `if (apiData.hasOwnProperty('modal') && ...) / else if (apiData.hasOwnProperty('modal') && ...) / else if (apiData.hasOwnProperty('modal'))` chain re-evaluated the same property check at every branch. Restructured to a single outer `if (apiData.hasOwnProperty('modal'))` with the Modals-availability check nested inside.

### `frontend/tools/check-icons.mjs`: fix Set spreading and remove dead `statSync`

- `[...sourceExtensions].some((ext) => entry.name.endsWith(ext))` spread the Set into a new array on every file entry. Replaced with `sourceExtensions.has(extname(entry.name))`, consistent with how `check-js-syntax.mjs` already does this.
- `statSync(file).isFile()` in `getDynamicNavigationIcons` was always true because `walkFiles` only yields non-directory entries. Removed the check and the now-unused `statSync` import.

### API layer: deduplicate role-type derivation and cache Proxy dispatcher

The expression `str_replace('model_', '', strtolower($identity::class))` appeared identically in `Identity`, `Proxy`, and `Dispatcher`. It is now the single `Identity::typeFromObject()` static method called from all three.

`Proxy::getDispatcher()` previously repeated the DI lookup and `instanceof` check on every API call. The resolved `Dispatcher` is now cached in a private field after the first resolution.