### PR TITLE
Prevent duplicate PayPal subscriptions on repeated subscr_signup IPNs

### DIFF
--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -205,23 +205,27 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements FOS
                 break;
 
             case 'subscr_signup':
-                $sd = [
-                    'client_id' => $client_id,
-                    'gateway_id' => $gateway_id,
-                    'currency' => $ipn['mc_currency'],
-                    'sid' => $ipn['subscr_id'],
-                    'status' => 'active',
-                    'period' => str_replace(' ', '', $ipn['period3']),
-                    'amount' => $ipn['amount3'],
-                    'rel_type' => 'invoice',
-                    'rel_id' => $invoice['id'],
-                ];
-                $api_admin->invoice_subscription_create($sd);
+                $existingSubscription = $this->di['db']->findOne('Subscription', 'sid = :sid', [':sid' => $ipn['subscr_id']]);
+
+                if (!$existingSubscription instanceof Model_Subscription) {
+                    $sd = [
+                        'client_id' => $client_id,
+                        'gateway_id' => $gateway_id,
+                        'currency' => $ipn['mc_currency'],
+                        'sid' => $ipn['subscr_id'],
+                        'status' => 'active',
+                        'period' => str_replace(' ', '', $ipn['period3']),
+                        'amount' => $ipn['amount3'],
+                        'rel_type' => 'invoice',
+                        'rel_id' => $invoice['id'],
+                    ];
+                    $api_admin->invoice_subscription_create($sd);
+                }
 
                 $t = [
                     'id' => $id,
-                    's_id' => $sd['sid'],
-                    's_period' => $sd['period'],
+                    's_id' => $ipn['subscr_id'],
+                    's_period' => str_replace(' ', '', $ipn['period3']),
                 ];
                 $api_admin->invoice_transaction_update($t);
 


### PR DESCRIPTION
## Summary

- Fixes a duplicate-subscription bug reported in [#3055](https://github.com/FOSSBilling/FOSSBilling/issues/3055): the `subscr_signup` PayPal IPN handler in `Payment_Adapter_PayPalEmail::processTransaction()` had no idempotency check before creating a new `Subscription` row, unlike the `subscr_payment`/`web_accept` path which is already well-guarded (status check, atomic claim, IPN-duplicate check).
- If PayPal resends or duplicates a `subscr_signup` IPN (which can happen close in time to the first renewal payment), FOSSBilling would call `invoice_subscription_create` again, creating a second `Subscription` row with the same `sid`. This plausibly explains the "duplicate renewal" / extra subscription notification symptom reported by multiple users in that issue's comments.
- The fix mirrors the existing dedup pattern already used in `Stripe.php`'s `createOrUpdateSubscription()`: look up an existing `Subscription` by `sid` via a direct DB query before creating a new one.

## Why

Investigated the two follow-up complaints left in the (closed) issue #3055 thread:
1. **Duplicate renewal on PayPal subscriptions** — confirmed a real gap (this PR fixes it).
2. **`.htaccess` overwrite / stuck maintenance mode during update** — not reproducible against current install/update code (installer only writes `.htaccess` if missing and never touches `data/.htaccess`; the update finalization flow has been reworked since). No code change made for these.