### PR TITLE
Guard missing order actions in Servicehosting admin template

### DIFF
--- a/src/modules/Servicehosting/templates/admin/mod_servicehosting_manage.html.twig
+++ b/src/modules/Servicehosting/templates/admin/mod_servicehosting_manage.html.twig
@@ -71,7 +71,7 @@
 </table>
 
 <div class="card-footer d-flex flex-wrap gap-2 justify-content-end">
-    {{ order_actions }}
+    {{ order_actions|default('') }}
     <a class="btn btn-primary" href="{{ server.cpanel_url }}" target="_blank">
         <svg class="icon">
             <use href="#server" />


### PR DESCRIPTION
Fixes #3878.

This change makes the Servicehosting admin manage template tolerate missing `order_actions`, matching the existing pattern used by neighboring service templates.

Changes:
- use `order_actions|default('')` in `mod_servicehosting_manage.html.twig`

Validation:
- `composer install`
- `src/vendor/bin/pest --test-directory ../tests tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php`
- `src/vendor/bin/pest --test-directory ../tests tests/Unit/FOSSBilling/Twig/TwigAstLinterTest.php`
- `src/vendor/bin/pest --test-directory ../tests src/modules/Servicehosting/tests/Unit`
- `src/vendor/bin/php-cs-fixer fix --dry-run --diff --sequential`
- `git diff --check`

Notes:
- `composer cs:check` was blocked locally by a sandbox socket restriction, so the equivalent PHP-CS-Fixer dry run was executed sequentially.