### PR TITLE
#3863 Followup Cleanup

### DIFF
--- a/src/modules/Cart/Api/Guest.php
+++ b/src/modules/Cart/Api/Guest.php
@@ -58,7 +58,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         $currencyRepository = $currencyService->getCurrencyRepository();
         $currency = $currencyRepository->findOneByCode($data['currency']);
         if (!$currency instanceof Currency) {
-            throw new \FOSSBilling\Exception('Currency not found');
+            throw new \FOSSBilling\InformationException('Currency not found');
         }
         $cart = $this->getService()->getSessionCart();
 
@@ -156,7 +156,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
 
         $product = $productService->findOneActiveById((int) $data['id']);
         if (!$product instanceof \Box\Mod\Product\Entity\Product) {
-            throw new \FOSSBilling\Exception('Product not found');
+            throw new \FOSSBilling\InformationException('Product not found');
         }
 
         if ($product->isAddon()) {

--- a/src/modules/Cart/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Cart/tests/Unit/Api/GuestTest.php
@@ -113,7 +113,7 @@ test('setCurrency throws exception when currency is not found', function (): voi
         'currency' => 'EUR',
     ];
 
-    expect(fn () => $guestApi->set_currency($data))->toThrow(FOSSBilling\Exception::class, 'Currency not found');
+    expect(fn () => $guestApi->set_currency($data))->toThrow(FOSSBilling\InformationException::class, 'Currency not found');
 });
 
 test('getCurrency returns array when currency found', function (): void {

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -535,7 +535,7 @@ class Service implements InjectionAwareInterface
         }
 
         if (!$client instanceof \Model_Client) {
-            throw new \FOSSBilling\Exception('Client not found');
+            throw new \FOSSBilling\InformationException('Client not found');
         }
 
         return $client;

--- a/src/modules/Client/tests/Unit/ServiceTest.php
+++ b/src/modules/Client/tests/Unit/ServiceTest.php
@@ -681,7 +681,7 @@ test('get throws exception when client not found', function (): void {
 
     $data = ['id' => 0];
     $service->get($data);
-})->throws(FOSSBilling\Exception::class, 'Client not found');
+})->throws(FOSSBilling\InformationException::class, 'Client not found');
 
 test('getClientBalance returns numeric', function (): void {
     $service = new Box\Mod\Client\Service();

--- a/src/modules/Email/Api/Admin.php
+++ b/src/modules/Email/Api/Admin.php
@@ -48,10 +48,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     {
         $this->checkPermissions('email', 'view_email_history');
 
-        $service = $this->getService();
-        $model = $service->getEmailById($data['id']);
+        $model = $this->getService()->getActivityClientEmailRepository()->findOneByIdOrFail((int) $data['id']);
 
-        return $service->toApiArray($model);
+        return $model->toApiArray();
     }
 
     /**

--- a/src/modules/Email/Api/Client.php
+++ b/src/modules/Email/Api/Client.php
@@ -54,7 +54,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
             (int) $data['id'],
         );
 
-        return $this->getService()->toApiArray($model);
+        return $model->toApiArray();
     }
 
     /**

--- a/src/modules/Email/Entity/ActivityClientEmail.php
+++ b/src/modules/Email/Entity/ActivityClientEmail.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use FOSSBilling\Doctrine\TimestampTrait;
 use FOSSBilling\Interfaces\ApiArrayInterface;
 use FOSSBilling\Interfaces\TimestampInterface;
+use FOSSBilling\Tools;
 
 /**
  * One row per email that FOSSBilling sent to a client.
@@ -62,7 +63,7 @@ class ActivityClientEmail implements ApiArrayInterface, TimestampInterface
             'sender' => $this->sender,
             'recipients' => $this->recipients,
             'subject' => $this->subject,
-            'content_html' => $this->contentHtml,
+            'content_html' => Tools::sanitizeContent($this->contentHtml ?? ''),
             'content_text' => $this->contentText,
             'created_at' => $this->getCreatedAt()?->format('Y-m-d H:i:s'),
             'updated_at' => $this->getUpdatedAt()?->format('Y-m-d H:i:s'),

--- a/src/modules/Email/Repository/ActivityClientEmailRepository.php
+++ b/src/modules/Email/Repository/ActivityClientEmailRepository.php
@@ -93,7 +93,7 @@ class ActivityClientEmailRepository extends EntityRepository
     {
         $email = $this->find($id);
         if (!$email instanceof ActivityClientEmail) {
-            throw new \FOSSBilling\Exception('Email not found');
+            throw new \FOSSBilling\InformationException('Email not found');
         }
 
         return $email;
@@ -106,7 +106,7 @@ class ActivityClientEmailRepository extends EntityRepository
     {
         $email = $this->findOneForClientById($clientId, $id);
         if (!$email instanceof ActivityClientEmail) {
-            throw new \FOSSBilling\Exception('Email not found');
+            throw new \FOSSBilling\InformationException('Email not found');
         }
 
         return $email;

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -21,7 +21,6 @@ use Box\Mod\Email\Repository\QueuedEmailRepository;
 use FOSSBilling\Config;
 use FOSSBilling\Environment;
 use FOSSBilling\PaginationOptions;
-use FOSSBilling\Tools;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -99,95 +98,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         ];
     }
 
-    public function getSearchQuery($data): array
-    {
-        $query = 'SELECT * FROM activity_client_email';
-
-        $search = $data['search'] ?? null;
-        $id = $data['id'] ?? null;
-        $client_id = $data['client_id'] ?? null;
-        $sender = $data['sender'] ?? null;
-        $recipient = $data['recipient'] ?? null;
-        $subject = $data['subject'] ?? null;
-        $date_from = $data['date_from'] ?? null;
-        $date_to = $data['date_to'] ?? null;
-
-        $where = [];
-        $bindings = [];
-
-        if ($id !== null && $id !== '') {
-            $where[] = 'id = :id';
-            $bindings[':id'] = (int) $id;
-        }
-
-        if ($search) {
-            $search = "%$search%";
-            $where[] = '(sender LIKE :sender OR recipients LIKE :recipient OR subject LIKE :subject OR content_text LIKE :content_text OR content_html LIKE :content_html)';
-            $bindings[':sender'] = $search;
-            $bindings[':recipient'] = $search;
-            $bindings[':subject'] = $search;
-            $bindings[':content_text'] = $search;
-            $bindings[':content_html'] = $search;
-        }
-
-        if ($sender !== null && $sender !== '') {
-            $where[] = 'sender LIKE :filter_sender';
-            $bindings[':filter_sender'] = '%' . $sender . '%';
-        }
-
-        if ($recipient !== null && $recipient !== '') {
-            $where[] = 'recipients LIKE :filter_recipient';
-            $bindings[':filter_recipient'] = '%' . $recipient . '%';
-        }
-
-        if ($subject !== null && $subject !== '') {
-            $where[] = 'subject LIKE :filter_subject';
-            $bindings[':filter_subject'] = '%' . $subject . '%';
-        }
-
-        if ($client_id !== null) {
-            $where[] = 'client_id = :client_id';
-            $bindings[':client_id'] = $client_id;
-        }
-
-        if ($date_from !== null && $date_from !== '') {
-            $where[] = 'created_at >= :date_from';
-            $bindings[':date_from'] = date('Y-m-d 00:00:00', strtotime((string) $date_from));
-        }
-
-        if ($date_to !== null && $date_to !== '') {
-            $where[] = 'created_at <= :date_to';
-            $bindings[':date_to'] = date('Y-m-d 23:59:59', strtotime((string) $date_to));
-        }
-
-        if (!empty($where)) {
-            $query = $query . ' WHERE ' . implode(' AND ', $where);
-        }
-        $query .= ' ORDER BY id DESC';
-
-        return [$query, $bindings];
-    }
-
     public function rmByClient(\Model_Client $client): bool
     {
         $this->getActivityClientEmailRepository()->deleteByClientId((int) $client->id);
 
         return true;
-    }
-
-    public function toApiArray(ActivityClientEmail $model, $deep = true): array
-    {
-        return [
-            'id' => $model->getId(),
-            'client_id' => $model->getClientId(),
-            'sender' => $model->getSender(),
-            'recipients' => $model->getRecipients(),
-            'subject' => $model->getSubject(),
-            'content_html' => Tools::sanitizeContent($model->getContentHtml() ?? ''),
-            'content_text' => $model->getContentText(),
-            'created_at' => $model->getCreatedAt()?->format('Y-m-d H:i:s'),
-            'updated_at' => $model->getUpdatedAt()?->format('Y-m-d H:i:s'),
-        ];
     }
 
     public function setVars(EmailTemplate $template, array $vars): bool
@@ -810,11 +725,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $this->di['logger']->info('Reset email template: %s', $template->getActionCode());
 
         return true;
-    }
-
-    public function getEmailById($id): ActivityClientEmail
-    {
-        return $this->getActivityClientEmailRepository()->findOneByIdOrFail((int) $id);
     }
 
     public function templateCreate($actionCode, $subject, $content, $enabled = 0, $category = null): EmailTemplate

--- a/src/modules/Email/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Email/tests/Unit/Api/AdminTest.php
@@ -79,15 +79,15 @@ test('email get', function (): void {
 
     $expected = $model->toApiArray();
 
+    $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
+    $repo->shouldReceive('findOneByIdOrFail')
+        ->once()
+        ->with($data['id'])
+        ->andReturn($model);
+
     $service = Mockery::mock(Box\Mod\Email\Service::class)->makePartial();
-    $service
-    ->shouldReceive('getEmailById')
-    ->atLeast()->once()
-    ->andReturn($model);
-    $service
-    ->shouldReceive('toApiArray')
-    ->atLeast()->once()
-    ->andReturn($expected);
+    $service->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
+    $service->shouldNotReceive('toApiArray');
 
     $di = container();
     $adminApi->setDi($di);

--- a/src/modules/Email/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Email/tests/Unit/Api/AdminTest.php
@@ -169,7 +169,7 @@ test('resend exception email not found', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $di = container();
     $adminApi->setDi($di);
@@ -178,7 +178,7 @@ test('resend exception email not found', function (): void {
     $emailService->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
     $adminApi->setService($emailService);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $this->expectExceptionMessage('Email not found');
     $adminApi->email_resend($data);
 });
@@ -192,7 +192,7 @@ test('delete exception email not found', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $di = container();
     $adminApi->setDi($di);
@@ -201,7 +201,7 @@ test('delete exception email not found', function (): void {
     $emailService->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
     $adminApi->setService($emailService);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $this->expectExceptionMessage('Email not found');
     $adminApi->email_delete($data);
 });

--- a/src/modules/Email/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Email/tests/Unit/Api/ClientTest.php
@@ -64,9 +64,7 @@ test('get', function (): void {
 
     $service = Mockery::mock(Box\Mod\Email\Service::class)->makePartial();
     $service->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
-    $service->shouldReceive('toApiArray')
-        ->atLeast()->once()
-        ->andReturn([]);
+    $service->shouldNotReceive('toApiArray');
     $clientApi->setService($service);
 
     $di = container();

--- a/src/modules/Email/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Email/tests/Unit/Api/ClientTest.php
@@ -86,7 +86,7 @@ test('get not found exception', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneForClientByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $service = Mockery::mock(Box\Mod\Email\Service::class)->makePartial();
     $service->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
@@ -101,7 +101,7 @@ test('get not found exception', function (): void {
 
     $clientApi->setService($service);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $result = $clientApi->get(['id' => 1]);
     expect($result)->toBeArray();
 });
@@ -142,7 +142,7 @@ test('resend not found exception', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneForClientByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $service = Mockery::mock(Box\Mod\Email\Service::class)->makePartial();
     $service->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
@@ -158,7 +158,7 @@ test('resend not found exception', function (): void {
 
     $clientApi->setService($service);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $result = $clientApi->resend(['id' => 1]);
     expect($result)->toBeArray();
 });
@@ -197,7 +197,7 @@ test('delete not found exception', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneForClientByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $service = Mockery::mock(Box\Mod\Email\Service::class)->makePartial();
     $service->shouldReceive('getActivityClientEmailRepository')->andReturn($repo);
@@ -213,7 +213,7 @@ test('delete not found exception', function (): void {
 
     $clientApi->setService($service);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $result = $clientApi->delete(['id' => 1]);
     expect($result)->toBeArray();
 });

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -104,65 +104,6 @@ test('di returns dependency injection container', function (): void {
     expect($result)->toBe($di);
 });
 
-dataset('getSearchQueryProvider', fn (): array => [
-    [
-        [],
-        'SELECT * FROM activity_client_email ORDER BY id DESC',
-        [],
-    ],
-    [
-        [
-            'search' => 'search_query',
-        ],
-        'SELECT * FROM activity_client_email WHERE (sender LIKE :sender OR recipients LIKE :recipient OR subject LIKE :subject OR content_text LIKE :content_text OR content_html LIKE :content_html) ORDER BY id DESC',
-        [
-            ':sender' => '%search_query%',
-            ':recipient' => '%search_query%',
-            ':subject' => '%search_query%',
-            ':content_text' => '%search_query%',
-            ':content_html' => '%search_query%',
-        ],
-    ],
-    [
-        [
-            'client_id' => 5,
-        ],
-        'SELECT * FROM activity_client_email WHERE client_id = :client_id ORDER BY id DESC',
-        [
-            ':client_id' => 5,
-        ],
-    ],
-    [
-        [
-            'search' => 'search_query',
-            'client_id' => 5,
-        ],
-        'SELECT * FROM activity_client_email WHERE (sender LIKE :sender OR recipients LIKE :recipient OR subject LIKE :subject OR content_text LIKE :content_text OR content_html LIKE :content_html) AND client_id = :client_id ORDER BY id DESC',
-        [
-            ':sender' => '%search_query%',
-            ':recipient' => '%search_query%',
-            ':subject' => '%search_query%',
-            ':content_text' => '%search_query%',
-            ':content_html' => '%search_query%',
-            ':client_id' => 5,
-        ],
-    ],
-]);
-
-test('getSearchQuery returns query and bindings', function (array $data, string $query, array $bindings): void {
-    $service = new Box\Mod\Email\Service();
-    $di = container();
-
-    $service->setDi($di);
-    $result = $service->getSearchQuery($data);
-
-    expect($result[0])->toBeString();
-    expect($result[1])->toBeArray();
-
-    expect($result[0])->toBe($query);
-    expect($result[1])->toBe($bindings);
-})->with('getSearchQueryProvider');
-
 test('rmByClient removes emails for client', function (): void {
     $service = new Box\Mod\Email\Service();
     $di = container();
@@ -184,15 +125,13 @@ test('rmByClient removes emails for client', function (): void {
     expect($result)->toBeTrue();
 });
 
-test('toApiArray returns API array for email', function (): void {
-    $service = new Box\Mod\Email\Service();
-
+test('ActivityClientEmail toApiArray returns sanitized API array', function (): void {
     $id = 10;
     $client_id = 5;
     $sender = 'sender@example.com';
     $recipients = 'recipient@example.com';
     $subject = 'Subject';
-    $content_html = 'HTML';
+    $content_html = '<script>alert("x")</script><p>HTML</p>';
     $content_text = 'TEXT';
     $created = new DateTime('-1 day');
     $updated = new DateTime();
@@ -214,13 +153,13 @@ test('toApiArray returns API array for email', function (): void {
         'sender' => $sender,
         'recipients' => $recipients,
         'subject' => $subject,
-        'content_html' => $content_html,
+        'content_html' => FOSSBilling\Tools::sanitizeContent($content_html),
         'content_text' => $content_text,
         'created_at' => $created->format('Y-m-d H:i:s'),
         'updated_at' => $updated->format('Y-m-d H:i:s'),
     ];
 
-    $result = $service->toApiArray($model);
+    $result = $model->toApiArray();
     expect($result)->toBeArray();
     expect($result)->toBe($expected);
 });
@@ -701,43 +640,6 @@ test('updateTemplate updates template', function (array $data, string $templateR
     $result = $emailService->updateTemplate($templateModel, $data['enabled'], $data['category'], $data['subject'], @$data['content']);
     expect($result)->toBeTrue();
 })->with('template_updateProvider');
-
-test('getEmailById returns email by ID', function (): void {
-    $service = new Box\Mod\Email\Service();
-
-    $id = 1;
-    $model = new Box\Mod\Email\Entity\ActivityClientEmail();
-    \Tests\Helpers\setEntityId($model, $id);
-
-    $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
-    $repo->shouldReceive('findOneByIdOrFail')
-        ->once()
-        ->with($id)
-        ->andReturn($model);
-
-    $di = container();
-    $di['em'] = emailBuildEm($repo);
-    $service->setDi($di);
-
-    $result = $service->getEmailById($id);
-
-    expect($result->getId())->toBe($id);
-});
-
-test('getEmailById throws exception when email not found', function (): void {
-    $service = new Box\Mod\Email\Service();
-
-    $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
-    $repo->shouldReceive('findOneByIdOrFail')
-        ->andThrow(new FOSSBilling\InformationException('Email not found'));
-
-    $di = container();
-    $di['em'] = emailBuildEm($repo);
-    $service->setDi($di);
-
-    expect(fn (): Box\Mod\Email\Entity\ActivityClientEmail => $service->getEmailById(5))
-        ->toThrow(FOSSBilling\InformationException::class);
-});
 
 test('templateCreate creates new template', function (): void {
     $service = new Box\Mod\Email\Service();

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -729,14 +729,14 @@ test('getEmailById throws exception when email not found', function (): void {
 
     $repo = Mockery::mock(Box\Mod\Email\Repository\ActivityClientEmailRepository::class);
     $repo->shouldReceive('findOneByIdOrFail')
-        ->andThrow(new FOSSBilling\Exception('Email not found'));
+        ->andThrow(new FOSSBilling\InformationException('Email not found'));
 
     $di = container();
     $di['em'] = emailBuildEm($repo);
     $service->setDi($di);
 
     expect(fn (): Box\Mod\Email\Entity\ActivityClientEmail => $service->getEmailById(5))
-        ->toThrow(FOSSBilling\Exception::class);
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('templateCreate creates new template', function (): void {

--- a/src/modules/Extension/Api/Admin.php
+++ b/src/modules/Extension/Api/Admin.php
@@ -286,7 +286,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $service = $this->getService();
         $ext = $service->getExtensionRepository()->findOneByTypeAndName($data['type'], $data['id']);
         if (!$ext instanceof Extension) {
-            throw new \FOSSBilling\Exception('Extension not found');
+            throw new \FOSSBilling\InformationException('Extension not found');
         }
 
         return $ext;

--- a/src/modules/Extension/Repository/ExtensionRepository.php
+++ b/src/modules/Extension/Repository/ExtensionRepository.php
@@ -60,6 +60,14 @@ class ExtensionRepository extends EntityRepository
     }
 
     /**
+     * @return Extension[]
+     */
+    public function findByType(string $type): array
+    {
+        return $this->findBy(['type' => $type]);
+    }
+
+    /**
      * Return all extensions of a given type that are currently installed.
      *
      * @return Extension[]
@@ -67,6 +75,17 @@ class ExtensionRepository extends EntityRepository
     public function findInstalledByType(string $type): array
     {
         return $this->findBy(['type' => $type, 'status' => Extension::STATUS_INSTALLED]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findInstalledNamesByType(string $type): array
+    {
+        return array_map(
+            static fn (Extension $extension): string => (string) $extension->getName(),
+            $this->findInstalledByType($type),
+        );
     }
 
     /**

--- a/src/modules/Extension/Service.php
+++ b/src/modules/Extension/Service.php
@@ -110,7 +110,7 @@ class Service implements InjectionAwareInterface
 
     public function removeNotExistingModules(): int
     {
-        $list = $this->getExtensionRepository()->findBy(['type' => Extension::TYPE_MOD]);
+        $list = $this->getExtensionRepository()->findByType(Extension::TYPE_MOD);
         $removedItems = 0;
         foreach ($list as $ext) {
             try {
@@ -136,9 +136,8 @@ class Service implements InjectionAwareInterface
     {
         $this->removeNotExistingModules();
 
-        $installedEntities = $this->getExtensionRepository()->getSearchQueryBuilder($filter)
-            ->andWhere('e.status = :status')
-            ->setParameter('status', Extension::STATUS_INSTALLED)
+        $installedEntities = $this->getExtensionRepository()
+            ->getSearchQueryBuilder([...$filter, 'status' => Extension::STATUS_INSTALLED])
             ->getQuery()
             ->getResult();
 
@@ -578,16 +577,7 @@ class Service implements InjectionAwareInterface
 
     public function getInstalledMods()
     {
-        $query = $this->di['dbal']->createQueryBuilder();
-        $query
-            ->select('name')
-            ->from('extension')
-            ->where('type = :type')
-            ->andWhere('status = :status')
-            ->setParameter('type', 'mod')
-            ->setParameter('status', 'installed');
-
-        return $query->executeQuery()->fetchFirstColumn();
+        return $this->getExtensionRepository()->findInstalledNamesByType(Extension::TYPE_MOD);
     }
 
     private function installModule(Extension $ext): bool
@@ -779,22 +769,7 @@ class Service implements InjectionAwareInterface
      */
     public function getCoreAndActiveModules(): array
     {
-        $query = $this->di['dbal']->createQueryBuilder();
-        $query
-            ->select('name', 'name')
-            ->from('extension')
-            ->where('type = :type')
-            ->andWhere('status = :status')
-            ->setParameter('type', 'mod')
-            ->setParameter('status', 'installed');
-        $result = $query->executeQuery();
-        $extensions = $result->fetchAllKeyValue();
-
-        if (!$extensions) {
-            $list = [];
-        } else {
-            $list = array_values($extensions);
-        }
+        $list = $this->getExtensionRepository()->findInstalledNamesByType(Extension::TYPE_MOD);
 
         $extensionMod = $this->di['mod']('extension');
         $mods = $extensionMod->getCoreModules();

--- a/src/modules/Extension/tests/Unit/Repository/ExtensionRepositoryTest.php
+++ b/src/modules/Extension/tests/Unit/Repository/ExtensionRepositoryTest.php
@@ -60,6 +60,16 @@ test('findOneByTypeAndName delegates to findOneBy', function (): void {
     expect($repo->findOneByTypeAndName('mod', 'sample'))->toBeNull();
 });
 
+test('findByType delegates to findBy', function (): void {
+    $repo = Mockery::mock(ExtensionRepository::class)->makePartial();
+    $repo->shouldReceive('findBy')
+        ->once()
+        ->with(['type' => 'mod'])
+        ->andReturn([]);
+
+    expect($repo->findByType('mod'))->toBe([]);
+});
+
 test('findInstalledByType returns installed extensions', function (): void {
     $repo = Mockery::mock(ExtensionRepository::class)->makePartial();
     $repo->shouldReceive('findBy')
@@ -68,6 +78,19 @@ test('findInstalledByType returns installed extensions', function (): void {
         ->andReturn([]);
 
     expect($repo->findInstalledByType('mod'))->toBe([]);
+});
+
+test('findInstalledNamesByType returns names for installed extensions', function (): void {
+    $extension = new Extension();
+    $extension->setName('sample');
+
+    $repo = Mockery::mock(ExtensionRepository::class)->makePartial();
+    $repo->shouldReceive('findInstalledByType')
+        ->once()
+        ->with('mod')
+        ->andReturn([$extension]);
+
+    expect($repo->findInstalledNamesByType('mod'))->toBe(['sample']);
 });
 
 test('existsActiveByTypeAndName returns true when found', function (): void {

--- a/src/modules/Extension/tests/Unit/ServiceTest.php
+++ b/src/modules/Extension/tests/Unit/ServiceTest.php
@@ -298,7 +298,7 @@ test('getAdminNavigation returns admin navigation', function (): void {
         ->andReturn([]);
 
     $di = container();
-    $di['mod'] = $di->protect(fn (): Mockery\MockInterface => $modMock);
+    $di['mod'] = $di->protect(fn ($name): Mockery\MockInterface => $modMock);
     $di['tools'] = new FOSSBilling\Tools();
     $di['em'] = extensionBuildEm($extensionRepository);
 

--- a/src/modules/Extension/tests/Unit/ServiceTest.php
+++ b/src/modules/Extension/tests/Unit/ServiceTest.php
@@ -145,8 +145,8 @@ test('removeNotExistingModules removes non-existing modules', function (): void 
     $modMock->shouldReceive('getManifest')->andThrow(new Exception());
 
     $extensionRepository = Mockery::mock(ExtensionRepository::class);
-    $extensionRepository->shouldReceive('findBy')
-        ->with(['type' => Extension::TYPE_MOD])
+    $extensionRepository->shouldReceive('findByType')
+        ->with(Extension::TYPE_MOD)
         ->atLeast()
         ->once()
         ->andReturn([$ext]);
@@ -211,7 +211,7 @@ test('getExtensionsList returns filtered extensions list', function (): void {
 
     $extensionRepository = Mockery::mock(ExtensionRepository::class);
     $extensionRepository->shouldReceive('getSearchQueryBuilder')->andReturn($qb);
-    $extensionRepository->shouldReceive('findBy')->andReturn([]);
+    $extensionRepository->shouldReceive('findByType')->andReturn([]);
 
     $em = extensionBuildEm($extensionRepository);
     $em->shouldReceive('remove')->andReturnNull();
@@ -260,7 +260,7 @@ test('getExtensionsList returns only installed extensions', function (): void {
 
     $extensionRepository = Mockery::mock(ExtensionRepository::class);
     $extensionRepository->shouldReceive('getSearchQueryBuilder')->andReturn($qb);
-    $extensionRepository->shouldReceive('findBy')->andReturn([]);
+    $extensionRepository->shouldReceive('findByType')->andReturn([]);
 
     $em = extensionBuildEm($extensionRepository);
     $em->shouldReceive('remove')->andReturnNull();
@@ -288,86 +288,19 @@ test('getExtensionsList returns only installed extensions', function (): void {
 
 test('getAdminNavigation returns admin navigation', function (): void {
     $service = new Service();
-    $extensionServiceMock = Mockery::mock(Service::class)->makePartial();
-    $extensionServiceMock->shouldAllowMockingProtectedMethods();
-    $extensionServiceMock->shouldReceive('getConfig')
-        ->atLeast()
+    $modMock = Mockery::mock(FOSSBilling\Module::class);
+    $modMock->shouldReceive('getCoreModules')->once()->andReturn([]);
+
+    $extensionRepository = Mockery::mock(ExtensionRepository::class);
+    $extensionRepository->shouldReceive('findInstalledNamesByType')
         ->once()
+        ->with(Extension::TYPE_MOD)
         ->andReturn([]);
 
-    $staffServiceMock = Mockery::mock(Box\Mod\Staff\Service::class);
-    $staffServiceMock->shouldReceive('hasPermission')
-        ->atLeast()
-        ->once()
-        ->andReturn(true);
-
-    $dbalMock = new class {
-        public function createQueryBuilder(): object
-        {
-            return new class {
-                public function select($field)
-                {
-                    return $this;
-                }
-
-                public function from($table)
-                {
-                    return $this;
-                }
-
-                public function where($cond)
-                {
-                    return $this;
-                }
-
-                public function andWhere($cond)
-                {
-                    return $this;
-                }
-
-                public function setParameter($key, $val)
-                {
-                    return $this;
-                }
-
-                public function executeQuery()
-                {
-                    return $this;
-                }
-
-                public function fetchFirstColumn(): array
-                {
-                    return [];
-                }
-            };
-        }
-    };
-
-    $link = 'extension';
-
-    $urlMock = Mockery::mock('Box_Url');
-    $urlMock->shouldReceive('adminLink')
-        ->atLeast()
-        ->once()
-        ->andReturn('http://fossbilling.org/index.php?_url=/' . $link);
-
     $di = container();
-    $di['mod'] = $di->protect(function ($name) use ($di) {
-        $mod = new FOSSBilling\Module($name);
-        $mod->setDi($di);
-
-        return $mod;
-    });
+    $di['mod'] = $di->protect(fn (): Mockery\MockInterface => $modMock);
     $di['tools'] = new FOSSBilling\Tools();
-    $di['mod_service'] = $di->protect(function ($mod) use ($extensionServiceMock, $staffServiceMock) {
-        if ($mod == 'staff') {
-            return $staffServiceMock;
-        }
-
-        return $extensionServiceMock;
-    });
-    $di['url'] = $urlMock;
-    $di['dbal'] = $dbalMock;
+    $di['em'] = extensionBuildEm($extensionRepository);
 
     $service->setDi($di);
     $result = $service->getAdminNavigation(new Model_Admin());
@@ -666,51 +599,15 @@ test('downloadAndExtract throws exception when download URL is missing', functio
 
 test('getInstalledMods returns installed modules', function (): void {
     $service = new Service();
-    $dbalMock = new class {
-        public function createQueryBuilder(): object
-        {
-            return new class {
-                public function select($field)
-                {
-                    return $this;
-                }
 
-                public function from($table)
-                {
-                    return $this;
-                }
-
-                public function where($cond)
-                {
-                    return $this;
-                }
-
-                public function andWhere($cond)
-                {
-                    return $this;
-                }
-
-                public function setParameter($key, $val)
-                {
-                    return $this;
-                }
-
-                public function executeQuery()
-                {
-                    return $this;
-                }
-
-                public function fetchFirstColumn(): array
-                {
-                    return [];
-                }
-            };
-        }
-    };
+    $extensionRepository = Mockery::mock(ExtensionRepository::class);
+    $extensionRepository->shouldReceive('findInstalledNamesByType')
+        ->once()
+        ->with(Extension::TYPE_MOD)
+        ->andReturn([]);
 
     $di = new Pimple\Container();
-    $di['dbal'] = $dbalMock;
-    $di['em'] = extensionBuildEm();
+    $di['em'] = extensionBuildEm($extensionRepository);
 
     $service->setDi($di);
     $result = $service->getInstalledMods();

--- a/src/modules/Formbuilder/Service.php
+++ b/src/modules/Formbuilder/Service.php
@@ -266,7 +266,7 @@ class Service implements InjectionAwareInterface
         )->fetchAssociative();
 
         if ($result === false) {
-            throw new \FOSSBilling\Exception('Form was not found');
+            throw new \FOSSBilling\InformationException('Form was not found');
         }
 
         $result['style'] = json_decode($result['style'] ?? '', true);
@@ -328,7 +328,7 @@ class Service implements InjectionAwareInterface
         )->fetchAssociative();
 
         if ($result === false) {
-            throw new \FOSSBilling\Exception('Field was not found');
+            throw new \FOSSBilling\InformationException('Field was not found');
         }
 
         $required = [
@@ -359,7 +359,7 @@ class Service implements InjectionAwareInterface
     {
         $deleted = $this->getDbal()->executeStatement('DELETE FROM form_field WHERE id = ?', [$data['id']]);
         if ($deleted === 0) {
-            throw new \FOSSBilling\Exception('Field was not found');
+            throw new \FOSSBilling\InformationException('Field was not found');
         }
 
         $this->di['logger']->info('Deleted custom field %s', $data['id']);

--- a/src/modules/Invoice/Api/Client.php
+++ b/src/modules/Invoice/Api/Client.php
@@ -55,7 +55,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
         $identity = $this->getIdentity();
         $model = $this->getDi()['db']->findOne('Invoice', 'hash = :hash AND client_id = :client_id', ['hash' => $data['hash'], 'client_id' => $identity->id]);
         if (!$model) {
-            throw new \FOSSBilling\Exception('Invoice was not found');
+            throw new \FOSSBilling\InformationException('Invoice was not found');
         }
 
         return $this->getService()->toApiArray($model, true, $identity);
@@ -75,7 +75,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
     {
         $model = $this->getDi()['db']->findOne('ClientOrder', 'client_id = ? and id = ?', [$this->getIdentity()->id, $data['order_id']]);
         if (!$model instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
         if ($model->price <= 0) {
             throw new \FOSSBilling\InformationException('Order :id is free. No need to generate invoice.', [':id' => $model->id]);

--- a/src/modules/Invoice/Api/Guest.php
+++ b/src/modules/Invoice/Api/Guest.php
@@ -32,7 +32,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
     public function get($data)
     {
         if (!preg_match('/^[a-f0-9]{30,60}$/', (string) $data['hash'])) {
-            throw new \FOSSBilling\Exception('Invalid invoice hash', null, 4001);
+            throw new \FOSSBilling\InformationException('Invalid invoice hash', null, 4001);
         }
 
         $this->getDi()['rate_limiter']->consumeOrThrow('invoice_get_ip', (string) $this->getIp());
@@ -40,7 +40,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getDi()['db']->findOne('Invoice', 'hash = :hash', ['hash' => $data['hash']]);
         if (!$model) {
-            throw new \FOSSBilling\Exception('Invoice was not found');
+            throw new \FOSSBilling\InformationException('Invoice was not found');
         }
         $service = $this->getService();
         $service->checkInvoiceAuth($model, InvoiceOperation::READ);
@@ -87,7 +87,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         }
 
         if (empty($data['gateway_id'])) {
-            throw new \FOSSBilling\Exception('Payment method not found. Missing param gateway_id', null, 811);
+            throw new \FOSSBilling\InformationException('Payment method not found. Missing param gateway_id', null, 811);
         }
 
         $this->getDi()['rate_limiter']->consumeOrThrow('invoice_payment_ip', (string) $this->getIp());

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1472,14 +1472,14 @@ class Service implements InjectionAwareInterface
 
         $invoice = $this->di['db']->findOne('Invoice', 'hash = ?', [$data['hash']]);
         if (!$invoice instanceof \Model_Invoice) {
-            throw new \FOSSBilling\Exception('Invoice not found', null, 812);
+            throw new \FOSSBilling\InformationException('Invoice not found', null, 812);
         }
 
         $this->checkInvoiceAuth($invoice, InvoiceOperation::PAYMENT);
 
         $gtw = $this->di['db']->load('PayGateway', $data['gateway_id']);
         if (!$gtw instanceof \Model_PayGateway) {
-            throw new \FOSSBilling\Exception('Payment method not found', null, 813);
+            throw new \FOSSBilling\InformationException('Payment method not found', null, 813);
         }
 
         if (!$gtw->enabled) {
@@ -1547,7 +1547,7 @@ class Service implements InjectionAwareInterface
         $invoice = $this->di['db']->findOne('Invoice', 'hash = :hash', [':hash' => $hash]);
 
         if (!$invoice instanceof \Model_Invoice) {
-            throw new \FOSSBilling\Exception('Invoice not found');
+            throw new \FOSSBilling\InformationException('Invoice not found');
         }
 
         $this->checkInvoiceAuth($invoice, InvoiceOperation::READ);

--- a/src/modules/Invoice/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/ClientTest.php
@@ -73,7 +73,7 @@ test('throws exception when invoice is not found', function (): void {
 
     $data['hash'] = md5('1');
     expect(fn () => $api->get($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Invoice was not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Invoice was not found');
 });
 
 test('creates renewal invoice', function (): void {
@@ -161,7 +161,7 @@ test('throws exception when creating renewal invoice for order not found', funct
     $data['order_id'] = 1;
 
     expect(fn () => $api->renewal_invoice($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Order not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Order not found');
 });
 
 test('creates funds invoice', function (): void {

--- a/src/modules/Invoice/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/GuestTest.php
@@ -70,7 +70,7 @@ test('throws exception when invoice is not found', function (): void {
 
     $data['hash'] = md5('1');
     expect(fn () => $api->get($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Invoice was not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Invoice was not found');
 });
 
 test('gets active gateways', function (): void {
@@ -123,7 +123,7 @@ test('throws exception when payment gateway id is missing', function (): void {
     ];
 
     expect(fn () => $api->payment($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Payment method not found. Missing param gateway_id');
+        ->toThrow(FOSSBilling\InformationException::class, 'Payment method not found. Missing param gateway_id');
 });
 
 test('generates PDF', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1832,7 +1832,7 @@ test('throws exception when processing invoice not found', function (): void {
     $service->setDi($di);
 
     expect(fn (): array => $service->processInvoice($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Invoice not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Invoice not found');
 });
 
 test('throws exception when processing invoice with gateway not found', function (): void {
@@ -1859,7 +1859,7 @@ test('throws exception when processing invoice with gateway not found', function
     $service->setDi($di);
 
     expect(fn (): array => $service->processInvoice($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Payment method not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Payment method not found');
 });
 
 test('throws exception when processing invoice with gateway not enabled', function (): void {

--- a/src/modules/Massmailer/Api/Admin.php
+++ b/src/modules/Massmailer/Api/Admin.php
@@ -328,7 +328,7 @@ Order our services at {{ "order"|url }}
     {
         $model = $this->getService()->getMessageRepository()->find((int) $data['id']);
         if (!$model instanceof MassmailerMessage) {
-            throw new \FOSSBilling\Exception('Message not found');
+            throw new \FOSSBilling\InformationException('Message not found');
         }
 
         return $model;

--- a/src/modules/Massmailer/Service.php
+++ b/src/modules/Massmailer/Service.php
@@ -279,7 +279,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     {
         $model = $this->getMessageRepository()->find((int) $params['msg_id']);
         if (!$model instanceof MassmailerMessage) {
-            throw new \Exception('Mass mail message not found');
+            throw new \FOSSBilling\InformationException('Mass mail message not found');
         }
         $this->sendMessage($model, (int) $params['client_id']);
     }

--- a/src/modules/News/Api/Admin.php
+++ b/src/modules/News/Api/Admin.php
@@ -43,7 +43,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @param array $data ['id' => int|null, 'slug' => string|null]
      *
-     * @throws \FOSSBilling\Exception if ID/slug is missing or news item not found
+     * @throws \FOSSBilling\InformationException if ID/slug is missing or news item not found
      */
     public function get(array $data): array
     {
@@ -67,7 +67,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         }
 
         if (!$post instanceof Post) {
-            throw new \FOSSBilling\Exception('News item not found.');
+            throw new \FOSSBilling\InformationException('News item not found.');
         }
 
         /** @todo Doctrine: Replace with actual Admin entity once it's migrated to Doctrine. */
@@ -92,7 +92,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $post = $repo->find($data['id']);
 
         if (!$post instanceof Post) {
-            throw new \FOSSBilling\Exception('News item not found');
+            throw new \FOSSBilling\InformationException('News item not found');
         }
 
         $service = $this->getService();
@@ -162,7 +162,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $post = $repo->find($data['id']);
 
         if (!$post instanceof Post) {
-            throw new \FOSSBilling\Exception('News item not found');
+            throw new \FOSSBilling\InformationException('News item not found');
         }
 
         $this->getDi()['em']->remove($post);

--- a/src/modules/News/Api/Guest.php
+++ b/src/modules/News/Api/Guest.php
@@ -42,7 +42,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
      *
      * @param array $data ['id' => int|null, 'slug' => string|null]
      *
-     * @throws \FOSSBilling\Exception if ID/slug is missing or news item not found
+     * @throws \FOSSBilling\InformationException if ID/slug is missing or news item not found
      */
     public function get(array $data): array
     {
@@ -50,7 +50,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         $slug = $data['slug'] ?? null;
 
         if (!$id && !$slug) {
-            throw new \FOSSBilling\Exception('ID or slug is required.');
+            throw new \FOSSBilling\InformationException('ID or slug is required.');
         }
 
         /** @var \Box\Mod\News\Repository\PostRepository $repo */
@@ -64,7 +64,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         }
 
         if (!$post || $post->getStatus() !== Post::STATUS_ACTIVE) {
-            throw new \FOSSBilling\Exception('News item not found.');
+            throw new \FOSSBilling\InformationException('News item not found.');
         }
 
         /**@todo Doctrine: Replace with actual Admin entity once it's migrated to Doctrine. */

--- a/src/modules/Notification/Service.php
+++ b/src/modules/Notification/Service.php
@@ -103,7 +103,7 @@ class Service implements InjectionAwareInterface
     {
         $meta = $this->getExtensionMetaRepository()->findOneByExtensionAndId('mod_notification', $id);
         if (!$meta instanceof ExtensionMeta || $meta->getMetaKey() !== 'message') {
-            throw new \FOSSBilling\Exception('Notification message was not found');
+            throw new \FOSSBilling\InformationException('Notification message was not found');
         }
 
         return $meta;

--- a/src/modules/Order/Api/Client.php
+++ b/src/modules/Order/Api/Client.php
@@ -124,7 +124,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
 
         $order = $this->getService()->findForClientById($this->getIdentity(), $data['id']);
         if (!$order instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
 
         return $order;

--- a/src/modules/Product/Api/Admin.php
+++ b/src/modules/Product/Api/Admin.php
@@ -220,7 +220,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return array
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['id' => 'Addon ID was not passed'])]
     public function addon_get($data)
@@ -229,7 +229,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getService()->findProductById((int) $data['id']);
         if (!$model instanceof Product || !$model->isAddon()) {
-            throw new \FOSSBilling\Exception('Addon not found');
+            throw new \FOSSBilling\InformationException('Addon not found');
         }
         $service = $this->getService();
 
@@ -257,7 +257,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return bool
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['id' => 'Addon ID was not passed'])]
     public function addon_update($data)
@@ -266,7 +266,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getService()->findProductById((int) $data['id']);
         if (!$model instanceof Product || !$model->isAddon()) {
-            throw new \FOSSBilling\Exception('Addon not found');
+            throw new \FOSSBilling\InformationException('Addon not found');
         }
         $this->di['logger']->info('Updated addon #%s', $model->getId());
 

--- a/src/modules/Product/Api/Guest.php
+++ b/src/modules/Product/Api/Guest.php
@@ -71,7 +71,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         }
 
         if (!$model instanceof Product) {
-            throw new \FOSSBilling\Exception('Product not found');
+            throw new \FOSSBilling\InformationException('Product not found');
         }
 
         return $service->toApiArray($model);

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -826,7 +826,7 @@ class Service implements InjectionAwareInterface
     {
         $category = $this->getProductCategoryRepository()->findById($id);
         if (!$category instanceof ProductCategory) {
-            throw new \FOSSBilling\Exception('Category not found');
+            throw new \FOSSBilling\InformationException('Category not found');
         }
 
         return $category;
@@ -1188,7 +1188,7 @@ class Service implements InjectionAwareInterface
     {
         $promo = $this->getPromoRepository()->find($id);
         if (!$promo instanceof Promo) {
-            throw new \FOSSBilling\Exception('Promo not found');
+            throw new \FOSSBilling\InformationException('Promo not found');
         }
 
         return $promo;
@@ -1726,7 +1726,7 @@ class Service implements InjectionAwareInterface
     {
         $productPayment = $this->getProductPaymentRepository()->find($id);
         if (!$productPayment instanceof ProductPayment) {
-            throw new \FOSSBilling\Exception('Product payment not found');
+            throw new \FOSSBilling\InformationException('Product payment not found');
         }
 
         return $productPayment;
@@ -1832,7 +1832,7 @@ class Service implements InjectionAwareInterface
     {
         $product = $this->getProductRepository()->find($id);
         if (!$product instanceof Product) {
-            throw new \FOSSBilling\Exception('Product not found');
+            throw new \FOSSBilling\InformationException('Product not found');
         }
 
         return $product;

--- a/src/modules/Product/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Product/tests/Unit/Api/GuestTest.php
@@ -70,7 +70,7 @@ test('throws exception when product not found', function (): void {
     $api->setService($serviceMock);
 
     expect(fn () => $api->get($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Product not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Product not found');
 });
 
 test('gets paginated product list', function (): void {

--- a/src/modules/Servicecustom/Service.php
+++ b/src/modules/Servicecustom/Service.php
@@ -92,7 +92,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     {
         $product = $this->di['mod_service']('product')->findProductById((int) $order->product_id);
         if (!$product instanceof Product) {
-            throw new \FOSSBilling\Exception('Product not found');
+            throw new \FOSSBilling\InformationException('Product not found');
         }
 
         $model = $this->di['db']->dispense('ServiceCustom');
@@ -261,7 +261,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         if ($clientId !== null) {
             $order = $this->di['db']->findOne('ClientOrder', 'id = ? AND client_id = ?', [$orderId, $clientId]);
             if (!$order instanceof \Model_ClientOrder) {
-                throw new \FOSSBilling\Exception('Order not found');
+                throw new \FOSSBilling\InformationException('Order not found');
             }
 
             if ($order->status !== \Model_ClientOrder::STATUS_ACTIVE) {
@@ -292,7 +292,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         // check if plugin exists. If plugin does not exist, do not throw error. Simply add to log
         $file = Path::join('Plugin', $plugin, "{$plugin}.php");
         if (!Environment::isTesting() && !$this->filesystem->exists(Path::join(PATH_LIBRARY, $file))) {
-            $e = new \FOSSBilling\Exception('Plugin class file :file was not found', [':file' => $file], 3124);
+            $e = new \FOSSBilling\InformationException('Plugin class file :file was not found', [':file' => $file], 3124);
             // @phpstan-ignore if.alwaysFalse (DEBUG is a runtime constant that may be true during debugging)
             if (DEBUG) {
                 error_log($e->getMessage());

--- a/src/modules/Servicecustom/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicecustom/tests/Unit/ServiceTest.php
@@ -557,7 +557,7 @@ test('get service custom by order id rejects order owned by another client', fun
     $service->setDi($di);
 
     expect(fn () => $service->getServiceCustomByOrderId(1, 42))
-        ->toThrow(Exception::class, 'Order not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Order not found');
 });
 
 test('get service custom by order id order service not found exception', function (): void {

--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -171,7 +171,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return array
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['tld' => 'TLD is missing'])]
     public function tld_get($data)
@@ -185,7 +185,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getService()->tldFindOneByTld($tld);
         if (!$model instanceof \Model_Tld) {
-            throw new \FOSSBilling\Exception('TLD not found');
+            throw new \FOSSBilling\InformationException('TLD not found');
         }
 
         return $this->getService()->tldToApiArray($model, $this->identity);
@@ -196,7 +196,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return array
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['id' => 'ID is missing'])]
     public function tld_get_id($data)
@@ -205,7 +205,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getService()->tldFindOneById($data['id']);
         if (!$model instanceof \Model_Tld) {
-            throw new \FOSSBilling\Exception('ID not found');
+            throw new \FOSSBilling\InformationException('TLD not found');
         }
 
         return $this->getService()->tldToApiArray($model, $this->identity);
@@ -216,7 +216,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return bool
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['tld' => 'TLD is missing'])]
     public function tld_delete($data)
@@ -226,7 +226,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $model = $this->getService()->tldFindOneByTld($data['tld']);
 
         if (!$model instanceof \Model_Tld) {
-            throw new \FOSSBilling\Exception('TLD not found');
+            throw new \FOSSBilling\InformationException('TLD not found');
         }
         // check if tld is used by any domain
         $service_domains = $this->getDi()['db']->find('ServiceDomain', 'tld = :tld', [':tld' => $data['tld']]);
@@ -273,7 +273,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return bool
      *
-     * @throws \FOSSBilling\Exception
+     * @throws \FOSSBilling\InformationException
      */
     #[RequiredParams(['tld' => 'TLD is missing'])]
     public function tld_update($data)
@@ -282,7 +282,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $model = $this->getService()->tldFindOneByTld($data['tld']);
         if (!$model instanceof \Model_Tld) {
-            throw new \FOSSBilling\Exception('TLD not found');
+            throw new \FOSSBilling\InformationException('TLD not found');
         }
 
         return $this->getService()->tldUpdate($model, $data);

--- a/src/modules/Servicedomain/Api/Client.php
+++ b/src/modules/Servicedomain/Api/Client.php
@@ -119,7 +119,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
 
         $order = $orderService->findForClientById($this->getIdentity(), $data['order_id']);
         if (!$order instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
 
         $s = $orderService->getOrderService($order);

--- a/src/modules/Servicedomain/Api/Guest.php
+++ b/src/modules/Servicedomain/Api/Guest.php
@@ -64,7 +64,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
     {
         $model = $this->getService()->tldFindOneByTld($data['tld']);
         if (!$model instanceof \Model_Tld) {
-            throw new \FOSSBilling\Exception('TLD not found');
+            throw new \FOSSBilling\InformationException('TLD not found');
         }
 
         return $this->getService()->tldToApiArray($model);

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -124,7 +124,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
             $tld = $this->tldFindOneByTld($data['transfer_tld']);
             if (!$tld instanceof \Model_Tld) {
-                throw new \FOSSBilling\Exception('TLD not found');
+                throw new \FOSSBilling\InformationException('TLD not found');
             }
 
             $domain = $data['transfer_sld'] . $tld->tld;
@@ -153,7 +153,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
             $tld = $this->tldFindOneByTld($data['register_tld']);
             if (!$tld instanceof \Model_Tld) {
-                throw new \FOSSBilling\Exception('TLD not found');
+                throw new \FOSSBilling\InformationException('TLD not found');
             }
 
             $years = (int) $data['register_years'];
@@ -980,7 +980,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     {
         $file = Path::join(PATH_LIBRARY, 'Registrar', 'Adapter', "{$model->registrar}.php");
         if (!$this->filesystem->exists($file)) {
-            throw new \FOSSBilling\Exception('Domain registrar :adapter was not found', [':adapter' => $model->registrar]);
+            throw new \FOSSBilling\InformationException('Domain registrar :adapter was not found', [':adapter' => $model->registrar]);
         }
 
         $class = sprintf('Registrar_Adapter_%s', $model->registrar);
@@ -989,7 +989,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         }
 
         if (!class_exists($class)) {
-            throw new \FOSSBilling\Exception('Registrar :adapter was not found', [':adapter' => $class]);
+            throw new \FOSSBilling\InformationException('Registrar :adapter was not found', [':adapter' => $class]);
         }
 
         return $class;

--- a/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
@@ -276,7 +276,7 @@ test('throws exception when getting tld not found', function (): void {
     ];
 
     expect(fn () => $adminApi->tld_get($data))
-        ->toThrow(FOSSBilling\Exception::class);
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('deletes tld', function (): void {
@@ -333,7 +333,7 @@ test('throws exception when deleting tld not found', function (): void {
     ];
 
     expect(fn () => $adminApi->tld_delete($data))
-        ->toThrow(FOSSBilling\Exception::class);
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('creates tld', function (): void {
@@ -380,7 +380,7 @@ test('throws exception when creating already registered tld', function (): void 
     ];
 
     expect(fn () => $adminApi->tld_create($data))
-        ->toThrow(FOSSBilling\Exception::class);
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('updates tld', function (): void {

--- a/src/modules/Servicedomain/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/GuestTest.php
@@ -85,7 +85,7 @@ test('throws exception when getting pricing for tld not found', function (): voi
     ];
 
     expect(fn () => $guestApi->pricing($data))
-        ->toThrow(FOSSBilling\Exception::class);
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('checks domain availability', function (): void {

--- a/src/modules/Servicedownloadable/Api/Client.php
+++ b/src/modules/Servicedownloadable/Api/Client.php
@@ -34,7 +34,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
         $identity = $this->getIdentity();
         $order = $this->getDi()['db']->findOne('ClientOrder', 'id = :id AND client_id = :client_id', [':id' => $data['order_id'], ':client_id' => $identity->id]);
         if (!$order instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
 
         $orderService = $this->getDi()['mod_service']('order');

--- a/src/modules/Servicedownloadable/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Servicedownloadable/tests/Unit/Api/ClientTest.php
@@ -50,7 +50,7 @@ test('throws exception when sending file with order not found', function (): voi
     $api->setDi($di);
 
     expect(fn (): bool => $api->send_file($data))
-        ->toThrow(FOSSBilling\Exception::class, 'Order not found');
+        ->toThrow(FOSSBilling\InformationException::class, 'Order not found');
 });
 
 test('throws exception when sending file with order not activated', function (): void {

--- a/src/modules/Servicehosting/Api/Client.php
+++ b/src/modules/Servicehosting/Api/Client.php
@@ -85,13 +85,13 @@ class Client extends \FOSSBilling\Api\AbstractApi
         $identity = $this->getIdentity();
         $order = $this->getDi()['db']->findOne('ClientOrder', 'id = ? and client_id = ?', [$data['order_id'], $identity->id]);
         if (!$order instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
 
         $orderService = $this->getDi()['mod_service']('order');
         $s = $orderService->getOrderService($order);
         if (!$s instanceof \Model_ServiceHosting || $order->status !== \Model_ClientOrder::STATUS_ACTIVE) {
-            throw new \FOSSBilling\Exception('Order is not activated');
+            throw new \FOSSBilling\InformationException('Order is not activated');
         }
 
         return [$order, $s];

--- a/src/modules/Servicehosting/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Servicehosting/tests/Unit/Api/ClientTest.php
@@ -173,7 +173,7 @@ test('testGetServiceOrderNotActivated', function (): void {
     $clientModel->id = 1;
     $api->setIdentity($clientModel);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $this->expectExceptionMessage('Order is not activated');
     $api->_getService($data);
 });
@@ -201,7 +201,7 @@ test('testGetServiceOrderNotFound', function (): void {
     $clientModel->id = 1;
     $api->setIdentity($clientModel);
 
-    $this->expectException(FOSSBilling\Exception::class);
+    $this->expectException(FOSSBilling\InformationException::class);
     $this->expectExceptionMessage('Order not found');
     $api->_getService($data);
 });

--- a/src/modules/Servicelicense/Api/Client.php
+++ b/src/modules/Servicelicense/Api/Client.php
@@ -44,7 +44,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
         $order = $this->getDi()['db']->findOne('ClientOrder', 'id = :id AND client_id = :client_id', $bindings);
 
         if (!$order instanceof \Model_ClientOrder) {
-            throw new \FOSSBilling\Exception('Order not found');
+            throw new \FOSSBilling\InformationException('Order not found');
         }
 
         if ($order->status !== \Model_ClientOrder::STATUS_ACTIVE) {

--- a/src/modules/Support/Entity/SupportTicket.php
+++ b/src/modules/Support/Entity/SupportTicket.php
@@ -186,6 +186,20 @@ class SupportTicket implements ApiArrayInterface, TimestampInterface
         return $helpdesk->canReopen();
     }
 
+    public function close(): self
+    {
+        $this->status = self::STATUS_CLOSED;
+
+        return $this;
+    }
+
+    public function markTaskComplete(): self
+    {
+        $this->relStatus = self::REL_STATUS_COMPLETE;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/modules/Support/Repository/HelpdeskRepository.php
+++ b/src/modules/Support/Repository/HelpdeskRepository.php
@@ -50,6 +50,16 @@ class HelpdeskRepository extends EntityRepository
         return $pairs;
     }
 
+    /**
+     * @param list<int> $ids
+     *
+     * @return Helpdesk[]
+     */
+    public function findByIds(array $ids): array
+    {
+        return $ids === [] ? [] : $this->findBy(['id' => $ids]);
+    }
+
     public function countTickets(int $helpdeskId): int
     {
         return (int) $this->getEntityManager()->getConnection()->fetchOne(

--- a/src/modules/Support/Repository/SupportTicketMessageRepository.php
+++ b/src/modules/Support/Repository/SupportTicketMessageRepository.php
@@ -23,7 +23,7 @@ class SupportTicketMessageRepository extends EntityRepository
     {
         $message = $this->find($id);
         if (!$message instanceof SupportTicketMessage) {
-            throw new \FOSSBilling\Exception('Ticket message not found');
+            throw new \FOSSBilling\InformationException('Ticket message not found');
         }
 
         return $message;

--- a/src/modules/Support/Repository/SupportTicketMessageRepository.php
+++ b/src/modules/Support/Repository/SupportTicketMessageRepository.php
@@ -45,6 +45,16 @@ class SupportTicketMessageRepository extends EntityRepository
     }
 
     /**
+     * @param list<int> $ids
+     *
+     * @return SupportTicketMessage[]
+     */
+    public function findByIds(array $ids): array
+    {
+        return $ids === [] ? [] : $this->findBy(['id' => $ids]);
+    }
+
+    /**
      * Return the first (oldest) message on a ticket — used to show a preview
      * snippet in ticket listings. Returns null if the ticket has no messages.
      */

--- a/src/modules/Support/Repository/SupportTicketNoteRepository.php
+++ b/src/modules/Support/Repository/SupportTicketNoteRepository.php
@@ -23,7 +23,7 @@ class SupportTicketNoteRepository extends EntityRepository
     {
         $note = $this->find($id);
         if (!$note instanceof SupportTicketNote) {
-            throw new \FOSSBilling\Exception('Note not found');
+            throw new \FOSSBilling\InformationException('Note not found');
         }
 
         return $note;

--- a/src/modules/Support/Repository/SupportTicketRepository.php
+++ b/src/modules/Support/Repository/SupportTicketRepository.php
@@ -152,6 +152,24 @@ class SupportTicketRepository extends EntityRepository
     }
 
     /**
+     * @return SupportTicket[]
+     */
+    public function findByClientId(int $clientId): array
+    {
+        return $this->findBy(['clientId' => $clientId]);
+    }
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return SupportTicket[]
+     */
+    public function findByIds(array $ids): array
+    {
+        return $ids === [] ? [] : $this->findBy(['id' => $ids]);
+    }
+
+    /**
      * Find a single ticket owned by the given client, throwing if it does not exist.
      */
     public function findOneByClientOrFail(int $clientId, int $id): SupportTicket
@@ -216,6 +234,17 @@ class SupportTicketRepository extends EntityRepository
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    public function hasPendingTaskForClient(int $clientId, int $relId, string $relType, string $relTask): bool
+    {
+        return $this->findOneBy([
+            'clientId' => $clientId,
+            'relId' => $relId,
+            'relType' => $relType,
+            'relTask' => $relTask,
+            'relStatus' => SupportTicket::REL_STATUS_PENDING,
+        ]) instanceof SupportTicket;
     }
 
     /**

--- a/src/modules/Support/Repository/SupportTicketRepository.php
+++ b/src/modules/Support/Repository/SupportTicketRepository.php
@@ -137,7 +137,7 @@ class SupportTicketRepository extends EntityRepository
     {
         $ticket = $this->find($id);
         if (!$ticket instanceof SupportTicket) {
-            throw new \FOSSBilling\Exception('Ticket not found');
+            throw new \FOSSBilling\InformationException('Ticket not found');
         }
 
         return $ticket;
@@ -158,7 +158,7 @@ class SupportTicketRepository extends EntityRepository
     {
         $ticket = $this->findOneByClient($clientId, $id);
         if (!$ticket instanceof SupportTicket) {
-            throw new \FOSSBilling\Exception('Ticket not found');
+            throw new \FOSSBilling\InformationException('Ticket not found');
         }
 
         return $ticket;

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -143,7 +143,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         try {
             $ticketObj = $supportService->getTicketById((int) $params['id']);
-            $isGuestTicket = $supportService->isGuestTicket($ticketObj);
+            $isGuestTicket = $ticketObj->isGuestTicket();
             $identity = $isGuestTicket ? null : $di['loggedin_client'];
             $ticketArr = $supportService->toApiArray($ticketObj, true, $identity);
 
@@ -175,7 +175,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $ticketArr = $supportService->toApiArray($ticketObj, true, $identity);
 
             $email = [];
-            if ($supportService->isGuestTicket($ticketObj)) {
+            if ($ticketObj->isGuestTicket()) {
                 $email['to'] = $ticketObj->getAuthorEmail();
                 $email['to_name'] = $ticketObj->getAuthorName();
             } else {
@@ -202,7 +202,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $ticketArr = $supportService->toApiArray($ticketObj, true, $identity);
 
             $email = [];
-            if ($supportService->isGuestTicket($ticketObj)) {
+            if ($ticketObj->isGuestTicket()) {
                 $email['to'] = $ticketObj->getAuthorEmail();
                 $email['to_name'] = $ticketObj->getAuthorName();
             } else {
@@ -229,7 +229,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $ticketArr = $supportService->toApiArray($ticketObj, true, $identity);
 
             $email = [];
-            if ($supportService->isGuestTicket($ticketObj)) {
+            if ($ticketObj->isGuestTicket()) {
                 $email['to'] = $ticketObj->getAuthorEmail();
                 $email['to_name'] = $ticketObj->getAuthorName();
             } else {
@@ -258,11 +258,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->getSupportTicketNoteRepository()->findOneByIdOrFail($id);
     }
 
-    public function isGuestTicket(SupportTicket $ticket): bool
-    {
-        return $ticket->isGuestTicket();
-    }
-
     /**
      * Return array of ticket statuses.
      */
@@ -281,135 +276,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function findOneByClient(\Model_Client $c, int $id): SupportTicket
     {
         return $this->getSupportTicketRepository()->findOneByClientOrFail((int) $c->id, $id);
-    }
-
-    public function getSearchQuery(array $data): array
-    {
-        $query = 'SELECT st.*
-                FROM support_ticket st
-                JOIN support_ticket_message stm ON stm.support_ticket_id = st.id
-                LEFT JOIN client c ON st.client_id = c.id';
-
-        $search = $data['search'] ?? null;
-        $id = $data['id'] ?? null;
-        $status = $data['status'] ?? null;
-        $client = $data['client'] ?? null;
-        $client_id = $data['client_id'] ?? null;
-        $order_id = $data['order_id'] ?? null;
-        $subject = $data['subject'] ?? null;
-        $content = $data['content'] ?? null;
-        $helpdesk = $data['support_helpdesk_id'] ?? null;
-        $created_at = $data['created_at'] ?? null;
-        $date_from = $data['date_from'] ?? null;
-        $date_to = $data['date_to'] ?? null;
-        $priority = $data['priority'] ?? null;
-        $auth = $data['auth'] ?? null;
-        $name = $data['name'] ?? null;
-        $email = $data['email'] ?? null;
-
-        $where = [];
-        $bindings = [];
-
-        if ($id) {
-            $where[] = 'st.id = :ticket_id';
-            $bindings[':ticket_id'] = $id;
-        }
-
-        if ($priority) {
-            $where[] = 'st.priority = :priority';
-            $bindings[':priority'] = $priority;
-        }
-
-        if ($helpdesk) {
-            $where[] = 'st.support_helpdesk_id = :support_helpdesk_id';
-            $bindings[':support_helpdesk_id'] = $helpdesk;
-        }
-
-        if ($client) {
-            $where[] = 'c.first_name LIKE :first_name';
-            $where[] = 'c.last_name LIKE :last_name';
-            $bindings[':first_name'] = '%' . $client . '%';
-            $bindings[':last_name'] = '%' . $client . '%';
-        }
-
-        if ($client_id) {
-            $where[] = 'c.id = :client_id';
-            $bindings[':client_id'] = $client_id;
-        }
-
-        if ($auth === 'guest') {
-            $where[] = 'st.client_id IS NULL AND st.access_hash IS NOT NULL';
-        } elseif ($auth === 'client') {
-            $where[] = 'st.client_id IS NOT NULL';
-        }
-
-        if ($name) {
-            $where[] = 'st.author_name LIKE :filter_author_name';
-            $bindings[':filter_author_name'] = '%' . $name . '%';
-        }
-
-        if ($email) {
-            $where[] = 'st.author_email LIKE :filter_author_email';
-            $bindings[':filter_author_email'] = '%' . $email . '%';
-        }
-
-        if ($content) {
-            $where[] = 'stm.content LIKE :content';
-            $bindings[':content'] = '%' . $content . '%';
-        }
-
-        if ($subject) {
-            $where[] = 'st.subject LIKE :subject';
-            $bindings[':subject'] = '%' . $subject . '%';
-        }
-
-        if ($status) {
-            $where[] = 'st.status = :status';
-            $bindings[':status'] = $status;
-        }
-
-        if ($order_id) {
-            $where[] = 'st.rel_type = :rel_type AND st.rel_id = :rel_id';
-            $bindings[':rel_type'] = SupportTicket::REL_TYPE_ORDER;
-            $bindings[':rel_id'] = $order_id;
-        }
-
-        if ($created_at) {
-            $where[] = "DATE_FORMAT(st.created_at, '%Y-%m-%d') = :created_at";
-            $bindings[':created_at'] = date('Y-m-d', strtotime((string) $created_at));
-        }
-
-        if ($date_from) {
-            $where[] = 'UNIX_TIMESTAMP(st.created_at) >= :date_from';
-            $bindings[':date_from'] = strtotime((string) $date_from);
-        }
-
-        if ($date_to) {
-            $where[] = 'UNIX_TIMESTAMP(st.created_at) <= :date_to';
-            $bindings[':date_to'] = strtotime((string) $date_to);
-        }
-        // smartSearch
-        if ($search) {
-            if (is_numeric($search)) {
-                $where[] = 'st.id = :ticket_id';
-                $bindings[':ticket_id'] = $search;
-            } else {
-                $search = '%' . $search . '%';
-                $where[] = '(stm.content LIKE :content OR st.subject LIKE :subject OR st.author_name LIKE :author_name OR st.author_email LIKE :author_email)';
-                $bindings[':content'] = $search;
-                $bindings[':subject'] = $search;
-                $bindings[':author_name'] = $search;
-                $bindings[':author_email'] = $search;
-            }
-        }
-
-        if (!empty($where)) {
-            $query = $query . ' WHERE ' . implode(' AND ', $where);
-        }
-
-        $query .= ' GROUP BY st.id ORDER BY st.priority ASC, st.id DESC';
-
-        return [$query, $bindings];
     }
 
     public function counter(): array
@@ -441,18 +307,12 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function checkIfTaskAlreadyExists(\Model_Client $client, int $rel_id, string $rel_type, string $rel_task): bool
     {
-        return $this->getSupportTicketRepository()->findOneBy([
-            'clientId' => (int) $client->id,
-            'relId' => $rel_id,
-            'relType' => $rel_type,
-            'relTask' => $rel_task,
-            'relStatus' => SupportTicket::REL_STATUS_PENDING,
-        ]) instanceof SupportTicket;
+        return $this->getSupportTicketRepository()->hasPendingTaskForClient((int) $client->id, $rel_id, $rel_type, $rel_task);
     }
 
     public function closeTicket(SupportTicket $ticket, \Model_Admin|\Model_Client|\Model_Guest $identity): bool
     {
-        $ticket->setStatus(SupportTicket::STATUS_CLOSED);
+        $ticket->close();
         $this->di['em']->flush();
 
         if ($identity instanceof \Model_Admin) {
@@ -468,7 +328,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function autoClose(SupportTicket $model): bool
     {
-        $model->setStatus(SupportTicket::STATUS_CLOSED);
+        $model->close();
         $this->di['em']->flush();
         $this->di['logger']->info('Ticket %s was closed', $model->getId());
 
@@ -516,7 +376,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function rmByClient(\Model_Client $client): void
     {
         $em = $this->di['em'];
-        foreach ($this->getSupportTicketRepository()->findBy(['clientId' => (int) $client->id]) as $ticket) {
+        foreach ($this->getSupportTicketRepository()->findByClientId((int) $client->id) as $ticket) {
             $em->remove($ticket);
         }
         $em->flush();
@@ -648,7 +508,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $firstMessageIdsByTicket = $this->getSupportTicketMessageRepository()->findFirstIdsByTicketIds($ticketIds);
             $messageIds = array_values($firstMessageIdsByTicket);
             if (!empty($messageIds)) {
-                $messages = $this->getSupportTicketMessageRepository()->findBy(['id' => $messageIds]);
+                $messages = $this->getSupportTicketMessageRepository()->findByIds($messageIds);
                 foreach ($messages as $message) {
                     $ticket = $message->getSupportTicket();
                     $firstMessages[$ticket instanceof SupportTicket ? ($ticket->getId() ?? 0) : 0] = $message;
@@ -658,7 +518,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
         $helpdesks = [];
         if (!empty($helpdeskIds)) {
-            $helpdeskModels = $this->getHelpdeskRepository()->findBy(['id' => $helpdeskIds]);
+            $helpdeskModels = $this->getHelpdeskRepository()->findByIds($helpdeskIds);
             foreach ($helpdeskModels as $helpdesk) {
                 $helpdesks[$helpdesk->getId()] = $helpdesk;
             }
@@ -729,7 +589,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     private function getBatchForApiWithModels(array $ids, bool $deep, $identity): array
     {
-        $tickets = $this->getSupportTicketRepository()->findBy(['id' => $ids]);
+        $tickets = $this->getSupportTicketRepository()->findByIds($ids);
         if (empty($tickets)) {
             return [];
         }
@@ -776,7 +636,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     private function getClientApiArrayForTicket(SupportTicket $ticket, \Model_Admin|\Model_Client|null $identity = null): array
     {
-        if ($this->isGuestTicket($ticket)) {
+        if ($ticket->isGuestTicket()) {
             return [];
         }
 
@@ -813,7 +673,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     private function getTicketAuthor(SupportTicket $ticket, \Model_Admin|\Model_Client|null $identity = null): array
     {
-        if ($this->isGuestTicket($ticket)) {
+        if ($ticket->isGuestTicket()) {
             $author = [
                 'name' => $ticket->getAuthorName(),
                 'role' => 'guest',
@@ -898,7 +758,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             ['id' => $clientId]
         );
 
-        if ($row === false) {
+        if ($row === false || !isset($row['id'], $row['first_name'], $row['last_name'], $row['email'])) {
             return null;
         }
 
@@ -987,7 +847,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $author = $this->fetchClientSummary($clientId);
             $role = 'client';
         } else {
-            if ($ticket instanceof SupportTicket && $this->isGuestTicket($ticket)) {
+            if ($ticket instanceof SupportTicket && $ticket->isGuestTicket()) {
                 return [
                     'name' => $ticket->getAuthorName(),
                     'email' => $ticket->getAuthorEmail(),
@@ -1051,7 +911,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     public function ticketMessageUpdate(SupportTicketMessage $model, string $content): bool
     {
         $model->setContent($content);
-        $model->setUpdatedAt(new \DateTime());
 
         $this->di['em']->flush();
 
@@ -1532,8 +1391,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function ticketTaskComplete(SupportTicket $model): bool
     {
-        $model->setRelStatus(SupportTicket::REL_STATUS_COMPLETE);
-        $model->setUpdatedAt(new \DateTime());
+        $model->markTaskComplete();
         $this->di['em']->flush();
 
         $this->di['logger']->info('Marked ticket #%s task as complete', $model->getId());

--- a/src/modules/Support/tests/Unit/Repository/SupportTicketRepositoryTest.php
+++ b/src/modules/Support/tests/Unit/Repository/SupportTicketRepositoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+declare(strict_types=1);
+
+use Box\Mod\Support\Entity\SupportTicket;
+use Box\Mod\Support\Repository\SupportTicketRepository;
+
+test('findByClientId delegates to findBy', function (): void {
+    $repo = Mockery::mock(SupportTicketRepository::class)->makePartial();
+    $repo->shouldReceive('findBy')
+        ->once()
+        ->with(['clientId' => 5])
+        ->andReturn([]);
+
+    expect($repo->findByClientId(5))->toBe([]);
+});
+
+test('findByIds delegates to findBy', function (): void {
+    $repo = Mockery::mock(SupportTicketRepository::class)->makePartial();
+    $repo->shouldReceive('findBy')
+        ->once()
+        ->with(['id' => [2, 3]])
+        ->andReturn([]);
+
+    expect($repo->findByIds([2, 3]))->toBe([]);
+});
+
+test('hasPendingTaskForClient checks pending task criteria', function (): void {
+    $repo = Mockery::mock(SupportTicketRepository::class)->makePartial();
+    $repo->shouldReceive('findOneBy')
+        ->once()
+        ->with([
+            'clientId' => 1,
+            'relId' => 7,
+            'relType' => SupportTicket::REL_TYPE_ORDER,
+            'relTask' => SupportTicket::REL_TASK_UPGRADE,
+            'relStatus' => SupportTicket::REL_STATUS_PENDING,
+        ])
+        ->andReturn(new SupportTicket());
+
+    expect($repo->hasPendingTaskForClient(1, 7, SupportTicket::REL_TYPE_ORDER, SupportTicket::REL_TASK_UPGRADE))->toBeTrue();
+});

--- a/src/modules/Support/tests/Unit/ServiceTest.php
+++ b/src/modules/Support/tests/Unit/ServiceTest.php
@@ -476,7 +476,7 @@ test('throws exception when ticket not found by client', function (): void {
     $service = Mockery::mock(Service::class)->makePartial();
     $repo = Mockery::mock(SupportTicketRepository::class);
     $repo->shouldReceive('findOneByClientOrFail')->atLeast()->once()
-        ->andThrow(new FOSSBilling\Exception('Ticket not found'));
+        ->andThrow(new FOSSBilling\InformationException('Ticket not found'));
     $service->shouldReceive('getSupportTicketRepository')->atLeast()->once()
         ->andReturn($repo);
 
@@ -488,7 +488,7 @@ test('throws exception when ticket not found by client', function (): void {
     $client->id = 1;
 
     $service->findOneByClient($client, 1);
-})->throws(FOSSBilling\Exception::class);
+})->throws(FOSSBilling\InformationException::class);
 
 dataset('searchQueryData', [
     [

--- a/src/modules/Support/tests/Unit/ServiceTest.php
+++ b/src/modules/Support/tests/Unit/ServiceTest.php
@@ -490,52 +490,6 @@ test('throws exception when ticket not found by client', function (): void {
     $service->findOneByClient($client, 1);
 })->throws(FOSSBilling\InformationException::class);
 
-dataset('searchQueryData', [
-    [
-        [
-            'search' => 'query',
-            'id' => 1,
-            'status' => 'open',
-            'client_id' => 1,
-            'client' => 'Client name',
-            'order_id' => 1,
-            'subject' => 'subject',
-            'content' => 'Content',
-            'support_helpdesk_id' => 1,
-            'created_at' => date('Y-m-d H:i:s'),
-            'date_from' => date('Y-m-d H:i:s'),
-            'date_to' => date('Y-m-d H:i:s'),
-            'priority' => 1,
-        ],
-    ],
-    [
-        [
-            'search' => 1,
-            'id' => 1,
-            'status' => 'open',
-            'client_id' => 1,
-            'client' => 'Client name',
-            'order_id' => 1,
-            'subject' => 'subject',
-            'content' => 'Content',
-            'support_helpdesk_id' => 1,
-            'created_at' => date('Y-m-d H:i:s'),
-            'date_from' => date('Y-m-d H:i:s'),
-            'date_to' => date('Y-m-d H:i:s'),
-            'priority' => 1,
-        ],
-    ],
-]);
-
-test('gets search query', function ($data): void {
-    $service = new Service();
-    $di = container();
-    $service->setDi($di);
-    [$query, $bindings] = $service->getSearchQuery($data);
-    expect($query)->toBeString();
-    expect($bindings)->toBeArray();
-})->with('searchQueryData');
-
 test('counts tickets', function (): void {
     $service = new Service();
     $arr = [
@@ -648,13 +602,10 @@ test('gets active tickets count for order', function (): void {
 test('checks if task already exists returns true', function (): void {
     $service = new Service();
 
-    $existingTicket = new SupportTicket();
-    setEntityId($existingTicket, 1);
-
     $repoMock = Mockery::mock(SupportTicketRepository::class);
-    $repoMock->shouldReceive('findOneBy')
+    $repoMock->shouldReceive('hasPendingTaskForClient')
         ->atLeast()->once()
-        ->andReturn($existingTicket);
+        ->andReturn(true);
 
     $emMock = Mockery::mock(EntityManagerInterface::class);
     supportWireKbRepositories($emMock, supportTicketRepo: $repoMock);
@@ -674,9 +625,9 @@ test('checks if task already exists returns false', function (): void {
     $service = new Service();
 
     $repoMock = Mockery::mock(SupportTicketRepository::class);
-    $repoMock->shouldReceive('findOneBy')
+    $repoMock->shouldReceive('hasPendingTaskForClient')
         ->atLeast()->once()
-        ->andReturn(null);
+        ->andReturn(false);
 
     $emMock = Mockery::mock(EntityManagerInterface::class);
     supportWireKbRepositories($emMock, supportTicketRepo: $repoMock);
@@ -717,6 +668,7 @@ test('closes a ticket', function ($identity): void {
 
     $result = $service->closeTicket($ticket, $identity);
     expect($result)->toBeTrue();
+    expect($ticket->getStatus())->toBe(SupportTicket::STATUS_CLOSED);
 })->with('closeTicketIdentities');
 
 test('auto closes a ticket', function (): void {
@@ -735,6 +687,7 @@ test('auto closes a ticket', function (): void {
 
     $result = $service->autoClose($ticket);
     expect($result)->toBeTrue();
+    expect($ticket->getStatus())->toBe(SupportTicket::STATUS_CLOSED);
 });
 
 test('checks if ticket can be reopened when not closed', function (): void {
@@ -781,7 +734,7 @@ test('removes tickets by client', function (): void {
     setEntityId($model, 1);
 
     $repo = Mockery::mock(SupportTicketRepository::class);
-    $repo->shouldReceive('findBy')->atLeast()->once()
+    $repo->shouldReceive('findByClientId')->atLeast()->once()
         ->andReturn([$model]);
     $service->shouldReceive('getSupportTicketRepository')->atLeast()->once()
         ->andReturn($repo);
@@ -1876,6 +1829,7 @@ test('ticket message update', function (): void {
 
     $result = $service->ticketMessageUpdate($message, 'Content');
     expect($result)->toBeTrue();
+    expect($message->getContent())->toBe('Content');
 });
 
 dataset('ticketReplyProvider', function () {
@@ -2101,6 +2055,7 @@ test('ticket task complete', function (): void {
 
     $result = $service->ticketTaskComplete($model);
     expect($result)->toBeTrue();
+    expect($model->getRelStatus())->toBe(SupportTicket::REL_STATUS_COMPLETE);
 });
 
 /*


### PR DESCRIPTION
Cleanup following #3863 to remove dead or duplicated methods.

Also bundled another patch that switches to using InformationException instead of a regular Exception where more appropriate.