### PR TITLE
Speed up CI: share Docker test image, dedupe PHPStan, fix cache contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/php-build-test.yml
     with:
-      # Only main writes the shared registry cache; other branches just read it, so
-      # concurrent branch pushes don't stomp on each other's cache entries.
+      # Only main writes the shared registry cache, so concurrent branch pushes don't stomp on it.
       write-cache: ${{ github.ref == 'refs/heads/main' }}
 
   live-tests-pr:
@@ -162,10 +161,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
     uses: ./.github/workflows/preview-build.yml
     with:
-      # This job only ever runs for non-main branches (see the `if` above), so it never
-      # holds the authoritative cache; main's own preview-docker job (docker-build.yml,
-      # cache-scope cache-preview) keeps that warm. Writing here too just lets concurrent
-      # branch pushes stomp on each other's cache entries for no lasting benefit.
+      # This job only runs for non-main branches; main's preview-docker job keeps the cache warm.
       write-cache: false
 
   preview-docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/php-build-test.yml
     with:
-      write-cache: true
+      # Only main writes the shared registry cache; other branches just read it, so
+      # concurrent branch pushes don't stomp on each other's cache entries.
+      write-cache: ${{ github.ref == 'refs/heads/main' }}
 
   live-tests-pr:
     name: 'Live Tests'
@@ -160,7 +162,11 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
     uses: ./.github/workflows/preview-build.yml
     with:
