### PR TITLE
Address code review follow-ups from admin groups/permissions rework

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -40,9 +40,9 @@ LOCK TABLES `admin_group` WRITE;
 
 INSERT INTO `admin_group` (`id`, `name`, `system_name`, `parent_id`, `permissions`, `protected`, `created_at`, `updated_at`)
 VALUES
-	(1,'Super Administrator','super_admin',NULL,NULL,1,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(2,'Support Lead','support_lead',1,'{"support":{"access":true,"view":true,"manage_tickets":true,"manage_helpdesk":true,"manage_canned":true,"manage_kb":true},"staff":{"access":true,"view":true,"create_and_edit_staff":true,"reset_staff_password":true,"manage_groups":true,"manage_settings":true}}',0,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(3,'Support Staff','support_staff',2,'{"support":{"access":true,"view":true,"manage_tickets":true}}',0,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'Super Administrator','super_admin',NULL,NULL,1,NOW(),NOW()),
+	(2,'Support Lead','support_lead',1,'{"support":{"access":true,"view":true,"manage_tickets":true,"manage_helpdesk":true,"manage_canned":true,"manage_kb":true},"staff":{"access":true,"view":true,"create_and_edit_staff":true,"reset_staff_password":true,"manage_groups":true,"manage_settings":true}}',0,NOW(),NOW()),
+	(3,'Support Staff','support_staff',2,'{"support":{"access":true,"view":true,"manage_tickets":true}}',0,NOW(),NOW());
 
 /*!40000 ALTER TABLE `admin_group` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -75,7 +75,7 @@ LOCK TABLES `client_group` WRITE;
 
 INSERT INTO `client_group` (`id`, `title`, `created_at`, `updated_at`)
 VALUES
-	(1,'Default','2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'Default',NOW(),NOW());
 
 /*!40000 ALTER TABLE `client_group` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -109,7 +109,7 @@ LOCK TABLES `currency` WRITE;
 
 INSERT INTO `currency` (`id`, `code`, `is_default`, `conversion_rate`, `created_at`, `updated_at`)
 VALUES
-	(1,'USD',1,1.000000,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'USD',1,1.000000,NOW(),NOW());
 
 /*!40000 ALTER TABLE `currency` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -169,9 +169,9 @@ LOCK TABLES `support_kb_article` WRITE;
 
 INSERT INTO `support_kb_article` (`id`, `kb_article_category_id`, `views`, `title`, `content`, `slug`, `status`, `created_at`, `updated_at`)
 VALUES
-	(1,2,0,'How to contact support','Registered clients can contact our support team:\n------------------------------------------------------------\n\n* Login to clients area\n* Select **Support** menu item\n* Click **Submit new ticket**\n* Fill the form and press *Submit*\n\nGuests can contact our support team:\n------------------------------------------------------------\n\n* Use our contact form.\n* Fill the form and click *Submit*\n','how-to-contact-support','active','2026-06-25 12:00:00','2026-06-25 12:00:00'),
-    (2,2,0,'How to place a new order','To place a new order, follow these steps:\n------------------------------------------------------------\n\n* Select the product/service you would like to order via the *Order* page.\n* Depending on your selected product/service, you might need to provide additional information to complete the order request.\n* Click \"Continue\". Your selected product/service will now be in the shopping cart.\n* If you have a promo code, you can apply it now and get a discount.\n* Click on \"Checkout\" button to proceed with the checkout process.\n    * If you are already logged in, you will be automatically redirected to the invoice for the newly purchased product/service.\n    * If you are a registered client but not logged in, you can provide your login details.\n    * If you have never purchased any service from us, please fill out the client sign up form and then continue the checkout process.\n* Choose your preferred payment method. A list of all available payment methods will be listed below the invoice details.\n* You will be redirected to the payment page, through which you can pay for the product/service you would like to order. \n* After successful payment, you will be redirected to the invoice page.\n* Depending on selected services your order may be reviewed and activated by our staff members, otherwise it will be activated automatically.\n* You will receive a confirmation email once your order is active, at which time you will be able to login and manage your services.\n','how-to-place-new-order','active','2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(3,2,0,'Example article','Example article heading\n------------------------------------------------------------\n\nThis is a placeholder article. Replace with helpful content for clients, such as guides, tutorials, or FAQs.','example-article','active','2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,2,0,'How to contact support','Registered clients can contact our support team:\n------------------------------------------------------------\n\n* Login to clients area\n* Select **Support** menu item\n* Click **Submit new ticket**\n* Fill the form and press *Submit*\n\nGuests can contact our support team:\n------------------------------------------------------------\n\n* Use our contact form.\n* Fill the form and click *Submit*\n','how-to-contact-support','active',NOW(),NOW()),
+    (2,2,0,'How to place a new order','To place a new order, follow these steps:\n------------------------------------------------------------\n\n* Select the product/service you would like to order via the *Order* page.\n* Depending on your selected product/service, you might need to provide additional information to complete the order request.\n* Click \"Continue\". Your selected product/service will now be in the shopping cart.\n* If you have a promo code, you can apply it now and get a discount.\n* Click on \"Checkout\" button to proceed with the checkout process.\n    * If you are already logged in, you will be automatically redirected to the invoice for the newly purchased product/service.\n    * If you are a registered client but not logged in, you can provide your login details.\n    * If you have never purchased any service from us, please fill out the client sign up form and then continue the checkout process.\n* Choose your preferred payment method. A list of all available payment methods will be listed below the invoice details.\n* You will be redirected to the payment page, through which you can pay for the product/service you would like to order. \n* After successful payment, you will be redirected to the invoice page.\n* Depending on selected services your order may be reviewed and activated by our staff members, otherwise it will be activated automatically.\n* You will receive a confirmation email once your order is active, at which time you will be able to login and manage your services.\n','how-to-place-new-order','active',NOW(),NOW()),
+	(3,2,0,'Example article','Example article heading\n------------------------------------------------------------\n\nThis is a placeholder article. Replace with helpful content for clients, such as guides, tutorials, or FAQs.','example-article','active',NOW(),NOW());
 
 /*!40000 ALTER TABLE `support_kb_article` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -185,8 +185,8 @@ LOCK TABLES `support_kb_article_category` WRITE;
 
 INSERT INTO `support_kb_article_category` (`id`, `title`, `description`, `slug`, `created_at`, `updated_at`)
 VALUES
-	(1,'Frequently asked questions','Section for common issues','faq','2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(2,'How to''s','Section dedicated for tutorials','how-to','2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'Frequently asked questions','Section for common issues','faq',NOW(),NOW()),
+	(2,'How to''s','Section dedicated for tutorials','how-to',NOW(),NOW());
 
 /*!40000 ALTER TABLE `support_kb_article_category` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -215,9 +215,9 @@ LOCK TABLES `post` WRITE;
 
 INSERT INTO `post` (`id`, `admin_id`, `title`, `description`, `content`, `slug`, `status`, `image`, `section`, `publish_at`, `published_at`, `expires_at`, `created_at`, `updated_at`)
 VALUES
-	(1,1,'FOSSBilling needs your donations','Donations are crucial for the success and sustainability of FOSSBilling and other open-source projects. We need your help.','Donations are crucial for the success and sustainability of FOSSBilling and other open-source projects. Without financial support from users and the broader community, it is difficult for these projects to continue to grow and evolve.\nDonations help to cover the costs of development and maintenance. Developing and maintaining software requires time and resources, and without financial support, it can be challenging for open-source projects to sustain their efforts.\n\nThe FOSSBilling project has expenses such as hosting, hardware, software, and other costs associated with developing and maintaining FOSSBilling and other open-source projects. Your donations also help cover some of the maintainers'' expenses.\nClick [here](https://fossbilling.org/donate) to donate to the FOSSBilling project.','fossbilling-needs-your-donations','active',NULL,NULL,NULL,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(2,1,'Check out great features of FOSSBilling','FOSSBilling supports automated billing, invoicing, product provisioning', '* Supports automated billing, invoicing, product provisioning\n* Automatically create accounts as soon as the payment is received, suspend when account becomes overdue, terminate when a specified amount of time passes.\n* FOSSBilling is perfectly created to sell shared and reseller hosting accounts, software licenses and downloadable products.\n* Integrated helpdesk, knowledgebase, news and announcements system.\n','great-features-of-fossbilling','active',NULL,NULL,NULL,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(3,1,'FOSSBilling is customizable','You can create your own simple or advanced hooks on FOSSBilling events.','* You can create your own simple or advanced hooks on FOSSBilling events. For example, send notification via sms when new client signs up.\n* Create custom theme for your client interface\n','fossbilling-is-customizable','active',NULL,NULL,NULL,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,1,'FOSSBilling needs your donations','Donations are crucial for the success and sustainability of FOSSBilling and other open-source projects. We need your help.','Donations are crucial for the success and sustainability of FOSSBilling and other open-source projects. Without financial support from users and the broader community, it is difficult for these projects to continue to grow and evolve.\nDonations help to cover the costs of development and maintenance. Developing and maintaining software requires time and resources, and without financial support, it can be challenging for open-source projects to sustain their efforts.\n\nThe FOSSBilling project has expenses such as hosting, hardware, software, and other costs associated with developing and maintaining FOSSBilling and other open-source projects. Your donations also help cover some of the maintainers'' expenses.\nClick [here](https://fossbilling.org/donate) to donate to the FOSSBilling project.','fossbilling-needs-your-donations','active',NULL,NULL,NULL,NULL,NULL,NOW(),NOW()),
+	(2,1,'Check out great features of FOSSBilling','FOSSBilling supports automated billing, invoicing, product provisioning', '* Supports automated billing, invoicing, product provisioning\n* Automatically create accounts as soon as the payment is received, suspend when account becomes overdue, terminate when a specified amount of time passes.\n* FOSSBilling is perfectly created to sell shared and reseller hosting accounts, software licenses and downloadable products.\n* Integrated helpdesk, knowledgebase, news and announcements system.\n','great-features-of-fossbilling','active',NULL,NULL,NULL,NULL,NULL,NOW(),NOW()),
+	(3,1,'FOSSBilling is customizable','You can create your own simple or advanced hooks on FOSSBilling events.','* You can create your own simple or advanced hooks on FOSSBilling events. For example, send notification via sms when new client signs up.\n* Create custom theme for your client interface\n','fossbilling-is-customizable','active',NULL,NULL,NULL,NULL,NULL,NOW(),NOW());
 
 /*!40000 ALTER TABLE `post` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -231,7 +231,7 @@ LOCK TABLES `product` WRITE;
 
 INSERT INTO `product` (`id`, `product_category_id`, `product_payment_id`, `form_id`, `title`, `slug`, `description`, `unit`, `active`, `status`, `hidden`, `is_addon`, `setup`, `addons`, `icon_url`, `allow_quantity_select`, `stock_control`, `quantity_in_stock`, `plugin`, `plugin_config`, `upgrades`, `priority`, `config`, `created_at`, `updated_at`, `type`)
 VALUES
-	(1,1,NULL,NULL,'Domains registration and transfer','domain-checker',NULL,'product',1,'enabled',0,0,'after_payment',NULL,NULL,0,0,0,NULL,NULL,NULL,1,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00','domain');
+	(1,1,NULL,NULL,'Domains registration and transfer','domain-checker',NULL,'product',1,'enabled',0,0,'after_payment',NULL,NULL,0,0,0,NULL,NULL,NULL,1,NULL,NOW(),NOW(),'domain');
 
 /*!40000 ALTER TABLE `product` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -245,7 +245,7 @@ LOCK TABLES `product_category` WRITE;
 
 INSERT INTO `product_category` (`id`, `title`, `description`, `icon_url`, `created_at`, `updated_at`)
 VALUES
-	(1,'Default category',NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'Default category',NULL,NULL,NOW(),NOW());
 
 /*!40000 ALTER TABLE `product_category` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -304,38 +304,38 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','79',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(2,'company_name','Company Name',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(3,'company_email','support@yourcompany.com',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(5,'company_logo','public/branding/logo.svg',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(6,'company_logo_dark','public/branding/logo-dark.svg',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(7,'company_address_1','Demo address line 1',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(8,'company_address_2','Demo address line 2',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(9,'company_address_3','Demo address line 3',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(10,'company_tel','+123 456 12345',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(11,'company_tos','This is a sample Terms of Service. Please replace this with your own legal terms.\nInclude details such as:\n- Your company name and address\n- Conditions of service\n- Payment and refund policies\n- Service-level agreements (SLAs)',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(12,'company_privacy_policy','This is a sample Privacy Policy. Please replace this with your company''s actual privacy terms.\nInclude details such as:\n- How customer data is collected and used\n- Security measures\n- Third-party sharing policies\n- Customer rights',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(13,'company_note','This is a placeholder for your About Us page. It will be available in /about-us.\nReplace this with information about your company, such as:\n- Your company history and mission\n- Services offered\n- Values and vision\n- Contact or support information\n- Any other details you want your clients to know about your business',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(14,'invoice_series','FOSS',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(15,'invoice_due_days','5',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(16,'invoice_auto_approval','1',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(17,'invoice_issue_days_before_expire','14',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(18,'theme','huraga',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(19,'issue_invoice_days_before_expire','7',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(20,'invoice_refund_logic','credit_note',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(21,'invoice_cn_series','CN-',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(22,'invoice_cn_starting_number','1',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(23,'invoice_starting_number','1',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(24,'nameserver_1',NULL,0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(25,'nameserver_2',NULL,0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(26,'nameserver_3',NULL,0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(27,'nameserver_4',NULL,0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(28,'funds_min_amount','10',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(29,'funds_max_amount','200',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(30,'company_favicon','public/branding/favicon.ico',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00'),
-	(31,'hide_company_public',1,0,NULL,NULL,'2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(32,'invoice_hash_lifetime_days','90',0,NULL,NULL,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'last_patch','79',0,NULL,NULL,NOW(),NOW()),
+	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
+	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
+	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),
+	(5,'company_logo','public/branding/logo.svg',0,NULL,NULL,NOW(),NOW()),
+	(6,'company_logo_dark','public/branding/logo-dark.svg',0,NULL,NULL,NOW(),NOW()),
+	(7,'company_address_1','Demo address line 1',0,NULL,NULL,NOW(),NOW()),
+	(8,'company_address_2','Demo address line 2',0,NULL,NULL,NOW(),NOW()),
+	(9,'company_address_3','Demo address line 3',0,NULL,NULL,NOW(),NOW()),
+	(10,'company_tel','+123 456 12345',0,NULL,NULL,NOW(),NOW()),
+	(11,'company_tos','This is a sample Terms of Service. Please replace this with your own legal terms.\nInclude details such as:\n- Your company name and address\n- Conditions of service\n- Payment and refund policies\n- Service-level agreements (SLAs)',0,NULL,NULL,NOW(),NOW()),
+	(12,'company_privacy_policy','This is a sample Privacy Policy. Please replace this with your company''s actual privacy terms.\nInclude details such as:\n- How customer data is collected and used\n- Security measures\n- Third-party sharing policies\n- Customer rights',0,NULL,NULL,NOW(),NOW()),
+	(13,'company_note','This is a placeholder for your About Us page. It will be available in /about-us.\nReplace this with information about your company, such as:\n- Your company history and mission\n- Services offered\n- Values and vision\n- Contact or support information\n- Any other details you want your clients to know about your business',0,NULL,NULL,NOW(),NOW()),
+	(14,'invoice_series','FOSS',0,NULL,NULL,NOW(),NOW()),
+	(15,'invoice_due_days','5',0,NULL,NULL,NOW(),NOW()),
+	(16,'invoice_auto_approval','1',0,NULL,NULL,NOW(),NOW()),
+	(17,'invoice_issue_days_before_expire','14',0,NULL,NULL,NOW(),NOW()),
+	(18,'theme','huraga',0,NULL,NULL,NOW(),NOW()),
+	(19,'issue_invoice_days_before_expire','7',0,NULL,NULL,NOW(),NOW()),
+	(20,'invoice_refund_logic','credit_note',0,NULL,NULL,NOW(),NOW()),
+	(21,'invoice_cn_series','CN-',0,NULL,NULL,NOW(),NOW()),
+	(22,'invoice_cn_starting_number','1',0,NULL,NULL,NOW(),NOW()),
+	(23,'invoice_starting_number','1',0,NULL,NULL,NOW(),NOW()),
+	(24,'nameserver_1',NULL,0,NULL,NULL,NOW(),NOW()),
+	(25,'nameserver_2',NULL,0,NULL,NULL,NOW(),NOW()),
+	(26,'nameserver_3',NULL,0,NULL,NULL,NOW(),NOW()),
+	(27,'nameserver_4',NULL,0,NULL,NULL,NOW(),NOW()),
+	(28,'funds_min_amount','10',0,NULL,NULL,NOW(),NOW()),
+	(29,'funds_max_amount','200',0,NULL,NULL,NOW(),NOW()),
+	(30,'company_favicon','public/branding/favicon.ico',0,NULL,NULL,NOW(),NOW()),
+	(31,'hide_company_public',1,0,NULL,NULL,NOW(), NOW()),
+	(32,'invoice_hash_lifetime_days','90',0,NULL,NULL,NOW(),NOW());
 
 /*!40000 ALTER TABLE `setting` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -354,7 +354,7 @@ LOCK TABLES `support_helpdesk` WRITE;
 
 INSERT INTO `support_helpdesk` (`id`, `name`, `email`, `close_after`, `can_reopen`, `signature`, `created_at`, `updated_at`)
 VALUES
-	(1,'General','info@yourcompany.com',24,0,'Always a pleasure to help. Wishing you a great day!','2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,'General','info@yourcompany.com',24,0,'Always a pleasure to help. Wishing you a great day!',NOW(),NOW());
 
 /*!40000 ALTER TABLE `support_helpdesk` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -368,23 +368,23 @@ LOCK TABLES `support_pr` WRITE;
 
 INSERT INTO `support_pr` (`id`, `support_pr_category_id`, `title`, `content`, `created_at`, `updated_at`)
 VALUES
-	(1, 1, 'Welcome Message', 'Hi,\n\nThank you for choosing our hosting services.\n\nIf you need any assistance just create a support ticket anytime, we are here to help.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(2, 1, 'Message Acknowledgement', 'Hi there,\n\nThank you for reaching out. We will take a look at your issue and get back to you as soon as possible.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(3, 2, 'Issue Resolved', 'The reported issue has been resolved on your account.\n\nIf you are still experiencing problems, have any further questions or need additional support, feel free to contact us.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(4, 2, 'Request Completed', 'Your request has been completed.\n\nLet us know if there is anything else we can help you with.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(5, 2, 'Website Check', 'We have checked your website and everything appears to be working correctly on our end.\n\nPlease check from your side and let us know if you still encounter any issues.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(6, 2, 'Request for Error Details', 'Are you seeing any specific error messages?\n\nIf so, please copy and paste the full message here and it will make it much quicker for us to help you quickly find the cause of the issue and get it resolved.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(7, 3, 'Invoice Paid Confirmation', 'Hello,\n\nWe have received your payment successfully and your invoice has been marked as paid.\n\nThank you!', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(8, 3, 'Invoice Reminder', 'Hello,\n\nThis is a friendly reminder that you have an unpaid invoice.\n\nPlease log in to your client area to complete the payment to avoid further action.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(9, 3, 'Account Suspension Warning', 'Hello,\n\nYour account is at risk of suspension due to an outstanding issue. Please take action as soon as possible to avoid service interruption.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(10, 4, 'Plan Upgrade Complete', 'Hello,\n\nYour hosting plan has been successfully upgraded. The new resources are now active on your account.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(11, 4, 'Password Reset Instructions', 'Hello,\n\nTo reset your password, please click the "Forgot Password" link on the login page and follow the instructions provided.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(12, 4, 'Request for Product Info', 'Could you please let us know which domain name or hosting plan you are having the issue with?\n\nThis will help us to find the issue and get it solved for you much more easily.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(13, 5, 'DNS Not Pointing', 'Your domain is currently not pointing to our servers.\n\nPlease update the nameservers at your domain registrar. Note that it may take up to 24 hours for the changes to fully take effect.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(14, 5, 'Backup Restored', 'Hello,\n\nYour requested backup has been successfully restored. Please verify that everything is working as expected.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(15, 5, 'Ticket Escalated', 'Hello,\n\nWe have escalated your request to our senior support team. You will receive a response shortly. Thank you for your patience.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(16, 6, 'Scheduled Maintenance Notice', 'Hello,\n\nWe will be performing scheduled maintenance soon that may affect your sites. Temporary service interruptions could possibly occur. Thank you for your understanding.', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(17, 7, 'Domain Renewal Reminder', 'Hello,\n\nOne of your domains is expiring soon, this is just a reminder to renew your domain to avoid any service interruption.', '2026-06-25 12:00:00', '2026-06-25 12:00:00');
+	(1, 1, 'Welcome Message', 'Hi,\n\nThank you for choosing our hosting services.\n\nIf you need any assistance just create a support ticket anytime, we are here to help.', NOW(), NOW()),
+	(2, 1, 'Message Acknowledgement', 'Hi there,\n\nThank you for reaching out. We will take a look at your issue and get back to you as soon as possible.', NOW(), NOW()),
+	(3, 2, 'Issue Resolved', 'The reported issue has been resolved on your account.\n\nIf you are still experiencing problems, have any further questions or need additional support, feel free to contact us.', NOW(), NOW()),
+	(4, 2, 'Request Completed', 'Your request has been completed.\n\nLet us know if there is anything else we can help you with.', NOW(), NOW()),
+	(5, 2, 'Website Check', 'We have checked your website and everything appears to be working correctly on our end.\n\nPlease check from your side and let us know if you still encounter any issues.', NOW(), NOW()),
+	(6, 2, 'Request for Error Details', 'Are you seeing any specific error messages?\n\nIf so, please copy and paste the full message here and it will make it much quicker for us to help you quickly find the cause of the issue and get it resolved.', NOW(), NOW()),
+	(7, 3, 'Invoice Paid Confirmation', 'Hello,\n\nWe have received your payment successfully and your invoice has been marked as paid.\n\nThank you!', NOW(), NOW()),
+	(8, 3, 'Invoice Reminder', 'Hello,\n\nThis is a friendly reminder that you have an unpaid invoice.\n\nPlease log in to your client area to complete the payment to avoid further action.', NOW(), NOW()),
+	(9, 3, 'Account Suspension Warning', 'Hello,\n\nYour account is at risk of suspension due to an outstanding issue. Please take action as soon as possible to avoid service interruption.', NOW(), NOW()),
+	(10, 4, 'Plan Upgrade Complete', 'Hello,\n\nYour hosting plan has been successfully upgraded. The new resources are now active on your account.', NOW(), NOW()),
+	(11, 4, 'Password Reset Instructions', 'Hello,\n\nTo reset your password, please click the "Forgot Password" link on the login page and follow the instructions provided.', NOW(), NOW()),
+	(12, 4, 'Request for Product Info', 'Could you please let us know which domain name or hosting plan you are having the issue with?\n\nThis will help us to find the issue and get it solved for you much more easily.', NOW(), NOW()),
+	(13, 5, 'DNS Not Pointing', 'Your domain is currently not pointing to our servers.\n\nPlease update the nameservers at your domain registrar. Note that it may take up to 24 hours for the changes to fully take effect.', NOW(), NOW()),
+	(14, 5, 'Backup Restored', 'Hello,\n\nYour requested backup has been successfully restored. Please verify that everything is working as expected.', NOW(), NOW()),
+	(15, 5, 'Ticket Escalated', 'Hello,\n\nWe have escalated your request to our senior support team. You will receive a response shortly. Thank you for your patience.', NOW(), NOW()),
+	(16, 6, 'Scheduled Maintenance Notice', 'Hello,\n\nWe will be performing scheduled maintenance soon that may affect your sites. Temporary service interruptions could possibly occur. Thank you for your understanding.', NOW(), NOW()),
+	(17, 7, 'Domain Renewal Reminder', 'Hello,\n\nOne of your domains is expiring soon, this is just a reminder to renew your domain to avoid any service interruption.', NOW(), NOW());
 
 /*!40000 ALTER TABLE `support_pr` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -398,13 +398,13 @@ LOCK TABLES `support_pr_category` WRITE;
 
 INSERT INTO `support_pr_category` (`id`, `title`, `created_at`, `updated_at`)
 VALUES
-	(1, 'Greetings', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(2, 'General Support', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(3, 'Billing & Payments', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(4, 'Account Management', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(5, 'Technical Issues', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(6, 'Notices & Maintenance', '2026-06-25 12:00:00', '2026-06-25 12:00:00'),
-	(7, 'Domain & SSL', '2026-06-25 12:00:00', '2026-06-25 12:00:00');
+	(1, 'Greetings', NOW(), NOW()),
+	(2, 'General Support', NOW(), NOW()),
+	(3, 'Billing & Payments', NOW(), NOW()),
+	(4, 'Account Management', NOW(), NOW()),
+	(5, 'Technical Issues', NOW(), NOW()),
+	(6, 'Notices & Maintenance', NOW(), NOW()),
+	(7, 'Domain & SSL', NOW(), NOW());
 
 /*!40000 ALTER TABLE `support_pr_category` ENABLE KEYS */;
 UNLOCK TABLES;
@@ -438,7 +438,7 @@ LOCK TABLES `tld` WRITE;
 
 INSERT INTO `tld` (`id`, `tld_registrar_id`, `tld`, `price_registration`, `price_renew`, `price_transfer`, `allow_register`, `allow_transfer`, `active`, `min_years`, `created_at`, `updated_at`)
 VALUES
-	(1,1,'.com',11.99,11.99,11.99,1,1,1,1,'2026-06-25 12:00:00','2026-06-25 12:00:00');
+	(1,1,'.com',11.99,11.99,11.99,1,1,1,1,NOW(),NOW());
 
 /*!40000 ALTER TABLE `tld` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -190,36 +190,21 @@ class Service implements InjectionAwareInterface
         $extensionService = $this->di['mod_service']('Extension');
         $modulePermissions = $extensionService->getSpecificModulePermissions($module);
         $permissions = $this->getPermissions($member->id);
-        $defaultPermissions = $permissions['default'] ?? [];
-        $hasWildcardAccess = is_array($defaultPermissions) && (bool) ($defaultPermissions['all'] ?? false);
-
         $canAlwaysAccess = $modulePermissions['can_always_access'] ?? false;
 
         if (!$canAlwaysAccess) {
             // They have no permissions or don't have any access to that module
             if (
                 empty($permissions)
-                || (
-                    !array_key_exists($module, $permissions)
-                    && !$hasWildcardAccess
-                )
-                || (
-                    array_key_exists($module, $permissions)
-                    && (
-                        !is_array($permissions[$module])
-                        || !($permissions[$module]['access'] ?? false)
-                    )
-                )
+                || !array_key_exists($module, $permissions)
+                || !is_array($permissions[$module])
+                || !($permissions[$module]['access'] ?? false)
             ) {
                 return false;
             }
         }
 
         if (!is_null($key)) {
-            if (!array_key_exists($module, $permissions) && $hasWildcardAccess) {
-                return true;
-            }
-
             $modulePermissions = $permissions[$module] ?? [];
 
             if (!is_array($modulePermissions) || !array_key_exists($key, $modulePermissions)) {
@@ -385,7 +370,7 @@ class Service implements InjectionAwareInterface
         $id = $data['id'] ?? null;
         $search = $data['search'] ?? null;
         $status = $data['status'] ?? null;
-        $no_cron = Tools::normalizeBoolean($data['no_cron'] ?? false);
+        $no_cron = Tools::normalizeBoolean($data['no_cron'] ?? null, true);
 
         $where = [];
         $bindings = [];

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -830,20 +830,20 @@ test('getList returns paginated result', function (): void {
 
 // Data provider for searchFilters
 dataset('searchFilters', fn (): array => [
-    'empty filters' => [
+    'empty filters exclude cron by default' => [
         [],
-        'SELECT * FROM admin',
-        [],
+        'system_name != :system_name',
+        [':system_name' => Model_Admin::SYSTEM_CRON],
     ],
     'search by keyword' => [
         ['search' => 'keyword'],
         '(name LIKE :name OR email LIKE :email )',
-        [':name' => '%keyword%', ':email' => '%keyword%'],
+        [':name' => '%keyword%', ':email' => '%keyword%', ':system_name' => Model_Admin::SYSTEM_CRON],
     ],
     'filter by status' => [
         ['status' => 'active'],
         'status = :status',
-        [':status' => 'active'],
+        [':status' => 'active', ':system_name' => Model_Admin::SYSTEM_CRON],
     ],
     'filter by no_cron' => [
         ['no_cron' => 'true'],

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -293,7 +293,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
                 if ($this->getDi()['mod_service']('Staff')->isSuperAdministrator($this->identity->id)) {
                     return;
                 }
-            } catch (\Throwable) {
+            } catch (\Doctrine\DBAL\Exception) {
                 // If the installation hasn't migrated to the new group structure yet,
                 // Manually look for the old "admin" role
                 if (

--- a/src/modules/System/tests/Unit/Api/AdminTest.php
+++ b/src/modules/System/tests/Unit/Api/AdminTest.php
@@ -174,7 +174,7 @@ test('update finalization status falls back to legacy admin while pending', func
     $api->setIdentity($admin);
 
     $staffService = Mockery::mock(Box\Mod\Staff\Service::class);
-    $staffService->shouldReceive('isSuperAdministrator')->once()->with(1)->andThrow(new RuntimeException('admin groups unavailable'));
+    $staffService->shouldReceive('isSuperAdministrator')->once()->with(1)->andThrow(new class('admin groups unavailable') extends RuntimeException implements Doctrine\DBAL\Exception {});
 
     $updateFinalization = Mockery::mock();
     $updateFinalization->shouldReceive('isRequired')->once()->andReturn(true);
@@ -202,7 +202,7 @@ test('update finalization status rejects legacy non-admin while pending', functi
     $api->setIdentity($admin);
 
     $staffService = Mockery::mock(Box\Mod\Staff\Service::class);
-    $staffService->shouldReceive('isSuperAdministrator')->once()->with(1)->andThrow(new RuntimeException('admin groups unavailable'));
+    $staffService->shouldReceive('isSuperAdministrator')->once()->with(1)->andThrow(new class('admin groups unavailable') extends RuntimeException implements Doctrine\DBAL\Exception {});
 
     $updateFinalization = Mockery::mock();
     $updateFinalization->shouldReceive('isRequired')->once()->andReturn(true);
@@ -219,4 +219,27 @@ test('update finalization status rejects legacy non-admin while pending', functi
 
     expect(fn () => $api->update_finalization_status())
         ->toThrow(FOSSBilling\InformationException::class, 'You need to be a Super Administrator to finalize this update.');
+});
+
+test('update finalization status does not mask unrelated errors from isSuperAdministrator while pending', function (): void {
+    $api = new Box\Mod\System\Api\Admin();
+
+    $admin = new Model_Admin();
+    $admin->loadBean(new Tests\Helpers\DummyBean());
+    $admin->id = 1;
+    $api->setIdentity($admin);
+
+    $staffService = Mockery::mock(Box\Mod\Staff\Service::class);
+    $staffService->shouldReceive('isSuperAdministrator')->once()->with(1)->andThrow(new RuntimeException('unexpected failure'));
+
+    $updateFinalization = Mockery::mock();
+    $updateFinalization->shouldReceive('isRequired')->once()->andReturn(true);
+
+    $di = container();
+    $di['update_finalization'] = $updateFinalization;
+    $di['mod_service'] = $di->protect(fn (string $serviceName): mixed => $serviceName === 'Staff' ? $staffService : false);
+    $api->setDi($di);
+
+    expect(fn () => $api->update_finalization_status())
+        ->toThrow(RuntimeException::class, 'unexpected failure');
 });


### PR DESCRIPTION
## Summary
Follow-up to #3821 addressing the suggestions raised in code review:

- **Cron account no longer hidden by default in staff listings**: `Staff::getSearchQuery()` used to have `no_cron` forced to `true` server-side, but #3821 removed that hardcode entirely (to make the "Exclude Cron User" UI toggle actually work), leaving the default as `false`. Any API caller that omits `no_cron` now gets the internal cron service account back by default. This restores a safe default (`no_cron` defaults to `true` when the parameter is omitted) while keeping the caller-controlled override introduced in #3821.
- **Removed dead wildcard-permission code**: `Staff::hasPermission()` still checked a legacy `permissions.default.all` wildcard flag from the old per-admin permission system. Since permissions moved to groups in #3821 and no group-permission UI/API can set that key anymore, the branch was unreachable. Simplified the method accordingly (no behavior change, since the flag could never be set to `true` in practice).
- **Narrowed an overly broad `catch (\Throwable)`**: `System\Api\Admin::checkUpdateFinalizationPermissions()` catches errors from `isSuperAdministrator()` to fall back to a legacy `role` column check for installs that haven't migrated yet. Narrowed the catch to `Doctrine\DBAL\Exception` so unrelated failures (e.g. genuine bugs) propagate instead of silently triggering the legacy-compat fallback.
- **Seed timestamps generated at install time**: #3821 also bumped every `created_at`/`updated_at` literal in `src/install/sql/content.sql` to a single fixed date, which just goes stale again and needs another manual bump down the line. Replaced those literals with `NOW()`, since `content.sql` is executed as raw SQL statements (both by the web installer and by manual imports per `config-sample.php`), so each fresh install now gets accurate, current timestamps automatically.