### PR TITLE
Expose custom client IDs

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -110,7 +110,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * @optional string $password - client password
      * @optional string $auth_type - client authorization type. Default null
      * @optional string $last_name - client last name
-     * @optional string $aid - alternative ID. If you import clients from other systems you can use this field to store foreign system ID
+     * @optional string $aid - Custom client ID. If you import clients from other systems you can use this field to store the existing customer ID.
      * @optional string $group_id - client group id
      * @optional string $status - client status: "active, suspended, canceled"
      * @optional string $created_at - ISO 8601 date for client creation date
@@ -217,7 +217,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * @optional string $first_name - client first_name
      * @optional string $last_name - client last_name
      * @optional string $status - client status
-     * @optional string $aid - Alternative id. Usually used by import tools.
+     * @optional string $aid - Custom client ID. Usually used by import tools to store an existing customer ID.
      * @optional string $gender - Gender - values: male|female|nonbinary|other
      * @optional string $country - Country
      * @optional string $city - city

--- a/src/modules/Client/templates/admin/mod_client_index.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_index.html.twig
@@ -135,7 +135,7 @@
                             <div class="col-md-6 col-xl-3">
                                 <div>
                                     <label class="form-label text-muted small mb-1" for="filter-client-id">{{ 'Client ID'|trans }}</label>
-                                    <input class="form-control" type="text" id="filter-client-id" name="id" value="{{ request.id }}" placeholder="{{ 'Client ID'|trans }}">
+                                    <input class="form-control" type="text" id="filter-client-id" name="id" value="{{ request.id }}" placeholder="{{ 'Numeric or custom ID'|trans }}">
                                 </div>
                             </div>
                             <div class="col-md-6 col-xl-3">

--- a/src/modules/Client/templates/admin/mod_client_manage.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_manage.html.twig
@@ -95,6 +95,12 @@
                                         <td class="w-50 text-end">{{ 'Client ID'|trans }}:</td>
                                         <td>{{ client.id }}</td>
                                     </tr>
+                                    {% if client.aid %}
+                                    <tr>
+                                        <td class="text-end">{{ 'Custom Client ID'|trans }}:</td>
+                                        <td>{{ client.aid }}</td>
+                                    </tr>
+                                    {% endif %}
                                     <tr>
                                         <td class="text-end">{{ 'Name'|trans }}:</td>
                                         <td>{{ client.first_name }} {{ client.last_name }}</td>
@@ -351,8 +357,8 @@
                             <h6 class="card-title text-secondary mb-3">{{ 'Additional Settings'|trans }}</h6>
                             <div class="row g-3">
                                 <div class="col-xl-6">
-                                    <label class="form-label">{{ 'Alternative ID'|trans }}</label>
-                                    <input class="form-control" type="text" name="aid" value="{{ client.aid }}" placeholder="{{ 'Used to identify client on foreign system. Usually used by importers'|trans }}">
+                                    <label class="form-label">{{ 'Custom Client ID'|trans }}</label>
+                                    <input class="form-control" type="text" name="aid" value="{{ client.aid }}" placeholder="{{ 'Existing customer ID from another system'|trans }}">
                                 </div>
                                 <div class="col-xl-3">
                                     <label class="form-label">{{ 'Currency'|trans }}</label>

--- a/src/modules/Client/templates/admin/mod_client_new_form.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_new_form.html.twig
@@ -26,6 +26,10 @@
                             <input id="new-client-email" type="email" name="email" class="form-control" placeholder="client@fossbilling.org" required>
                         </div>
                         <div class="col-12">
+                            <label class="form-label" for="new-client-aid">{{ 'Custom Client ID'|trans }}</label>
+                            <input id="new-client-aid" type="text" name="aid" class="form-control" placeholder="{{ 'Existing customer ID from another system'|trans }}">
+                        </div>
+                        <div class="col-12">
                             <label class="form-label" for="new-client-password">{{ 'Password'|trans }}</label>
                             <input id="new-client-password" type="password" name="password" class="form-control" placeholder="{{ 'Optional initial password'|trans }}">
                             <div class="form-text">{{ 'Leave blank to let the client set a password from the welcome email.'|trans }}</div>

--- a/src/modules/Client/tests/Unit/ServiceTest.php
+++ b/src/modules/Client/tests/Unit/ServiceTest.php
@@ -811,6 +811,7 @@ test('adminCreateClient returns int', function (): void {
         'password' => uniqid(),
         'email' => 'test@unit.vm',
         'first_name' => 'test',
+        'aid' => 'LEGACY-1001',
     ];
 
     $dbMock = Mockery::mock('\Box_Database');
@@ -845,6 +846,7 @@ test('adminCreateClient returns int', function (): void {
 
     $result = $service->adminCreateClient($data);
     expect($result)->toBeInt();
+    expect($clientModel->aid)->toBe('LEGACY-1001');
 });
 
 test('deleteGroup returns true', function (): void {


### PR DESCRIPTION
## What changed
- Exposes the existing `client.aid` field as a Custom Client ID in the admin create and edit flows.
- Shows the custom ID on the admin client summary when present.
- Clarifies that the client ID filter accepts either the numeric ID or custom ID.
- Updates admin API docs for the existing `aid` field and adds a focused persistence assertion.

## Why
Issue #1952 asks for custom customer IDs during migrations from systems with alphanumeric customer identifiers. FOSSBilling already has `client.aid` for foreign-system IDs, but the admin UI did not expose it during client creation.

Closes #1952.