### PR TITLE
Stop mapping timers before debugbar collection

### DIFF
--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -307,12 +307,17 @@ class Box_App
     /**
      * @param RouteDefinition[] $routes
      */
-    private function dispatchRouteDefinitions(array $routes): ?Response
+    private function dispatchRouteDefinitions(array $routes, ?string $mappingMeasureName = null): ?Response
     {
         foreach ($routes as $route) {
             $routeMatch = $this->routeMatcher()->match($route->httpMethod, $route->path, $route->conditions, $this->url, $this->getRequest()->getMethod());
             if (!$routeMatch->matched) {
                 continue;
+            }
+
+            $timeCollector = $this->debugBar->getCollector('time');
+            if ($mappingMeasureName !== null && $timeCollector->hasStartedMeasure($mappingMeasureName)) {
+                $timeCollector->stopMeasure($mappingMeasureName);
             }
 
             if ($route->controllerClass !== null) {
@@ -437,23 +442,23 @@ class Box_App
         $timeCollector = $this->debugBar->getCollector('time');
 
         $timeCollector->startMeasure('sharedMapping', 'Checking shared mappings');
-        $response = $this->dispatchRouteDefinitions($this->sharedRouteDefinitions);
+        $response = $this->dispatchRouteDefinitions($this->sharedRouteDefinitions, 'sharedMapping');
         if ($response instanceof Response) {
-            $timeCollector->stopMeasure('sharedMapping');
-
             return $response;
         }
-        $timeCollector->stopMeasure('sharedMapping');
+        if ($timeCollector->hasStartedMeasure('sharedMapping')) {
+            $timeCollector->stopMeasure('sharedMapping');
+        }
 
         // this class mappings
         $timeCollector->startMeasure('mapping', 'Checking mappings');
-        $response = $this->dispatchRouteDefinitions($this->routeDefinitions);
+        $response = $this->dispatchRouteDefinitions($this->routeDefinitions, 'mapping');
         if ($response instanceof Response) {
-            $timeCollector->stopMeasure('mapping');
-
             return $response;
         }
-        $timeCollector->stopMeasure('mapping');
+        if ($timeCollector->hasStartedMeasure('mapping')) {
+            $timeCollector->stopMeasure('mapping');
+        }
 
         $e = new FOSSBilling\InformationException('Page :url not found', [':url' => $this->url], 404);
 

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -304,6 +304,13 @@ class Box_App
         }
     }
 
+    private function stopMeasureIfStarted(TimeDataCollector $timeCollector, string $measureName): void
+    {
+        if ($timeCollector->hasStartedMeasure($measureName)) {
+            $timeCollector->stopMeasure($measureName);
+        }
+    }
+
     /**
      * @param RouteDefinition[] $routes
      */
@@ -317,8 +324,8 @@ class Box_App
 
             /** @var TimeDataCollector $timeCollector */
             $timeCollector = $this->debugBar->getCollector('time');
-            if ($mappingMeasureName !== null && $timeCollector->hasStartedMeasure($mappingMeasureName)) {
-                $timeCollector->stopMeasure($mappingMeasureName);
+            if ($mappingMeasureName !== null) {
+                $this->stopMeasureIfStarted($timeCollector, $mappingMeasureName);
             }
 
             if ($route->controllerClass !== null) {
@@ -447,9 +454,7 @@ class Box_App
         if ($response instanceof Response) {
             return $response;
         }
-        if ($timeCollector->hasStartedMeasure('sharedMapping')) {
-            $timeCollector->stopMeasure('sharedMapping');
-        }
+        $this->stopMeasureIfStarted($timeCollector, 'sharedMapping');
 
         // this class mappings
         $timeCollector->startMeasure('mapping', 'Checking mappings');
@@ -457,9 +462,7 @@ class Box_App
         if ($response instanceof Response) {
             return $response;
         }
-        if ($timeCollector->hasStartedMeasure('mapping')) {
-            $timeCollector->stopMeasure('mapping');
-        }
+        $this->stopMeasureIfStarted($timeCollector, 'mapping');
 
         $e = new FOSSBilling\InformationException('Page :url not found', [':url' => $this->url], 404);
 

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -315,6 +315,7 @@ class Box_App
                 continue;
             }
 
+            /** @var TimeDataCollector $timeCollector */
             $timeCollector = $this->debugBar->getCollector('time');
             if ($mappingMeasureName !== null && $timeCollector->hasStartedMeasure($mappingMeasureName)) {
                 $timeCollector->stopMeasure($mappingMeasureName);

--- a/tests/Unit/Box/AppRouteDispatchTest.php
+++ b/tests/Unit/Box/AppRouteDispatchTest.php
@@ -32,6 +32,13 @@ class BoxAppRouteDispatchSharedController implements FOSSBilling\InjectionAwareI
             ? 'di:available'
             : 'di:missing';
     }
+
+    public function collectDebugbar(Box_App $app): string
+    {
+        $app->getDebugBar()->getData();
+
+        return 'shared-debugbar:collected';
+    }
 }
 
 class BoxAppRouteDispatchApp extends Box_App
@@ -55,8 +62,20 @@ class BoxAppRouteDispatchApp extends Box_App
             return;
         }
 
+        if ($this->routeMode === 'shared-debugbar-collect') {
+            $this->get('/shared-debugbar-collect', 'collectDebugbar', [], BoxAppRouteDispatchSharedController::class);
+
+            return;
+        }
+
         if ($this->routeMode === 'default-argument') {
             $this->get('/default', 'withDefault');
+
+            return;
+        }
+
+        if ($this->routeMode === 'debugbar-collect') {
+            $this->get('/debugbar-collect', 'collectDebugbar');
 
             return;
         }
@@ -77,6 +96,13 @@ class BoxAppRouteDispatchApp extends Box_App
     public function withDefault(string $tab = 'overview'): string
     {
         return 'default:' . $tab;
+    }
+
+    public function collectDebugbar(): string
+    {
+        $this->getDebugBar()->getData();
+
+        return 'debugbar:collected';
     }
 
     public function render($fileName, $variableArray = []): string
@@ -148,6 +174,20 @@ test('app dispatch uses controller default arguments when route params are absen
 
     expect($response->getStatusCode())->toBe(200)
         ->and($response->getContent())->toBe('default:overview');
+});
+
+test('app route mapping timing stops before debug bar data is collected during render', function (): void {
+    $response = routeDispatchApp('debugbar-collect', '/debugbar-collect')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('debugbar:collected');
+});
+
+test('app shared route mapping timing stops before debug bar data is collected during render', function (): void {
+    $response = routeDispatchApp('shared-debugbar-collect', '/shared-debugbar-collect')->run();
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getContent())->toBe('shared-debugbar:collected');
 });
 
 test('maintenance path allowlist uses literal prefixes and explicit wildcards', function (): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request routing so timing information is handled more reliably during route dispatch.
  * Fixed debugbar collection behavior for both standard and shared routes, ensuring each returns the expected collected response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->