### PR TITLE
Skip renewals for pending paid invoice items

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','82',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','83',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -632,7 +632,8 @@ CREATE TABLE `invoice_item` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `invoice_id_idx` (`invoice_id`)
+  KEY `invoice_id_idx` (`invoice_id`),
+  KEY `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`(32), `task`(32), `status`(32), `invoice_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -633,7 +633,7 @@ CREATE TABLE `invoice_item` (
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `invoice_id_idx` (`invoice_id`),
-  KEY `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`(32), `task`(32), `status`(32), `invoice_id`)
+  KEY `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`, `task`, `status`, `invoice_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -491,6 +491,7 @@ class UpdatePatcher implements InjectionAwareInterface
             80 => 'patch80',
             81 => 'patch81',
             82 => 'patch82',
+            83 => 'patch83',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2250,6 +2251,13 @@ class UpdatePatcher implements InjectionAwareInterface
                 SELECT 1 FROM email_template_group etg
                 WHERE etg.email_template_id = et.id AND etg.admin_group_id = ag.id
             )");
+    }
+
+    private function patch83(): void
+    {
+        if (!$this->tableHasIndex('invoice_item', 'invoice_item_pending_renewal_idx')) {
+            $this->executeSql('ALTER TABLE `invoice_item` ADD INDEX `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`(32), `task`(32), `status`(32), `invoice_id`)');
+        }
     }
 
     private function generateDownloadableStoredFilename(): string

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -2256,7 +2256,7 @@ class UpdatePatcher implements InjectionAwareInterface
     private function patch83(): void
     {
         if (!$this->tableHasIndex('invoice_item', 'invoice_item_pending_renewal_idx')) {
-            $this->executeSql('ALTER TABLE `invoice_item` ADD INDEX `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`(32), `task`(32), `status`(32), `invoice_id`)');
+            $this->executeSql('ALTER TABLE `invoice_item` ADD INDEX `invoice_item_pending_renewal_idx` (`rel_id`(20), `type`, `task`, `status`, `invoice_id`)');
         }
     }
 

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -332,6 +332,7 @@ class Service implements InjectionAwareInterface
                 AND co.period IS NOT NULL
                 AND co.expires_at IS NOT NULL
                 AND i.id IS NULL
+                /* Pair non-executed renewal items with paid invoices to skip renewals already queued for activation. */
                 AND NOT EXISTS (
                     SELECT 1
                     FROM invoice_item pending_item

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -331,7 +331,17 @@ class Service implements InjectionAwareInterface
                 AND co.invoice_option = :invoice_option
                 AND co.period IS NOT NULL
                 AND co.expires_at IS NOT NULL
-                AND i.id IS NULL';
+                AND i.id IS NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM invoice_item pending_item
+                    INNER JOIN invoice pending_invoice ON pending_invoice.id = pending_item.invoice_id
+                    WHERE pending_item.rel_id = co.id
+                    AND pending_item.type = :pending_item_type
+                    AND pending_item.task = :pending_item_task
+                    AND pending_item.status != :pending_item_status
+                    AND pending_invoice.status = :pending_invoice_status
+                )';
 
         $where = [];
         $bindings = [];
@@ -349,6 +359,10 @@ class Service implements InjectionAwareInterface
         $bindings[':status'] = \Model_ClientOrder::STATUS_ACTIVE;
         $bindings[':invoice_option'] = 'issue-invoice';
         $bindings[':unpaid_invoice_status'] = \Model_Invoice::STATUS_UNPAID;
+        $bindings[':pending_item_type'] = \Model_InvoiceItem::TYPE_ORDER;
+        $bindings[':pending_item_task'] = \Model_InvoiceItem::TASK_RENEW;
+        $bindings[':pending_item_status'] = \Model_InvoiceItem::STATUS_EXECUTED;
+        $bindings[':pending_invoice_status'] = \Model_Invoice::STATUS_PAID;
         $bindings[':days_until_expiration'] = $days_until_expiration;
 
         return [$query, $bindings];

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -833,11 +833,25 @@ test('getSoonExpiringActiveOrdersQuery builds expected SQL and bindings', functi
                 AND co.invoice_option = :invoice_option
                 AND co.period IS NOT NULL
                 AND co.expires_at IS NOT NULL
-                AND i.id IS NULL AND co.client_id = :client_id HAVING DATEDIFF(co.expires_at, NOW()) <= :days_until_expiration ORDER BY co.client_id DESC';
+                AND i.id IS NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM invoice_item pending_item
+                    INNER JOIN invoice pending_invoice ON pending_invoice.id = pending_item.invoice_id
+                    WHERE pending_item.rel_id = co.id
+                    AND pending_item.type = :pending_item_type
+                    AND pending_item.task = :pending_item_task
+                    AND pending_item.status != :pending_item_status
+                    AND pending_invoice.status = :pending_invoice_status
+                ) AND co.client_id = :client_id HAVING DATEDIFF(co.expires_at, NOW()) <= :days_until_expiration ORDER BY co.client_id DESC';
 
     $expectedBindings = [
         ':client_id' => $randId,
         ':unpaid_invoice_status' => Model_Invoice::STATUS_UNPAID,
+        ':pending_item_type' => Model_InvoiceItem::TYPE_ORDER,
+        ':pending_item_task' => Model_InvoiceItem::TASK_RENEW,
+        ':pending_item_status' => Model_InvoiceItem::STATUS_EXECUTED,
+        ':pending_invoice_status' => Model_Invoice::STATUS_PAID,
         ':status' => Model_ClientOrder::STATUS_ACTIVE,
         ':invoice_option' => 'issue-invoice',
         ':days_until_expiration' => $randId,

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -834,6 +834,7 @@ test('getSoonExpiringActiveOrdersQuery builds expected SQL and bindings', functi
                 AND co.period IS NOT NULL
                 AND co.expires_at IS NOT NULL
                 AND i.id IS NULL
+                /* Pair non-executed renewal items with paid invoices to skip renewals already queued for activation. */
                 AND NOT EXISTS (
                     SELECT 1
                     FROM invoice_item pending_item


### PR DESCRIPTION
Fixes #3726 [comment](https://github.com/FOSSBilling/FOSSBilling/issues/3726#issuecomment-4894355134).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soon-to-expire active order selection to exclude orders without an unpaid linked invoice and to ignore client orders with pending renewal-related invoice items tied to invoices in a pending state.
* **Tests**
  * Updated unit test SQL and bindings to match the revised filtering logic.
* **Chores**
  * Added a new composite database index for faster pending renewal/invoice lookups and advanced the stored patch level (including installation seed data).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->