-      write-cache: true
+      # This job only ever runs for non-main branches (see the `if` above), so it never
+      # holds the authoritative cache; main's own preview-docker job (docker-build.yml,
+      # cache-scope cache-preview) keeps that warm. Writing here too just lets concurrent
+      # branch pushes stomp on each other's cache entries for no lasting benefit.
+      write-cache: false
 
   preview-docker:
     name: 'Build and Push Preview Docker Image'

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -24,35 +24,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 'Lowercase github.repository'
-        run: |
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
-
       - name: 'Set up Docker Compose'
         uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2.3.0
 
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      # This job runs checked-out Cypress code, so it only reads the registry cache.
-      - name: 'Build Docker Test Image'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      # Reuses the image already built once in the PHP Build and Test (8.5) job
+      # instead of rebuilding it here.
+      - name: 'Download Test Image Artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          build-args: |
-            PHP_VERSION=8.5
-            INSTALL_TRANSLATIONS=false
-          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}-build-cache:cache-ci-8.5
-          context: .
-          load: true
-          tags: |
-            fossbilling:cypress-test
-          target: test
+          name: docker-test-image-8.5
+          path: /tmp
+
+      - name: 'Load Test Image'
+        run: docker load --input /tmp/test-image-8.5.tar
 
       - name: 'Run Cypress Tests'
         env:
           CYPRESS_PROJECT_ID: ${{ inputs.cypress-project-id }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-        run: bash ./.github/scripts/run-docker-cypress-tests.sh fossbilling:cypress-test
+        run: bash ./.github/scripts/run-docker-cypress-tests.sh fossbilling:test-8.5
 
       - name: 'Upload Cypress Artifacts'
         if: ${{ failure() && env.CYPRESS_RECORDING_DISABLED == 'true' }}

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -27,8 +27,7 @@ jobs:
       - name: 'Set up Docker Compose'
         uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2.3.0
 
-      # Reuses the image already built once in the PHP Build and Test (8.5) job
-      # instead of rebuilding it here.
+      # Reuses the image already built once in the PHP Build and Test (8.5) job.
       - name: 'Download Test Image Artifact'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -14,33 +14,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 'Set Registry Cache Image'
-        run: echo "CACHE_IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}-build-cache" >> "${GITHUB_ENV}"
-
       - name: 'Set up Docker Compose'
         uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2.3.0
 
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      # This job runs checked-out live-test code, so it only reads the registry cache.
-      - name: 'Build Docker Test Image'
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      # Reuses the image already built once in the PHP Build and Test (8.5) job
+      # instead of rebuilding it here.
+      - name: 'Download Test Image Artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          build-args: |
-            PHP_VERSION=8.5
-            INSTALL_TRANSLATIONS=false
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-ci-8.5
-          context: .
-          load: true
-          tags: |
-            fossbilling:live-test
-          target: test
+          name: docker-test-image-8.5
+          path: /tmp
+
+      - name: 'Load Test Image'
+        id: build
+        run: docker load --input /tmp/test-image-8.5.tar
 
       - name: 'Run Live Tests'
         id: live_tests
-        run: bash ./.github/scripts/run-docker-live-tests.sh fossbilling:live-test
+        run: bash ./.github/scripts/run-docker-live-tests.sh fossbilling:test-8.5
 
       - name: 'Write Job Summary'
         if: always()
@@ -50,11 +41,9 @@ jobs:
 
           | Item | Value |
           | --- | --- |
-          | Test image | `fossbilling:live-test` |
+          | Test image | `fossbilling:test-8.5` (shared artifact) |
           | PHP version | `8.5` |
-          | Registry cache | `${{ env.CACHE_IMAGE }}:cache-ci-8.5` |
-          | Cache mode | `read-only` |
           | Compose file | `.github/docker/live-tests.compose.yml` |
-          | Docker build | `${{ steps.build.outcome }}` |
+          | Image load | `${{ steps.build.outcome }}` |
           | Live tests | `${{ steps.live_tests.outcome }}` |
           EOF

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -17,8 +17,7 @@ jobs:
       - name: 'Set up Docker Compose'
         uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2.3.0
 
-      # Reuses the image already built once in the PHP Build and Test (8.5) job
-      # instead of rebuilding it here.
+      # Reuses the image already built once in the PHP Build and Test (8.5) job.
       - name: 'Download Test Image Artifact'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/php-build-test.yml
+++ b/.github/workflows/php-build-test.yml
@@ -86,7 +86,6 @@ jobs:
             ./src/vendor/bin/pest --test-directory ../tests --configuration phpunit.xml.dist --ci
 
       - name: 'Export Test Image Artifact'
-        id: export_image
         # Shared with live-tests/cypress-tests so they don't each rebuild the same image.
         if: matrix.php == '8.5'
         run: docker save --output /tmp/test-image-8.5.tar fossbilling:test-8.5

--- a/.github/workflows/php-build-test.yml
+++ b/.github/workflows/php-build-test.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: 'PHPStan'
         id: phpstan
+        # PHPStan analyses source, not runtime behavior, so one PHP version is sufficient coverage.
+        if: matrix.php == '8.3'
         run: |
           docker run --rm \
             --env APP_ENV=test \
@@ -82,6 +84,20 @@ jobs:
             --env APP_ENV=test \
             fossbilling:test-${{ matrix.php }} \
             ./src/vendor/bin/pest --test-directory ../tests --configuration phpunit.xml.dist --ci
+
+      - name: 'Export Test Image Artifact'
+        id: export_image
+        # Shared with live-tests/cypress-tests so they don't each rebuild the same image.
+        if: matrix.php == '8.5'
+        run: docker save --output /tmp/test-image-8.5.tar fossbilling:test-8.5
+
+      - name: 'Upload Test Image Artifact'
+        if: matrix.php == '8.5'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docker-test-image-8.5
+          path: /tmp/test-image-8.5.tar
+          retention-days: 1
 
       - name: 'Write Job Summary'
         if: always()


### PR DESCRIPTION
## Summary
- **Share one Docker test image instead of building it 3x.** `php-build-test` (PHP 8.5 leg), `live-tests`, and `cypress-tests` each independently rebuilt the identical PHP 8.5 `test` target image, paying for a full buildx setup + registry-cache pull every time. The 8.5 leg now exports the image via `docker save` and uploads it as a workflow artifact; `live-tests` and `cypress-tests` just download and `docker load` it instead of rebuilding.
- **Run PHPStan once instead of 3x.** PHPStan analyzes source, not runtime behavior, so running it identically across the full PHP 8.3/8.4/8.5 matrix was pure duplication. It now runs only on PHP 8.3; Pest still runs on all 3 versions since that's real behavioral coverage.
- **Stop cache writes from every branch push.** `php-build-test-push` and `preview-build-push` wrote to the shared GHCR registry cache (`cache-ci-*`, `cache-preview`) on every push to every branch, not just `main`. Concurrent branch pushes (including the frequent bot autofix branches this repo generates) could stomp on each other's cache entries, degrading hit rates for everyone. Cache writes are now gated to `main` only; other branches read-only, matching the existing PR path's behavior.