### PR TITLE
Remove legacy class header template

### DIFF
--- a/data/class-header-legacy.txt
+++ b/data/class-header-legacy.txt
@@ -1,8 +1,0 @@
-/**
- * Copyright 2022-2025 FOSSBilling
- * Copyright 2011-2021 BoxBilling, Inc.
- * SPDX-License-Identifier: Apache-2.0
- *
- * @copyright FOSSBilling (https://www.fossbilling.org)
- * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
- */

--- a/data/class-header.txt
+++ b/data/class-header.txt
@@ -1,7 +1,0 @@
-/**
- * Copyright 2022-2026 FOSSBilling
- * SPDX-License-Identifier: Apache-2.0
- *
- * @copyright FOSSBilling (https://www.fossbilling.org)
- * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
- */

--- a/data/class-header.txt
+++ b/data/class-header.txt
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */


### PR DESCRIPTION
This pull request removes the legacy copyright and license header from the `data/class-header-legacy.txt` file.