### PR TITLE
Optimise CI workflows with ubuntu-slim and Docker caching

### DIFF
--- a/.github/scripts/run-docker-cypress-tests.sh
+++ b/.github/scripts/run-docker-cypress-tests.sh
@@ -27,6 +27,11 @@ compose() {
 cleanup() {
   status=$?
 
+  if [[ -n "${cypress_pull_pid:-}" ]]; then
+    kill "${cypress_pull_pid}" 2>/dev/null || true
+    wait "${cypress_pull_pid}" 2>/dev/null || true
+  fi
+
   if [[ $status -ne 0 ]]; then
     compose exec -T app sh -c '
       cd /var/www/html
@@ -104,6 +109,9 @@ fi
 
 trap cleanup EXIT
 
+docker pull "${cypress_image}" &
+cypress_pull_pid=$!
+
 export FOSSBILLING_TEST_IMAGE="${image}"
 export FOSSBILLING_DB_NAME="${db_name}"
 export FOSSBILLING_DB_PASS="${db_pass}"
@@ -146,6 +154,9 @@ $config = require $configPath;
 $config["security"]["perform_session_fingerprinting"] = false;
 file_put_contents($configPath, "<?php\n\nreturn " . var_export($config, true) . ";\n");
 '
+
+wait "${cypress_pull_pid}"
+cypress_pull_pid=""
 
 # Chromium-based browsers are sensitive to Docker's default 64 MB /dev/shm size.
 docker run --rm \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
     # Keep PR and push callers separate because job permissions cannot be conditional.
     permissions:
       contents: read
-    needs: [ spellcheck ]
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' && github.event.action != 'unlabeled' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id }}
     uses: ./.github/workflows/php-build-test.yml
     with:
@@ -95,7 +94,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: [ spellcheck ]
     if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/php-build-test.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   merge-hold:
     name: 'Check for Merge Hold'
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: 'Check merge-hold label'
@@ -40,7 +40,7 @@ jobs:
       contents: read
       pull-requests: write
     if: ${{ github.event_name == 'pull_request_target' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
@@ -54,7 +54,7 @@ jobs:
       contents: write
       pull-requests: read
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
@@ -65,7 +65,7 @@ jobs:
 
   spellcheck:
     name: 'Spellcheck'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled' && github.event.action != 'unlabeled' && github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id) || github.event_name == 'push' }}
     steps:
@@ -194,7 +194,7 @@ jobs:
     name: 'Upload Preview Release'
     needs: [ preview-build-pr, preview-build-push, preview-docker ]
     if: ${{ !cancelled() && (needs['preview-build-pr'].result == 'success' || needs['preview-build-push'].result == 'success' || needs['preview-docker'].result == 'success') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     steps:
       - name: 'Download Preview Release Archive'
@@ -220,9 +220,12 @@ jobs:
 
       - name: 'Upload Downloadable Preview to S3'
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311 # master
-        with:
-          args: '--acl public-read --follow-symlinks'
+        run: |
+          aws s3 sync "${SOURCE_DIR}" "s3://${AWS_S3_BUCKET}/" \
+            --endpoint-url "${AWS_S3_ENDPOINT}" \
+            --acl public-read \
+            --follow-symlinks \
+            --no-progress
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -190,7 +190,7 @@ jobs:
           build-args: |
             FOSSBILLING_VERSION=${{ inputs.version }}
             SENTRY_DSN=${{ vars.SENTRY_DSN }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-release
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-release-amd64
           context: .
           target: release-artifact
           outputs: type=local,dest=./release-tree

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,8 +104,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           build-args: ${{ inputs.build-args }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }}
-          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }},mode=max
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }}-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }}-${{ matrix.suffix }},mode=max
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=docker.io/${{ inputs.meta-images }},name-canonical=true,push=true,push-by-digest=true
@@ -117,7 +117,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           build-args: ${{ inputs.build-args }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }}
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:${{ inputs.cache-scope }}-${{ matrix.suffix }}
           context: .
           outputs: type=local,dest=./release-tree
           provenance: false

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup:
     name: 'Delete Untagged GHCR Versions'
     if: ${{ github.repository == 'FOSSBilling/FOSSBilling' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
       - name: 'Delete Untagged GHCR Versions'

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -41,7 +41,7 @@ jobs:
             FOSSBILLING_VERSION=${{ github.sha }}
             FOSSBILLING_VERSION_TRUNCATE=7
             SENTRY_DSN=${{ vars.SENTRY_DSN }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview-amd64
           context: .
           target: release-artifact
           outputs: type=local,dest=./release-tree
@@ -56,8 +56,8 @@ jobs:
             FOSSBILLING_VERSION=${{ github.sha }}
             FOSSBILLING_VERSION_TRUNCATE=7
             SENTRY_DSN=${{ vars.SENTRY_DSN }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview
-          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview,mode=max
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview-amd64
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:cache-preview-amd64,mode=max
           context: .
           target: release-artifact
           outputs: type=local,dest=./release-tree
@@ -87,7 +87,7 @@ jobs:
           | Item | Value |
           | --- | --- |
           | Release version | `${{ github.sha }}` |
-          | Registry cache | `${{ env.CACHE_IMAGE }}:cache-preview` |
+          | Registry cache | `${{ env.CACHE_IMAGE }}:cache-preview-amd64` |
           | Cache mode | `${{ inputs.write-cache && 'read/write' || 'read-only' }}` |
           | Build target | `release-artifact` |
           | Build output | `./release-tree` |

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -49,8 +49,6 @@ jobs:
     with:
       target: runtime
       cache-scope: cache-release
-      extract-release-tree: true
-      release-tree-artifact-name: release-build
       meta-images: fossbilling/fossbilling
       meta-tags: |
         type=semver,pattern={{version}}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
     name: 'Check if Release is Latest'
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
     outputs:
       is_latest: ${{ steps.compare-latest.outputs.is_latest }}


### PR DESCRIPTION
Improvements to the CI/CD pipeline, focusing on optimizing Docker image pulls, improving caching strategies for multi-architecture builds, and reducing workflow runner resource usage. Key changes include parallelizing Docker image pulls for Cypress tests, refining Docker build cache keys for architecture-specific builds, switching workflow runners to `ubuntu-slim` to save resources, and updating S3 upload steps for more flexibility.