### PR TITLE
Ignore WIP/Draft PR titles in CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,9 @@ reviews:
   auto_review:
     enabled: false
     auto_incremental_review: false
+    ignore_title_keywords:
+      - "[WIP]"
+      - "[Draft]"
     ignore_usernames:
       - "renovate[bot]"
       - "dependabot[bot]"


### PR DESCRIPTION
This pull request updates the `.coderabbit.yaml` configuration to improve the auto-review process by adding a filter for pull request titles. Now, auto-reviews will be skipped for pull requests marked as work-in-progress or drafts.