### PR TITLE
Move migrated module lookups to repositories

### DIFF
--- a/src/modules/Currency/Repository/CurrencyRepository.php
+++ b/src/modules/Currency/Repository/CurrencyRepository.php
@@ -19,6 +19,16 @@ use Symfony\Component\Intl\Currencies;
 
 class CurrencyRepository extends EntityRepository
 {
+    public function getClientCurrencyCode(int $clientId): ?string
+    {
+        $currencyCode = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT currency FROM client WHERE id = :client_id',
+            ['client_id' => $clientId],
+        );
+
+        return is_string($currencyCode) && $currencyCode !== '' ? $currencyCode : null;
+    }
+
     /**
      * Build a QueryBuilder for searching currencies.
      *

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -149,13 +149,9 @@ class Service implements InjectionAwareInterface
      */
     public function getCurrencyByClientId(int $clientId): Currency
     {
-        $sql = 'SELECT currency FROM client WHERE id = :client_id';
-        $values = [':client_id' => $clientId];
+        $currencyCode = $this->currencyRepository->getClientCurrencyCode($clientId);
 
-        $db = $this->di['db'];
-        $currencyCode = $db->getCell($sql, $values);
-
-        if ($currencyCode === null || $currencyCode === '') {
+        if ($currencyCode === null) {
             $defaultCurrency = $this->currencyRepository->findDefault();
             if ($defaultCurrency === null) {
                 throw new \FOSSBilling\Exception('Default currency not found.');

--- a/src/modules/Currency/tests/Unit/ServiceTest.php
+++ b/src/modules/Currency/tests/Unit/ServiceTest.php
@@ -144,12 +144,12 @@ test('getCurrencyByClientId returns currency for client', function (?string $cur
     $model = Mockery::mock(Box\Mod\Currency\Entity\Currency::class);
 
     $di = new Pimple\Container();
-    $db = Mockery::mock('Box_Database');
-    $db->shouldReceive('getCell')
-        ->atLeast()->once()
-        ->andReturn($currency);
 
     $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class)->shouldIgnoreMissing();
+    $repositoryMock->shouldReceive('getClientCurrencyCode')
+        ->once()
+        ->with(1)
+        ->andReturn($currency);
     if ($expectsGetDefault === 'atLeastOnce') {
         $repositoryMock->shouldReceive('findDefault')
             ->atLeast()->once()
@@ -170,7 +170,6 @@ test('getCurrencyByClientId returns currency for client', function (?string $cur
         ->atLeast()->once()
         ->andReturn($repositoryMock);
 
-    $di['db'] = $db;
     $di['em'] = $emMock;
 
     $service = new Box\Mod\Currency\Service();

--- a/src/modules/News/Api/Admin.php
+++ b/src/modules/News/Api/Admin.php
@@ -71,7 +71,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         }
 
         /** @todo Doctrine: Replace with actual Admin entity once it's migrated to Doctrine. */
-        $admin = $this->getDi()['db']->getRow('SELECT name FROM admin WHERE id = :id', ['id' => $post->getAdminId()]);
+        $admin = $repo->findAdminSummary((int) $post->getAdminId()) ?? [];
 
         $post->setAdminData($admin);
 

--- a/src/modules/News/Api/Guest.php
+++ b/src/modules/News/Api/Guest.php
@@ -68,7 +68,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         }
 
         /**@todo Doctrine: Replace with actual Admin entity once it's migrated to Doctrine. */
-        $admin = $this->getDi()['db']->getRow('SELECT name FROM admin WHERE id = :id', ['id' => $post->getAdminId()]);
+        $admin = $repo->findAdminSummary((int) $post->getAdminId()) ?? [];
 
         $post->setAdminData($admin);
 

--- a/src/modules/News/Repository/PostRepository.php
+++ b/src/modules/News/Repository/PostRepository.php
@@ -19,6 +19,19 @@ use Doctrine\ORM\QueryBuilder;
 class PostRepository extends EntityRepository
 {
     /**
+     * @return array<string, mixed>|null
+     */
+    public function findAdminSummary(int $adminId): ?array
+    {
+        $row = $this->getEntityManager()->getConnection()->fetchAssociative(
+            'SELECT name FROM admin WHERE id = :id',
+            ['id' => $adminId],
+        );
+
+        return $row !== false ? $row : null;
+    }
+
+    /**
      * Build a QueryBuilder for searching posts with optional filters.
      *
      * @param array $data array of filters: 'status', 'search', etc

--- a/src/modules/Product/Repository/ProductRepository.php
+++ b/src/modules/Product/Repository/ProductRepository.php
@@ -18,6 +18,35 @@ use Doctrine\ORM\QueryBuilder;
 
 class ProductRepository extends EntityRepository
 {
+    public function getMaxPriority(): int
+    {
+        return (int) $this->createQueryBuilder('p')
+            ->select('MAX(p.priority)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @return array<int, string|null>
+     */
+    public function getAddonPairs(): array
+    {
+        $rows = $this->createQueryBuilder('p')
+            ->select('p.id, p.title')
+            ->where('p.isAddon = :isAddon')
+            ->setParameter('isAddon', true)
+            ->orderBy('p.id', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
+
+        $pairs = [];
+        foreach ($rows as $row) {
+            $pairs[(int) $row['id']] = $row['title'];
+        }
+
+        return $pairs;
+    }
+
     /**
      * @return array<int, string|null>
      */

--- a/src/modules/Product/Repository/PromoRedemptionRepository.php
+++ b/src/modules/Product/Repository/PromoRedemptionRepository.php
@@ -18,6 +18,45 @@ use Doctrine\ORM\QueryBuilder;
 
 class PromoRedemptionRepository extends EntityRepository
 {
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findClientSummary(int $clientId): ?array
+    {
+        $row = $this->getEntityManager()->getConnection()->fetchAssociative(
+            'SELECT id, first_name, last_name, email FROM client WHERE id = :id',
+            ['id' => $clientId],
+        );
+
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findOrderSummary(int $orderId): ?array
+    {
+        $row = $this->getEntityManager()->getConnection()->fetchAssociative(
+            'SELECT id, title, created_at FROM client_order WHERE id = :id',
+            ['id' => $orderId],
+        );
+
+        return $row !== false ? $row : null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findInvoiceSummary(int $invoiceId): ?array
+    {
+        $row = $this->getEntityManager()->getConnection()->fetchAssociative(
+            'SELECT id, serie_nr, status, created_at FROM invoice WHERE id = :id',
+            ['id' => $invoiceId],
+        );
+
+        return $row !== false ? $row : null;
+    }
+
     public function getSearchQueryBuilder(array $data): QueryBuilder
     {
         $qb = $this->createQueryBuilder('pr');

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -407,8 +407,7 @@ class Service implements InjectionAwareInterface
 
     public function createProduct($title, $type, $categoryId = null): int
     {
-        $sql = 'SELECT MAX(priority) FROM product LIMIT 1';
-        $priority = $this->di['db']->getCell($sql);
+        $priority = $this->getProductRepository()->getMaxPriority();
 
         $productPayment = $this->createDefaultProductPayment();
         $paymentId = (int) $productPayment->getId();
@@ -552,18 +551,7 @@ class Service implements InjectionAwareInterface
      */
     public function getAddons(): array
     {
-        $sql = 'SELECT id, title
-                FROM product
-                WHERE is_addon =1
-                ORDER by id asc';
-        $addons = $this->di['db']->getAll($sql);
-
-        $result = [];
-        foreach ($addons as $addon) {
-            $result[$addon['id']] = $addon['title'];
-        }
-
-        return $result;
+        return $this->getProductRepository()->getAddonPairs();
     }
 
     public function createAddon($title, $description = null, $setup = null, $status = null, $iconUrl = null): ?int
@@ -1450,10 +1438,7 @@ class Service implements InjectionAwareInterface
         $result['invoice'] = null;
 
         if (!empty($result['client_id'])) {
-            $client = $this->di['db']->getRow(
-                'SELECT id, first_name, last_name, email FROM client WHERE id = :id',
-                [':id' => $result['client_id']]
-            );
+            $client = $this->getPromoRedemptionRepository()->findClientSummary((int) $result['client_id']);
 
             $result['client'] = [
                 'id' => (int) $result['client_id'],
@@ -1464,10 +1449,7 @@ class Service implements InjectionAwareInterface
         }
 
         if (!empty($result['client_order_id'])) {
-            $order = $this->di['db']->getRow(
-                'SELECT id, title, created_at FROM client_order WHERE id = :id',
-                [':id' => $result['client_order_id']]
-            );
+            $order = $this->getPromoRedemptionRepository()->findOrderSummary((int) $result['client_order_id']);
 
             $result['order'] = [
                 'id' => (int) $result['client_order_id'],
@@ -1477,10 +1459,7 @@ class Service implements InjectionAwareInterface
         }
 
         if (!empty($result['invoice_id'])) {
-            $invoice = $this->di['db']->getRow(
-                'SELECT id, serie_nr, status, created_at FROM invoice WHERE id = :id',
-                [':id' => $result['invoice_id']]
-            );
+            $invoice = $this->getPromoRedemptionRepository()->findInvoiceSummary((int) $result['invoice_id']);
 
             $result['invoice'] = [
                 'id' => (int) $result['invoice_id'],

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -676,17 +676,14 @@ test('create product', function (): void {
 
     $newProductId = 1;
 
-    $dbMock = Mockery::mock('\Box_Database');
-    $dbMock->shouldReceive('getCell')->atLeast()->once()->andReturn(0);
-
     $toolMock = Mockery::mock(FOSSBilling\Tools::class);
     $toolMock->shouldReceive('slug')->atLeast()->once()->andReturn('title');
 
     $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('getMaxPriority')->once()->andReturn(0);
     $productRepo->shouldReceive('findOneBy')->once()->with(['slug' => 'title'])->andReturn(null);
 
     $di = container();
-    $di['db'] = $dbMock;
     $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo, null, productTestCreateProductEntity($newProductId), productTestCreateProductPaymentEntity(1));
     $di['tools'] = $toolMock;
     $di['logger'] = new Box_Log();
@@ -830,22 +827,15 @@ test('update config', function (): void {
 
 test('get addons', function (): void {
     $service = new Service();
-    $addonsRows = [
-        [
-            'id' => 1,
-            'title' => 'testTitle',
-        ],
-    ];
-
     $expected = [
         1 => 'testTitle',
     ];
 
-    $dbMock = Mockery::mock('\Box_Database');
-    $dbMock->shouldReceive('getAll')->atLeast()->once()->andReturn($addonsRows);
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('getAddonPairs')->once()->andReturn($expected);
 
     $di = container();
-    $di['db'] = $dbMock;
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
     $di['logger'] = new Box_Log();
 
     $service->setDi($di);


### PR DESCRIPTION
## Summary

- Move remaining low-risk Product, Currency, and News lookup logic from direct RedBean access into existing Doctrine repositories.
- Keep legacy API response shapes by using narrow DBAL compatibility helpers for tables that do not have Doctrine entities yet.
- Leave the checkout promo order update on RedBean because it still runs inside the RedBean checkout transaction.