### PR TITLE
Modernize HTTP routing and response handling

### DIFF
--- a/src/ipn.php
+++ b/src/ipn.php
@@ -11,22 +11,24 @@ declare(strict_types=1);
  */
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'load.php';
 
+use FOSSBilling\Http\ApiResponseFactory;
 use FOSSBilling\Http\ResponseEmitter;
+use FOSSBilling\Http\ResponseFactory;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /* @var Symfony\Component\HttpFoundation\Request $request */
 global $request;
 
 $di = include Path::join(PATH_ROOT, 'di.php');
 $di['translate']();
+$apiResponseFactory = new ApiResponseFactory();
 
 $invoiceID = $request->get('invoice_id');
 if ($invoiceID !== null) {
     $invoiceID = filter_var($invoiceID, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
     if ($invoiceID === false) {
-        emitResponse(new JsonResponse(['error' => ['message' => 'Invalid invoice ID']], 400));
+        emitResponse(new JsonResponse(['result' => null, 'error' => ['message' => 'Invalid invoice ID']], 400));
     }
 }
 
@@ -35,7 +37,7 @@ $gatewayID = $request->get('gateway_id');
 if ($gatewayID !== null) {
     $gatewayID = filter_var($gatewayID, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
     if ($gatewayID === false) {
-        emitResponse(new JsonResponse(['error' => ['message' => 'Invalid gateway ID']], 400));
+        emitResponse(new JsonResponse(['result' => null, 'error' => ['message' => 'Invalid gateway ID']], 400));
     }
 }
 
@@ -66,11 +68,7 @@ try {
     // fastcgi_finish_request().
     if ($isJsonWebhook && function_exists('fastcgi_finish_request')) {
         $transactionId = $service->create($ipn);
-        $res = ['result' => $transactionId, 'error' => null];
-        $response = new JsonResponse($res, 200, [
-            'Cache-Control' => 'no-cache, must-revalidate',
-            'Expires' => 'Mon, 26 Jul 1997 05:00:00 GMT',
-        ]);
+        $response = $apiResponseFactory->create($transactionId);
         (new ResponseEmitter())->emit($response, $request);
         fastcgi_finish_request();
 
@@ -80,10 +78,9 @@ try {
     }
 
     $output = $service->createAndProcess($ipn);
-    $res = ['result' => $output, 'error' => null];
+    $response = $apiResponseFactory->create($output);
 } catch (Exception $e) {
-    $res = ['result' => null, 'error' => ['message' => $e->getMessage()]];
-    $output = false;
+    $response = $apiResponseFactory->create(null, $e);
 }
 
 // redirect to invoice if gateways requires
@@ -91,10 +88,7 @@ if ($request->query->has('redirect') && $request->query->has('invoice_hash')) {
     $invoiceHash = $request->query->get('invoice_hash');
     $hash = preg_replace('/[^a-zA-Z0-9]/', '', is_string($invoiceHash) ? $invoiceHash : '');
     $url = $di['url']->link('invoice/' . $hash);
-    emitResponse(new RedirectResponse($url));
+    emitResponse((new ResponseFactory())->redirect($url));
 }
 
-emitResponse(new JsonResponse($res, 200, [
-    'Cache-Control' => 'no-cache, must-revalidate',
-    'Expires' => 'Mon, 26 Jul 1997 05:00:00 GMT',
-]));
+emitResponse($response);

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -16,17 +16,21 @@ use FOSSBilling\Config;
 use FOSSBilling\Http\HttpResponseException;
 use FOSSBilling\Http\RequestFactory;
 use FOSSBilling\Http\ResponseFactory;
+use FOSSBilling\Http\RouteDefinition;
 use FOSSBilling\Http\RouteMatcher;
 use FOSSBilling\InjectionAwareInterface;
 use FOSSBilling\Security\AuthenticationRequiredException;
 use FOSSBilling\Security\EmailValidationRequiredException;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class Box_App
 {
-    protected array $mappings = [];
-    protected array $shared = [];
+    /** @var RouteDefinition[] */
+    protected array $routeDefinitions = [];
+    /** @var RouteDefinition[] */
+    protected array $sharedRouteDefinitions = [];
     protected ArrayObject $options;
     protected ?Pimple\Container $di = null;
     protected string $ext = 'html.twig';
@@ -34,6 +38,8 @@ class Box_App
     protected string $url = '/';
     protected StandardDebugBar $debugBar;
     protected Request $request;
+    private ?ResponseFactory $responseFactory = null;
+    private ?RouteMatcher $routeMatcher = null;
 
     public $uri;
 
@@ -105,22 +111,22 @@ class Box_App
 
     public function get(string $url, string $methodName, ?array $conditions = [], ?string $class = null): void
     {
-        $this->event('get', $url, $methodName, $conditions, $class);
+        $this->registerRoute('get', $url, $methodName, $conditions, $class);
     }
 
     public function post(string $url, string $methodName, ?array $conditions = [], ?string $class = null): void
     {
-        $this->event('post', $url, $methodName, $conditions, $class);
+        $this->registerRoute('post', $url, $methodName, $conditions, $class);
     }
 
     public function put(string $url, string $methodName, ?array $conditions = [], ?string $class = null): void
     {
-        $this->event('put', $url, $methodName, $conditions, $class);
+        $this->registerRoute('put', $url, $methodName, $conditions, $class);
     }
 
     public function delete(string $url, string $methodName, ?array $conditions = [], ?string $class = null): void
     {
-        $this->event('delete', $url, $methodName, $conditions, $class);
+        $this->registerRoute('delete', $url, $methodName, $conditions, $class);
     }
 
     public function getRequest(): Request
@@ -133,19 +139,29 @@ class Box_App
         return RequestFactory::getRoutePath($this->getRequest());
     }
 
+    protected function responseFactory(): ResponseFactory
+    {
+        return $this->responseFactory ??= new ResponseFactory();
+    }
+
+    private function routeMatcher(): RouteMatcher
+    {
+        return $this->routeMatcher ??= new RouteMatcher();
+    }
+
     protected function normalizeResponse(mixed $result): Response
     {
-        return (new ResponseFactory())->normalize($result);
+        return $this->responseFactory()->normalize($result);
     }
 
     public function renderResponse(string $fileName, array $variableArray = [], int $statusCode = 200, array $headers = []): Response
     {
-        return (new ResponseFactory())->html($this->render($fileName, $variableArray), $statusCode, $headers);
+        return $this->responseFactory()->html($this->render($fileName, $variableArray), $statusCode, $headers);
     }
 
     public function errorResponse(Exception $e, ?int $statusCode = null, array $headers = []): Response
     {
-        return (new ResponseFactory())->error($this->render('error', ['exception' => $e]), $e, $statusCode, $headers);
+        return $this->responseFactory()->error($this->render('error', ['exception' => $e]), $e, $statusCode, $headers);
     }
 
     public function abortWithResponse(Response $response): never
@@ -176,14 +192,14 @@ class Box_App
             if ($e->getArea() === 'admin') {
                 $this->di['set_return_uri'];
 
-                return (new ResponseFactory())->redirect($this->di['url']->adminLink('staff/login'));
+                return $this->responseFactory()->redirect($this->di['url']->adminLink('staff/login'));
             }
 
             $this->di['set_return_uri'];
 
-            return (new ResponseFactory())->redirect($this->di['url']->link('login'));
+            return $this->responseFactory()->redirect($this->di['url']->link('login'));
         } catch (EmailValidationRequiredException) {
-            return (new ResponseFactory())->redirect($this->di['url']->link('client/profile'));
+            return $this->responseFactory()->redirect($this->di['url']->link('client/profile'));
         } catch (HttpResponseException $e) {
             return $e->getResponse();
         }
@@ -195,18 +211,18 @@ class Box_App
     public function redirect($path): never
     {
         $location = $this->di['url']->link($path);
-        $this->abortWithResponse((new ResponseFactory())->redirect($location));
+        $this->abortWithResponse($this->responseFactory()->redirect($location));
     }
 
     public function permanentRedirect($path): never
     {
         $location = $this->di['url']->link($path);
-        $this->abortWithResponse((new ResponseFactory())->redirect($location, 301));
+        $this->abortWithResponse($this->responseFactory()->redirect($location, 301));
     }
 
     public function redirectUrl(string $url, int $statusCode = 302): never
     {
-        $this->abortWithResponse((new ResponseFactory())->redirect($url, $statusCode));
+        $this->abortWithResponse($this->responseFactory()->redirect($url, $statusCode));
     }
 
     public function render($fileName, $variableArray = []): string
@@ -216,41 +232,39 @@ class Box_App
 
     public function sendFile($filename, $contentType, $path): never
     {
-        $this->abortWithResponse((new ResponseFactory())->file($filename, $contentType, $path));
+        $this->abortWithResponse($this->responseFactory()->file($filename, $contentType, $path));
     }
 
     public function sendDownload($filename, $path): never
     {
-        $this->abortWithResponse((new ResponseFactory())->download($filename, $path));
+        $this->abortWithResponse($this->responseFactory()->download($filename, $path));
     }
 
-    protected function executeShared($classname, $methodName, $params): mixed
+    private function invokeSharedController(string $classname, string $methodName, array $params): mixed
     {
         /** @var TimeDataCollector $timeCollector */
         $timeCollector = $this->debugBar->getCollector('time');
 
         $timeCollector->startMeasure('executeShared', 'Reflecting module controller (shared mapping)');
-        $class = new $classname();
-        if ($class instanceof InjectionAwareInterface) {
-            $class->setDi($this->di);
-        }
+        $class = $this->createSharedController($classname);
         $reflection = new ReflectionMethod($class::class, $methodName);
-        $args = [];
-        $args[] = $this; // first param always app instance
-
-        foreach ($reflection->getParameters() as $param) {
-            if (isset($params[$param->name])) {
-                $args[$param->name] = $params[$param->name];
-            } elseif ($param->isDefaultValueAvailable()) {
-                $args[$param->name] = $param->getDefaultValue();
-            }
-        }
+        $args = $this->buildControllerArguments($reflection, $params, true);
         $timeCollector->stopMeasure('executeShared');
 
         return $reflection->invokeArgs($class, $args);
     }
 
-    protected function execute($methodName, $params, $classname = null): mixed
+    private function createSharedController(string $classname): object
+    {
+        $controller = new $classname();
+        if ($controller instanceof InjectionAwareInterface) {
+            $controller->setDi($this->di);
+        }
+
+        return $controller;
+    }
+
+    private function invokeLocalController(string $methodName, array $params): mixed
     {
         /** @var TimeDataCollector $timeCollector */
         $timeCollector = $this->debugBar->getCollector('time');
@@ -258,7 +272,16 @@ class Box_App
         $timeCollector->startMeasure('execute', 'Reflecting module controller');
 
         $reflection = new ReflectionMethod(static::class, $methodName);
-        $args = [];
+        $args = $this->buildControllerArguments($reflection, $params);
+
+        $timeCollector->stopMeasure('execute');
+
+        return $reflection->invokeArgs($this, $args);
+    }
+
+    private function buildControllerArguments(ReflectionMethod $reflection, array $params, bool $includeApp = false): array
+    {
+        $args = $includeApp ? [$this] : [];
 
         foreach ($reflection->getParameters() as $param) {
             if (isset($params[$param->name])) {
@@ -268,19 +291,38 @@ class Box_App
             }
         }
 
-        $timeCollector->stopMeasure('execute');
-
-        return $reflection->invokeArgs($this, $args);
+        return $args;
     }
 
-    protected function event(string $httpMethod, string $url, string $methodName, ?array $conditions = [], ?string $classname = null): void
+    private function registerRoute(string $httpMethod, string $url, string $methodName, ?array $conditions = [], ?string $classname = null): void
     {
         if (method_exists($this, $methodName)) {
-            $this->mappings[] = [$httpMethod, $url, $methodName, $conditions];
+            $this->routeDefinitions[] = new RouteDefinition($httpMethod, $url, $methodName, $conditions);
         }
         if ($classname !== null) {
-            $this->shared[] = [$httpMethod, $url, $methodName, $conditions, $classname];
+            $this->sharedRouteDefinitions[] = new RouteDefinition($httpMethod, $url, $methodName, $conditions, $classname);
         }
+    }
+
+    /**
+     * @param RouteDefinition[] $routes
+     */
+    private function dispatchRouteDefinitions(array $routes): ?Response
+    {
+        foreach ($routes as $route) {
+            $routeMatch = $this->routeMatcher()->match($route->httpMethod, $route->path, $route->conditions, $this->url, $this->getRequest()->getMethod());
+            if (!$routeMatch->matched) {
+                continue;
+            }
+
+            if ($route->controllerClass !== null) {
+                return $this->normalizeResponse($this->invokeSharedController($route->controllerClass, $route->methodName, $routeMatch->params));
+            }
+
+            return $this->normalizeResponse($this->invokeLocalController($route->methodName, $routeMatch->params));
+        }
+
+        return null;
     }
 
     protected function checkAllowedURLs(): bool
@@ -299,15 +341,36 @@ class Box_App
         foreach ($adminApiPrefixes as $adminApiPrefix) {
             $systemUrl = SYSTEM_URL;
             $realAdminApiUrl = str_ends_with($systemUrl, '/') ? substr($systemUrl, 0, -1) . $adminApiPrefix : $systemUrl . $adminApiPrefix;
-            $allowedURLs[] = parse_url($realAdminApiUrl)['path'];
+            $allowedURLs[] = parse_url($realAdminApiUrl, PHP_URL_PATH);
         }
         foreach ($allowedURLs as $url) {
-            if (preg_match('/^' . str_replace('/', '\/', $url) . '(.*)/', $requestPath) !== 0) {
+            if ($this->pathMatchesMaintenancePattern($requestPath, (string) $url)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    protected function pathMatchesMaintenancePattern(string $requestPath, string $allowedPath): bool
+    {
+        $allowedPath = trim($allowedPath);
+        if ($allowedPath === '') {
+            return false;
+        }
+
+        if (!str_contains($allowedPath, '*')) {
+            return $this->pathStartsWith($requestPath, $allowedPath);
+        }
+
+        $pattern = str_replace('\*', '.*', preg_quote($allowedPath, '/'));
+
+        return preg_match('/^' . $pattern . '/', $requestPath) === 1;
+    }
+
+    private function pathStartsWith(string $requestPath, string $basePath): bool
+    {
+        return $requestPath === $basePath || str_starts_with($requestPath, rtrim($basePath, '/') . '/');
     }
 
     protected function checkAllowedIPs(): bool
@@ -315,31 +378,34 @@ class Box_App
         $allowedIPs = Config::getProperty('maintenance_mode.allowed_ips', []);
         $visitorIP = $this->di['request']->getClientIp();
 
-        // Check if the visitor is in using of the allowed IPs/networks
-        foreach ($allowedIPs as $network) {
-            if (!str_contains((string) $network, '/')) {
-                $network .= '/32';
-            }
-            [$network, $netmask] = explode('/', (string) $network, 2);
-            $network_decimal = ip2long($network);
-            $ip_decimal = ip2long($visitorIP);
-            $wildcard_decimal = 2 ** (32 - (int) $netmask) - 1;
-            $netmask_decimal = ~$wildcard_decimal;
-            if (($ip_decimal & $netmask_decimal) == ($network_decimal & $netmask_decimal)) {
-                return false;
-            }
+        if (is_string($visitorIP) && is_array($allowedIPs) && $this->ipMatchesMaintenanceAllowlist($visitorIP, $allowedIPs)) {
+            return false;
         }
 
         return true;
+    }
+
+    protected function ipMatchesMaintenanceAllowlist(string $visitorIP, array $allowedIPs): bool
+    {
+        $allowedIPs = array_values(array_filter(array_map(
+            static fn (mixed $ip): string => trim((string) $ip),
+            $allowedIPs,
+        )));
+
+        try {
+            return $allowedIPs !== [] && IpUtils::checkIp($visitorIP, $allowedIPs);
+        } catch (InvalidArgumentException) {
+            return false;
+        }
     }
 
     protected function checkAdminPrefix(): bool
     {
         $requestPath = $this->getRequestPath();
         $realAdminUrl = rtrim(SYSTEM_URL, '/') . ADMIN_PREFIX;
-        $realAdminPath = parse_url($realAdminUrl)['path'];
+        $realAdminPath = parse_url($realAdminUrl, PHP_URL_PATH);
 
-        if (preg_match('/^' . str_replace('/', '\/', $realAdminPath) . '(.*)/', $requestPath) !== 0) {
+        if ($this->pathStartsWith($requestPath, $realAdminPath)) {
             return false;
         }
 
@@ -371,30 +437,21 @@ class Box_App
         $timeCollector = $this->debugBar->getCollector('time');
 
         $timeCollector->startMeasure('sharedMapping', 'Checking shared mappings');
-        $sharedCount = count($this->shared);
-        $routeMatcher = new RouteMatcher();
-        for ($i = 0; $i < $sharedCount; ++$i) {
-            $mapping = $this->shared[$i];
-            $routeMatch = $routeMatcher->match($mapping[0], $mapping[1], $mapping[3], $this->url, $this->getRequest()->getMethod());
-            if ($routeMatch->matched) {
-                $timeCollector->stopMeasure('sharedMapping');
+        $response = $this->dispatchRouteDefinitions($this->sharedRouteDefinitions);
+        if ($response instanceof Response) {
+            $timeCollector->stopMeasure('sharedMapping');
 
-                return $this->normalizeResponse($this->executeShared($mapping[4], $mapping[2], $routeMatch->params));
-            }
+            return $response;
         }
         $timeCollector->stopMeasure('sharedMapping');
 
         // this class mappings
         $timeCollector->startMeasure('mapping', 'Checking mappings');
-        $mappingsCount = count($this->mappings);
-        for ($i = 0; $i < $mappingsCount; ++$i) {
-            $mapping = $this->mappings[$i];
-            $routeMatch = $routeMatcher->match($mapping[0], $mapping[1], $mapping[3], $this->url, $this->getRequest()->getMethod());
-            if ($routeMatch->matched) {
-                $timeCollector->stopMeasure('mapping');
+        $response = $this->dispatchRouteDefinitions($this->routeDefinitions);
+        if ($response instanceof Response) {
+            $timeCollector->stopMeasure('mapping');
 
-                return $this->normalizeResponse($this->execute($mapping[2], $routeMatch->params));
-            }
+            return $response;
         }
         $timeCollector->stopMeasure('mapping');
 

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 use FOSSBilling\Http\HttpResponseException;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class Box_AppAdmin extends Box_App
 {
@@ -27,9 +26,9 @@ class Box_AppAdmin extends Box_App
 
     protected function checkPermission(): void
     {
-        /**
+        /*
          * Disable permission checks when an update is pending finalization.
-         * 
+         *
          * This is to make sure update finalization still works when there are changes to the
          * permission system and patches need to be applied before everything starts working again.
          */
@@ -62,7 +61,7 @@ class Box_AppAdmin extends Box_App
     public function redirect($path): never
     {
         $location = $this->di['url']->adminLink($path);
-        $this->abortWithResponse(new RedirectResponse($location));
+        $this->abortWithResponse($this->responseFactory()->redirect($location));
     }
 
     /**

--- a/src/library/FOSSBilling/Http/ResponseFactory.php
+++ b/src/library/FOSSBilling/Http/ResponseFactory.php
@@ -36,7 +36,8 @@ final readonly class ResponseFactory
 
     public function error(string $content, \Exception $exception, ?int $statusCode = null, array $headers = []): Response
     {
-        $statusCode ??= $exception->getCode() > 0 ? $exception->getCode() : Response::HTTP_INTERNAL_SERVER_ERROR;
+        $exceptionCode = $exception->getCode();
+        $statusCode ??= $exceptionCode >= 100 && $exceptionCode < 600 ? $exceptionCode : Response::HTTP_INTERNAL_SERVER_ERROR;
 
         return $this->html($content, $statusCode, $headers);
     }

--- a/src/library/FOSSBilling/Http/RouteDefinition.php
+++ b/src/library/FOSSBilling/Http/RouteDefinition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling\Http;
+
+final readonly class RouteDefinition
+{
+    public function __construct(
+        public string $httpMethod,
+        public string $path,
+        public string $methodName,
+        public ?array $conditions = [],
+        public ?string $controllerClass = null,
+    ) {
+    }
+}

--- a/src/load.php
+++ b/src/load.php
@@ -201,6 +201,7 @@ function preInit(): void
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'RequestPayloadParser.php');
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'ResponseFactory.php');
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'ResponseEmitter.php');
+    require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'RouteDefinition.php');
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'RouteMatch.php');
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Http', 'RouteMatcher.php');
     require Path::join(PATH_LIBRARY, 'FOSSBilling', 'Config.php');

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -21,10 +21,10 @@ use FOSSBilling\Environment;
 use FOSSBilling\Http\ApiResponseFactory;
 use FOSSBilling\Http\HttpResponseException;
 use FOSSBilling\Http\RequestPayloadParser;
+use FOSSBilling\Http\ResponseFactory;
 use FOSSBilling\InjectionAwareInterface;
 use FOSSBilling\Security\AuthenticationRequiredException;
 use FOSSBilling\Security\EmailValidationRequiredException;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class Client implements InjectionAwareInterface
@@ -227,7 +227,7 @@ class Client implements InjectionAwareInterface
                 $redirectUrl = $this->di['url']->link('');
             }
 
-            return new RedirectResponse($redirectUrl);
+            return (new ResponseFactory())->redirect($redirectUrl);
         }
 
         return $this->renderJson($result);

--- a/src/modules/Api/tests/Unit/Controller/ClientTest.php
+++ b/src/modules/Api/tests/Unit/Controller/ClientTest.php
@@ -77,6 +77,19 @@ class ClientTestUpdateFinalizationDouble
     }
 }
 
+class ClientTestUrlDouble
+{
+    public function link(string $path): string
+    {
+        return 'https://client.example.test/' . ltrim($path, '/');
+    }
+
+    public function adminLink(string $path): string
+    {
+        return 'https://admin.example.test/' . ltrim($path, '/');
+    }
+}
+
 class TestableClient extends Client
 {
     public bool $hasValidSession = false;
@@ -144,10 +157,11 @@ class TestableClient extends Client
     }
 }
 
-function invokeApiCall(TestableClient $controller, string $role, string $class, string $method, array $params): void
+function invokeApiCall(TestableClient $controller, string $role, string $class, string $method, array $params): mixed
 {
     $reflection = new ReflectionMethod(Client::class, '_apiCall');
-    $reflection->invoke($controller, $role, $class, $method, $params);
+
+    return $reflection->invoke($controller, $role, $class, $method, $params);
 }
 
 function createTestController(array $sessionData = [], ?object $api = null, mixed $dispatcherResult = ['ok' => true]): array
@@ -167,6 +181,7 @@ function createTestController(array $sessionData = [], ?object $api = null, mixe
     $di['update_finalization'] = new ClientTestUpdateFinalizationDouble();
     $di['api_identity'] = $di->protect(fn (string $role): object => $api);
     $di['api_dispatcher'] = new ClientTestApiDispatcherDouble($dispatcherResult);
+    $di['url'] = new ClientTestUrlDouble();
 
     $controller = new TestableClient();
     $controller->setDi($di);
@@ -294,4 +309,14 @@ test('raw response bypasses JSON rendering', function (): void {
     expect($controller->sentResponse)->toBe($response);
     expect($controller->renderedData)->toBeNull();
     expect($controller->renderedException)->toBeNull();
+});
+
+test('non-AJAX client login returns a redirect response', function (): void {
+    [$controller] = createTestController();
+
+    $response = invokeApiCall($controller, 'guest', 'client', 'login', []);
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->isRedirect())->toBeTrue()
+        ->and($response->headers->get('Location'))->toBe('https://client.example.test/');
 });

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -17,13 +17,13 @@ use Dompdf\Dompdf;
 use FOSSBilling\Environment;
 use FOSSBilling\Http\HttpResponseException;
 use FOSSBilling\Http\RequestFactory;
+use FOSSBilling\Http\ResponseFactory;
 use FOSSBilling\InformationException;
 use FOSSBilling\InjectionAwareInterface;
 use FOSSBilling\Tools;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\HeaderUtils;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Loader\FilesystemLoader;
 
@@ -1472,14 +1472,14 @@ class Service implements InjectionAwareInterface
 
         $invoice = $this->di['db']->findOne('Invoice', 'hash = ?', [$data['hash']]);
         if (!$invoice instanceof \Model_Invoice) {
-            throw new \FOSSBilling\InformationException('Invoice not found', null, 812);
+            throw new InformationException('Invoice not found', null, 812);
         }
 
         $this->checkInvoiceAuth($invoice, InvoiceOperation::PAYMENT);
 
         $gtw = $this->di['db']->load('PayGateway', $data['gateway_id']);
         if (!$gtw instanceof \Model_PayGateway) {
-            throw new \FOSSBilling\InformationException('Payment method not found', null, 813);
+            throw new InformationException('Payment method not found', null, 813);
         }
 
         if (!$gtw->enabled) {
@@ -1547,7 +1547,7 @@ class Service implements InjectionAwareInterface
         $invoice = $this->di['db']->findOne('Invoice', 'hash = :hash', [':hash' => $hash]);
 
         if (!$invoice instanceof \Model_Invoice) {
-            throw new \FOSSBilling\InformationException('Invoice not found');
+            throw new InformationException('Invoice not found');
         }
 
         $this->checkInvoiceAuth($invoice, InvoiceOperation::READ);
@@ -1814,25 +1814,30 @@ class Service implements InjectionAwareInterface
         $isOwner = $client !== null && (int) $invoiceClientId === (int) $client->id;
 
         if (!$isOwner && $this->isHashExpired($invoice)) {
-            $api_str = '/api/';
-            $url = RequestFactory::getRoutePath($this->di['request']);
-            if (strncasecmp($url, $api_str, strlen($api_str)) === 0) {
+            if ($this->isApiRouteRequest()) {
                 throw new InformationException('This invoice link has expired', [], 403);
             }
 
-            throw new HttpResponseException(new RedirectResponse($this->di['url']->link('invoice')));
+            $this->redirectToInvoiceList();
         }
 
         if (!$hashAccessAllowed && !$isOwner) {
-            $api_str = '/api/';
-            $url = RequestFactory::getRoutePath($this->di['request']);
-            if (strncasecmp($url, $api_str, strlen($api_str)) === 0) {
+            if ($this->isApiRouteRequest()) {
                 throw new InformationException('You do not have permission to perform this action', [], 403);
             }
-            $invoiceLink = $this->di['url']->link('invoice');
 
-            throw new HttpResponseException(new RedirectResponse($invoiceLink));
+            $this->redirectToInvoiceList();
         }
+    }
+
+    private function isApiRouteRequest(): bool
+    {
+        return str_starts_with(RequestFactory::getRoutePath($this->di['request']), '/api/');
+    }
+
+    private function redirectToInvoiceList(): never
+    {
+        throw new HttpResponseException((new ResponseFactory())->redirect($this->di['url']->link('invoice')));
     }
 
     /**

--- a/tests/Unit/Box/AppRouteDispatchTest.php
+++ b/tests/Unit/Box/AppRouteDispatchTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request;
+
+class BoxAppRouteDispatchSharedController implements FOSSBilling\InjectionAwareInterface
+{
+    private ?Pimple\Container $di = null;
+
+    public function setDi(Pimple\Container $di): void
+    {
+        $this->di = $di;
+    }
+
+    public function priority(Box_App $app, string $id): string
+    {
+        return 'shared:' . $id;
+    }
+
+    public function injected(Box_App $app): string
+    {
+        return $this->di instanceof Pimple\Container && $this->di['shared_marker'] === 'available'
+            ? 'di:available'
+            : 'di:missing';
+    }
+}
+
+class BoxAppRouteDispatchApp extends Box_App
+{
+    public function __construct(private readonly string $routeMode)
+    {
+        parent::__construct();
+    }
+
+    protected function init(): void
+    {
+        if ($this->routeMode === 'shared-priority') {
+            $this->get('/priority/:id', 'priority', ['id' => '[0-9]+'], BoxAppRouteDispatchSharedController::class);
+
+            return;
+        }
+
+        if ($this->routeMode === 'shared-di') {
+            $this->get('/shared-di', 'injected', [], BoxAppRouteDispatchSharedController::class);
+
+            return;
+        }
+
+        if ($this->routeMode === 'default-argument') {
+            $this->get('/default', 'withDefault');
+
+            return;
+        }
+
+        $this->get('/local/:id', 'local', ['id' => '[0-9]+']);
+    }
+
+    public function local(string $id): string
+    {
+        return 'local:' . $id;
+    }
+
+    public function priority(string $id): string
+    {
+        return 'local:' . $id;
+    }
+
+    public function withDefault(string $tab = 'overview'): string
+    {
+        return 'default:' . $tab;
+    }
+
+    public function render($fileName, $variableArray = []): string
+    {
+        return 'error';
+    }
+}
+
+class BoxAppMaintenanceCheckApp extends Box_App
+{
+    public function pathAllowed(string $requestPath, string $allowedPath): bool
+    {
+        return $this->pathMatchesMaintenancePattern($requestPath, $allowedPath);
+    }
+
+    public function ipAllowed(string $visitorIP, array $allowedIPs): bool
+    {
+        return $this->ipMatchesMaintenanceAllowlist($visitorIP, $allowedIPs);
+    }
+}
+
+function routeDispatchApp(string $routeMode, string $path): BoxAppRouteDispatchApp
+{
+    $app = new BoxAppRouteDispatchApp($routeMode);
+
+    $di = new Pimple\Container();
+    $di['request'] = Request::create('http://localhost' . $path);
+    $di['shared_marker'] = 'available';
+    $di['logger'] = new class {
+        public function setChannel(string $channel): self
+        {
+            return $this;
+        }
+
+        public function info(string|Stringable $message, array $context = []): void
+        {
+        }
+    };
+
+    $app->setDi($di);
+    $app->setUrl($path);
+
+    return $app;
+}
+
+test('app dispatches local route definitions with matched parameters', function (): void {
+    $response = routeDispatchApp('local', '/local/42')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('local:42');
+});
+
+test('app preserves shared controller route priority over local routes', function (): void {
+    $response = routeDispatchApp('shared-priority', '/priority/42')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('shared:42');
+});
+
+test('app injects the DI container into shared route controllers', function (): void {
+    $response = routeDispatchApp('shared-di', '/shared-di')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('di:available');
+});
+
+test('app dispatch uses controller default arguments when route params are absent', function (): void {
+    $response = routeDispatchApp('default-argument', '/default')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('default:overview');
+});
+
+test('maintenance path allowlist uses literal prefixes and explicit wildcards', function (): void {
+    $app = new BoxAppMaintenanceCheckApp();
+
+    expect($app->pathAllowed('/status', '/status'))->toBeTrue()
+        ->and($app->pathAllowed('/status/deep', '/status'))->toBeTrue()
+        ->and($app->pathAllowed('/status-page', '/status'))->toBeFalse()
+        ->and($app->pathAllowed('/api/guest/staff/login', '/api/guest/staff/*'))->toBeTrue()
+        ->and($app->pathAllowed('/docs/v10', '/docs/v1.0'))->toBeFalse()
+        ->and($app->pathAllowed('/api/admin', ''))->toBeFalse();
+});
+
+test('maintenance IP allowlist supports exact IPs, CIDR ranges, and IPv6', function (): void {
+    $app = new BoxAppMaintenanceCheckApp();
+
+    expect($app->ipAllowed('203.0.113.10', ['203.0.113.10']))->toBeTrue()
+        ->and($app->ipAllowed('203.0.113.55', ['203.0.113.0/24']))->toBeTrue()
+        ->and($app->ipAllowed('2001:db8::1', ['2001:db8::/32']))->toBeTrue()
+        ->and($app->ipAllowed('198.51.100.10', ['203.0.113.0/24']))->toBeFalse()
+        ->and($app->ipAllowed('198.51.100.10', ['not-an-ip-range']))->toBeFalse();
+});

--- a/tests/Unit/FOSSBilling/ResponseFactoryTest.php
+++ b/tests/Unit/FOSSBilling/ResponseFactoryTest.php
@@ -32,7 +32,8 @@ test('response factory creates error responses using exception codes or internal
     $factory = new ResponseFactory();
 
     expect($factory->error('not found', new RuntimeException('Missing', 404))->getStatusCode())->toBe(404)
-        ->and($factory->error('error', new RuntimeException('Broken'))->getStatusCode())->toBe(Response::HTTP_INTERNAL_SERVER_ERROR);
+        ->and($factory->error('error', new RuntimeException('Broken'))->getStatusCode())->toBe(Response::HTTP_INTERNAL_SERVER_ERROR)
+        ->and($factory->error('legacy', new RuntimeException('Legacy code', 981))->getStatusCode())->toBe(Response::HTTP_INTERNAL_SERVER_ERROR);
 });
 
 test('response factory creates redirect responses', function (): void {


### PR DESCRIPTION
## Summary

This PR continues the HTTP modernization work around Symfony HttpFoundation and the legacy `Box_App` request flow.

It replaces positional route arrays with explicit route definitions, centralizes route dispatch and controller invocation, and moves more response creation through focused HTTP helpers where that improves clarity. It also tightens maintenance-mode path/IP matching and removes duplicated redirect/JSON response handling in module and IPN paths.

## Changes

- Add `FOSSBilling\Http\RouteDefinition` for app route registration.
- Refactor `Box_App` route dispatch away from positional arrays and legacy `event()`/`execute()` naming.
- Reuse `ResponseFactory` and `RouteMatcher` inside `Box_App`.
- Use `ResponseFactory` for admin/module redirects where appropriate.
- Harden `ResponseFactory::error()` so legacy application exception codes do not become invalid HTTP status codes.
- Replace manual maintenance-mode IP matching with Symfony `IpUtils`.
- Make maintenance path allowlist matching explicit, escaped, and wildcard-aware.
- Clean up IPN JSON envelope and redirect response creation with existing HTTP factories.
- Add focused tests for route dispatch, shared-controller DI injection, maintenance matching, API login redirects, and legacy exception status handling.
