### PR TITLE
Backfill `manage_settings` permission for existing staff groups

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','79',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','80',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -484,7 +484,8 @@ class UpdatePatcher implements InjectionAwareInterface
             76 => 'patch76',
             77 => 'patch77',
             78 => 'patch78',
-            79 => 'patch79'
+            79 => 'patch79',
+            80 => 'patch80',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2153,6 +2154,45 @@ class UpdatePatcher implements InjectionAwareInterface
              ON DUPLICATE KEY UPDATE name = 'Support Staff', parent_id = :parent_id, permissions = :permissions, protected = 0, updated_at = :updated_at",
             ['parent_id' => $supportLeadGroupId, 'permissions' => $supportStaffPermissions, 'created_at' => $now, 'updated_at' => $now],
         );
+    }
+
+    private function patch80(): void
+    {
+        // #3856 started requiring an explicit "manage_settings" permission to view or edit a
+        // module's settings (e.g. Scheduled Tasks), but existing staff groups that already had
+        // general access to those modules never had the new permission granted, silently
+        // locking non-super-admin staff out of settings pages they could previously use.
+        // Grant it wherever a group already had module access, to preserve prior behavior.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/3873
+        $modules = [
+            'activity', 'antispam', 'cookieconsent', 'cron', 'formbuilder',
+            'invoice', 'massmailer', 'order', 'orderbutton', 'seo', 'support', 'theme',
+        ];
+
+        $groups = $this->fetchAll('SELECT id, permissions FROM admin_group WHERE permissions IS NOT NULL');
+
+        foreach ($groups as $group) {
+            $permissions = json_decode((string) $group['permissions'], true);
+            if (!is_array($permissions)) {
+                continue;
+            }
+
+            $changed = false;
+            foreach ($modules as $module) {
+                if (($permissions[$module]['access'] ?? false) && !isset($permissions[$module]['manage_settings'])) {
+                    $permissions[$module]['manage_settings'] = true;
+                    $changed = true;
+                }
+            }
+
+            if ($changed) {
+                $this->executeSql('UPDATE admin_group SET permissions = :permissions, updated_at = :updated_at WHERE id = :id', [
+                    'permissions' => json_encode($permissions, JSON_THROW_ON_ERROR),
+                    'updated_at' => date('Y-m-d H:i:s'),
+                    'id' => $group['id'],
+                ]);
+            }
+        }
     }
 
     private function generateDownloadableStoredFilename(): string

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -2187,7 +2187,7 @@ class UpdatePatcher implements InjectionAwareInterface
 
             if ($changed) {
                 $this->executeSql('UPDATE admin_group SET permissions = :permissions, updated_at = :updated_at WHERE id = :id', [
-                    'permissions' => json_encode($permissions, JSON_THROW_ON_ERROR),
+                    'permissions' => json_encode($permissions),
                     'updated_at' => date('Y-m-d H:i:s'),
                     'id' => $group['id'],
                 ]);

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -2164,12 +2164,20 @@ class UpdatePatcher implements InjectionAwareInterface
         // locking non-super-admin staff out of settings pages they could previously use.
         // Grant it wherever a group already had module access, to preserve prior behavior.
         // @see https://github.com/FOSSBilling/FOSSBilling/issues/3873
+        //
+        // The staff group form only submits checked checkboxes, so a group edited on or after
+        // #3856 (2026-06-28, when the manage_settings checkbox first existed) that has no
+        // manage_settings key made a deliberate choice to leave it unchecked, not a legacy gap.
+        // Restrict the backfill to groups untouched since before that date so we don't clobber
+        // an intentional choice, including the default groups patch79 just created above.
         $modules = [
             'activity', 'antispam', 'cookieconsent', 'cron', 'formbuilder',
             'invoice', 'massmailer', 'order', 'orderbutton', 'seo', 'support', 'theme',
         ];
 
-        $groups = $this->fetchAll('SELECT id, permissions FROM admin_group WHERE permissions IS NOT NULL');
+        $groups = $this->fetchAll('SELECT id, permissions FROM admin_group WHERE permissions IS NOT NULL AND updated_at < :cutoff', [
+            'cutoff' => '2026-06-28 00:00:00',
+        ]);
 
         foreach ($groups as $group) {
             $permissions = json_decode((string) $group['permissions'], true);


### PR DESCRIPTION
## Summary

Fixes the root cause behind [#3873](https://github.com/FOSSBilling/FOSSBilling/issues/3873) ("Error when viewing 'Scheduled Tasks' in the admin ui").

- PR #3856 started enforcing an explicit `manage_settings` permission before allowing a staff member to view or edit a module's settings (e.g. the Cron/"Scheduled Tasks" page, Order/Invoice export settings, Support KB settings, etc.).
- Existing staff groups that already had general `access` to those modules never had this new permission key stored in their `admin_group.permissions` JSON, since it didn't exist before that change. As a result, any non-Super-Administrator staff account that previously could view/manage those settings started getting a 403 "You do not have permission to perform this action" error after upgrading — while Super Admin accounts (which bypass all permission checks) were unaffected. That mismatch explains the conflicting reports in #3873: the reporter hit the new check with a regular staff account, the commenter didn't reproduce it because they tested as Super Admin.
- The UI itself is fine — `manage_settings` is already normalized into a proper toggleable checkbox in the staff group permission editor (`Extension\Service::getSpecificModulePermissions()`), so newly created/edited groups work correctly. The gap was purely historical: groups configured before the enforcement change shipped have no `manage_settings` key at all.

Fixes #3873.