### PR TITLE
Fix cron settings defaults

### DIFF
--- a/src/modules/Cron/templates/admin/mod_cron_settings.html.twig
+++ b/src/modules/Cron/templates/admin/mod_cron_settings.html.twig
@@ -23,6 +23,8 @@
 {% block content %}
     {% set cron = admin.cron_info %}
     {% set params = admin.extension_config_get({ 'ext': 'mod_cron' }) %}
+    {% set guest_cron = params.guest_cron|default(false) %}
+    {% set cron_hash = params.cron_hash|default('') %}
     <div class="card">
         <div class="card-header">
             <div>
@@ -76,13 +78,13 @@
                         <p class="text-secondary mb-0">{{ 'Toggle to enable or disable the guest cron URL. A security hash is generated automatically when enabled.'|trans }}</p>
                     </div>
                     <label class="form-check form-switch form-switch-2 m-0">
-                        <input class="form-check-input" name="guest_cron" type="checkbox" {% if params.guest_cron %}checked="checked"{% endif %} onchange="document.getElementById('guest-cron-form').requestSubmit()">
+                        <input class="form-check-input" name="guest_cron" type="checkbox" {% if guest_cron %}checked="checked"{% endif %} onchange="document.getElementById('guest-cron-form').requestSubmit()">
                         <span class="form-check-label">{{ 'Enable Guest Access'|trans }}</span>
                     </label>
                 </div>
-                {% if params.guest_cron and params.cron_hash %}
+                {% if guest_cron and cron_hash %}
                     <label class="form-label" for="guest-cron-url">{{ 'Guest Cron URL'|trans }}</label>
-                    <input id="guest-cron-url" class="form-control font-monospace mb-2" type="text" value="{{ 'cron/run'|api_url(role: 'guest', query: {hash: params.cron_hash}) }}" readonly>
+                    <input id="guest-cron-url" class="form-control font-monospace mb-2" type="text" value="{{ 'cron/run'|api_url(role: 'guest', query: {hash: cron_hash}) }}" readonly>
                     <div class="d-flex justify-content-end mb-3">
                         <a class="btn btn-outline-warning" href="{{ 'cron/regenerate_cron_hash'|api_url }}" {{ fb_api_link({message: 'Hash Regenerated'|trans, reload: true}) }}>
                             {{ 'Regenerate Hash'|trans }}

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -12,6 +12,40 @@ declare(strict_types=1);
 
 use Tests\Support\StrictTemplateRenderer;
 
+test('cron settings renders when module config has not been saved', function (): void {
+    $renderer = new StrictTemplateRenderer();
+    $admin = new class {
+        public function __isset(string $name): bool
+        {
+            return $name === 'cron_info';
+        }
+
+        public function __get(string $name): mixed
+        {
+            return match ($name) {
+                'cron_info' => [
+                    'cron_path' => '/var/www/fossbilling/cron.php',
+                    'last_cron_exec' => null,
+                ],
+                default => null,
+            };
+        }
+
+        public function extension_config_get(array $data): array
+        {
+            return ['ext' => $data['ext']];
+        }
+    };
+
+    $html = $renderer->renderTemplate(PATH_MODS . '/Cron/templates/admin/mod_cron_settings.html.twig', [
+        'admin' => $admin,
+    ]);
+
+    expect($html)->toContain('Guest Cron Endpoint')
+        ->and($html)->not->toContain('checked="checked"')
+        ->and($html)->not->toContain('Guest Cron URL');
+});
+
 /*
  * Verify that every FOSSBilling template compiles and renders successfully under
  * `strict_variables => true`. This catches undefined variable/attribute/key access,


### PR DESCRIPTION
## What Changed

- Default missing cron module config values before rendering the admin cron settings template.
- Add a strict Twig regression test for the unsaved cron module config state.

## Why

Fixes #3902. On installations where `extension_config_get({ ext: 'mod_cron' })` returns only the extension key, the template accessed `params.guest_cron` directly and Twig raised `Key "guest_cron" ... does not exist`.