### PR TITLE
Use zstd compression for Docker image artifacts

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -31,11 +31,11 @@ jobs:
       - name: 'Download Test Image Artifact'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: docker-test-image-8.5
+          name: test-image-8.5.tar.zst
           path: /tmp
 
       - name: 'Load Test Image'
-        run: docker load --input /tmp/test-image-8.5.tar
+        run: zstd --decompress --stdout /tmp/test-image-8.5.tar.zst | docker load
 
       - name: 'Run Cypress Tests'
         env:

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -21,12 +21,12 @@ jobs:
       - name: 'Download Test Image Artifact'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: docker-test-image-8.5
+          name: test-image-8.5.tar.zst
           path: /tmp
 
       - name: 'Load Test Image'
         id: build
-        run: docker load --input /tmp/test-image-8.5.tar
+        run: zstd --decompress --stdout /tmp/test-image-8.5.tar.zst | docker load
 
       - name: 'Run Live Tests'
         id: live_tests

--- a/.github/workflows/php-build-test.yml
+++ b/.github/workflows/php-build-test.yml
@@ -88,14 +88,14 @@ jobs:
       - name: 'Export Test Image Artifact'
         # Shared with live-tests/cypress-tests so they don't each rebuild the same image.
         if: matrix.php == '8.5'
-        run: docker save --output /tmp/test-image-8.5.tar fossbilling:test-8.5
+        run: docker save fossbilling:test-8.5 | zstd -T0 -6 --stdout > /tmp/test-image-8.5.tar.zst
 
       - name: 'Upload Test Image Artifact'
         if: matrix.php == '8.5'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: docker-test-image-8.5
-          path: /tmp/test-image-8.5.tar
+          archive: false
+          path: /tmp/test-image-8.5.tar.zst
           retention-days: 1
 
       - name: 'Write Job Summary'


### PR DESCRIPTION
Updates the GitHub Actions workflows to use compressed Docker image artifacts with Zstandard (`zstd`) compression instead of raw tar files. This change optimises storage and speeds up artifact upload and download in the CI pipeline.