### PR TITLE
Refactor API and frontend helpers with improved testing

### DIFF
--- a/frontend/core/api-helpers.mjs
+++ b/frontend/core/api-helpers.mjs
@@ -1,0 +1,130 @@
+function injectCSRFToken(params, token) {
+  if (params instanceof FormData) {
+    if (!params.has('CSRFToken')) {
+      params.append('CSRFToken', token);
+    }
+  } else if (params && typeof params === 'object') {
+    if (!params.CSRFToken) {
+      params.CSRFToken = token;
+    }
+  }
+  return params;
+}
+
+function buildRequestBody(method, params, url) {
+  const methodLower = method.toLowerCase();
+  const isFormData = params instanceof FormData;
+  let body = null;
+
+  if (methodLower === 'get') {
+    if (isFormData) {
+      for (const [key, value] of params.entries()) {
+        url.searchParams.append(key, value);
+      }
+    } else if (params && typeof params === 'object') {
+      Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
+    } else if (params) {
+      url.search = params;
+    }
+  } else if (['post', 'put', 'patch', 'delete'].includes(methodLower)) {
+    if (isFormData || typeof params === 'string') {
+      body = params;
+    } else {
+      body = JSON.stringify(params);
+    }
+  }
+
+  return { body, isFormData };
+}
+
+function buildHeaders({ url, body, isFormData, csrfToken, origin }) {
+  const headers = {
+    'Accept': 'application/json',
+    'X-CSRF-Token': csrfToken || '',
+  };
+  if (url.origin === origin) {
+    headers['X-Requested-With'] = 'XMLHttpRequest';
+  }
+  if (body && !isFormData) {
+    headers['Content-Type'] = 'application/json';
+  }
+  return headers;
+}
+
+async function parseResponseBody(response) {
+  if (response.status === 204) {
+    return { payload: null, rawText: '' };
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return { payload: null, rawText: '' };
+  }
+
+  try {
+    return { payload: JSON.parse(text), rawText: text };
+  } catch {
+    return { payload: null, rawText: text };
+  }
+}
+
+function validateHttpResponse(response, parsed) {
+  if (!response.ok) {
+    const error = new Error(parsed.payload?.error?.message || `HTTP error ${response.status}: ${response.statusText}`);
+    error.code = parsed.payload?.error?.code || `http_${response.status}`;
+    error.status = response.status;
+    error.rawBody = parsed.rawText;
+    throw error;
+  }
+
+  if (parsed.rawText && parsed.payload === null) {
+    throw new Error('Invalid or non-JSON response from server');
+  }
+
+  return parsed.payload;
+}
+
+function interpretResponse(payload) {
+  if (!payload) {
+    return null;
+  }
+
+  if (payload.error) {
+    const error = new Error(payload.error.message || 'Unknown API error');
+    error.code = payload.error.code;
+    throw error;
+  }
+
+  return payload.result;
+}
+
+function normalizeApiError(error, { timeoutMs, timeoutMessage }) {
+  if (error.name === 'AbortError') {
+    return {
+      message: timeoutMessage || `Request timed out after ${timeoutMs / 1000} seconds`,
+      code: 'timeout_error',
+    };
+  }
+
+  if (error.name === 'TypeError' && error.message.includes('NetworkError')) {
+    return {
+      message: 'Network connection error',
+      code: 'network_error',
+    };
+  }
+
+  return {
+    message: error.message || 'Unknown error occurred',
+    code: error.code || 'unknown_error',
+  };
+}
+
+export {
+  injectCSRFToken,
+  buildRequestBody,
+  buildHeaders,
+  parseResponseBody,
+  validateHttpResponse,
+  interpretResponse,
+  normalizeApiError,
+};

--- a/frontend/core/api-helpers.mjs
+++ b/frontend/core/api-helpers.mjs
@@ -19,12 +19,17 @@ function buildRequestBody(method, params, url) {
   if (methodLower === 'get') {
     if (isFormData) {
       for (const [key, value] of params.entries()) {
-        url.searchParams.append(key, value);
+        if (key !== 'CSRFToken') {
+          url.searchParams.append(key, value);
+        }
       }
     } else if (params && typeof params === 'object') {
-      Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
+      Object.keys(params)
+        .filter((key) => key !== 'CSRFToken')
+        .forEach((key) => url.searchParams.append(key, params[key]));
     } else if (params) {
       url.search = params;
+      url.searchParams.delete('CSRFToken');
     }
   } else if (['post', 'put', 'patch', 'delete'].includes(methodLower)) {
     if (isFormData || typeof params === 'string') {
@@ -40,10 +45,10 @@ function buildRequestBody(method, params, url) {
 function buildHeaders({ url, body, isFormData, csrfToken, origin }) {
   const headers = {
     'Accept': 'application/json',
-    'X-CSRF-Token': csrfToken || '',
   };
   if (url.origin === origin) {
     headers['X-Requested-With'] = 'XMLHttpRequest';
+    headers['X-CSRF-Token'] = csrfToken || '';
   }
   if (body && !isFormData) {
     headers['Content-Type'] = 'application/json';
@@ -106,7 +111,7 @@ function normalizeApiError(error, { timeoutMs, timeoutMessage }) {
     };
   }
 
-  if (error.name === 'TypeError' && error.message.includes('NetworkError')) {
+  if (error.name === 'TypeError' && /NetworkError|Failed to fetch|Load failed/i.test(error.message)) {
     return {
       message: 'Network connection error',
       code: 'network_error',

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -8,6 +8,8 @@
  * with this source code in the file LICENSE
  */
 
+import { parseDataAttr } from './parse-data-attr.mjs';
+
 /**
  * Tools for the API wrapper.
  */
@@ -70,126 +72,6 @@ const Tools = {
     } catch (error) {
       return false;
     }
-  },
-
-  /**
-   * Parses the data attribute value from a DOM element and validates known fields.
-   *
-   * @param {string} dataAttrValue The value of the data attribute to parse.
-   * @returns {object} The parsed and validated data.
-   * @throws {Error} If the data attribute value is invalid or does not match the schema.
-   **/
-  parseDataAttr: function (dataAttrValue) {
-    if (!dataAttrValue) {
-      return {};
-    }
-
-    let data;
-    try {
-      data = JSON.parse(dataAttrValue);
-    } catch (error) {
-      throw new Error('Invalid JSON in data-fb-api attribute.');
-    }
-
-    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-      throw new Error('data-fb-api must be a JSON object.');
-    }
-
-    const assertString = (value, key) => {
-      if (typeof value !== 'string') {
-        throw new Error(`data-fb-api.${key} must be a string.`);
-      }
-    };
-
-    const assertBoolean = (value, key) => {
-      if (typeof value !== 'boolean') {
-        throw new Error(`data-fb-api.${key} must be a boolean.`);
-      }
-    };
-
-    const assertPositiveNumber = (value, key) => {
-      if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-        throw new Error(`data-fb-api.${key} must be a positive number.`);
-      }
-    };
-
-    if (Object.prototype.hasOwnProperty.call(data, 'href')) {
-      assertString(data.href, 'href');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'type')) {
-      assertString(data.type, 'type');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'endpoint')) {
-      assertString(data.endpoint, 'endpoint');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'callback')) {
-      assertString(data.callback, 'callback');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'message')) {
-      assertString(data.message, 'message');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'redirect')) {
-      assertString(data.redirect, 'redirect');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'reload')) {
-      assertBoolean(data.reload, 'reload');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'preventNavigation')) {
-      assertBoolean(data.preventNavigation, 'preventNavigation');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'timeoutMs')) {
-      assertPositiveNumber(data.timeoutMs, 'timeoutMs');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'timeoutMessage')) {
-      assertString(data.timeoutMessage, 'timeoutMessage');
-    }
-    if (Object.prototype.hasOwnProperty.call(data, 'params')) {
-      if (typeof data.params !== 'object' || data.params === null || Array.isArray(data.params)) {
-        throw new Error('data-fb-api.params must be an object.');
-      }
-    }
-
-    if (Object.prototype.hasOwnProperty.call(data, 'loading')) {
-      const loading = data.loading;
-      if (typeof loading !== 'object' || loading === null || Array.isArray(loading)) {
-        throw new Error('data-fb-api.loading must be an object.');
-      }
-
-      const loadingStringFields = ['message', 'button', 'target', 'alertClass'];
-      loadingStringFields.forEach((field) => {
-        if (Object.prototype.hasOwnProperty.call(loading, field)) {
-          assertString(loading[field], `loading.${field}`);
-        }
-      });
-    }
-
-    if (Object.prototype.hasOwnProperty.call(data, 'modal')) {
-      const modal = data.modal;
-      if (typeof modal !== 'object' || modal === null || Array.isArray(modal)) {
-        throw new Error('data-fb-api.modal must be an object.');
-      }
-      if (typeof modal.type !== 'string') {
-        throw new Error('data-fb-api.modal.type must be a string.');
-      }
-
-      const allowedTypes = ['confirm', 'danger', 'prompt'];
-      if (!allowedTypes.includes(modal.type)) {
-        throw new Error(`data-fb-api.modal.type must be one of: ${allowedTypes.join(', ')}.`);
-      }
-
-      if (modal.type === 'prompt' && typeof modal.key !== 'string') {
-        throw new Error('data-fb-api.modal.key is required for prompt modals.');
-      }
-
-      const modalStringFields = ['title', 'content', 'button', 'buttonColor', 'label', 'value', 'key'];
-      modalStringFields.forEach((field) => {
-        if (Object.prototype.hasOwnProperty.call(modal, field)) {
-          assertString(modal[field], `modal.${field}`);
-        }
-      });
-    }
-
-    return data;
   },
 
   /**
@@ -273,6 +155,8 @@ const Tools = {
     return JSON.stringify(this.serializeFormDataToObject(formData));
   }
 };
+
+Tools.parseDataAttr = parseDataAttr;
 
 /**
  * Creates an API for a specific role (admin, client, guest).

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -243,8 +243,11 @@ const API = {
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     const csrfToken = Tools.getCSRFToken();
     const urlObj = new URL(url);
+    const isSameOrigin = urlObj.origin === window.location.origin;
 
-    injectCSRFToken(params, csrfToken);
+    if (isSameOrigin) {
+      injectCSRFToken(params, csrfToken);
+    }
     const { body, isFormData } = buildRequestBody(method, params, urlObj);
     const headers = buildHeaders({ url: urlObj, body, isFormData, csrfToken, origin: window.location.origin });
 

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -9,6 +9,15 @@
  */
 
 import { parseDataAttr } from './parse-data-attr.mjs';
+import {
+  injectCSRFToken,
+  buildRequestBody,
+  buildHeaders,
+  parseResponseBody,
+  validateHttpResponse,
+  interpretResponse,
+  normalizeApiError,
+} from './api-helpers.mjs';
 
 /**
  * Tools for the API wrapper.
@@ -228,79 +237,23 @@ const API = {
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    const parseResponseBody = async (response) => {
-      if (response.status === 204) {
-        return { payload: null, rawText: '' };
-      }
+    const csrfToken = Tools.getCSRFToken();
+    const urlObj = new URL(url);
 
-      const text = await response.text();
-      if (!text) {
-        return { payload: null, rawText: '' };
-      }
-
-      try {
-        return { payload: JSON.parse(text), rawText: text };
-      } catch (error) {
-        return { payload: null, rawText: text };
-      }
-    };
-
-    url = new URL(url);
-    const isFormData = params instanceof FormData;
-
-    if (isFormData) {
-      if (!params.has('CSRFToken')) {
-        params.append('CSRFToken', Tools.getCSRFToken());
-      }
-    } else if (params && typeof params === 'object') {
-      if (!params.CSRFToken) {
-        params.CSRFToken = Tools.getCSRFToken();
-      }
-    }
-
-    let body = null;
-    const methodLower = method.toLowerCase();
-    if (methodLower === 'get') {
-      if (isFormData) {
-        for (const [key, value] of params.entries()) {
-          url.searchParams.append(key, value);
-        }
-      } else if (params && typeof params === 'object') {
-        Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
-      } else if (params) {
-        url.search = params;
-      }
-    } else if (['post', 'put', 'patch', 'delete'].includes(methodLower)) {
-      if (isFormData) {
-        body = params;
-      } else if (typeof params === 'string') {
-        body = params;
-      } else {
-        body = JSON.stringify(params);
-      }
-    }
-
-    const headers = {
-      'Accept': 'application/json',
-      'X-CSRF-Token': Tools.getCSRFToken() || '',
-    };
-    if (url.origin === window.location.origin) {
-      headers['X-Requested-With'] = 'XMLHttpRequest';
-    }
-    if (body && !isFormData) {
-      headers['Content-Type'] = 'application/json';
-    }
+    injectCSRFToken(params, csrfToken);
+    const { body, isFormData } = buildRequestBody(method, params, urlObj);
+    const headers = buildHeaders({ url: urlObj, body, isFormData, csrfToken, origin: window.location.origin });
 
     const fetchOptions = {
       method: method,
       headers: headers,
       signal: controller.signal
     };
-    if (methodLower !== 'get') {
+    if (method.toLowerCase() !== 'get') {
       fetchOptions.body = body;
     }
 
-    return fetch(url.toString(), fetchOptions)
+    return fetch(urlObj.toString(), fetchOptions)
       .then(async (response) => {
         clearTimeout(timeoutId);
 
@@ -309,64 +262,20 @@ const API = {
           return;
         }
 
-        const { payload, rawText } = await parseResponseBody(response);
-
-        if (!response.ok) {
-          const error = new Error(payload?.error?.message || `HTTP error ${response.status}: ${response.statusText}`);
-          error.code = payload?.error?.code || `http_${response.status}`;
-          error.status = response.status;
-          error.rawBody = rawText;
-          throw error;
-        }
-
-        if (rawText && payload === null) {
-          throw new Error('Invalid or non-JSON response from server');
-        }
-
-        return payload;
+        const parsed = await parseResponseBody(response);
+        return validateHttpResponse(response, parsed);
       })
-      .then((response) => {
-        if (!response) {
-          if (typeof successHandler === 'function') {
-            successHandler(null);
-          }
-
-          return null;
-        }
-
-        if (response.error) {
-          const error = new Error(response.error.message || 'Unknown API error');
-          error.code = response.error.code;
-          throw error;
-        }
-
+      .then((payload) => {
+        const result = interpretResponse(payload);
         if (typeof successHandler === 'function') {
-          successHandler(response.result);
+          successHandler(result);
         }
-
-        return response.result;
+        return result;
       })
       .catch((error) => {
         clearTimeout(timeoutId);
 
-        let errorObj;
-        if (error.name === 'AbortError') {
-          errorObj = {
-            message: timeoutMessage || `Request timed out after ${timeoutMs / 1000} seconds`,
-            code: 'timeout_error'
-          };
-        } else if (error.name === 'TypeError' && error.message.includes('NetworkError')) {
-          errorObj = {
-            message: 'Network connection error',
-            code: 'network_error'
-          };
-        } else {
-          errorObj = {
-            message: error.message || 'Unknown error occurred',
-            code: error.code || 'unknown_error'
-          };
-        }
-
+        const errorObj = normalizeApiError(error, { timeoutMs, timeoutMessage });
         console.error(`API Error: ${errorObj.message}`);
 
         if (typeof errorHandler === 'function') {

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -407,12 +407,16 @@ const API = {
       headers['Content-Type'] = 'application/json';
     }
 
-    return fetch(url.toString(), {
+    const fetchOptions = {
       method: method,
       headers: headers,
-      body: body,
       signal: controller.signal
-    })
+    };
+    if (methodLower !== 'get') {
+      fetchOptions.body = body;
+    }
+
+    return fetch(url.toString(), fetchOptions)
       .then(async (response) => {
         clearTimeout(timeoutId);
 

--- a/frontend/core/api.js
+++ b/frontend/core/api.js
@@ -18,6 +18,10 @@ import {
   interpretResponse,
   normalizeApiError,
 } from './api-helpers.mjs';
+import {
+  dispatchLinkAction,
+  createLinkLoadingState,
+} from './link-helpers.mjs';
 
 /**
  * Tools for the API wrapper.
@@ -451,107 +455,12 @@ const API = {
         }
 
         linkElement.dataset.fbApiBound = 'true';
-        let requestInProgress = false;
-        let loadingAlert = null;
-        let beforeUnloadHandler = null;
-        let originalHtml = null;
-        let originalAriaBusy = null;
-        let originalAriaDisabled = null;
-        let originallyDisabled = false;
-
-        const getLoadingTarget = (selector) => {
-          if (selector) {
-            try {
-              const target = document.querySelector(selector);
-              if (target) {
-                return target;
-              }
-            } catch (error) {
-              console.warn('Invalid loading target selector:', selector);
-            }
-          }
-
-          return linkElement.closest('.card-footer') || linkElement.parentElement;
-        };
-
-        const setLoadingState = (apiData) => {
-          requestInProgress = true;
-          originalHtml = linkElement.innerHTML;
-          originalAriaBusy = linkElement.getAttribute('aria-busy');
-          originalAriaDisabled = linkElement.getAttribute('aria-disabled');
-          originallyDisabled = linkElement.classList.contains('disabled');
-
-          linkElement.setAttribute('aria-busy', 'true');
-          linkElement.setAttribute('aria-disabled', 'true');
-          linkElement.classList.add('disabled');
-
-          if (apiData.loading?.button) {
-            const spinner = document.createElement('span');
-            spinner.className = 'spinner-border spinner-border-sm me-2';
-            spinner.setAttribute('aria-hidden', 'true');
-
-            linkElement.replaceChildren(spinner, document.createTextNode(apiData.loading.button));
-          }
-
-          if (apiData.loading?.message) {
-            const target = getLoadingTarget(apiData.loading.target);
-            if (target) {
-              loadingAlert = document.createElement('div');
-              loadingAlert.className = apiData.loading.alertClass || 'alert alert-info mt-3 mb-0';
-              loadingAlert.setAttribute('role', 'status');
-              loadingAlert.textContent = apiData.loading.message;
-              target.appendChild(loadingAlert);
-            }
-          }
-
-          if (apiData.preventNavigation) {
-            beforeUnloadHandler = (event) => {
-              event.preventDefault();
-              event.returnValue = '';
-            };
-            window.addEventListener('beforeunload', beforeUnloadHandler);
-          }
-        };
-
-        const resetLoadingState = () => {
-          if (!requestInProgress) {
-            return;
-          }
-
-          requestInProgress = false;
-
-          if (originalHtml !== null) {
-            linkElement.innerHTML = originalHtml;
-          }
-          if (originalAriaBusy === null) {
-            linkElement.removeAttribute('aria-busy');
-          } else {
-            linkElement.setAttribute('aria-busy', originalAriaBusy);
-          }
-          if (originalAriaDisabled === null) {
-            linkElement.removeAttribute('aria-disabled');
-          } else {
-            linkElement.setAttribute('aria-disabled', originalAriaDisabled);
-          }
-          if (!originallyDisabled) {
-            linkElement.classList.remove('disabled');
-          }
-
-          if (loadingAlert) {
-            loadingAlert.remove();
-            loadingAlert = null;
-          }
-
-          if (beforeUnloadHandler) {
-            window.removeEventListener('beforeunload', beforeUnloadHandler);
-            beforeUnloadHandler = null;
-          }
-        };
+        const loadingState = createLinkLoadingState(linkElement);
 
         linkElement.addEventListener('click', function (event) {
           event.preventDefault();
 
-          if (requestInProgress) {
+          if (loadingState.isInProgress()) {
             return;
           }
 
@@ -575,7 +484,7 @@ const API = {
 
           const handleApiRequest = (method, href, params = {}) => {
             if (apiData.loading || apiData.preventNavigation) {
-              setLoadingState(apiData);
+              loadingState.set(apiData);
             }
 
             const url = apiData.href || href;
@@ -584,11 +493,11 @@ const API = {
               : params;
             API.makeRequest(method, Tools.getBaseURL(url), mergedParams,
               (result) => {
-                resetLoadingState();
+                loadingState.reset();
                 API._afterComplete(linkElement, result);
               },
               (error) => {
-                resetLoadingState();
+                loadingState.reset();
                 FOSSBilling.ui.notify(`${error.message} (${error.code})`, 'error');
               },
               true,
@@ -597,48 +506,8 @@ const API = {
             );
           };
 
-          if (apiData.hasOwnProperty('modal')) {
-            if (typeof Modals === 'undefined' || typeof Modals.create !== 'function') {
-              if (apiData.modal.type === 'prompt') {
-                const value = window.prompt(apiData.modal.label ?? apiData.modal.title ?? '', apiData.modal.value ?? '');
-                if (value) {
-                  const p = {};
-                  p[apiData.modal.key] = value;
-                  handleApiRequest('GET', linkElement.getAttribute('href'), p);
-                }
-              } else if (window.confirm(apiData.modal.content || apiData.modal.title || 'Are you sure?')) {
-                handleApiRequest('GET', linkElement.getAttribute('href'));
-              }
-            } else if (apiData.modal.type === 'prompt') {
-              Modals.create({
-                type: apiData.modal.type,
-                title: apiData.modal.title,
-                label: apiData.modal.label ?? 'Label',
-                value: apiData.modal.value ?? '',
-                promptConfirmCallback: (value) => {
-                  if (value) {
-                    const p = {};
-                    const name = apiData.modal.key;
-                    p[name] = value;
-                    handleApiRequest('GET', linkElement.getAttribute('href'), p);
-                  }
-                },
-              });
-            } else {
-              Modals.create({
-                type: (apiData.modal.type === 'confirm') ? 'small-confirm' : apiData.modal.type,
-                title: apiData.modal.title,
-                content: apiData.modal.content ?? '',
-                confirmButton: apiData.modal.button ?? 'Confirm',
-                confirmButtonColor: apiData.modal.buttonColor ?? 'primary',
-                confirmCallback: () => {
-                  handleApiRequest('GET', linkElement.getAttribute('href'));
-                },
-              });
-            }
-          } else {
-            handleApiRequest('GET', linkElement.getAttribute('href'));
-          }
+          const modalsLib = typeof Modals !== 'undefined' ? Modals : null;
+          dispatchLinkAction(apiData, rawHref, modalsLib, handleApiRequest);
         });
       });
     }

--- a/frontend/core/link-helpers.mjs
+++ b/frontend/core/link-helpers.mjs
@@ -1,0 +1,188 @@
+/**
+ * Extracted helpers for data-fb-api link interactions.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ */
+
+/**
+ * Build a params object from a prompt modal configuration and the user-entered value.
+ *
+ * @param {object} modalConfig  The `modal` sub-object from parsed data-fb-api.
+ * @param {string} value        The value entered by the user.
+ * @returns {object}            Single-key object, e.g. `{ key: value }`.
+ */
+export function buildPromptParams(modalConfig, value) {
+  const p = {};
+  p[modalConfig.key] = value;
+  return p;
+}
+
+/**
+ * Dispatch a link click through the appropriate modal flow (or directly) and
+ * invoke `onRequest` when the user confirms.
+ *
+ * @param {object}      apiData     Parsed data-fb-api configuration.
+ * @param {string}      rawHref     The link element's href attribute value.
+ * @param {object|null} modalsLib   The global Modals library (or null when unavailable).
+ * @param {function}    onRequest   Callback: (method, href, params?) => void.
+ */
+export function dispatchLinkAction(apiData, rawHref, modalsLib, onRequest) {
+  if (!apiData.hasOwnProperty('modal')) {
+    onRequest('GET', rawHref);
+    return;
+  }
+
+  const modal = apiData.modal;
+
+  if (!modalsLib || typeof modalsLib.create !== 'function') {
+    if (modal.type === 'prompt') {
+      const value = window.prompt(modal.label ?? modal.title ?? '', modal.value ?? '');
+      if (value) {
+        onRequest('GET', rawHref, buildPromptParams(modal, value));
+      }
+    } else if (window.confirm(modal.content || modal.title || 'Are you sure?')) {
+      onRequest('GET', rawHref);
+    }
+  } else if (modal.type === 'prompt') {
+    modalsLib.create({
+      type: modal.type,
+      title: modal.title,
+      label: modal.label ?? 'Label',
+      value: modal.value ?? '',
+      promptConfirmCallback: (value) => {
+        if (value) {
+          onRequest('GET', rawHref, buildPromptParams(modal, value));
+        }
+      },
+    });
+  } else {
+    modalsLib.create({
+      type: modal.type === 'confirm' ? 'small-confirm' : modal.type,
+      title: modal.title,
+      content: modal.content ?? '',
+      confirmButton: modal.button ?? 'Confirm',
+      confirmButtonColor: modal.buttonColor ?? 'primary',
+      confirmCallback: () => {
+        onRequest('GET', rawHref);
+      },
+    });
+  }
+}
+
+/**
+ * Create a loading-state manager for a single link element.
+ *
+ * Tracks original DOM state, applies loading visual feedback (spinner button,
+ * loading message, aria attributes), and restores everything on `reset()`.
+ *
+ * @param {HTMLElement} linkElement  The `<a>` element to manage.
+ * @returns {{set: Function, reset: Function, isInProgress: Function}}
+ */
+export function createLinkLoadingState(linkElement) {
+  let requestInProgress = false;
+  let loadingAlert = null;
+  let beforeUnloadHandler = null;
+  let originalHtml = null;
+  let originalAriaBusy = null;
+  let originalAriaDisabled = null;
+  let originallyDisabled = false;
+
+  const getLoadingTarget = (selector) => {
+    if (selector) {
+      try {
+        const target = document.querySelector(selector);
+        if (target) {
+          return target;
+        }
+      } catch (error) {
+        console.warn('Invalid loading target selector:', selector);
+      }
+    }
+
+    return linkElement.closest('.card-footer') || linkElement.parentElement;
+  };
+
+  const set = (apiData) => {
+    requestInProgress = true;
+    originalHtml = linkElement.innerHTML;
+    originalAriaBusy = linkElement.getAttribute('aria-busy');
+    originalAriaDisabled = linkElement.getAttribute('aria-disabled');
+    originallyDisabled = linkElement.classList.contains('disabled');
+
+    linkElement.setAttribute('aria-busy', 'true');
+    linkElement.setAttribute('aria-disabled', 'true');
+    linkElement.classList.add('disabled');
+
+    if (apiData.loading?.button) {
+      const spinner = document.createElement('span');
+      spinner.className = 'spinner-border spinner-border-sm me-2';
+      spinner.setAttribute('aria-hidden', 'true');
+
+      linkElement.replaceChildren(spinner, document.createTextNode(apiData.loading.button));
+    }
+
+    if (apiData.loading?.message) {
+      const target = getLoadingTarget(apiData.loading.target);
+      if (target) {
+        loadingAlert = document.createElement('div');
+        loadingAlert.className = apiData.loading.alertClass || 'alert alert-info mt-3 mb-0';
+        loadingAlert.setAttribute('role', 'status');
+        loadingAlert.textContent = apiData.loading.message;
+        target.appendChild(loadingAlert);
+      }
+    }
+
+    if (apiData.preventNavigation) {
+      beforeUnloadHandler = (event) => {
+        event.preventDefault();
+        event.returnValue = '';
+      };
+      window.addEventListener('beforeunload', beforeUnloadHandler);
+    }
+  };
+
+  const reset = () => {
+    if (!requestInProgress) {
+      return;
+    }
+
+    requestInProgress = false;
+
+    if (originalHtml !== null) {
+      linkElement.innerHTML = originalHtml;
+    }
+    if (originalAriaBusy === null) {
+      linkElement.removeAttribute('aria-busy');
+    } else {
+      linkElement.setAttribute('aria-busy', originalAriaBusy);
+    }
+    if (originalAriaDisabled === null) {
+      linkElement.removeAttribute('aria-disabled');
+    } else {
+      linkElement.setAttribute('aria-disabled', originalAriaDisabled);
+    }
+    if (!originallyDisabled) {
+      linkElement.classList.remove('disabled');
+    }
+
+    if (loadingAlert) {
+      loadingAlert.remove();
+      loadingAlert = null;
+    }
+
+    if (beforeUnloadHandler) {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+      beforeUnloadHandler = null;
+    }
+  };
+
+  return {
+    set,
+    reset,
+    isInProgress: () => requestInProgress,
+  };
+}

--- a/frontend/core/link-helpers.mjs
+++ b/frontend/core/link-helpers.mjs
@@ -9,19 +9,6 @@
  */
 
 /**
- * Build a params object from a prompt modal configuration and the user-entered value.
- *
- * @param {object} modalConfig  The `modal` sub-object from parsed data-fb-api.
- * @param {string} value        The value entered by the user.
- * @returns {object}            Single-key object, e.g. `{ key: value }`.
- */
-export function buildPromptParams(modalConfig, value) {
-  const p = {};
-  p[modalConfig.key] = value;
-  return p;
-}
-
-/**
  * Dispatch a link click through the appropriate modal flow (or directly) and
  * invoke `onRequest` when the user confirms.
  *
@@ -42,7 +29,7 @@ export function dispatchLinkAction(apiData, rawHref, modalsLib, onRequest) {
     if (modal.type === 'prompt') {
       const value = window.prompt(modal.label ?? modal.title ?? '', modal.value ?? '');
       if (value) {
-        onRequest('GET', rawHref, buildPromptParams(modal, value));
+        onRequest('GET', rawHref, { [modal.key]: value });
       }
     } else if (window.confirm(modal.content || modal.title || 'Are you sure?')) {
       onRequest('GET', rawHref);
@@ -55,7 +42,7 @@ export function dispatchLinkAction(apiData, rawHref, modalsLib, onRequest) {
       value: modal.value ?? '',
       promptConfirmCallback: (value) => {
         if (value) {
-          onRequest('GET', rawHref, buildPromptParams(modal, value));
+          onRequest('GET', rawHref, { [modal.key]: value });
         }
       },
     });

--- a/frontend/core/package.json
+++ b/frontend/core/package.json
@@ -1,4 +1,0 @@
-{
-  "private": true,
-  "type": "module"
-}

--- a/frontend/core/package.json
+++ b/frontend/core/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/frontend/core/parse-data-attr.mjs
+++ b/frontend/core/parse-data-attr.mjs
@@ -141,14 +141,3 @@ export function parseDataAttr(dataAttrValue) {
 
   return data;
 }
-
-export {
-  assertString,
-  assertBoolean,
-  assertPositiveNumber,
-  assertPlainObject,
-  validateLoading,
-  validateModal,
-  TOP_LEVEL_SCHEMA,
-  MODAL_ALLOWED_TYPES,
-};

--- a/frontend/core/parse-data-attr.mjs
+++ b/frontend/core/parse-data-attr.mjs
@@ -1,0 +1,154 @@
+/**
+ * FOSSBilling API for JavaScript — data-fb-api attribute parser.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license   Apache-2.0
+ *
+ * This source file is subject to the Apache-2.0 License that is bundled
+ * with this source code in the file LICENSE
+ *
+ * Pure, side-effect-free validators for the JSON object stored in a
+ * `data-fb-api` attribute. Exported so it can be unit-tested in Node
+ * without a DOM; bundled into src/public/assets/js/api.js by esbuild.
+ */
+
+const assertString = (value, key) => {
+  if (typeof value !== 'string') {
+    throw new Error(`data-fb-api.${key} must be a string.`);
+  }
+};
+
+const assertBoolean = (value, key) => {
+  if (typeof value !== 'boolean') {
+    throw new Error(`data-fb-api.${key} must be a boolean.`);
+  }
+};
+
+const assertPositiveNumber = (value, key) => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`data-fb-api.${key} must be a positive number.`);
+  }
+};
+
+const assertPlainObject = (value, key) => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`data-fb-api.${key} must be an object.`);
+  }
+};
+
+/**
+ * Map of top-level data-fb-api fields to their scalar validators.
+ * Looping over this replaces the per-field hasOwnProperty boilerplate.
+ */
+const TOP_LEVEL_SCHEMA = {
+  href: assertString,
+  type: assertString,
+  endpoint: assertString,
+  callback: assertString,
+  message: assertString,
+  redirect: assertString,
+  reload: assertBoolean,
+  preventNavigation: assertBoolean,
+  timeoutMs: assertPositiveNumber,
+  timeoutMessage: assertString,
+  params: assertPlainObject,
+};
+
+const LOADING_STRING_FIELDS = ['message', 'button', 'target', 'alertClass'];
+
+const MODAL_ALLOWED_TYPES = ['confirm', 'danger', 'prompt'];
+const MODAL_STRING_FIELDS = ['title', 'content', 'button', 'buttonColor', 'label', 'value', 'key'];
+
+/**
+ * Validates the optional `loading` sub-object.
+ *
+ * @param {*} loading The value of data-fb-api.loading.
+ * @throws {Error} If `loading` is not an object or one of its string fields is invalid.
+ */
+function validateLoading(loading) {
+  assertPlainObject(loading, 'loading');
+
+  for (const field of LOADING_STRING_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(loading, field)) {
+      assertString(loading[field], `loading.${field}`);
+    }
+  }
+}
+
+/**
+ * Validates the optional `modal` sub-object, including its `type` enum
+ * and the conditional requirement that prompt modals declare a `key`.
+ *
+ * @param {*} modal The value of data-fb-api.modal.
+ * @throws {Error} If `modal` is structurally invalid.
+ */
+function validateModal(modal) {
+  assertPlainObject(modal, 'modal');
+
+  if (typeof modal.type !== 'string') {
+    throw new Error('data-fb-api.modal.type must be a string.');
+  }
+  if (!MODAL_ALLOWED_TYPES.includes(modal.type)) {
+    throw new Error(`data-fb-api.modal.type must be one of: ${MODAL_ALLOWED_TYPES.join(', ')}.`);
+  }
+  if (modal.type === 'prompt' && typeof modal.key !== 'string') {
+    throw new Error('data-fb-api.modal.key is required for prompt modals.');
+  }
+
+  for (const field of MODAL_STRING_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(modal, field)) {
+      assertString(modal[field], `modal.${field}`);
+    }
+  }
+}
+
+/**
+ * Parses the data attribute value from a DOM element and validates known fields.
+ *
+ * @param {string} dataAttrValue The value of the data attribute to parse.
+ * @returns {object} The parsed and validated data.
+ * @throws {Error} If the data attribute value is invalid or does not match the schema.
+ **/
+export function parseDataAttr(dataAttrValue) {
+  if (!dataAttrValue) {
+    return {};
+  }
+
+  let data;
+  try {
+    data = JSON.parse(dataAttrValue);
+  } catch (error) {
+    throw new Error('Invalid JSON in data-fb-api attribute.');
+  }
+
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('data-fb-api must be a JSON object.');
+  }
+
+  for (const [key, validator] of Object.entries(TOP_LEVEL_SCHEMA)) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      validator(data[key], key);
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(data, 'loading')) {
+    validateLoading(data.loading);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(data, 'modal')) {
+    validateModal(data.modal);
+  }
+
+  return data;
+}
+
+export {
+  assertString,
+  assertBoolean,
+  assertPositiveNumber,
+  assertPlainObject,
+  validateLoading,
+  validateModal,
+  TOP_LEVEL_SCHEMA,
+  MODAL_ALLOWED_TYPES,
+};

--- a/frontend/core/tests/api-helpers.test.mjs
+++ b/frontend/core/tests/api-helpers.test.mjs
@@ -28,14 +28,21 @@ describe('API request helpers', () => {
 
   test('puts GET parameters in the URL', () => {
     const url = new URL('https://example.test/api');
-    assert.deepEqual(buildRequestBody('GET', { id: 1 }, url), { body: null, isFormData: false });
+    assert.deepEqual(buildRequestBody('GET', { id: 1, CSRFToken: 'secret' }, url), { body: null, isFormData: false });
     assert.equal(url.searchParams.get('id'), '1');
+    assert.equal(url.searchParams.has('CSRFToken'), false);
 
     const form = new FormData();
     form.append('name', 'Ada');
+    form.append('CSRFToken', 'secret');
     const formUrl = new URL('https://example.test/api');
     assert.equal(buildRequestBody('GET', form, formUrl).body, null);
     assert.equal(formUrl.searchParams.get('name'), 'Ada');
+    assert.equal(formUrl.searchParams.has('CSRFToken'), false);
+
+    const stringUrl = new URL('https://example.test/api');
+    buildRequestBody('GET', 'name=Ada&CSRFToken=secret', stringUrl);
+    assert.equal(stringUrl.search, '?name=Ada');
   });
 
   test('builds mutation request bodies', () => {
@@ -70,6 +77,7 @@ describe('API request helpers', () => {
       origin: 'https://other.test',
     });
     assert.equal(crossOrigin['X-Requested-With'], undefined);
+    assert.equal(crossOrigin['X-CSRF-Token'], undefined);
     assert.equal(crossOrigin['Content-Type'], undefined);
   });
 });
@@ -119,6 +127,14 @@ describe('API response helpers', () => {
     );
     assert.deepEqual(
       normalizeApiError({ name: 'TypeError', message: 'NetworkError failed' }, {}),
+      { message: 'Network connection error', code: 'network_error' },
+    );
+    assert.deepEqual(
+      normalizeApiError({ name: 'TypeError', message: 'Failed to fetch' }, {}),
+      { message: 'Network connection error', code: 'network_error' },
+    );
+    assert.deepEqual(
+      normalizeApiError({ name: 'TypeError', message: 'Load failed' }, {}),
       { message: 'Network connection error', code: 'network_error' },
     );
     assert.deepEqual(

--- a/frontend/core/tests/api-helpers.test.mjs
+++ b/frontend/core/tests/api-helpers.test.mjs
@@ -1,0 +1,411 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  injectCSRFToken,
+  buildRequestBody,
+  buildHeaders,
+  parseResponseBody,
+  validateHttpResponse,
+  interpretResponse,
+  normalizeApiError,
+} from '../api-helpers.mjs';
+
+const mockResponse = (status, body, { statusText = '' } = {}) => ({
+  status,
+  ok: status >= 200 && status < 300,
+  statusText,
+  text: async () => body,
+});
+
+const mockUrl = (origin = 'https://app.test') => new URL(`${origin}/api/admin/test`);
+
+describe('injectCSRFToken', () => {
+  test('appends CSRFToken to FormData when missing', () => {
+    const fd = new FormData();
+    injectCSRFToken(fd, 'tok123');
+    assert.equal(fd.get('CSRFToken'), 'tok123');
+  });
+
+  test('does not overwrite CSRFToken in FormData when present', () => {
+    const fd = new FormData();
+    fd.append('CSRFToken', 'existing');
+    injectCSRFToken(fd, 'tok123');
+    assert.equal(fd.get('CSRFToken'), 'existing');
+  });
+
+  test('assigns CSRFToken on plain object when missing', () => {
+    const obj = { foo: 'bar' };
+    injectCSRFToken(obj, 'tok456');
+    assert.equal(obj.CSRFToken, 'tok456');
+    assert.equal(obj.foo, 'bar');
+  });
+
+  test('does not overwrite CSRFToken on plain object when present', () => {
+    const obj = { CSRFToken: 'existing' };
+    injectCSRFToken(obj, 'tok456');
+    assert.equal(obj.CSRFToken, 'existing');
+  });
+
+  test('returns null unchanged', () => {
+    assert.equal(injectCSRFToken(null, 'tok'), null);
+  });
+
+  test('returns undefined unchanged', () => {
+    assert.equal(injectCSRFToken(undefined, 'tok'), undefined);
+  });
+
+  test('returns string params unchanged', () => {
+    assert.equal(injectCSRFToken('raw-string', 'tok'), 'raw-string');
+  });
+
+  test('does not set CSRFToken on falsy empty string token for FormData', () => {
+    const fd = new FormData();
+    injectCSRFToken(fd, '');
+    assert.equal(fd.get('CSRFToken'), '');
+  });
+});
+
+describe('buildRequestBody', () => {
+  test('GET with object → params in URL search, body null', () => {
+    const url = mockUrl();
+    const { body, isFormData } = buildRequestBody('GET', { id: 1, name: 'x' }, url);
+    assert.equal(body, null);
+    assert.equal(isFormData, false);
+    assert.equal(url.searchParams.get('id'), '1');
+    assert.equal(url.searchParams.get('name'), 'x');
+  });
+
+  test('GET with FormData → params in URL search, body null', () => {
+    const url = mockUrl();
+    const fd = new FormData();
+    fd.append('id', '1');
+    const { body, isFormData } = buildRequestBody('GET', fd, url);
+    assert.equal(body, null);
+    assert.equal(isFormData, true);
+    assert.equal(url.searchParams.get('id'), '1');
+  });
+
+  test('GET with string → sets url.search', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('GET', 'foo=bar&baz=1', url);
+    assert.equal(body, null);
+    assert.equal(url.searchParams.get('foo'), 'bar');
+    assert.equal(url.searchParams.get('baz'), '1');
+  });
+
+  test('GET with null → no URL params, body null', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('GET', null, url);
+    assert.equal(body, null);
+    assert.equal(url.search, '');
+  });
+
+  test('POST with object → body is JSON string', () => {
+    const url = mockUrl();
+    const { body, isFormData } = buildRequestBody('POST', { id: 1 }, url);
+    assert.deepEqual(JSON.parse(body), { id: 1 });
+    assert.equal(isFormData, false);
+  });
+
+  test('POST with FormData → body is the FormData itself', () => {
+    const url = mockUrl();
+    const fd = new FormData();
+    const { body, isFormData } = buildRequestBody('POST', fd, url);
+    assert.equal(body, fd);
+    assert.equal(isFormData, true);
+  });
+
+  test('POST with string → body is the string as-is', () => {
+    const url = mockUrl();
+    const { body, isFormData } = buildRequestBody('POST', 'raw-body', url);
+    assert.equal(body, 'raw-body');
+    assert.equal(isFormData, false);
+  });
+
+  test('PUT with object → body is JSON string', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('PUT', { id: 2 }, url);
+    assert.deepEqual(JSON.parse(body), { id: 2 });
+  });
+
+  test('PATCH with object → body is JSON string', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('PATCH', { id: 3 }, url);
+    assert.deepEqual(JSON.parse(body), { id: 3 });
+  });
+
+  test('DELETE with object → body is JSON string', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('DELETE', { id: 4 }, url);
+    assert.deepEqual(JSON.parse(body), { id: 4 });
+  });
+
+  test('POST with null → body is "null" JSON string (JSON.stringify(null))', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('POST', null, url);
+    assert.equal(body, 'null');
+  });
+
+  test('POST with undefined → body is undefined JSON string', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('POST', undefined, url);
+    assert.equal(body, undefined);
+  });
+
+  test('method is case-insensitive', () => {
+    const url = mockUrl();
+    const { body } = buildRequestBody('PoSt', { id: 5 }, url);
+    assert.deepEqual(JSON.parse(body), { id: 5 });
+  });
+});
+
+describe('buildHeaders', () => {
+  test('same-origin + JSON body → X-Requested-With and Content-Type', () => {
+    const url = mockUrl('https://app.test');
+    const headers = buildHeaders({ url, body: '{"id":1}', isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
+    assert.equal(headers['Accept'], 'application/json');
+    assert.equal(headers['X-CSRF-Token'], 'tok');
+    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
+    assert.equal(headers['Content-Type'], 'application/json');
+  });
+
+  test('cross-origin → no X-Requested-With', () => {
+    const url = mockUrl('https://other.test');
+    const headers = buildHeaders({ url, body: '{"id":1}', isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
+    assert.equal(headers['X-Requested-With'], undefined);
+    assert.equal(headers['Content-Type'], 'application/json');
+  });
+
+  test('same-origin + FormData body → X-Requested-With, no Content-Type', () => {
+    const url = mockUrl('https://app.test');
+    const fd = new FormData();
+    const headers = buildHeaders({ url, body: fd, isFormData: true, csrfToken: 'tok', origin: 'https://app.test' });
+    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
+    assert.equal(headers['Content-Type'], undefined);
+  });
+
+  test('same-origin + null body → X-Requested-With, no Content-Type', () => {
+    const url = mockUrl('https://app.test');
+    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
+    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
+    assert.equal(headers['Content-Type'], undefined);
+  });
+
+  test('empty CSRF token → X-CSRF-Token is empty string', () => {
+    const url = mockUrl('https://app.test');
+    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: '', origin: 'https://app.test' });
+    assert.equal(headers['X-CSRF-Token'], '');
+  });
+
+  test('Accept header is always application/json', () => {
+    const url = mockUrl('https://app.test');
+    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: '', origin: 'https://app.test' });
+    assert.equal(headers['Accept'], 'application/json');
+  });
+});
+
+describe('parseResponseBody', () => {
+  test('204 status → { payload: null, rawText: "" }', async () => {
+    const result = await parseResponseBody(mockResponse(204, ''));
+    assert.deepEqual(result, { payload: null, rawText: '' });
+  });
+
+  test('empty body text → { payload: null, rawText: "" }', async () => {
+    const result = await parseResponseBody(mockResponse(200, ''));
+    assert.deepEqual(result, { payload: null, rawText: '' });
+  });
+
+  test('valid JSON → parsed payload with rawText', async () => {
+    const result = await parseResponseBody(mockResponse(200, '{"result":42}'));
+    assert.deepEqual(result.payload, { result: 42 });
+    assert.equal(result.rawText, '{"result":42}');
+  });
+
+  test('invalid JSON → { payload: null, rawText: original }', async () => {
+    const result = await parseResponseBody(mockResponse(200, 'not-json'));
+    assert.equal(result.payload, null);
+    assert.equal(result.rawText, 'not-json');
+  });
+
+  test('valid JSON array → parsed as array', async () => {
+    const result = await parseResponseBody(mockResponse(200, '[1,2,3]'));
+    assert.deepEqual(result.payload, [1, 2, 3]);
+  });
+
+  test('valid JSON null literal → payload is null (parsed)', async () => {
+    const result = await parseResponseBody(mockResponse(200, 'null'));
+    assert.equal(result.payload, null);
+    assert.equal(result.rawText, 'null');
+  });
+});
+
+describe('validateHttpResponse', () => {
+  test('!ok without error payload → throws with HTTP error message and code', () => {
+    const response = mockResponse(500, '', { statusText: 'Internal Server Error' });
+    assert.throws(
+      () => validateHttpResponse(response, { payload: null, rawText: '' }),
+      (err) => err.message === 'HTTP error 500: Internal Server Error' && err.code === 'http_500'
+    );
+  });
+
+  test('!ok with error payload → uses API error message and code', () => {
+    const response = mockResponse(422, '', { statusText: 'Unprocessable Entity' });
+    const parsed = { payload: { error: { message: 'Validation failed', code: 'validation_error' } }, rawText: '' };
+    assert.throws(
+      () => validateHttpResponse(response, parsed),
+      (err) => err.message === 'Validation failed' && err.code === 'validation_error'
+    );
+  });
+
+  test('!ok error includes .status and .rawBody', () => {
+    const response = mockResponse(403, 'forbidden', { statusText: 'Forbidden' });
+    const parsed = { payload: null, rawText: 'forbidden' };
+    try {
+      validateHttpResponse(response, parsed);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.status, 403);
+      assert.equal(err.rawBody, 'forbidden');
+    }
+  });
+
+  test('ok + rawText + null payload → throws non-JSON error', () => {
+    const response = mockResponse(200, 'broken');
+    assert.throws(
+      () => validateHttpResponse(response, { payload: null, rawText: 'broken' }),
+      /Invalid or non-JSON response from server/
+    );
+  });
+
+  test('ok + valid payload → returns payload', () => {
+    const response = mockResponse(200, '{"result":42}');
+    const result = validateHttpResponse(response, { payload: { result: 42 }, rawText: '{"result":42}' });
+    assert.deepEqual(result, { result: 42 });
+  });
+
+  test('ok + empty body (204-style) → returns null payload', () => {
+    const response = mockResponse(200, '');
+    const result = validateHttpResponse(response, { payload: null, rawText: '' });
+    assert.equal(result, null);
+  });
+
+  test('!ok falls back to http_ status code when API error has no code', () => {
+    const response = mockResponse(404, '', { statusText: 'Not Found' });
+    const parsed = { payload: { error: { message: 'Not found' } }, rawText: '' };
+    assert.throws(
+      () => validateHttpResponse(response, parsed),
+      (err) => err.code === 'http_404'
+    );
+  });
+});
+
+describe('interpretResponse', () => {
+  test('null → returns null', () => {
+    assert.equal(interpretResponse(null), null);
+  });
+
+  test('undefined → returns null', () => {
+    assert.equal(interpretResponse(undefined), null);
+  });
+
+  test('payload with .error → throws with error.message and error.code', () => {
+    const payload = { error: { message: 'Access denied', code: 'forbidden' } };
+    assert.throws(
+      () => interpretResponse(payload),
+      (err) => err.message === 'Access denied' && err.code === 'forbidden'
+    );
+  });
+
+  test('payload.error without message → throws "Unknown API error"', () => {
+    const payload = { error: {} };
+    assert.throws(
+      () => interpretResponse(payload),
+      /Unknown API error/
+    );
+  });
+
+  test('valid payload → returns .result', () => {
+    const payload = { result: { id: 1, name: 'test' } };
+    assert.deepEqual(interpretResponse(payload), { id: 1, name: 'test' });
+  });
+
+  test('payload.result is falsy (0) → returns 0', () => {
+    const payload = { result: 0 };
+    assert.equal(interpretResponse(payload), 0);
+  });
+
+  test('payload.result is null → returns null', () => {
+    const payload = { result: null };
+    assert.equal(interpretResponse(payload), null);
+  });
+});
+
+describe('normalizeApiError', () => {
+  test('AbortError with timeoutMessage → uses custom message', () => {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: 'Custom timeout' });
+    assert.equal(result.message, 'Custom timeout');
+    assert.equal(result.code, 'timeout_error');
+  });
+
+  test('AbortError without timeoutMessage → default message with seconds', () => {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'Request timed out after 30 seconds');
+    assert.equal(result.code, 'timeout_error');
+  });
+
+  test('AbortError with 5000ms → "5 seconds"', () => {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    const result = normalizeApiError(error, { timeoutMs: 5000, timeoutMessage: null });
+    assert.equal(result.message, 'Request timed out after 5 seconds');
+  });
+
+  test('TypeError with NetworkError → network_error', () => {
+    const error = new TypeError('Failed to fetch: NetworkError when attempting to fetch resource');
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'Network connection error');
+    assert.equal(result.code, 'network_error');
+  });
+
+  test('TypeError without NetworkError → falls through to generic', () => {
+    const error = new TypeError('Some other type error');
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.code, 'unknown_error');
+  });
+
+  test('generic error with code → preserves message and code', () => {
+    const error = new Error('Something broke');
+    error.code = 'custom_code';
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'Something broke');
+    assert.equal(result.code, 'custom_code');
+  });
+
+  test('generic error without code → code is unknown_error', () => {
+    const error = new Error('Something broke');
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'Something broke');
+    assert.equal(result.code, 'unknown_error');
+  });
+
+  test('error without message → message is "Unknown error occurred"', () => {
+    const error = new Error();
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'Unknown error occurred');
+    assert.equal(result.code, 'unknown_error');
+  });
+
+  test('HTTP error thrown by validateHttpResponse → preserved via generic branch', () => {
+    const error = new Error('HTTP error 500: Internal Server Error');
+    error.code = 'http_500';
+    error.status = 500;
+    error.rawBody = '';
+    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
+    assert.equal(result.message, 'HTTP error 500: Internal Server Error');
+    assert.equal(result.code, 'http_500');
+  });
+});

--- a/frontend/core/tests/api-helpers.test.mjs
+++ b/frontend/core/tests/api-helpers.test.mjs
@@ -1,411 +1,129 @@
-import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
 import {
-  injectCSRFToken,
-  buildRequestBody,
   buildHeaders,
-  parseResponseBody,
-  validateHttpResponse,
+  buildRequestBody,
+  injectCSRFToken,
   interpretResponse,
   normalizeApiError,
+  parseResponseBody,
+  validateHttpResponse,
 } from '../api-helpers.mjs';
 
-const mockResponse = (status, body, { statusText = '' } = {}) => ({
-  status,
-  ok: status >= 200 && status < 300,
-  statusText,
-  text: async () => body,
-});
+describe('API request helpers', () => {
+  test('injects a missing CSRF token without replacing an existing one', () => {
+    const params = {};
+    assert.equal(injectCSRFToken(params, 'token'), params);
+    assert.equal(params.CSRFToken, 'token');
 
-const mockUrl = (origin = 'https://app.test') => new URL(`${origin}/api/admin/test`);
+    const existing = { CSRFToken: 'existing' };
+    injectCSRFToken(existing, 'token');
+    assert.equal(existing.CSRFToken, 'existing');
 
-describe('injectCSRFToken', () => {
-  test('appends CSRFToken to FormData when missing', () => {
-    const fd = new FormData();
-    injectCSRFToken(fd, 'tok123');
-    assert.equal(fd.get('CSRFToken'), 'tok123');
+    const form = new FormData();
+    injectCSRFToken(form, 'token');
+    assert.equal(form.get('CSRFToken'), 'token');
   });
 
-  test('does not overwrite CSRFToken in FormData when present', () => {
-    const fd = new FormData();
-    fd.append('CSRFToken', 'existing');
-    injectCSRFToken(fd, 'tok123');
-    assert.equal(fd.get('CSRFToken'), 'existing');
-  });
-
-  test('assigns CSRFToken on plain object when missing', () => {
-    const obj = { foo: 'bar' };
-    injectCSRFToken(obj, 'tok456');
-    assert.equal(obj.CSRFToken, 'tok456');
-    assert.equal(obj.foo, 'bar');
-  });
-
-  test('does not overwrite CSRFToken on plain object when present', () => {
-    const obj = { CSRFToken: 'existing' };
-    injectCSRFToken(obj, 'tok456');
-    assert.equal(obj.CSRFToken, 'existing');
-  });
-
-  test('returns null unchanged', () => {
-    assert.equal(injectCSRFToken(null, 'tok'), null);
-  });
-
-  test('returns undefined unchanged', () => {
-    assert.equal(injectCSRFToken(undefined, 'tok'), undefined);
-  });
-
-  test('returns string params unchanged', () => {
-    assert.equal(injectCSRFToken('raw-string', 'tok'), 'raw-string');
-  });
-
-  test('does not set CSRFToken on falsy empty string token for FormData', () => {
-    const fd = new FormData();
-    injectCSRFToken(fd, '');
-    assert.equal(fd.get('CSRFToken'), '');
-  });
-});
-
-describe('buildRequestBody', () => {
-  test('GET with object → params in URL search, body null', () => {
-    const url = mockUrl();
-    const { body, isFormData } = buildRequestBody('GET', { id: 1, name: 'x' }, url);
-    assert.equal(body, null);
-    assert.equal(isFormData, false);
+  test('puts GET parameters in the URL', () => {
+    const url = new URL('https://example.test/api');
+    assert.deepEqual(buildRequestBody('GET', { id: 1 }, url), { body: null, isFormData: false });
     assert.equal(url.searchParams.get('id'), '1');
-    assert.equal(url.searchParams.get('name'), 'x');
+
+    const form = new FormData();
+    form.append('name', 'Ada');
+    const formUrl = new URL('https://example.test/api');
+    assert.equal(buildRequestBody('GET', form, formUrl).body, null);
+    assert.equal(formUrl.searchParams.get('name'), 'Ada');
   });
 
-  test('GET with FormData → params in URL search, body null', () => {
-    const url = mockUrl();
-    const fd = new FormData();
-    fd.append('id', '1');
-    const { body, isFormData } = buildRequestBody('GET', fd, url);
-    assert.equal(body, null);
-    assert.equal(isFormData, true);
-    assert.equal(url.searchParams.get('id'), '1');
+  test('builds mutation request bodies', () => {
+    const url = new URL('https://example.test/api');
+    assert.equal(buildRequestBody('POST', { id: 1 }, url).body, '{"id":1}');
+    assert.equal(buildRequestBody('PATCH', 'raw', url).body, 'raw');
+
+    const form = new FormData();
+    assert.equal(buildRequestBody('DELETE', form, url).body, form);
   });
 
-  test('GET with string → sets url.search', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('GET', 'foo=bar&baz=1', url);
-    assert.equal(body, null);
-    assert.equal(url.searchParams.get('foo'), 'bar');
-    assert.equal(url.searchParams.get('baz'), '1');
-  });
+  test('builds same-origin JSON headers', () => {
+    const url = new URL('https://example.test/api');
+    assert.deepEqual(buildHeaders({
+      url,
+      body: '{}',
+      isFormData: false,
+      csrfToken: 'token',
+      origin: url.origin,
+    }), {
+      Accept: 'application/json',
+      'X-CSRF-Token': 'token',
+      'X-Requested-With': 'XMLHttpRequest',
+      'Content-Type': 'application/json',
+    });
 
-  test('GET with null → no URL params, body null', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('GET', null, url);
-    assert.equal(body, null);
-    assert.equal(url.search, '');
-  });
-
-  test('POST with object → body is JSON string', () => {
-    const url = mockUrl();
-    const { body, isFormData } = buildRequestBody('POST', { id: 1 }, url);
-    assert.deepEqual(JSON.parse(body), { id: 1 });
-    assert.equal(isFormData, false);
-  });
-
-  test('POST with FormData → body is the FormData itself', () => {
-    const url = mockUrl();
-    const fd = new FormData();
-    const { body, isFormData } = buildRequestBody('POST', fd, url);
-    assert.equal(body, fd);
-    assert.equal(isFormData, true);
-  });
-
-  test('POST with string → body is the string as-is', () => {
-    const url = mockUrl();
-    const { body, isFormData } = buildRequestBody('POST', 'raw-body', url);
-    assert.equal(body, 'raw-body');
-    assert.equal(isFormData, false);
-  });
-
-  test('PUT with object → body is JSON string', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('PUT', { id: 2 }, url);
-    assert.deepEqual(JSON.parse(body), { id: 2 });
-  });
-
-  test('PATCH with object → body is JSON string', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('PATCH', { id: 3 }, url);
-    assert.deepEqual(JSON.parse(body), { id: 3 });
-  });
-
-  test('DELETE with object → body is JSON string', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('DELETE', { id: 4 }, url);
-    assert.deepEqual(JSON.parse(body), { id: 4 });
-  });
-
-  test('POST with null → body is "null" JSON string (JSON.stringify(null))', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('POST', null, url);
-    assert.equal(body, 'null');
-  });
-
-  test('POST with undefined → body is undefined JSON string', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('POST', undefined, url);
-    assert.equal(body, undefined);
-  });
-
-  test('method is case-insensitive', () => {
-    const url = mockUrl();
-    const { body } = buildRequestBody('PoSt', { id: 5 }, url);
-    assert.deepEqual(JSON.parse(body), { id: 5 });
+    const crossOrigin = buildHeaders({
+      url,
+      body: new FormData(),
+      isFormData: true,
+      csrfToken: null,
+      origin: 'https://other.test',
+    });
+    assert.equal(crossOrigin['X-Requested-With'], undefined);
+    assert.equal(crossOrigin['Content-Type'], undefined);
   });
 });
 
-describe('buildHeaders', () => {
-  test('same-origin + JSON body → X-Requested-With and Content-Type', () => {
-    const url = mockUrl('https://app.test');
-    const headers = buildHeaders({ url, body: '{"id":1}', isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
-    assert.equal(headers['Accept'], 'application/json');
-    assert.equal(headers['X-CSRF-Token'], 'tok');
-    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
-    assert.equal(headers['Content-Type'], 'application/json');
-  });
-
-  test('cross-origin → no X-Requested-With', () => {
-    const url = mockUrl('https://other.test');
-    const headers = buildHeaders({ url, body: '{"id":1}', isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
-    assert.equal(headers['X-Requested-With'], undefined);
-    assert.equal(headers['Content-Type'], 'application/json');
-  });
-
-  test('same-origin + FormData body → X-Requested-With, no Content-Type', () => {
-    const url = mockUrl('https://app.test');
-    const fd = new FormData();
-    const headers = buildHeaders({ url, body: fd, isFormData: true, csrfToken: 'tok', origin: 'https://app.test' });
-    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
-    assert.equal(headers['Content-Type'], undefined);
-  });
-
-  test('same-origin + null body → X-Requested-With, no Content-Type', () => {
-    const url = mockUrl('https://app.test');
-    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: 'tok', origin: 'https://app.test' });
-    assert.equal(headers['X-Requested-With'], 'XMLHttpRequest');
-    assert.equal(headers['Content-Type'], undefined);
-  });
-
-  test('empty CSRF token → X-CSRF-Token is empty string', () => {
-    const url = mockUrl('https://app.test');
-    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: '', origin: 'https://app.test' });
-    assert.equal(headers['X-CSRF-Token'], '');
-  });
-
-  test('Accept header is always application/json', () => {
-    const url = mockUrl('https://app.test');
-    const headers = buildHeaders({ url, body: null, isFormData: false, csrfToken: '', origin: 'https://app.test' });
-    assert.equal(headers['Accept'], 'application/json');
-  });
-});
-
-describe('parseResponseBody', () => {
-  test('204 status → { payload: null, rawText: "" }', async () => {
-    const result = await parseResponseBody(mockResponse(204, ''));
-    assert.deepEqual(result, { payload: null, rawText: '' });
-  });
-
-  test('empty body text → { payload: null, rawText: "" }', async () => {
-    const result = await parseResponseBody(mockResponse(200, ''));
-    assert.deepEqual(result, { payload: null, rawText: '' });
-  });
-
-  test('valid JSON → parsed payload with rawText', async () => {
-    const result = await parseResponseBody(mockResponse(200, '{"result":42}'));
-    assert.deepEqual(result.payload, { result: 42 });
-    assert.equal(result.rawText, '{"result":42}');
-  });
-
-  test('invalid JSON → { payload: null, rawText: original }', async () => {
-    const result = await parseResponseBody(mockResponse(200, 'not-json'));
-    assert.equal(result.payload, null);
-    assert.equal(result.rawText, 'not-json');
-  });
-
-  test('valid JSON array → parsed as array', async () => {
-    const result = await parseResponseBody(mockResponse(200, '[1,2,3]'));
-    assert.deepEqual(result.payload, [1, 2, 3]);
-  });
-
-  test('valid JSON null literal → payload is null (parsed)', async () => {
-    const result = await parseResponseBody(mockResponse(200, 'null'));
-    assert.equal(result.payload, null);
-    assert.equal(result.rawText, 'null');
-  });
-});
-
-describe('validateHttpResponse', () => {
-  test('!ok without error payload → throws with HTTP error message and code', () => {
-    const response = mockResponse(500, '', { statusText: 'Internal Server Error' });
-    assert.throws(
-      () => validateHttpResponse(response, { payload: null, rawText: '' }),
-      (err) => err.message === 'HTTP error 500: Internal Server Error' && err.code === 'http_500'
+describe('API response helpers', () => {
+  test('parses JSON, empty, and invalid response bodies', async () => {
+    assert.deepEqual(await parseResponseBody({ status: 204 }), { payload: null, rawText: '' });
+    assert.deepEqual(
+      await parseResponseBody({ status: 200, text: async () => '{"result":1}' }),
+      { payload: { result: 1 }, rawText: '{"result":1}' },
+    );
+    assert.deepEqual(
+      await parseResponseBody({ status: 200, text: async () => '<html>' }),
+      { payload: null, rawText: '<html>' },
     );
   });
 
-  test('!ok with error payload → uses API error message and code', () => {
-    const response = mockResponse(422, '', { statusText: 'Unprocessable Entity' });
-    const parsed = { payload: { error: { message: 'Validation failed', code: 'validation_error' } }, rawText: '' };
+  test('validates HTTP responses', () => {
+    const parsed = { payload: { result: 1 }, rawText: '{"result":1}' };
+    assert.equal(validateHttpResponse({ ok: true }, parsed), parsed.payload);
     assert.throws(
-      () => validateHttpResponse(response, parsed),
-      (err) => err.message === 'Validation failed' && err.code === 'validation_error'
+      () => validateHttpResponse(
+        { ok: false, status: 422, statusText: 'Invalid' },
+        { payload: { error: { message: 'Bad input', code: 'bad_input' } }, rawText: 'body' },
+      ),
+      (error) => error.message === 'Bad input' && error.code === 'bad_input' && error.status === 422,
+    );
+    assert.throws(
+      () => validateHttpResponse({ ok: true }, { payload: null, rawText: '<html>' }),
+      /non-JSON response/,
     );
   });
 
-  test('!ok error includes .status and .rawBody', () => {
-    const response = mockResponse(403, 'forbidden', { statusText: 'Forbidden' });
-    const parsed = { payload: null, rawText: 'forbidden' };
-    try {
-      validateHttpResponse(response, parsed);
-      assert.fail('should have thrown');
-    } catch (err) {
-      assert.equal(err.status, 403);
-      assert.equal(err.rawBody, 'forbidden');
-    }
-  });
-
-  test('ok + rawText + null payload → throws non-JSON error', () => {
-    const response = mockResponse(200, 'broken');
-    assert.throws(
-      () => validateHttpResponse(response, { payload: null, rawText: 'broken' }),
-      /Invalid or non-JSON response from server/
-    );
-  });
-
-  test('ok + valid payload → returns payload', () => {
-    const response = mockResponse(200, '{"result":42}');
-    const result = validateHttpResponse(response, { payload: { result: 42 }, rawText: '{"result":42}' });
-    assert.deepEqual(result, { result: 42 });
-  });
-
-  test('ok + empty body (204-style) → returns null payload', () => {
-    const response = mockResponse(200, '');
-    const result = validateHttpResponse(response, { payload: null, rawText: '' });
-    assert.equal(result, null);
-  });
-
-  test('!ok falls back to http_ status code when API error has no code', () => {
-    const response = mockResponse(404, '', { statusText: 'Not Found' });
-    const parsed = { payload: { error: { message: 'Not found' } }, rawText: '' };
-    assert.throws(
-      () => validateHttpResponse(response, parsed),
-      (err) => err.code === 'http_404'
-    );
-  });
-});
-
-describe('interpretResponse', () => {
-  test('null → returns null', () => {
+  test('returns results and throws API errors', () => {
     assert.equal(interpretResponse(null), null);
-  });
-
-  test('undefined → returns null', () => {
-    assert.equal(interpretResponse(undefined), null);
-  });
-
-  test('payload with .error → throws with error.message and error.code', () => {
-    const payload = { error: { message: 'Access denied', code: 'forbidden' } };
+    assert.equal(interpretResponse({ result: 0 }), 0);
     assert.throws(
-      () => interpretResponse(payload),
-      (err) => err.message === 'Access denied' && err.code === 'forbidden'
+      () => interpretResponse({ error: { message: 'Denied', code: 'denied' } }),
+      (error) => error.message === 'Denied' && error.code === 'denied',
     );
   });
 
-  test('payload.error without message → throws "Unknown API error"', () => {
-    const payload = { error: {} };
-    assert.throws(
-      () => interpretResponse(payload),
-      /Unknown API error/
+  test('normalizes timeout, network, and generic errors', () => {
+    assert.deepEqual(
+      normalizeApiError({ name: 'AbortError' }, { timeoutMs: 5000 }),
+      { message: 'Request timed out after 5 seconds', code: 'timeout_error' },
     );
-  });
-
-  test('valid payload → returns .result', () => {
-    const payload = { result: { id: 1, name: 'test' } };
-    assert.deepEqual(interpretResponse(payload), { id: 1, name: 'test' });
-  });
-
-  test('payload.result is falsy (0) → returns 0', () => {
-    const payload = { result: 0 };
-    assert.equal(interpretResponse(payload), 0);
-  });
-
-  test('payload.result is null → returns null', () => {
-    const payload = { result: null };
-    assert.equal(interpretResponse(payload), null);
-  });
-});
-
-describe('normalizeApiError', () => {
-  test('AbortError with timeoutMessage → uses custom message', () => {
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: 'Custom timeout' });
-    assert.equal(result.message, 'Custom timeout');
-    assert.equal(result.code, 'timeout_error');
-  });
-
-  test('AbortError without timeoutMessage → default message with seconds', () => {
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'Request timed out after 30 seconds');
-    assert.equal(result.code, 'timeout_error');
-  });
-
-  test('AbortError with 5000ms → "5 seconds"', () => {
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    const result = normalizeApiError(error, { timeoutMs: 5000, timeoutMessage: null });
-    assert.equal(result.message, 'Request timed out after 5 seconds');
-  });
-
-  test('TypeError with NetworkError → network_error', () => {
-    const error = new TypeError('Failed to fetch: NetworkError when attempting to fetch resource');
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'Network connection error');
-    assert.equal(result.code, 'network_error');
-  });
-
-  test('TypeError without NetworkError → falls through to generic', () => {
-    const error = new TypeError('Some other type error');
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.code, 'unknown_error');
-  });
-
-  test('generic error with code → preserves message and code', () => {
-    const error = new Error('Something broke');
-    error.code = 'custom_code';
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'Something broke');
-    assert.equal(result.code, 'custom_code');
-  });
-
-  test('generic error without code → code is unknown_error', () => {
-    const error = new Error('Something broke');
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'Something broke');
-    assert.equal(result.code, 'unknown_error');
-  });
-
-  test('error without message → message is "Unknown error occurred"', () => {
-    const error = new Error();
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'Unknown error occurred');
-    assert.equal(result.code, 'unknown_error');
-  });
-
-  test('HTTP error thrown by validateHttpResponse → preserved via generic branch', () => {
-    const error = new Error('HTTP error 500: Internal Server Error');
-    error.code = 'http_500';
-    error.status = 500;
-    error.rawBody = '';
-    const result = normalizeApiError(error, { timeoutMs: 30000, timeoutMessage: null });
-    assert.equal(result.message, 'HTTP error 500: Internal Server Error');
-    assert.equal(result.code, 'http_500');
+    assert.deepEqual(
+      normalizeApiError({ name: 'TypeError', message: 'NetworkError failed' }, {}),
+      { message: 'Network connection error', code: 'network_error' },
+    );
+    assert.deepEqual(
+      normalizeApiError({ message: 'Denied', code: 'denied' }, {}),
+      { message: 'Denied', code: 'denied' },
+    );
   });
 });

--- a/frontend/core/tests/link-helpers.test.mjs
+++ b/frontend/core/tests/link-helpers.test.mjs
@@ -1,388 +1,190 @@
-import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  buildPromptParams,
-  dispatchLinkAction,
-  createLinkLoadingState,
-} from '../link-helpers.mjs';
+import { describe, test } from 'node:test';
+
+import { createLinkLoadingState, dispatchLinkAction } from '../link-helpers.mjs';
 
 globalThis.window = globalThis;
 
-const mockCreatedElement = () => ({
+const createClassList = (classes = []) => ({
+  classes: new Set(classes),
+  add(value) { this.classes.add(value); },
+  remove(value) { this.classes.delete(value); },
+  contains(value) { return this.classes.has(value); },
+});
+
+const createElement = () => ({
   className: '',
-  _attrs: {},
-  getAttribute(name) { return this._attrs[name] ?? null; },
-  setAttribute(name, value) { this._attrs[name] = String(value); },
-  classList: { _set: new Set(), add(c) { this._set.add(c); }, remove(c) { this._set.delete(c); }, contains(c) { return this._set.has(c); } },
+  attributes: {},
+  classList: createClassList(),
+  getAttribute(name) { return this.attributes[name] ?? null; },
+  setAttribute(name, value) { this.attributes[name] = String(value); },
 });
 
 globalThis.document = {
-  createElement: (tag) => mockCreatedElement(),
-  createTextNode: (text) => ({ nodeType: 3, textContent: text, nodeName: '#text' }),
+  createElement,
+  createTextNode: (text) => ({ textContent: text }),
+  querySelector: () => null,
 };
 
-const mockLinkElement = (overrides = {}) => ({
+const createLink = ({ disabled = false, parent = null } = {}) => ({
   innerHTML: '<span>Original</span>',
-  classList: {
-    _classes: new Set(overrides.disabled ? ['disabled'] : []),
-    add(c) { this._classes.add(c); },
-    remove(c) { this._classes.delete(c); },
-    contains(c) { return this._classes.has(c); },
-  },
-  _attrs: {},
-  getAttribute(name) { return this._attrs[name] ?? null; },
-  setAttribute(name, value) { this._attrs[name] = String(value); },
-  removeAttribute(name) { delete this._attrs[name]; },
-  _children: null,
-  replaceChildren(...nodes) { this._children = nodes; },
-  _parent: null,
-  closest() { return this._parent; },
-  parentElement: null,
-  ...overrides,
-});
-
-const mockEventTarget = () => {
-  const listeners = {};
-  return {
-    addEventListener(name, fn) { listeners[name] = fn; },
-    removeEventListener(name, fn) {
-      if (listeners[name] === fn) { delete listeners[name]; }
-    },
-    _fire(name, event) { if (listeners[name]) { listeners[name](event); } },
-    _has(name) { return !!listeners[name]; },
-  };
-};
-
-describe('buildPromptParams', () => {
-  test('builds single-key object from modal config', () => {
-    const result = buildPromptParams({ key: 'domain' }, 'example.com');
-    assert.deepEqual(result, { domain: 'example.com' });
-  });
-
-  test('preserves empty string values', () => {
-    const result = buildPromptParams({ key: 'note' }, '');
-    assert.deepEqual(result, { note: '' });
-  });
-
-  test('handles special characters in key and value', () => {
-    const result = buildPromptParams({ key: 'weird-key' }, 'value with spaces');
-    assert.deepEqual(result, { 'weird-key': 'value with spaces' });
-  });
+  attributes: {},
+  classList: createClassList(disabled ? ['disabled'] : []),
+  parentElement: parent,
+  getAttribute(name) { return this.attributes[name] ?? null; },
+  setAttribute(name, value) { this.attributes[name] = String(value); },
+  removeAttribute(name) { delete this.attributes[name]; },
+  replaceChildren(...children) { this.children = children; },
+  closest() { return parent; },
 });
 
 describe('dispatchLinkAction', () => {
-  test('no modal property calls onRequest directly', () => {
-    let called = null;
-    const apiData = { href: '/api/test' };
-    dispatchLinkAction(apiData, '/link', null, (method, href) => {
-      called = { method, href };
-    });
-    assert.equal(called.method, 'GET');
-    assert.equal(called.href, '/link');
+  test('dispatches links without a modal directly', () => {
+    let request;
+    dispatchLinkAction({}, '/endpoint', null, (...args) => { request = args; });
+    assert.deepEqual(request, ['GET', '/endpoint']);
   });
 
-  test('no modal property does not pass params argument', () => {
-    let callArgs;
-    dispatchLinkAction({}, '/link', null, (...args) => { callArgs = args; });
-    assert.equal(callArgs.length, 2);
+  test('uses native confirm when the modal library is unavailable', () => {
+    let request;
+    window.confirm = (message) => {
+      assert.equal(message, 'Continue?');
+      return true;
+    };
+
+    dispatchLinkAction(
+      { modal: { type: 'confirm', content: 'Continue?' } },
+      '/endpoint',
+      null,
+      (...args) => { request = args; },
+    );
+    assert.deepEqual(request, ['GET', '/endpoint']);
+
+    window.confirm = () => false;
+    request = undefined;
+    dispatchLinkAction(
+      { modal: { type: 'danger' } },
+      '/endpoint',
+      null,
+      (...args) => { request = args; },
+    );
+    assert.equal(request, undefined);
   });
 
-  test('native prompt with truthy value calls onRequest with param', () => {
-    const origPrompt = globalThis.prompt;
-    globalThis.prompt = () => 'typed-value';
-    try {
-      let called = null;
-      const apiData = { modal: { type: 'prompt', key: 'name', label: 'Enter name', title: 'Prompt Title', value: 'default' } };
-      dispatchLinkAction(apiData, '/link', null, (method, href, params) => {
-        called = { method, href, params };
-      });
-      assert.equal(called.method, 'GET');
-      assert.equal(called.href, '/link');
-      assert.deepEqual(called.params, { name: 'typed-value' });
-    } finally {
-      globalThis.prompt = origPrompt;
-    }
+  test('uses native prompt and maps the answer to the configured key', () => {
+    window.prompt = (label, value) => {
+      assert.equal(label, 'Reason');
+      assert.equal(value, 'Default');
+      return 'Because';
+    };
+
+    let request;
+    dispatchLinkAction(
+      { modal: { type: 'prompt', key: 'reason', label: 'Reason', value: 'Default' } },
+      '/endpoint',
+      null,
+      (...args) => { request = args; },
+    );
+    assert.deepEqual(request, ['GET', '/endpoint', { reason: 'Because' }]);
   });
 
-  test('native prompt with falsy value does not call onRequest', () => {
-    const origPrompt = globalThis.prompt;
-    globalThis.prompt = () => null;
-    try {
-      let called = false;
-      dispatchLinkAction({ modal: { type: 'prompt', key: 'name' } }, '/link', null, () => { called = true; });
-      assert.equal(called, false);
-    } finally {
-      globalThis.prompt = origPrompt;
-    }
-  });
+  test('configures library confirm and prompt callbacks', () => {
+    const created = [];
+    const modals = { create: (config) => created.push(config) };
+    const requests = [];
 
-  test('native prompt uses modal.label fallback to modal.title', () => {
-    const origPrompt = globalThis.prompt;
-    let promptArgs;
-    globalThis.prompt = (message, defaultValue) => { promptArgs = { message, defaultValue }; return null; };
-    try {
-      dispatchLinkAction({ modal: { type: 'prompt', key: 'x', title: 'Fallback Title' } }, '/link', null, () => {});
-      assert.equal(promptArgs.message, 'Fallback Title');
-      assert.equal(promptArgs.defaultValue, '');
-    } finally {
-      globalThis.prompt = origPrompt;
-    }
-  });
+    dispatchLinkAction(
+      { modal: { type: 'confirm', title: 'Delete', button: 'Delete', buttonColor: 'danger' } },
+      '/delete',
+      modals,
+      (...args) => requests.push(args),
+    );
+    assert.equal(created[0].type, 'small-confirm');
+    assert.equal(created[0].confirmButton, 'Delete');
+    created[0].confirmCallback();
 
-  test('native prompt uses modal.label when present', () => {
-    const origPrompt = globalThis.prompt;
-    let promptMessage;
-    globalThis.prompt = (message) => { promptMessage = message; return null; };
-    try {
-      dispatchLinkAction({ modal: { type: 'prompt', key: 'x', label: 'Custom Label', title: 'Title' } }, '/link', null, () => {});
-      assert.equal(promptMessage, 'Custom Label');
-    } finally {
-      globalThis.prompt = origPrompt;
-    }
-  });
+    dispatchLinkAction(
+      { modal: { type: 'prompt', key: 'name', title: 'Name' } },
+      '/rename',
+      modals,
+      (...args) => requests.push(args),
+    );
+    assert.equal(created[1].label, 'Label');
+    created[1].promptConfirmCallback('New name');
 
-  test('native confirm with user OK calls onRequest', () => {
-    const origConfirm = globalThis.confirm;
-    globalThis.confirm = () => true;
-    try {
-      let called = null;
-      const apiData = { modal: { type: 'confirm', content: 'Are you sure?' } };
-      dispatchLinkAction(apiData, '/link', null, (method, href) => { called = { method, href }; });
-      assert.equal(called.method, 'GET');
-      assert.equal(called.href, '/link');
-    } finally {
-      globalThis.confirm = origConfirm;
-    }
-  });
-
-  test('native confirm with user cancel does not call onRequest', () => {
-    const origConfirm = globalThis.confirm;
-    globalThis.confirm = () => false;
-    try {
-      let called = false;
-      dispatchLinkAction({ modal: { type: 'confirm', content: 'Sure?' } }, '/link', null, () => { called = true; });
-      assert.equal(called, false);
-    } finally {
-      globalThis.confirm = origConfirm;
-    }
-  });
-
-  test('native confirm falls back to title then default message', () => {
-    const origConfirm = globalThis.confirm;
-    let confirmMsg;
-    globalThis.confirm = (msg) => { confirmMsg = msg; return false; };
-    try {
-      dispatchLinkAction({ modal: { type: 'confirm', title: 'Title fallback' } }, '/link', null, () => {});
-      assert.equal(confirmMsg, 'Title fallback');
-
-      globalThis.confirm = (msg) => { confirmMsg = msg; return false; };
-      dispatchLinkAction({ modal: { type: 'confirm' } }, '/link', null, () => {});
-      assert.equal(confirmMsg, 'Are you sure?');
-    } finally {
-      globalThis.confirm = origConfirm;
-    }
-  });
-
-  test('Modals.create prompt with truthy value calls onRequest via callback', () => {
-    const modalsLib = { create: (config) => { config.promptConfirmCallback('user-entered'); } };
-    let called = null;
-    const apiData = { modal: { type: 'prompt', key: 'email', title: 'Enter email', label: 'Email', value: '' } };
-    dispatchLinkAction(apiData, '/link', modalsLib, (method, href, params) => { called = { method, href, params }; });
-    assert.equal(called.method, 'GET');
-    assert.deepEqual(called.params, { email: 'user-entered' });
-  });
-
-  test('Modals.create prompt with falsy value does not call onRequest', () => {
-    const modalsLib = { create: (config) => { config.promptConfirmCallback(''); } };
-    let called = false;
-    dispatchLinkAction({ modal: { type: 'prompt', key: 'x' } }, '/link', modalsLib, () => { called = true; });
-    assert.equal(called, false);
-  });
-
-  test('Modals.create prompt passes correct config', () => {
-    let capturedConfig;
-    const modalsLib = { create: (config) => { capturedConfig = config; config.promptConfirmCallback(null); } };
-    const apiData = { modal: { type: 'prompt', key: 'k', title: 'T', label: 'L', value: 'V' } };
-    dispatchLinkAction(apiData, '/link', modalsLib, () => {});
-    assert.equal(capturedConfig.type, 'prompt');
-    assert.equal(capturedConfig.title, 'T');
-    assert.equal(capturedConfig.label, 'L');
-    assert.equal(capturedConfig.value, 'V');
-  });
-
-  test('Modals.create prompt uses default label when missing', () => {
-    let capturedConfig;
-    const modalsLib = { create: (config) => { capturedConfig = config; config.promptConfirmCallback(null); } };
-    dispatchLinkAction({ modal: { type: 'prompt', key: 'k' } }, '/link', modalsLib, () => {});
-    assert.equal(capturedConfig.label, 'Label');
-    assert.equal(capturedConfig.value, '');
-  });
-
-  test('Modals.create confirm calls onRequest via confirmCallback', () => {
-    const modalsLib = { create: (config) => { config.confirmCallback(); } };
-    let called = null;
-    dispatchLinkAction({ modal: { type: 'confirm', title: 'Sure?' } }, '/link', modalsLib, (method, href) => { called = { method, href }; });
-    assert.equal(called.method, 'GET');
-    assert.equal(called.href, '/link');
-  });
-
-  test('Modals.create maps type "confirm" to "small-confirm"', () => {
-    let capturedType;
-    const modalsLib = { create: (config) => { capturedType = config.type; config.confirmCallback(); } };
-    dispatchLinkAction({ modal: { type: 'confirm' } }, '/link', modalsLib, () => {});
-    assert.equal(capturedType, 'small-confirm');
-  });
-
-  test('Modals.create preserves non-confirm modal types as-is', () => {
-    let capturedType;
-    const modalsLib = { create: (config) => { capturedType = config.type; config.confirmCallback(); } };
-    dispatchLinkAction({ modal: { type: 'danger' } }, '/link', modalsLib, () => {});
-    assert.equal(capturedType, 'danger');
-  });
-
-  test('Modals.create confirm passes full config with defaults', () => {
-    let c;
-    const modalsLib = { create: (config) => { c = config; config.confirmCallback(); } };
-    dispatchLinkAction({ modal: { type: 'confirm', title: 'Delete?', content: 'This will delete the item.', button: 'Delete', buttonColor: 'danger' } }, '/link', modalsLib, () => {});
-    assert.equal(c.title, 'Delete?');
-    assert.equal(c.content, 'This will delete the item.');
-    assert.equal(c.confirmButton, 'Delete');
-    assert.equal(c.confirmButtonColor, 'danger');
-  });
-
-  test('Modals.create confirm applies default button and color', () => {
-    let c;
-    const modalsLib = { create: (config) => { c = config; config.confirmCallback(); } };
-    dispatchLinkAction({ modal: { type: 'confirm', title: 'X' } }, '/link', modalsLib, () => {});
-    assert.equal(c.confirmButton, 'Confirm');
-    assert.equal(c.confirmButtonColor, 'primary');
-    assert.equal(c.content, '');
-  });
-
-  test('modalsLib without create function falls back to native confirm', () => {
-    const origConfirm = globalThis.confirm;
-    globalThis.confirm = () => true;
-    try {
-      let called = false;
-      dispatchLinkAction({ modal: { type: 'confirm', content: 'OK?' } }, '/link', {}, () => { called = true; });
-      assert.equal(called, true);
-    } finally {
-      globalThis.confirm = origConfirm;
-    }
+    assert.deepEqual(requests, [
+      ['GET', '/delete'],
+      ['GET', '/rename', { name: 'New name' }],
+    ]);
   });
 });
 
 describe('createLinkLoadingState', () => {
-  test('isInProgress is false initially', () => {
-    const el = mockLinkElement();
-    const state = createLinkLoadingState(el);
-    assert.equal(state.isInProgress(), false);
-  });
+  test('sets and restores link state', () => {
+    const link = createLink();
+    const state = createLinkLoadingState(link);
 
-  test('set marks in progress and adds disabled + aria attributes', () => {
-    const el = mockLinkElement();
-    const state = createLinkLoadingState(el);
-    state.set({ loading: null });
+    assert.equal(state.isInProgress(), false);
+    state.set({ loading: { button: 'Saving' } });
     assert.equal(state.isInProgress(), true);
-    assert.equal(el.getAttribute('aria-busy'), 'true');
-    assert.equal(el.getAttribute('aria-disabled'), 'true');
-    assert.equal(el.classList.contains('disabled'), true);
-  });
+    assert.equal(link.classList.contains('disabled'), true);
+    assert.equal(link.getAttribute('aria-busy'), 'true');
+    assert.equal(link.children[1].textContent, 'Saving');
 
-  test('reset restores original state and clears in-progress', () => {
-    const el = mockLinkElement();
-    const state = createLinkLoadingState(el);
-    state.set({ loading: null });
     state.reset();
     assert.equal(state.isInProgress(), false);
-    assert.equal(el.getAttribute('aria-busy'), null);
-    assert.equal(el.getAttribute('aria-disabled'), null);
-    assert.equal(el.classList.contains('disabled'), false);
+    assert.equal(link.classList.contains('disabled'), false);
+    assert.equal(link.getAttribute('aria-busy'), null);
+    assert.equal(link.innerHTML, '<span>Original</span>');
   });
 
-  test('reset is no-op when not in progress', () => {
-    const el = mockLinkElement();
-    const state = createLinkLoadingState(el);
+  test('preserves pre-existing accessibility and disabled state', () => {
+    const link = createLink({ disabled: true });
+    link.setAttribute('aria-busy', 'pending');
+    link.setAttribute('aria-disabled', 'mixed');
+    const state = createLinkLoadingState(link);
+
+    state.set({});
     state.reset();
-    assert.equal(state.isInProgress(), false);
+
+    assert.equal(link.classList.contains('disabled'), true);
+    assert.equal(link.getAttribute('aria-busy'), 'pending');
+    assert.equal(link.getAttribute('aria-disabled'), 'mixed');
   });
 
-  test('set with loading.button replaces link children with spinner + text', () => {
-    const el = mockLinkElement();
-    const state = createLinkLoadingState(el);
-    state.set({ loading: { button: 'Loading...' } });
-    assert.ok(el._children);
-    assert.equal(el._children.length, 2);
-    assert.equal(el._children[0].className, 'spinner-border spinner-border-sm me-2');
-    assert.equal(el._children[0].getAttribute('aria-hidden'), 'true');
-    assert.equal(el._children[1].nodeType, 3);
-    assert.equal(el._children[1].textContent, 'Loading...');
-  });
+  test('adds and removes loading messages and navigation guards', () => {
+    const parent = {
+      children: [],
+      appendChild(child) { this.children.push(child); },
+    };
+    const removed = [];
+    const listeners = new Map();
+    window.addEventListener = (name, listener) => listeners.set(name, listener);
+    window.removeEventListener = (name, listener) => {
+      if (listeners.get(name) === listener) {
+        listeners.delete(name);
+      }
+    };
 
-  test('set restores innerHTML on reset after button change', () => {
-    const el = mockLinkElement();
-    const originalHtml = el.innerHTML;
-    const state = createLinkLoadingState(el);
-    state.set({ loading: { button: 'Working...' } });
+    const originalCreateElement = document.createElement;
+    document.createElement = () => {
+      const element = originalCreateElement();
+      element.remove = () => removed.push(element);
+      return element;
+    };
+
+    const state = createLinkLoadingState(createLink({ parent }));
+    state.set({
+      loading: { message: 'Still working', alertClass: 'notice' },
+      preventNavigation: true,
+    });
+
+    assert.equal(parent.children[0].textContent, 'Still working');
+    assert.equal(parent.children[0].className, 'notice');
+    assert.equal(listeners.has('beforeunload'), true);
+
     state.reset();
-    assert.equal(el.innerHTML, originalHtml);
-  });
-
-  test('set preserves existing aria-busy value on reset', () => {
-    const el = mockLinkElement();
-    el._attrs['aria-busy'] = 'false';
-    const state = createLinkLoadingState(el);
-    state.set({ loading: null });
-    state.reset();
-    assert.equal(el.getAttribute('aria-busy'), 'false');
-  });
-
-  test('set preserves existing aria-disabled value on reset', () => {
-    const el = mockLinkElement();
-    el._attrs['aria-disabled'] = 'false';
-    const state = createLinkLoadingState(el);
-    state.set({ loading: null });
-    state.reset();
-    assert.equal(el.getAttribute('aria-disabled'), 'false');
-  });
-
-  test('set does not remove disabled class if link was originally disabled', () => {
-    const el = mockLinkElement({ disabled: true });
-    const state = createLinkLoadingState(el);
-    state.set({ loading: null });
-    state.reset();
-    assert.equal(el.classList.contains('disabled'), true);
-  });
-
-  test('preventNavigation adds and removes beforeunload listener', () => {
-    const origWindow = globalThis.window;
-    const eventTarget = mockEventTarget();
-    globalThis.window = Object.assign({}, origWindow, eventTarget);
-
-    try {
-      const el = mockLinkElement();
-      const state = createLinkLoadingState(el);
-      state.set({ preventNavigation: true });
-      assert.equal(eventTarget._has('beforeunload'), true);
-      state.reset();
-      assert.equal(eventTarget._has('beforeunload'), false);
-    } finally {
-      globalThis.window = origWindow;
-    }
-  });
-
-  test('preventNavigation false does not add beforeunload listener', () => {
-    const origWindow = globalThis.window;
-    const eventTarget = mockEventTarget();
-    globalThis.window = Object.assign({}, origWindow, eventTarget);
-
-    try {
-      const el = mockLinkElement();
-      const state = createLinkLoadingState(el);
-      state.set({ loading: null });
-      assert.equal(eventTarget._has('beforeunload'), false);
-    } finally {
-      globalThis.window = origWindow;
-    }
+    assert.equal(removed.length, 1);
+    assert.equal(listeners.has('beforeunload'), false);
   });
 });

--- a/frontend/core/tests/link-helpers.test.mjs
+++ b/frontend/core/tests/link-helpers.test.mjs
@@ -1,0 +1,388 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildPromptParams,
+  dispatchLinkAction,
+  createLinkLoadingState,
+} from '../link-helpers.mjs';
+
+globalThis.window = globalThis;
+
+const mockCreatedElement = () => ({
+  className: '',
+  _attrs: {},
+  getAttribute(name) { return this._attrs[name] ?? null; },
+  setAttribute(name, value) { this._attrs[name] = String(value); },
+  classList: { _set: new Set(), add(c) { this._set.add(c); }, remove(c) { this._set.delete(c); }, contains(c) { return this._set.has(c); } },
+});
+
+globalThis.document = {
+  createElement: (tag) => mockCreatedElement(),
+  createTextNode: (text) => ({ nodeType: 3, textContent: text, nodeName: '#text' }),
+};
+
+const mockLinkElement = (overrides = {}) => ({
+  innerHTML: '<span>Original</span>',
+  classList: {
+    _classes: new Set(overrides.disabled ? ['disabled'] : []),
+    add(c) { this._classes.add(c); },
+    remove(c) { this._classes.delete(c); },
+    contains(c) { return this._classes.has(c); },
+  },
+  _attrs: {},
+  getAttribute(name) { return this._attrs[name] ?? null; },
+  setAttribute(name, value) { this._attrs[name] = String(value); },
+  removeAttribute(name) { delete this._attrs[name]; },
+  _children: null,
+  replaceChildren(...nodes) { this._children = nodes; },
+  _parent: null,
+  closest() { return this._parent; },
+  parentElement: null,
+  ...overrides,
+});
+
+const mockEventTarget = () => {
+  const listeners = {};
+  return {
+    addEventListener(name, fn) { listeners[name] = fn; },
+    removeEventListener(name, fn) {
+      if (listeners[name] === fn) { delete listeners[name]; }
+    },
+    _fire(name, event) { if (listeners[name]) { listeners[name](event); } },
+    _has(name) { return !!listeners[name]; },
+  };
+};
+
+describe('buildPromptParams', () => {
+  test('builds single-key object from modal config', () => {
+    const result = buildPromptParams({ key: 'domain' }, 'example.com');
+    assert.deepEqual(result, { domain: 'example.com' });
+  });
+
+  test('preserves empty string values', () => {
+    const result = buildPromptParams({ key: 'note' }, '');
+    assert.deepEqual(result, { note: '' });
+  });
+
+  test('handles special characters in key and value', () => {
+    const result = buildPromptParams({ key: 'weird-key' }, 'value with spaces');
+    assert.deepEqual(result, { 'weird-key': 'value with spaces' });
+  });
+});
+
+describe('dispatchLinkAction', () => {
+  test('no modal property calls onRequest directly', () => {
+    let called = null;
+    const apiData = { href: '/api/test' };
+    dispatchLinkAction(apiData, '/link', null, (method, href) => {
+      called = { method, href };
+    });
+    assert.equal(called.method, 'GET');
+    assert.equal(called.href, '/link');
+  });
+
+  test('no modal property does not pass params argument', () => {
+    let callArgs;
+    dispatchLinkAction({}, '/link', null, (...args) => { callArgs = args; });
+    assert.equal(callArgs.length, 2);
+  });
+
+  test('native prompt with truthy value calls onRequest with param', () => {
+    const origPrompt = globalThis.prompt;
+    globalThis.prompt = () => 'typed-value';
+    try {
+      let called = null;
+      const apiData = { modal: { type: 'prompt', key: 'name', label: 'Enter name', title: 'Prompt Title', value: 'default' } };
+      dispatchLinkAction(apiData, '/link', null, (method, href, params) => {
+        called = { method, href, params };
+      });
+      assert.equal(called.method, 'GET');
+      assert.equal(called.href, '/link');
+      assert.deepEqual(called.params, { name: 'typed-value' });
+    } finally {
+      globalThis.prompt = origPrompt;
+    }
+  });
+
+  test('native prompt with falsy value does not call onRequest', () => {
+    const origPrompt = globalThis.prompt;
+    globalThis.prompt = () => null;
+    try {
+      let called = false;
+      dispatchLinkAction({ modal: { type: 'prompt', key: 'name' } }, '/link', null, () => { called = true; });
+      assert.equal(called, false);
+    } finally {
+      globalThis.prompt = origPrompt;
+    }
+  });
+
+  test('native prompt uses modal.label fallback to modal.title', () => {
+    const origPrompt = globalThis.prompt;
+    let promptArgs;
+    globalThis.prompt = (message, defaultValue) => { promptArgs = { message, defaultValue }; return null; };
+    try {
+      dispatchLinkAction({ modal: { type: 'prompt', key: 'x', title: 'Fallback Title' } }, '/link', null, () => {});
+      assert.equal(promptArgs.message, 'Fallback Title');
+      assert.equal(promptArgs.defaultValue, '');
+    } finally {
+      globalThis.prompt = origPrompt;
+    }
+  });
+
+  test('native prompt uses modal.label when present', () => {
+    const origPrompt = globalThis.prompt;
+    let promptMessage;
+    globalThis.prompt = (message) => { promptMessage = message; return null; };
+    try {
+      dispatchLinkAction({ modal: { type: 'prompt', key: 'x', label: 'Custom Label', title: 'Title' } }, '/link', null, () => {});
+      assert.equal(promptMessage, 'Custom Label');
+    } finally {
+      globalThis.prompt = origPrompt;
+    }
+  });
+
+  test('native confirm with user OK calls onRequest', () => {
+    const origConfirm = globalThis.confirm;
+    globalThis.confirm = () => true;
+    try {
+      let called = null;
+      const apiData = { modal: { type: 'confirm', content: 'Are you sure?' } };
+      dispatchLinkAction(apiData, '/link', null, (method, href) => { called = { method, href }; });
+      assert.equal(called.method, 'GET');
+      assert.equal(called.href, '/link');
+    } finally {
+      globalThis.confirm = origConfirm;
+    }
+  });
+
+  test('native confirm with user cancel does not call onRequest', () => {
+    const origConfirm = globalThis.confirm;
+    globalThis.confirm = () => false;
+    try {
+      let called = false;
+      dispatchLinkAction({ modal: { type: 'confirm', content: 'Sure?' } }, '/link', null, () => { called = true; });
+      assert.equal(called, false);
+    } finally {
+      globalThis.confirm = origConfirm;
+    }
+  });
+
+  test('native confirm falls back to title then default message', () => {
+    const origConfirm = globalThis.confirm;
+    let confirmMsg;
+    globalThis.confirm = (msg) => { confirmMsg = msg; return false; };
+    try {
+      dispatchLinkAction({ modal: { type: 'confirm', title: 'Title fallback' } }, '/link', null, () => {});
+      assert.equal(confirmMsg, 'Title fallback');
+
+      globalThis.confirm = (msg) => { confirmMsg = msg; return false; };
+      dispatchLinkAction({ modal: { type: 'confirm' } }, '/link', null, () => {});
+      assert.equal(confirmMsg, 'Are you sure?');
+    } finally {
+      globalThis.confirm = origConfirm;
+    }
+  });
+
+  test('Modals.create prompt with truthy value calls onRequest via callback', () => {
+    const modalsLib = { create: (config) => { config.promptConfirmCallback('user-entered'); } };
+    let called = null;
+    const apiData = { modal: { type: 'prompt', key: 'email', title: 'Enter email', label: 'Email', value: '' } };
+    dispatchLinkAction(apiData, '/link', modalsLib, (method, href, params) => { called = { method, href, params }; });
+    assert.equal(called.method, 'GET');
+    assert.deepEqual(called.params, { email: 'user-entered' });
+  });
+
+  test('Modals.create prompt with falsy value does not call onRequest', () => {
+    const modalsLib = { create: (config) => { config.promptConfirmCallback(''); } };
+    let called = false;
+    dispatchLinkAction({ modal: { type: 'prompt', key: 'x' } }, '/link', modalsLib, () => { called = true; });
+    assert.equal(called, false);
+  });
+
+  test('Modals.create prompt passes correct config', () => {
+    let capturedConfig;
+    const modalsLib = { create: (config) => { capturedConfig = config; config.promptConfirmCallback(null); } };
+    const apiData = { modal: { type: 'prompt', key: 'k', title: 'T', label: 'L', value: 'V' } };
+    dispatchLinkAction(apiData, '/link', modalsLib, () => {});
+    assert.equal(capturedConfig.type, 'prompt');
+    assert.equal(capturedConfig.title, 'T');
+    assert.equal(capturedConfig.label, 'L');
+    assert.equal(capturedConfig.value, 'V');
+  });
+
+  test('Modals.create prompt uses default label when missing', () => {
+    let capturedConfig;
+    const modalsLib = { create: (config) => { capturedConfig = config; config.promptConfirmCallback(null); } };
+    dispatchLinkAction({ modal: { type: 'prompt', key: 'k' } }, '/link', modalsLib, () => {});
+    assert.equal(capturedConfig.label, 'Label');
+    assert.equal(capturedConfig.value, '');
+  });
+
+  test('Modals.create confirm calls onRequest via confirmCallback', () => {
+    const modalsLib = { create: (config) => { config.confirmCallback(); } };
+    let called = null;
+    dispatchLinkAction({ modal: { type: 'confirm', title: 'Sure?' } }, '/link', modalsLib, (method, href) => { called = { method, href }; });
+    assert.equal(called.method, 'GET');
+    assert.equal(called.href, '/link');
+  });
+
+  test('Modals.create maps type "confirm" to "small-confirm"', () => {
+    let capturedType;
+    const modalsLib = { create: (config) => { capturedType = config.type; config.confirmCallback(); } };
+    dispatchLinkAction({ modal: { type: 'confirm' } }, '/link', modalsLib, () => {});
+    assert.equal(capturedType, 'small-confirm');
+  });
+
+  test('Modals.create preserves non-confirm modal types as-is', () => {
+    let capturedType;
+    const modalsLib = { create: (config) => { capturedType = config.type; config.confirmCallback(); } };
+    dispatchLinkAction({ modal: { type: 'danger' } }, '/link', modalsLib, () => {});
+    assert.equal(capturedType, 'danger');
+  });
+
+  test('Modals.create confirm passes full config with defaults', () => {
+    let c;
+    const modalsLib = { create: (config) => { c = config; config.confirmCallback(); } };
+    dispatchLinkAction({ modal: { type: 'confirm', title: 'Delete?', content: 'This will delete the item.', button: 'Delete', buttonColor: 'danger' } }, '/link', modalsLib, () => {});
+    assert.equal(c.title, 'Delete?');
+    assert.equal(c.content, 'This will delete the item.');
+    assert.equal(c.confirmButton, 'Delete');
+    assert.equal(c.confirmButtonColor, 'danger');
+  });
+
+  test('Modals.create confirm applies default button and color', () => {
+    let c;
+    const modalsLib = { create: (config) => { c = config; config.confirmCallback(); } };
+    dispatchLinkAction({ modal: { type: 'confirm', title: 'X' } }, '/link', modalsLib, () => {});
+    assert.equal(c.confirmButton, 'Confirm');
+    assert.equal(c.confirmButtonColor, 'primary');
+    assert.equal(c.content, '');
+  });
+
+  test('modalsLib without create function falls back to native confirm', () => {
+    const origConfirm = globalThis.confirm;
+    globalThis.confirm = () => true;
+    try {
+      let called = false;
+      dispatchLinkAction({ modal: { type: 'confirm', content: 'OK?' } }, '/link', {}, () => { called = true; });
+      assert.equal(called, true);
+    } finally {
+      globalThis.confirm = origConfirm;
+    }
+  });
+});
+
+describe('createLinkLoadingState', () => {
+  test('isInProgress is false initially', () => {
+    const el = mockLinkElement();
+    const state = createLinkLoadingState(el);
+    assert.equal(state.isInProgress(), false);
+  });
+
+  test('set marks in progress and adds disabled + aria attributes', () => {
+    const el = mockLinkElement();
+    const state = createLinkLoadingState(el);
+    state.set({ loading: null });
+    assert.equal(state.isInProgress(), true);
+    assert.equal(el.getAttribute('aria-busy'), 'true');
+    assert.equal(el.getAttribute('aria-disabled'), 'true');
+    assert.equal(el.classList.contains('disabled'), true);
+  });
+
+  test('reset restores original state and clears in-progress', () => {
+    const el = mockLinkElement();
+    const state = createLinkLoadingState(el);
+    state.set({ loading: null });
+    state.reset();
+    assert.equal(state.isInProgress(), false);
+    assert.equal(el.getAttribute('aria-busy'), null);
+    assert.equal(el.getAttribute('aria-disabled'), null);
+    assert.equal(el.classList.contains('disabled'), false);
+  });
+
+  test('reset is no-op when not in progress', () => {
+    const el = mockLinkElement();
+    const state = createLinkLoadingState(el);
+    state.reset();
+    assert.equal(state.isInProgress(), false);
+  });
+
+  test('set with loading.button replaces link children with spinner + text', () => {
+    const el = mockLinkElement();
+    const state = createLinkLoadingState(el);
+    state.set({ loading: { button: 'Loading...' } });
+    assert.ok(el._children);
+    assert.equal(el._children.length, 2);
+    assert.equal(el._children[0].className, 'spinner-border spinner-border-sm me-2');
+    assert.equal(el._children[0].getAttribute('aria-hidden'), 'true');
+    assert.equal(el._children[1].nodeType, 3);
+    assert.equal(el._children[1].textContent, 'Loading...');
+  });
+
+  test('set restores innerHTML on reset after button change', () => {
+    const el = mockLinkElement();
+    const originalHtml = el.innerHTML;
+    const state = createLinkLoadingState(el);
+    state.set({ loading: { button: 'Working...' } });
+    state.reset();
+    assert.equal(el.innerHTML, originalHtml);
+  });
+
+  test('set preserves existing aria-busy value on reset', () => {
+    const el = mockLinkElement();
+    el._attrs['aria-busy'] = 'false';
+    const state = createLinkLoadingState(el);
+    state.set({ loading: null });
+    state.reset();
+    assert.equal(el.getAttribute('aria-busy'), 'false');
+  });
+
+  test('set preserves existing aria-disabled value on reset', () => {
+    const el = mockLinkElement();
+    el._attrs['aria-disabled'] = 'false';
+    const state = createLinkLoadingState(el);
+    state.set({ loading: null });
+    state.reset();
+    assert.equal(el.getAttribute('aria-disabled'), 'false');
+  });
+
+  test('set does not remove disabled class if link was originally disabled', () => {
+    const el = mockLinkElement({ disabled: true });
+    const state = createLinkLoadingState(el);
+    state.set({ loading: null });
+    state.reset();
+    assert.equal(el.classList.contains('disabled'), true);
+  });
+
+  test('preventNavigation adds and removes beforeunload listener', () => {
+    const origWindow = globalThis.window;
+    const eventTarget = mockEventTarget();
+    globalThis.window = Object.assign({}, origWindow, eventTarget);
+
+    try {
+      const el = mockLinkElement();
+      const state = createLinkLoadingState(el);
+      state.set({ preventNavigation: true });
+      assert.equal(eventTarget._has('beforeunload'), true);
+      state.reset();
+      assert.equal(eventTarget._has('beforeunload'), false);
+    } finally {
+      globalThis.window = origWindow;
+    }
+  });
+
+  test('preventNavigation false does not add beforeunload listener', () => {
+    const origWindow = globalThis.window;
+    const eventTarget = mockEventTarget();
+    globalThis.window = Object.assign({}, origWindow, eventTarget);
+
+    try {
+      const el = mockLinkElement();
+      const state = createLinkLoadingState(el);
+      state.set({ loading: null });
+      assert.equal(eventTarget._has('beforeunload'), false);
+    } finally {
+      globalThis.window = origWindow;
+    }
+  });
+});

--- a/frontend/core/tests/parse-data-attr.test.mjs
+++ b/frontend/core/tests/parse-data-attr.test.mjs
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for parseDataAttr — the validator that parses the JSON object
+ * stored in a `data-fb-api` HTML attribute.
+ *
+ * Uses Node's built-in node:test runner (zero external dependencies).
+ * Run via: `npm run test:js`.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseDataAttr,
+  assertString,
+  assertBoolean,
+  assertPositiveNumber,
+  assertPlainObject,
+  validateLoading,
+  validateModal,
+  TOP_LEVEL_SCHEMA,
+  MODAL_ALLOWED_TYPES,
+} from '../parse-data-attr.mjs';
+
+const rejects = async (fn, message) => {
+  await assert.throws(fn, (err) => {
+    assert.ok(err instanceof Error, `expected Error, got ${typeof err}`);
+    assert.equal(err.message, message, `error message mismatch`);
+    return true;
+  });
+};
+
+test('parseDataAttr returns an empty object for falsy input', () => {
+  assert.deepEqual(parseDataAttr(''), {});
+  assert.deepEqual(parseDataAttr(null), {});
+  assert.deepEqual(parseDataAttr(undefined), {});
+  assert.deepEqual(parseDataAttr(0), {});
+});
+
+test('parseDataAttr throws on invalid JSON', async () => {
+  await rejects(() => parseDataAttr('{not json'), 'Invalid JSON in data-fb-api attribute.');
+  await rejects(() => parseDataAttr('"unclosed'), 'Invalid JSON in data-fb-api attribute.');
+});
+
+test('parseDataAttr requires the parsed value to be a JSON object (not array/scalar/null)', async () => {
+  await rejects(() => parseDataAttr('[]'), 'data-fb-api must be a JSON object.');
+  await rejects(() => parseDataAttr('42'), 'data-fb-api must be a JSON object.');
+  await rejects(() => parseDataAttr('"a string"'), 'data-fb-api must be a JSON object.');
+  await rejects(() => parseDataAttr('true'), 'data-fb-api must be a JSON object.');
+  await rejects(() => parseDataAttr('null'), 'data-fb-api must be a JSON object.');
+});
+
+test('parseDataAttr returns a shallow-equivalent object for the empty object case', () => {
+  assert.deepEqual(parseDataAttr('{}'), {});
+});
+
+for (const key of ['href', 'type', 'endpoint', 'callback', 'message', 'redirect']) {
+  test(`parseDataAttr validates that ${key} is a string`, async () => {
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ [key]: 123 })),
+      `data-fb-api.${key} must be a string.`
+    );
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ [key]: true })),
+      `data-fb-api.${key} must be a string.`
+    );
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ [key]: {} })),
+      `data-fb-api.${key} must be a string.`
+    );
+  });
+
+  test(`parseDataAttr accepts a valid string for ${key}`, () => {
+    const input = { [key]: 'value' };
+    assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+  });
+}
+
+for (const key of ['reload', 'preventNavigation']) {
+  test(`parseDataAttr validates that ${key} is a boolean`, async () => {
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ [key]: 'true' })),
+      `data-fb-api.${key} must be a boolean.`
+    );
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ [key]: 1 })),
+      `data-fb-api.${key} must be a boolean.`
+    );
+  });
+
+  test(`parseDataAttr accepts true and false for ${key}`, () => {
+    assert.deepEqual(parseDataAttr(JSON.stringify({ [key]: true })), { [key]: true });
+    assert.deepEqual(parseDataAttr(JSON.stringify({ [key]: false })), { [key]: false });
+  });
+}
+
+test('parseDataAttr validates that timeoutMs is a positive finite number', async () => {
+  await rejects(() => parseDataAttr('{"timeoutMs": -1}'), 'data-fb-api.timeoutMs must be a positive number.');
+  await rejects(() => parseDataAttr('{"timeoutMs": 0}'), 'data-fb-api.timeoutMs must be a positive number.');
+  await rejects(() => parseDataAttr('{"timeoutMs": "1000"}'), 'data-fb-api.timeoutMs must be a positive number.');
+  await rejects(
+    () => parseDataAttr(JSON.stringify({ timeoutMs: null })),
+    'data-fb-api.timeoutMs must be a positive number.'
+  );
+});
+
+test('parseDataAttr validates that timeoutMessage is a string', async () => {
+  await rejects(
+    () => parseDataAttr('{"timeoutMessage": 5}'),
+    'data-fb-api.timeoutMessage must be a string.'
+  );
+});
+
+test('parseDataAttr validates that params is a plain object', async () => {
+  await rejects(() => parseDataAttr('{"params": []}'), 'data-fb-api.params must be an object.');
+  await rejects(() => parseDataAttr('{"params": "x"}'), 'data-fb-api.params must be an object.');
+  await rejects(() => parseDataAttr('{"params": null}'), 'data-fb-api.params must be an object.');
+});
+
+test('parseDataAttr accepts a valid params object', () => {
+  const input = { params: { id: 1, name: 'x' } };
+  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+});
+
+test('parseDataAttr validates the loading sub-object structure', async () => {
+  await rejects(() => parseDataAttr('{"loading": []}'), 'data-fb-api.loading must be an object.');
+  await rejects(() => parseDataAttr('{"loading": "x"}'), 'data-fb-api.loading must be an object.');
+  await rejects(() => parseDataAttr('{"loading": null}'), 'data-fb-api.loading must be an object.');
+});
+
+for (const field of ['message', 'button', 'target', 'alertClass']) {
+  test(`parseDataAttr validates loading.${field} is a string`, async () => {
+    await rejects(
+      () => parseDataAttr(JSON.stringify({ loading: { [field]: 5 } })),
+      `data-fb-api.loading.${field} must be a string.`
+    );
+  });
+}
+
+test('parseDataAttr accepts a fully populated valid loading object', () => {
+  const input = { loading: { message: 'm', button: 'b', target: '#t', alertClass: 'c' } };
+  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+});
+
+test('parseDataAttr validates the modal sub-object structure', async () => {
+  await rejects(() => parseDataAttr('{"modal": []}'), 'data-fb-api.modal must be an object.');
+  await rejects(() => parseDataAttr('{"modal": "x"}'), 'data-fb-api.modal must be an object.');
+  await rejects(() => parseDataAttr('{"modal": null}'), 'data-fb-api.modal must be an object.');
+});
+
+test('parseDataAttr requires modal.type to be a string', async () => {
+  await rejects(
+    () => parseDataAttr('{"modal": {}}'),
+    'data-fb-api.modal.type must be a string.'
+  );
+  await rejects(
+    () => parseDataAttr('{"modal": {"type": 1}}'),
+    'data-fb-api.modal.type must be a string.'
+  );
+});
+
+test('parseDataAttr enforces the modal.type enum', async () => {
+  await rejects(
+    () => parseDataAttr('{"modal": {"type": "unknown"}}'),
+    `data-fb-api.modal.type must be one of: ${MODAL_ALLOWED_TYPES.join(', ')}.`
+  );
+});
+
+test('parseDataAttr requires modal.key for prompt modals', async () => {
+  await rejects(
+    () => parseDataAttr('{"modal": {"type": "prompt"}}'),
+    'data-fb-api.modal.key is required for prompt modals.'
+  );
+  await rejects(
+    () => parseDataAttr('{"modal": {"type": "prompt", "key": 1}}'),
+    'data-fb-api.modal.key is required for prompt modals.'
+  );
+});
+
+test('parseDataAttr accepts prompt modal when key is a string', () => {
+  const input = { modal: { type: 'prompt', key: 'reason' } };
+  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+});
+
+for (const field of ['title', 'content', 'button', 'buttonColor', 'label', 'value', 'key']) {
+  test(`parseDataAttr validates modal.${field} is a string when present`, async () => {
+    const payload = field === 'key'
+      ? { modal: { type: 'confirm', [field]: 1 } }
+      : { modal: { type: 'confirm', [field]: 1 } };
+    await rejects(
+      () => parseDataAttr(JSON.stringify(payload)),
+      `data-fb-api.modal.${field} must be a string.`
+    );
+  });
+}
+
+test('parseDataAttr accepts all three modal types when properly shaped', () => {
+  for (const type of MODAL_ALLOWED_TYPES) {
+    const input = { modal: { type, ...(type === 'prompt' ? { key: 'k' } : {}) } };
+    assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+  }
+});
+
+test('golden path: a fully populated valid data-fb-api value round-trips unchanged', () => {
+  const input = {
+    href: '/api/admin/example',
+    type: 'danger',
+    endpoint: 'admin/example',
+    callback: 'handleResult',
+    message: 'Saved',
+    redirect: '/admin',
+    reload: true,
+    preventNavigation: false,
+    timeoutMs: 45000,
+    timeoutMessage: 'Timed out',
+    params: { id: 7, label: 'x' },
+    loading: { message: 'Working', button: 'Wait', target: '#card', alertClass: 'alert-warning' },
+    modal: {
+      type: 'prompt',
+      title: 'Confirm',
+      content: 'Are you sure?',
+      button: 'Go',
+      buttonColor: 'danger',
+      label: 'Reason',
+      value: 'default',
+      key: 'reason',
+    },
+  };
+  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+});
+
+test('TOP_LEVEL_SCHEMA covers exactly the documented top-level fields', () => {
+  assert.deepEqual(
+    Object.keys(TOP_LEVEL_SCHEMA).sort(),
+    ['callback', 'endpoint', 'href', 'message', 'params', 'preventNavigation', 'redirect', 'reload', 'timeoutMessage', 'timeoutMs', 'type']
+  );
+});
+
+test('validators are usable in isolation', () => {
+  assertString('ok', 'href');
+  assertBoolean(true, 'reload');
+  assertPositiveNumber(1, 'timeoutMs');
+  assertPlainObject({}, 'params');
+
+  assert.throws(() => assertString(1, 'href'), /data-fb-api\.href must be a string\./);
+  assert.throws(() => assertBoolean('x', 'reload'), /data-fb-api\.reload must be a boolean\./);
+  assert.throws(() => assertPositiveNumber(0, 'timeoutMs'), /data-fb-api\.timeoutMs must be a positive number\./);
+  assert.throws(() => assertPlainObject([], 'params'), /data-fb-api\.params must be an object\./);
+});
+
+test('validateLoading and validateModal can be invoked directly', () => {
+  validateLoading({ message: 'm' });
+  validateModal({ type: 'confirm', title: 't' });
+
+  assert.throws(() => validateLoading(null), /data-fb-api\.loading must be an object\./);
+  assert.throws(() => validateModal({ type: 'nope' }), /must be one of:/);
+});
+
+test('parseDataAttr ignores unknown keys (forward-compatible with future schema additions)', () => {
+  const input = { href: '/x', futureField: 'whatever', nested: { a: 1 } };
+  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+});

--- a/frontend/core/tests/parse-data-attr.test.mjs
+++ b/frontend/core/tests/parse-data-attr.test.mjs
@@ -1,260 +1,74 @@
-/**
- * Unit tests for parseDataAttr — the validator that parses the JSON object
- * stored in a `data-fb-api` HTML attribute.
- *
- * Uses Node's built-in node:test runner (zero external dependencies).
- * Run via: `npm run test:js`.
- */
-
-import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  parseDataAttr,
-  assertString,
-  assertBoolean,
-  assertPositiveNumber,
-  assertPlainObject,
-  validateLoading,
-  validateModal,
-  TOP_LEVEL_SCHEMA,
-  MODAL_ALLOWED_TYPES,
-} from '../parse-data-attr.mjs';
+import { describe, test } from 'node:test';
 
-const rejects = async (fn, message) => {
-  await assert.throws(fn, (err) => {
-    assert.ok(err instanceof Error, `expected Error, got ${typeof err}`);
-    assert.equal(err.message, message, `error message mismatch`);
-    return true;
-  });
-};
+import { parseDataAttr } from '../parse-data-attr.mjs';
 
-test('parseDataAttr returns an empty object for falsy input', () => {
-  assert.deepEqual(parseDataAttr(''), {});
-  assert.deepEqual(parseDataAttr(null), {});
-  assert.deepEqual(parseDataAttr(undefined), {});
-  assert.deepEqual(parseDataAttr(0), {});
-});
+const parse = (value) => parseDataAttr(JSON.stringify(value));
 
-test('parseDataAttr throws on invalid JSON', async () => {
-  await rejects(() => parseDataAttr('{not json'), 'Invalid JSON in data-fb-api attribute.');
-  await rejects(() => parseDataAttr('"unclosed'), 'Invalid JSON in data-fb-api attribute.');
-});
+describe('parseDataAttr', () => {
+  test('handles empty and valid values', () => {
+    assert.deepEqual(parseDataAttr(''), {});
 
-test('parseDataAttr requires the parsed value to be a JSON object (not array/scalar/null)', async () => {
-  await rejects(() => parseDataAttr('[]'), 'data-fb-api must be a JSON object.');
-  await rejects(() => parseDataAttr('42'), 'data-fb-api must be a JSON object.');
-  await rejects(() => parseDataAttr('"a string"'), 'data-fb-api must be a JSON object.');
-  await rejects(() => parseDataAttr('true'), 'data-fb-api must be a JSON object.');
-  await rejects(() => parseDataAttr('null'), 'data-fb-api must be a JSON object.');
-});
-
-test('parseDataAttr returns a shallow-equivalent object for the empty object case', () => {
-  assert.deepEqual(parseDataAttr('{}'), {});
-});
-
-for (const key of ['href', 'type', 'endpoint', 'callback', 'message', 'redirect']) {
-  test(`parseDataAttr validates that ${key} is a string`, async () => {
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ [key]: 123 })),
-      `data-fb-api.${key} must be a string.`
-    );
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ [key]: true })),
-      `data-fb-api.${key} must be a string.`
-    );
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ [key]: {} })),
-      `data-fb-api.${key} must be a string.`
-    );
+    const data = {
+      href: '/api/client/profile/update',
+      reload: true,
+      timeoutMs: 5000,
+      params: { id: 1 },
+      loading: { message: 'Saving', button: 'Wait' },
+      modal: { type: 'prompt', key: 'reason', title: 'Reason' },
+    };
+    assert.deepEqual(parse(data), data);
   });
 
-  test(`parseDataAttr accepts a valid string for ${key}`, () => {
-    const input = { [key]: 'value' };
-    assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-  });
-}
+  test('rejects invalid JSON and non-object values', () => {
+    assert.throws(() => parseDataAttr('{'), /Invalid JSON/);
 
-for (const key of ['reload', 'preventNavigation']) {
-  test(`parseDataAttr validates that ${key} is a boolean`, async () => {
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ [key]: 'true' })),
-      `data-fb-api.${key} must be a boolean.`
-    );
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ [key]: 1 })),
-      `data-fb-api.${key} must be a boolean.`
-    );
+    for (const value of [null, [], 42, true, 'value']) {
+      assert.throws(() => parse(value), /must be a JSON object/);
+    }
   });
 
-  test(`parseDataAttr accepts true and false for ${key}`, () => {
-    assert.deepEqual(parseDataAttr(JSON.stringify({ [key]: true })), { [key]: true });
-    assert.deepEqual(parseDataAttr(JSON.stringify({ [key]: false })), { [key]: false });
+  test('validates top-level scalar fields', () => {
+    for (const key of ['href', 'type', 'endpoint', 'callback', 'message', 'redirect', 'timeoutMessage']) {
+      assert.throws(() => parse({ [key]: 1 }), new RegExp(`${key} must be a string`));
+    }
+
+    for (const key of ['reload', 'preventNavigation']) {
+      assert.throws(() => parse({ [key]: 'true' }), new RegExp(`${key} must be a boolean`));
+    }
+
+    for (const value of [0, -1, Infinity, '100']) {
+      assert.throws(() => parse({ timeoutMs: value }), /timeoutMs must be a positive number/);
+    }
+
+    for (const value of [null, [], 'params']) {
+      assert.throws(() => parse({ params: value }), /params must be an object/);
+    }
   });
-}
 
-test('parseDataAttr validates that timeoutMs is a positive finite number', async () => {
-  await rejects(() => parseDataAttr('{"timeoutMs": -1}'), 'data-fb-api.timeoutMs must be a positive number.');
-  await rejects(() => parseDataAttr('{"timeoutMs": 0}'), 'data-fb-api.timeoutMs must be a positive number.');
-  await rejects(() => parseDataAttr('{"timeoutMs": "1000"}'), 'data-fb-api.timeoutMs must be a positive number.');
-  await rejects(
-    () => parseDataAttr(JSON.stringify({ timeoutMs: null })),
-    'data-fb-api.timeoutMs must be a positive number.'
-  );
-});
+  test('validates loading fields', () => {
+    assert.throws(() => parse({ loading: [] }), /loading must be an object/);
 
-test('parseDataAttr validates that timeoutMessage is a string', async () => {
-  await rejects(
-    () => parseDataAttr('{"timeoutMessage": 5}'),
-    'data-fb-api.timeoutMessage must be a string.'
-  );
-});
-
-test('parseDataAttr validates that params is a plain object', async () => {
-  await rejects(() => parseDataAttr('{"params": []}'), 'data-fb-api.params must be an object.');
-  await rejects(() => parseDataAttr('{"params": "x"}'), 'data-fb-api.params must be an object.');
-  await rejects(() => parseDataAttr('{"params": null}'), 'data-fb-api.params must be an object.');
-});
-
-test('parseDataAttr accepts a valid params object', () => {
-  const input = { params: { id: 1, name: 'x' } };
-  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-});
-
-test('parseDataAttr validates the loading sub-object structure', async () => {
-  await rejects(() => parseDataAttr('{"loading": []}'), 'data-fb-api.loading must be an object.');
-  await rejects(() => parseDataAttr('{"loading": "x"}'), 'data-fb-api.loading must be an object.');
-  await rejects(() => parseDataAttr('{"loading": null}'), 'data-fb-api.loading must be an object.');
-});
-
-for (const field of ['message', 'button', 'target', 'alertClass']) {
-  test(`parseDataAttr validates loading.${field} is a string`, async () => {
-    await rejects(
-      () => parseDataAttr(JSON.stringify({ loading: { [field]: 5 } })),
-      `data-fb-api.loading.${field} must be a string.`
-    );
+    for (const key of ['message', 'button', 'target', 'alertClass']) {
+      assert.throws(() => parse({ loading: { [key]: false } }), new RegExp(`loading.${key} must be a string`));
+    }
   });
-}
 
-test('parseDataAttr accepts a fully populated valid loading object', () => {
-  const input = { loading: { message: 'm', button: 'b', target: '#t', alertClass: 'c' } };
-  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-});
+  test('validates modal type and string fields', () => {
+    assert.throws(() => parse({ modal: null }), /modal must be an object/);
+    assert.throws(() => parse({ modal: {} }), /modal.type must be a string/);
+    assert.throws(() => parse({ modal: { type: 'unknown' } }), /must be one of/);
+    assert.throws(() => parse({ modal: { type: 'prompt' } }), /modal.key is required/);
 
-test('parseDataAttr validates the modal sub-object structure', async () => {
-  await rejects(() => parseDataAttr('{"modal": []}'), 'data-fb-api.modal must be an object.');
-  await rejects(() => parseDataAttr('{"modal": "x"}'), 'data-fb-api.modal must be an object.');
-  await rejects(() => parseDataAttr('{"modal": null}'), 'data-fb-api.modal must be an object.');
-});
-
-test('parseDataAttr requires modal.type to be a string', async () => {
-  await rejects(
-    () => parseDataAttr('{"modal": {}}'),
-    'data-fb-api.modal.type must be a string.'
-  );
-  await rejects(
-    () => parseDataAttr('{"modal": {"type": 1}}'),
-    'data-fb-api.modal.type must be a string.'
-  );
-});
-
-test('parseDataAttr enforces the modal.type enum', async () => {
-  await rejects(
-    () => parseDataAttr('{"modal": {"type": "unknown"}}'),
-    `data-fb-api.modal.type must be one of: ${MODAL_ALLOWED_TYPES.join(', ')}.`
-  );
-});
-
-test('parseDataAttr requires modal.key for prompt modals', async () => {
-  await rejects(
-    () => parseDataAttr('{"modal": {"type": "prompt"}}'),
-    'data-fb-api.modal.key is required for prompt modals.'
-  );
-  await rejects(
-    () => parseDataAttr('{"modal": {"type": "prompt", "key": 1}}'),
-    'data-fb-api.modal.key is required for prompt modals.'
-  );
-});
-
-test('parseDataAttr accepts prompt modal when key is a string', () => {
-  const input = { modal: { type: 'prompt', key: 'reason' } };
-  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-});
-
-for (const field of ['title', 'content', 'button', 'buttonColor', 'label', 'value', 'key']) {
-  test(`parseDataAttr validates modal.${field} is a string when present`, async () => {
-    const payload = field === 'key'
-      ? { modal: { type: 'confirm', [field]: 1 } }
-      : { modal: { type: 'confirm', [field]: 1 } };
-    await rejects(
-      () => parseDataAttr(JSON.stringify(payload)),
-      `data-fb-api.modal.${field} must be a string.`
-    );
+    for (const key of ['title', 'content', 'button', 'buttonColor', 'label', 'value', 'key']) {
+      assert.throws(
+        () => parse({ modal: { type: 'confirm', [key]: false } }),
+        new RegExp(`modal.${key} must be a string`),
+      );
+    }
   });
-}
 
-test('parseDataAttr accepts all three modal types when properly shaped', () => {
-  for (const type of MODAL_ALLOWED_TYPES) {
-    const input = { modal: { type, ...(type === 'prompt' ? { key: 'k' } : {}) } };
-    assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-  }
-});
-
-test('golden path: a fully populated valid data-fb-api value round-trips unchanged', () => {
-  const input = {
-    href: '/api/admin/example',
-    type: 'danger',
-    endpoint: 'admin/example',
-    callback: 'handleResult',
-    message: 'Saved',
-    redirect: '/admin',
-    reload: true,
-    preventNavigation: false,
-    timeoutMs: 45000,
-    timeoutMessage: 'Timed out',
-    params: { id: 7, label: 'x' },
-    loading: { message: 'Working', button: 'Wait', target: '#card', alertClass: 'alert-warning' },
-    modal: {
-      type: 'prompt',
-      title: 'Confirm',
-      content: 'Are you sure?',
-      button: 'Go',
-      buttonColor: 'danger',
-      label: 'Reason',
-      value: 'default',
-      key: 'reason',
-    },
-  };
-  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
-});
-
-test('TOP_LEVEL_SCHEMA covers exactly the documented top-level fields', () => {
-  assert.deepEqual(
-    Object.keys(TOP_LEVEL_SCHEMA).sort(),
-    ['callback', 'endpoint', 'href', 'message', 'params', 'preventNavigation', 'redirect', 'reload', 'timeoutMessage', 'timeoutMs', 'type']
-  );
-});
-
-test('validators are usable in isolation', () => {
-  assertString('ok', 'href');
-  assertBoolean(true, 'reload');
-  assertPositiveNumber(1, 'timeoutMs');
-  assertPlainObject({}, 'params');
-
-  assert.throws(() => assertString(1, 'href'), /data-fb-api\.href must be a string\./);
-  assert.throws(() => assertBoolean('x', 'reload'), /data-fb-api\.reload must be a boolean\./);
-  assert.throws(() => assertPositiveNumber(0, 'timeoutMs'), /data-fb-api\.timeoutMs must be a positive number\./);
-  assert.throws(() => assertPlainObject([], 'params'), /data-fb-api\.params must be an object\./);
-});
-
-test('validateLoading and validateModal can be invoked directly', () => {
-  validateLoading({ message: 'm' });
-  validateModal({ type: 'confirm', title: 't' });
-
-  assert.throws(() => validateLoading(null), /data-fb-api\.loading must be an object\./);
-  assert.throws(() => validateModal({ type: 'nope' }), /must be one of:/);
-});
-
-test('parseDataAttr ignores unknown keys (forward-compatible with future schema additions)', () => {
-  const input = { href: '/x', futureField: 'whatever', nested: { a: 1 } };
-  assert.deepEqual(parseDataAttr(JSON.stringify(input)), input);
+  test('allows unknown fields for forward compatibility', () => {
+    assert.deepEqual(parse({ futureOption: { enabled: true } }), { futureOption: { enabled: true } });
+  });
 });

--- a/frontend/tools/check-icons.mjs
+++ b/frontend/tools/check-icons.mjs
@@ -3,6 +3,8 @@ import { dirname, extname, join, relative, resolve } from 'path';
 import { readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 
+import { parseManifest, extractIconReferencesFromContent, computeIconErrors } from './icon-check-helpers.mjs';
+
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 
 const themes = [
@@ -63,22 +65,6 @@ function isAreaTemplate(path, area) {
   return path.includes(`/templates/${area}/`);
 }
 
-function normalizeIconEntry(entry, defaultVariant) {
-  if (typeof entry === 'string') {
-    return {
-      name: entry,
-      variant: defaultVariant,
-      dynamic: false,
-    };
-  }
-
-  return {
-    name: entry.name,
-    variant: entry.variant || defaultVariant,
-    dynamic: entry.dynamic || false,
-  };
-}
-
 async function getDynamicNavigationIcons() {
   const icons = new Set();
 
@@ -105,21 +91,11 @@ async function getDynamicNavigationIcons() {
 
 async function checkTheme(theme) {
   const manifest = JSON.parse(await readFile(join(theme.themePath, 'icon-manifest.json'), 'utf8'));
-  const defaultVariant = manifest.defaultVariant || 'outline';
-  const manifestIcons = manifest.icons.map((entry) => normalizeIconEntry(entry, defaultVariant));
-  const manifestNames = new Set(manifestIcons.map((icon) => icon.name));
-  const declaredDynamicManifestNames = new Set(manifestIcons.filter((icon) => icon.dynamic).map((icon) => icon.name));
-  const dynamicManifestNames = new Set(declaredDynamicManifestNames);
+  const manifestData = parseManifest(manifest);
+
   const referencedIcons = new Set();
-  const errors = [];
   const legacyReferences = [];
   const externalSpriteReferences = [];
-
-  for (const icon of manifestIcons) {
-    if (theme.disallowFilled && icon.variant === 'filled') {
-      errors.push(`${theme.code}: "${icon.name}" requests the filled variant, but this theme styles icons as outline SVGs.`);
-    }
-  }
 
   for (const scanPath of theme.scanPaths) {
     for (const file of walkFiles(scanPath)) {
@@ -128,47 +104,24 @@ async function checkTheme(theme) {
       }
 
       const contents = await readFile(file, 'utf8');
+      const result = extractIconReferencesFromContent(contents);
 
-      if (contents.includes('xlink:href')) {
+      result.references.forEach((icon) => referencedIcons.add(icon));
+
+      if (result.hasLegacy) {
         legacyReferences.push(relative(rootDir, file));
       }
 
-      if (contents.includes('icons-sprite.svg#')) {
+      if (result.hasExternalSprite) {
         externalSpriteReferences.push(relative(rootDir, file));
-      }
-
-      for (const match of contents.matchAll(/<use\b[^>]*\b(?:href|xlink:href)=["'](?:[^#"']*)#([A-Za-z0-9_-]+)["']/g)) {
-        referencedIcons.add(match[1]);
       }
     }
   }
 
   const dynamicIcons = theme.dynamicNavigation ? await getDynamicNavigationIcons() : new Set();
-  const missing = [...referencedIcons, ...dynamicIcons].filter((icon) => !manifestNames.has(icon)).sort();
-  const unused = [...manifestNames].filter((icon) => !referencedIcons.has(icon) && !dynamicManifestNames.has(icon)).sort();
-  const undocumentedDynamic = [...dynamicIcons].filter((icon) => !declaredDynamicManifestNames.has(icon)).sort();
+  const errors = computeIconErrors(theme, manifestData, { referencedIcons, legacyReferences, externalSpriteReferences }, dynamicIcons);
 
-  if (legacyReferences.length > 0) {
-    errors.push(`${theme.code}: legacy xlink:href references remain in ${[...new Set(legacyReferences)].join(', ')}`);
-  }
-
-  if (externalSpriteReferences.length > 0) {
-    errors.push(`${theme.code}: external sprite references remain in ${[...new Set(externalSpriteReferences)].join(', ')}`);
-  }
-
-  if (missing.length > 0) {
-    errors.push(`${theme.code}: missing manifest icons: ${missing.join(', ')}`);
-  }
-
-  if (unused.length > 0) {
-    errors.push(`${theme.code}: unused manifest icons: ${unused.join(', ')}`);
-  }
-
-  if (undocumentedDynamic.length > 0) {
-    errors.push(`${theme.code}: dynamic icons should be marked in the manifest: ${undocumentedDynamic.join(', ')}`);
-  }
-
-  console.log(`${theme.code}: ${manifestNames.size} manifest icons, ${referencedIcons.size} static references, ${dynamicManifestNames.size} dynamic icons`);
+  console.log(`${theme.code}: ${manifestData.manifestNames.size} manifest icons, ${referencedIcons.size} static references, ${manifestData.dynamicManifestNames.size} dynamic icons`);
 
   return errors;
 }

--- a/frontend/tools/icon-check-helpers.mjs
+++ b/frontend/tools/icon-check-helpers.mjs
@@ -50,7 +50,7 @@ export function computeIconErrors(theme, manifestData, scanData, dynamicIcons) {
     }
   }
 
-  const missing = [...scanData.referencedIcons, ...dynamicIcons].filter((icon) => !manifestData.manifestNames.has(icon)).sort();
+  const missing = [...new Set([...scanData.referencedIcons, ...dynamicIcons])].filter((icon) => !manifestData.manifestNames.has(icon)).sort();
   const unused = [...manifestData.manifestNames].filter((icon) => !scanData.referencedIcons.has(icon) && !manifestData.dynamicManifestNames.has(icon)).sort();
   const undocumentedDynamic = [...dynamicIcons].filter((icon) => !manifestData.dynamicManifestNames.has(icon)).sort();
 

--- a/frontend/tools/icon-check-helpers.mjs
+++ b/frontend/tools/icon-check-helpers.mjs
@@ -1,0 +1,79 @@
+export function normalizeIconEntry(entry, defaultVariant) {
+  if (typeof entry === 'string') {
+    return {
+      name: entry,
+      variant: defaultVariant,
+      dynamic: false,
+    };
+  }
+
+  return {
+    name: entry.name,
+    variant: entry.variant || defaultVariant,
+    dynamic: entry.dynamic || false,
+  };
+}
+
+export function parseManifest(manifest) {
+  const defaultVariant = manifest.defaultVariant || 'outline';
+  const manifestIcons = manifest.icons.map((entry) => normalizeIconEntry(entry, defaultVariant));
+  const manifestNames = new Set(manifestIcons.map((icon) => icon.name));
+  const declaredDynamicManifestNames = new Set(manifestIcons.filter((icon) => icon.dynamic).map((icon) => icon.name));
+  const dynamicManifestNames = new Set(declaredDynamicManifestNames);
+
+  return { manifestIcons, manifestNames, declaredDynamicManifestNames, dynamicManifestNames };
+}
+
+const ICON_REF_REGEX = /<use\b[^>]*\b(?:href|xlink:href)=["'](?:[^#"']*)#([A-Za-z0-9_-]+)["']/g;
+
+export function extractIconReferencesFromContent(content) {
+  const references = [];
+
+  for (const match of content.matchAll(ICON_REF_REGEX)) {
+    if (match[1]) {
+      references.push(match[1]);
+    }
+  }
+
+  return {
+    references,
+    hasLegacy: content.includes('xlink:href'),
+    hasExternalSprite: content.includes('icons-sprite.svg#'),
+  };
+}
+
+export function computeIconErrors(theme, manifestData, scanData, dynamicIcons) {
+  const errors = [];
+
+  for (const icon of manifestData.manifestIcons) {
+    if (theme.disallowFilled && icon.variant === 'filled') {
+      errors.push(`${theme.code}: "${icon.name}" requests the filled variant, but this theme styles icons as outline SVGs.`);
+    }
+  }
+
+  const missing = [...scanData.referencedIcons, ...dynamicIcons].filter((icon) => !manifestData.manifestNames.has(icon)).sort();
+  const unused = [...manifestData.manifestNames].filter((icon) => !scanData.referencedIcons.has(icon) && !manifestData.dynamicManifestNames.has(icon)).sort();
+  const undocumentedDynamic = [...dynamicIcons].filter((icon) => !manifestData.declaredDynamicManifestNames.has(icon)).sort();
+
+  if (scanData.legacyReferences.length > 0) {
+    errors.push(`${theme.code}: legacy xlink:href references remain in ${[...new Set(scanData.legacyReferences)].join(', ')}`);
+  }
+
+  if (scanData.externalSpriteReferences.length > 0) {
+    errors.push(`${theme.code}: external sprite references remain in ${[...new Set(scanData.externalSpriteReferences)].join(', ')}`);
+  }
+
+  if (missing.length > 0) {
+    errors.push(`${theme.code}: missing manifest icons: ${missing.join(', ')}`);
+  }
+
+  if (unused.length > 0) {
+    errors.push(`${theme.code}: unused manifest icons: ${unused.join(', ')}`);
+  }
+
+  if (undocumentedDynamic.length > 0) {
+    errors.push(`${theme.code}: dynamic icons should be marked in the manifest: ${undocumentedDynamic.join(', ')}`);
+  }
+
+  return errors;
+}

--- a/frontend/tools/icon-check-helpers.mjs
+++ b/frontend/tools/icon-check-helpers.mjs
@@ -1,4 +1,4 @@
-export function normalizeIconEntry(entry, defaultVariant) {
+function normalizeIconEntry(entry, defaultVariant) {
   if (typeof entry === 'string') {
     return {
       name: entry,
@@ -18,10 +18,9 @@ export function parseManifest(manifest) {
   const defaultVariant = manifest.defaultVariant || 'outline';
   const manifestIcons = manifest.icons.map((entry) => normalizeIconEntry(entry, defaultVariant));
   const manifestNames = new Set(manifestIcons.map((icon) => icon.name));
-  const declaredDynamicManifestNames = new Set(manifestIcons.filter((icon) => icon.dynamic).map((icon) => icon.name));
-  const dynamicManifestNames = new Set(declaredDynamicManifestNames);
+  const dynamicManifestNames = new Set(manifestIcons.filter((icon) => icon.dynamic).map((icon) => icon.name));
 
-  return { manifestIcons, manifestNames, declaredDynamicManifestNames, dynamicManifestNames };
+  return { manifestIcons, manifestNames, dynamicManifestNames };
 }
 
 const ICON_REF_REGEX = /<use\b[^>]*\b(?:href|xlink:href)=["'](?:[^#"']*)#([A-Za-z0-9_-]+)["']/g;
@@ -53,7 +52,7 @@ export function computeIconErrors(theme, manifestData, scanData, dynamicIcons) {
 
   const missing = [...scanData.referencedIcons, ...dynamicIcons].filter((icon) => !manifestData.manifestNames.has(icon)).sort();
   const unused = [...manifestData.manifestNames].filter((icon) => !scanData.referencedIcons.has(icon) && !manifestData.dynamicManifestNames.has(icon)).sort();
-  const undocumentedDynamic = [...dynamicIcons].filter((icon) => !manifestData.declaredDynamicManifestNames.has(icon)).sort();
+  const undocumentedDynamic = [...dynamicIcons].filter((icon) => !manifestData.dynamicManifestNames.has(icon)).sort();
 
   if (scanData.legacyReferences.length > 0) {
     errors.push(`${theme.code}: legacy xlink:href references remain in ${[...new Set(scanData.legacyReferences)].join(', ')}`);

--- a/frontend/tools/tests/icon-check-helpers.test.mjs
+++ b/frontend/tools/tests/icon-check-helpers.test.mjs
@@ -45,20 +45,20 @@ describe('icon manifest helpers', () => {
       { code: 'test', disallowFilled: true },
       manifestData,
       {
-        referencedIcons: new Set(['missing']),
+        referencedIcons: new Set(['missing', 'shared']),
         legacyReferences: ['template.twig', 'template.twig'],
         externalSpriteReferences: ['other.twig'],
       },
-      new Set(['undocumented']),
+      new Set(['undocumented', 'shared']),
     );
 
     assert.deepEqual(errors, [
       'test: "filled" requests the filled variant, but this theme styles icons as outline SVGs.',
       'test: legacy xlink:href references remain in template.twig',
       'test: external sprite references remain in other.twig',
-      'test: missing manifest icons: missing, undocumented',
+      'test: missing manifest icons: missing, shared, undocumented',
       'test: unused manifest icons: filled, unused',
-      'test: dynamic icons should be marked in the manifest: undocumented',
+      'test: dynamic icons should be marked in the manifest: shared, undocumented',
     ]);
   });
 

--- a/frontend/tools/tests/icon-check-helpers.test.mjs
+++ b/frontend/tools/tests/icon-check-helpers.test.mjs
@@ -1,396 +1,74 @@
-import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
 
-import { normalizeIconEntry, parseManifest, extractIconReferencesFromContent, computeIconErrors } from '../icon-check-helpers.mjs';
+import {
+  computeIconErrors,
+  extractIconReferencesFromContent,
+  parseManifest,
+} from '../icon-check-helpers.mjs';
 
-const mockTheme = (overrides = {}) => ({
-  code: 'test',
-  area: 'admin',
-  disallowFilled: false,
-  dynamicNavigation: false,
-  ...overrides,
-});
-
-const mockManifestData = (overrides = {}) => {
-  const manifestIcons = overrides.manifestIcons ?? [
-    { name: 'home', variant: 'outline', dynamic: false },
-    { name: 'settings', variant: 'outline', dynamic: true },
-  ];
-  const manifestNames = overrides.manifestNames ?? new Set(manifestIcons.map((i) => i.name));
-  const declaredDynamicManifestNames = overrides.declaredDynamicManifestNames ?? new Set(manifestIcons.filter((i) => i.dynamic).map((i) => i.name));
-  const dynamicManifestNames = overrides.dynamicManifestNames ?? new Set(declaredDynamicManifestNames);
-
-  return { manifestIcons, manifestNames, declaredDynamicManifestNames, dynamicManifestNames };
-};
-
-const mockScanData = (overrides = {}) => ({
-  referencedIcons: overrides.referencedIcons ?? new Set(),
-  legacyReferences: overrides.legacyReferences ?? [],
-  externalSpriteReferences: overrides.externalSpriteReferences ?? [],
-});
-
-test.describe('normalizeIconEntry', () => {
-  test('string entry uses defaultVariant', () => {
-    assert.deepEqual(normalizeIconEntry('foo', 'outline'), { name: 'foo', variant: 'outline', dynamic: false });
-  });
-
-  test('object entry preserves explicit variant', () => {
-    assert.deepEqual(
-      normalizeIconEntry({ name: 'bar', variant: 'filled' }, 'outline'),
-      { name: 'bar', variant: 'filled', dynamic: false },
-    );
-  });
-
-  test('object entry without variant falls back to defaultVariant', () => {
-    assert.deepEqual(
-      normalizeIconEntry({ name: 'bar' }, 'outline'),
-      { name: 'bar', variant: 'outline', dynamic: false },
-    );
-  });
-
-  test('object entry with dynamic flag', () => {
-    assert.deepEqual(
-      normalizeIconEntry({ name: 'bar', dynamic: true }, 'outline'),
-      { name: 'bar', variant: 'outline', dynamic: true },
-    );
-  });
-
-  test('object entry with falsy dynamic defaults to false', () => {
-    assert.deepEqual(
-      normalizeIconEntry({ name: 'bar', dynamic: false }, 'outline'),
-      { name: 'bar', variant: 'outline', dynamic: false },
-    );
-  });
-
-  test('falsy variant in object entry falls back to defaultVariant', () => {
-    assert.deepEqual(
-      normalizeIconEntry({ name: 'bar', variant: '' }, 'solid'),
-      { name: 'bar', variant: 'solid', dynamic: false },
-    );
-  });
-});
-
-test.describe('parseManifest', () => {
-  test('defaultVariant defaults to outline when not specified', () => {
-    const data = parseManifest({ icons: ['foo'] });
-    assert.equal(data.manifestIcons[0].variant, 'outline');
-  });
-
-  test('custom defaultVariant is used', () => {
-    const data = parseManifest({ defaultVariant: 'filled', icons: ['foo'] });
-    assert.equal(data.manifestIcons[0].variant, 'filled');
-  });
-
-  test('empty icons array produces empty sets', () => {
-    const data = parseManifest({ icons: [] });
-    assert.equal(data.manifestIcons.length, 0);
-    assert.equal(data.manifestNames.size, 0);
-    assert.equal(data.declaredDynamicManifestNames.size, 0);
-    assert.equal(data.dynamicManifestNames.size, 0);
-  });
-
-  test('manifestNames contains all icon names', () => {
-    const data = parseManifest({ icons: ['a', 'b', 'c'] });
-    assert.deepEqual([...data.manifestNames], ['a', 'b', 'c']);
-  });
-
-  test('declaredDynamicManifestNames only includes dynamic: true icons', () => {
+describe('icon manifest helpers', () => {
+  test('normalizes manifest entries and tracks dynamic icons', () => {
     const data = parseManifest({
-      icons: [
-        'static-one',
-        { name: 'dyn-one', dynamic: true },
-        { name: 'static-two', dynamic: false },
-        { name: 'dyn-two', dynamic: true },
-      ],
+      defaultVariant: 'filled',
+      icons: ['home', { name: 'settings', variant: 'outline', dynamic: true }],
     });
-    assert.deepEqual([...data.declaredDynamicManifestNames], ['dyn-one', 'dyn-two']);
+
+    assert.deepEqual(data.manifestIcons, [
+      { name: 'home', variant: 'filled', dynamic: false },
+      { name: 'settings', variant: 'outline', dynamic: true },
+    ]);
+    assert.deepEqual([...data.manifestNames], ['home', 'settings']);
+    assert.deepEqual([...data.dynamicManifestNames], ['settings']);
   });
 
-  test('dynamicManifestNames is a separate Set with same contents as declaredDynamicManifestNames', () => {
-    const data = parseManifest({
-      icons: [{ name: 'dyn', dynamic: true }],
-    });
-    assert.deepEqual([...data.dynamicManifestNames], [...data.declaredDynamicManifestNames]);
-    assert.notEqual(data.dynamicManifestNames, data.declaredDynamicManifestNames);
-  });
+  test('extracts modern and legacy references', () => {
+    const result = extractIconReferencesFromContent(`
+      <use href="#icon-home"></use>
+      <use xlink:href="/icons-sprite.svg#icon-user"></use>
+    `);
 
-  test('mixed string and object entries are normalized consistently', () => {
-    const data = parseManifest({
-      defaultVariant: 'solid',
-      icons: ['str', { name: 'obj', variant: 'outline' }],
-    });
-    assert.equal(data.manifestIcons[0].name, 'str');
-    assert.equal(data.manifestIcons[0].variant, 'solid');
-    assert.equal(data.manifestIcons[1].name, 'obj');
-    assert.equal(data.manifestIcons[1].variant, 'outline');
-  });
-});
-
-test.describe('extractIconReferencesFromContent', () => {
-  test('empty content returns no references', () => {
-    const result = extractIconReferencesFromContent('');
-    assert.deepEqual(result.references, []);
-    assert.equal(result.hasLegacy, false);
-    assert.equal(result.hasExternalSprite, false);
-  });
-
-  test('plain text with no use tags returns empty', () => {
-    const result = extractIconReferencesFromContent('<div>hello</div>');
-    assert.deepEqual(result.references, []);
-  });
-
-  test('extracts icon from modern href syntax', () => {
-    const result = extractIconReferencesFromContent('<use href="#home" />');
-    assert.deepEqual(result.references, ['home']);
-  });
-
-  test('extracts icon from legacy xlink:href syntax', () => {
-    const result = extractIconReferencesFromContent('<use xlink:href="#home" />');
-    assert.deepEqual(result.references, ['home']);
+    assert.deepEqual(result.references, ['icon-home', 'icon-user']);
     assert.equal(result.hasLegacy, true);
-  });
-
-  test('extracts icon with path prefix before hash', () => {
-    const result = extractIconReferencesFromContent('<use href="/assets/sprite.svg#home" />');
-    assert.deepEqual(result.references, ['home']);
-  });
-
-  test('extracts icon with empty path prefix (just hash)', () => {
-    const result = extractIconReferencesFromContent('<use href="#home" />');
-    assert.deepEqual(result.references, ['home']);
-  });
-
-  test('extracts multiple icons from content', () => {
-    const content = '<use href="#home" /><use href="#settings" /><use xlink:href="#logout" />';
-    const result = extractIconReferencesFromContent(content);
-    assert.deepEqual(result.references, ['home', 'settings', 'logout']);
-  });
-
-  test('preserves duplicate references (caller deduplicates via Set)', () => {
-    const content = '<use href="#home" /><use href="#home" />';
-    const result = extractIconReferencesFromContent(content);
-    assert.deepEqual(result.references, ['home', 'home']);
-  });
-
-  test('handles icon names with dashes', () => {
-    const result = extractIconReferencesFromContent('<use href="#arrow-left" />');
-    assert.deepEqual(result.references, ['arrow-left']);
-  });
-
-  test('handles icon names with underscores', () => {
-    const result = extractIconReferencesFromContent('<use href="#arrow_left" />');
-    assert.deepEqual(result.references, ['arrow_left']);
-  });
-
-  test('handles icon names with numbers', () => {
-    const result = extractIconReferencesFromContent('<use href="#icon3d" />');
-    assert.deepEqual(result.references, ['icon3d']);
-  });
-
-  test('use tag without href attribute is skipped', () => {
-    const result = extractIconReferencesFromContent('<use class="something" />');
-    assert.deepEqual(result.references, []);
-  });
-
-  test('hasLegacy is true when xlink:href substring is present anywhere', () => {
-    const result = extractIconReferencesFromContent('<!-- uses xlink:href -->');
-    assert.equal(result.hasLegacy, true);
-  });
-
-  test('hasLegacy is false for modern href only', () => {
-    const result = extractIconReferencesFromContent('<use href="#home" />');
-    assert.equal(result.hasLegacy, false);
-  });
-
-  test('hasExternalSprite is true when icons-sprite.svg# is present', () => {
-    const result = extractIconReferencesFromContent('<img src="icons-sprite.svg#home" />');
     assert.equal(result.hasExternalSprite, true);
   });
 
-  test('hasExternalSprite is false when not present', () => {
-    const result = extractIconReferencesFromContent('<use href="#home" />');
-    assert.equal(result.hasExternalSprite, false);
-  });
-
-  test('single use tag with both href and xlink:href', () => {
-    const content = '<use href="#home" xlink:href="#home" />';
-    const result = extractIconReferencesFromContent(content);
-    assert.deepEqual(result.references, ['home']);
-    assert.equal(result.hasLegacy, true);
-  });
-});
-
-test.describe('computeIconErrors', () => {
-  test('no issues returns empty array', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({ manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }] });
-    const sd = mockScanData({ referencedIcons: new Set(['home']) });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.deepEqual(errors, []);
-  });
-
-  test('disallowFilled + filled variant produces error', () => {
-    const theme = mockTheme({ disallowFilled: true });
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'x', variant: 'filled', dynamic: false }],
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['x']) });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /"x" requests the filled variant/);
-  });
-
-  test('disallowFilled + outline variant produces no variant error', () => {
-    const theme = mockTheme({ disallowFilled: true });
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'x', variant: 'outline', dynamic: false }],
-      manifestNames: new Set(['x']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['x']) });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.deepEqual(errors, []);
-  });
-
-  test('no disallowFilled constraint allows filled variants', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'x', variant: 'filled', dynamic: false }],
-      manifestNames: new Set(['x']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['x']) });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.deepEqual(errors, []);
-  });
-
-  test('legacy references produce error', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({ manifestIcons: [], manifestNames: new Set() });
-    const sd = mockScanData({ legacyReferences: ['src/foo.twig', 'src/bar.twig'] });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /legacy xlink:href references remain in src\/foo\.twig, src\/bar\.twig/);
-  });
-
-  test('legacy references are deduplicated', () => {
-    const theme = mockTheme();
-    const md = mockManifestData();
-    const sd = mockScanData({ legacyReferences: ['src/foo.twig', 'src/foo.twig'] });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.match(errors[0], /src\/foo\.twig/);
-    assert.doesNotMatch(errors[0], /src\/foo\.twig.*src\/foo\.twig/);
-  });
-
-  test('external sprite references produce error', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({ manifestIcons: [], manifestNames: new Set() });
-    const sd = mockScanData({ externalSpriteReferences: ['src/baz.twig'] });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /external sprite references remain in src\/baz\.twig/);
-  });
-
-  test('missing icons (referenced but not in manifest) produce error sorted alphabetically', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
-      manifestNames: new Set(['home']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['zebra', 'home', 'apple']) });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /missing manifest icons: apple, zebra/);
-  });
-
-  test('missing includes dynamic icons not in manifest', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
-      manifestNames: new Set(['home']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['home']) });
-    const errors = computeIconErrors(theme, md, sd, new Set(['mystery']));
-    assert.match(errors[0], /missing manifest icons: mystery/);
-  });
-
-  test('unused icons (in manifest but not referenced) produce error', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
-      manifestNames: new Set(['home']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set() });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.match(errors[0], /unused manifest icons: home/);
-  });
-
-  test('unused does not flag dynamic manifest icons', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'dyn', variant: 'outline', dynamic: true }],
-      manifestNames: new Set(['dyn']),
-      dynamicManifestNames: new Set(['dyn']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set() });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    assert.deepEqual(errors, []);
-  });
-
-  test('undocumented dynamic icons produce error', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'undocumented', variant: 'outline', dynamic: false }],
-      declaredDynamicManifestNames: new Set(),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['undocumented']) });
-    const errors = computeIconErrors(theme, md, sd, new Set(['undocumented']));
-    assert.equal(errors.length, 1);
-    assert.match(errors[0], /dynamic icons should be marked in the manifest: undocumented/);
-  });
-
-  test('declared dynamic icons do not trigger undocumented error', () => {
-    const theme = mockTheme();
-    const md = mockManifestData({
-      manifestIcons: [{ name: 'declared', variant: 'outline', dynamic: true }],
-      declaredDynamicManifestNames: new Set(['declared']),
-    });
-    const sd = mockScanData({ referencedIcons: new Set(['declared']) });
-    const errors = computeIconErrors(theme, md, sd, new Set(['declared']));
-    assert.deepEqual(errors, []);
-  });
-
-  test('multiple error types at once', () => {
-    const theme = mockTheme({ disallowFilled: true });
-    const md = mockManifestData({
-      manifestIcons: [
-        { name: 'filled-icon', variant: 'filled', dynamic: false },
-        { name: 'unused-icon', variant: 'outline', dynamic: false },
+  test('reports manifest and reference errors', () => {
+    const manifestData = parseManifest({
+      icons: [
+        { name: 'filled', variant: 'filled' },
+        { name: 'dynamic', dynamic: true },
+        'unused',
       ],
-      manifestNames: new Set(['filled-icon', 'unused-icon']),
     });
-    const sd = mockScanData({
-      referencedIcons: new Set(['missing-icon']),
-      legacyReferences: ['legacy.twig'],
-      externalSpriteReferences: ['sprite.twig'],
-    });
-    const dynamicIcons = new Set(['undocumented-dyn']);
-    const errors = computeIconErrors(theme, md, sd, dynamicIcons);
-    assert.ok(errors.length >= 5);
-    const joined = errors.join('\n');
-    assert.ok(joined.includes('filled variant'));
-    assert.ok(joined.includes('legacy xlink:href'));
-    assert.ok(joined.includes('external sprite'));
-    assert.ok(joined.includes('missing manifest icons'));
-    assert.ok(joined.includes('unused manifest icons'));
-    assert.ok(joined.includes('dynamic icons should be marked'));
+    const errors = computeIconErrors(
+      { code: 'test', disallowFilled: true },
+      manifestData,
+      {
+        referencedIcons: new Set(['missing']),
+        legacyReferences: ['template.twig', 'template.twig'],
+        externalSpriteReferences: ['other.twig'],
+      },
+      new Set(['undocumented']),
+    );
+
+    assert.deepEqual(errors, [
+      'test: "filled" requests the filled variant, but this theme styles icons as outline SVGs.',
+      'test: legacy xlink:href references remain in template.twig',
+      'test: external sprite references remain in other.twig',
+      'test: missing manifest icons: missing, undocumented',
+      'test: unused manifest icons: filled, unused',
+      'test: dynamic icons should be marked in the manifest: undocumented',
+    ]);
   });
 
-  test('all error messages include theme code prefix', () => {
-    const theme = mockTheme({ code: 'huraga' });
-    const md = mockManifestData();
-    const sd = mockScanData({ legacyReferences: ['x.twig'] });
-    const errors = computeIconErrors(theme, md, sd, new Set());
-    for (const e of errors) {
-      assert.ok(e.startsWith('huraga: '), `expected prefix "huraga: " in "${e}"`);
-    }
+  test('accepts a consistent manifest', () => {
+    const manifestData = parseManifest({ icons: ['home', { name: 'dynamic', dynamic: true }] });
+    assert.deepEqual(computeIconErrors(
+      { code: 'test' },
+      manifestData,
+      { referencedIcons: new Set(['home']), legacyReferences: [], externalSpriteReferences: [] },
+      new Set(['dynamic']),
+    ), []);
   });
 });

--- a/frontend/tools/tests/icon-check-helpers.test.mjs
+++ b/frontend/tools/tests/icon-check-helpers.test.mjs
@@ -1,0 +1,396 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeIconEntry, parseManifest, extractIconReferencesFromContent, computeIconErrors } from '../icon-check-helpers.mjs';
+
+const mockTheme = (overrides = {}) => ({
+  code: 'test',
+  area: 'admin',
+  disallowFilled: false,
+  dynamicNavigation: false,
+  ...overrides,
+});
+
+const mockManifestData = (overrides = {}) => {
+  const manifestIcons = overrides.manifestIcons ?? [
+    { name: 'home', variant: 'outline', dynamic: false },
+    { name: 'settings', variant: 'outline', dynamic: true },
+  ];
+  const manifestNames = overrides.manifestNames ?? new Set(manifestIcons.map((i) => i.name));
+  const declaredDynamicManifestNames = overrides.declaredDynamicManifestNames ?? new Set(manifestIcons.filter((i) => i.dynamic).map((i) => i.name));
+  const dynamicManifestNames = overrides.dynamicManifestNames ?? new Set(declaredDynamicManifestNames);
+
+  return { manifestIcons, manifestNames, declaredDynamicManifestNames, dynamicManifestNames };
+};
+
+const mockScanData = (overrides = {}) => ({
+  referencedIcons: overrides.referencedIcons ?? new Set(),
+  legacyReferences: overrides.legacyReferences ?? [],
+  externalSpriteReferences: overrides.externalSpriteReferences ?? [],
+});
+
+test.describe('normalizeIconEntry', () => {
+  test('string entry uses defaultVariant', () => {
+    assert.deepEqual(normalizeIconEntry('foo', 'outline'), { name: 'foo', variant: 'outline', dynamic: false });
+  });
+
+  test('object entry preserves explicit variant', () => {
+    assert.deepEqual(
+      normalizeIconEntry({ name: 'bar', variant: 'filled' }, 'outline'),
+      { name: 'bar', variant: 'filled', dynamic: false },
+    );
+  });
+
+  test('object entry without variant falls back to defaultVariant', () => {
+    assert.deepEqual(
+      normalizeIconEntry({ name: 'bar' }, 'outline'),
+      { name: 'bar', variant: 'outline', dynamic: false },
+    );
+  });
+
+  test('object entry with dynamic flag', () => {
+    assert.deepEqual(
+      normalizeIconEntry({ name: 'bar', dynamic: true }, 'outline'),
+      { name: 'bar', variant: 'outline', dynamic: true },
+    );
+  });
+
+  test('object entry with falsy dynamic defaults to false', () => {
+    assert.deepEqual(
+      normalizeIconEntry({ name: 'bar', dynamic: false }, 'outline'),
+      { name: 'bar', variant: 'outline', dynamic: false },
+    );
+  });
+
+  test('falsy variant in object entry falls back to defaultVariant', () => {
+    assert.deepEqual(
+      normalizeIconEntry({ name: 'bar', variant: '' }, 'solid'),
+      { name: 'bar', variant: 'solid', dynamic: false },
+    );
+  });
+});
+
+test.describe('parseManifest', () => {
+  test('defaultVariant defaults to outline when not specified', () => {
+    const data = parseManifest({ icons: ['foo'] });
+    assert.equal(data.manifestIcons[0].variant, 'outline');
+  });
+
+  test('custom defaultVariant is used', () => {
+    const data = parseManifest({ defaultVariant: 'filled', icons: ['foo'] });
+    assert.equal(data.manifestIcons[0].variant, 'filled');
+  });
+
+  test('empty icons array produces empty sets', () => {
+    const data = parseManifest({ icons: [] });
+    assert.equal(data.manifestIcons.length, 0);
+    assert.equal(data.manifestNames.size, 0);
+    assert.equal(data.declaredDynamicManifestNames.size, 0);
+    assert.equal(data.dynamicManifestNames.size, 0);
+  });
+
+  test('manifestNames contains all icon names', () => {
+    const data = parseManifest({ icons: ['a', 'b', 'c'] });
+    assert.deepEqual([...data.manifestNames], ['a', 'b', 'c']);
+  });
+
+  test('declaredDynamicManifestNames only includes dynamic: true icons', () => {
+    const data = parseManifest({
+      icons: [
+        'static-one',
+        { name: 'dyn-one', dynamic: true },
+        { name: 'static-two', dynamic: false },
+        { name: 'dyn-two', dynamic: true },
+      ],
+    });
+    assert.deepEqual([...data.declaredDynamicManifestNames], ['dyn-one', 'dyn-two']);
+  });
+
+  test('dynamicManifestNames is a separate Set with same contents as declaredDynamicManifestNames', () => {
+    const data = parseManifest({
+      icons: [{ name: 'dyn', dynamic: true }],
+    });
+    assert.deepEqual([...data.dynamicManifestNames], [...data.declaredDynamicManifestNames]);
+    assert.notEqual(data.dynamicManifestNames, data.declaredDynamicManifestNames);
+  });
+
+  test('mixed string and object entries are normalized consistently', () => {
+    const data = parseManifest({
+      defaultVariant: 'solid',
+      icons: ['str', { name: 'obj', variant: 'outline' }],
+    });
+    assert.equal(data.manifestIcons[0].name, 'str');
+    assert.equal(data.manifestIcons[0].variant, 'solid');
+    assert.equal(data.manifestIcons[1].name, 'obj');
+    assert.equal(data.manifestIcons[1].variant, 'outline');
+  });
+});
+
+test.describe('extractIconReferencesFromContent', () => {
+  test('empty content returns no references', () => {
+    const result = extractIconReferencesFromContent('');
+    assert.deepEqual(result.references, []);
+    assert.equal(result.hasLegacy, false);
+    assert.equal(result.hasExternalSprite, false);
+  });
+
+  test('plain text with no use tags returns empty', () => {
+    const result = extractIconReferencesFromContent('<div>hello</div>');
+    assert.deepEqual(result.references, []);
+  });
+
+  test('extracts icon from modern href syntax', () => {
+    const result = extractIconReferencesFromContent('<use href="#home" />');
+    assert.deepEqual(result.references, ['home']);
+  });
+
+  test('extracts icon from legacy xlink:href syntax', () => {
+    const result = extractIconReferencesFromContent('<use xlink:href="#home" />');
+    assert.deepEqual(result.references, ['home']);
+    assert.equal(result.hasLegacy, true);
+  });
+
+  test('extracts icon with path prefix before hash', () => {
+    const result = extractIconReferencesFromContent('<use href="/assets/sprite.svg#home" />');
+    assert.deepEqual(result.references, ['home']);
+  });
+
+  test('extracts icon with empty path prefix (just hash)', () => {
+    const result = extractIconReferencesFromContent('<use href="#home" />');
+    assert.deepEqual(result.references, ['home']);
+  });
+
+  test('extracts multiple icons from content', () => {
+    const content = '<use href="#home" /><use href="#settings" /><use xlink:href="#logout" />';
+    const result = extractIconReferencesFromContent(content);
+    assert.deepEqual(result.references, ['home', 'settings', 'logout']);
+  });
+
+  test('preserves duplicate references (caller deduplicates via Set)', () => {
+    const content = '<use href="#home" /><use href="#home" />';
+    const result = extractIconReferencesFromContent(content);
+    assert.deepEqual(result.references, ['home', 'home']);
+  });
+
+  test('handles icon names with dashes', () => {
+    const result = extractIconReferencesFromContent('<use href="#arrow-left" />');
+    assert.deepEqual(result.references, ['arrow-left']);
+  });
+
+  test('handles icon names with underscores', () => {
+    const result = extractIconReferencesFromContent('<use href="#arrow_left" />');
+    assert.deepEqual(result.references, ['arrow_left']);
+  });
+
+  test('handles icon names with numbers', () => {
+    const result = extractIconReferencesFromContent('<use href="#icon3d" />');
+    assert.deepEqual(result.references, ['icon3d']);
+  });
+
+  test('use tag without href attribute is skipped', () => {
+    const result = extractIconReferencesFromContent('<use class="something" />');
+    assert.deepEqual(result.references, []);
+  });
+
+  test('hasLegacy is true when xlink:href substring is present anywhere', () => {
+    const result = extractIconReferencesFromContent('<!-- uses xlink:href -->');
+    assert.equal(result.hasLegacy, true);
+  });
+
+  test('hasLegacy is false for modern href only', () => {
+    const result = extractIconReferencesFromContent('<use href="#home" />');
+    assert.equal(result.hasLegacy, false);
+  });
+
+  test('hasExternalSprite is true when icons-sprite.svg# is present', () => {
+    const result = extractIconReferencesFromContent('<img src="icons-sprite.svg#home" />');
+    assert.equal(result.hasExternalSprite, true);
+  });
+
+  test('hasExternalSprite is false when not present', () => {
+    const result = extractIconReferencesFromContent('<use href="#home" />');
+    assert.equal(result.hasExternalSprite, false);
+  });
+
+  test('single use tag with both href and xlink:href', () => {
+    const content = '<use href="#home" xlink:href="#home" />';
+    const result = extractIconReferencesFromContent(content);
+    assert.deepEqual(result.references, ['home']);
+    assert.equal(result.hasLegacy, true);
+  });
+});
+
+test.describe('computeIconErrors', () => {
+  test('no issues returns empty array', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({ manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }] });
+    const sd = mockScanData({ referencedIcons: new Set(['home']) });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.deepEqual(errors, []);
+  });
+
+  test('disallowFilled + filled variant produces error', () => {
+    const theme = mockTheme({ disallowFilled: true });
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'x', variant: 'filled', dynamic: false }],
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['x']) });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /"x" requests the filled variant/);
+  });
+
+  test('disallowFilled + outline variant produces no variant error', () => {
+    const theme = mockTheme({ disallowFilled: true });
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'x', variant: 'outline', dynamic: false }],
+      manifestNames: new Set(['x']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['x']) });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.deepEqual(errors, []);
+  });
+
+  test('no disallowFilled constraint allows filled variants', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'x', variant: 'filled', dynamic: false }],
+      manifestNames: new Set(['x']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['x']) });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.deepEqual(errors, []);
+  });
+
+  test('legacy references produce error', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({ manifestIcons: [], manifestNames: new Set() });
+    const sd = mockScanData({ legacyReferences: ['src/foo.twig', 'src/bar.twig'] });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /legacy xlink:href references remain in src\/foo\.twig, src\/bar\.twig/);
+  });
+
+  test('legacy references are deduplicated', () => {
+    const theme = mockTheme();
+    const md = mockManifestData();
+    const sd = mockScanData({ legacyReferences: ['src/foo.twig', 'src/foo.twig'] });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.match(errors[0], /src\/foo\.twig/);
+    assert.doesNotMatch(errors[0], /src\/foo\.twig.*src\/foo\.twig/);
+  });
+
+  test('external sprite references produce error', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({ manifestIcons: [], manifestNames: new Set() });
+    const sd = mockScanData({ externalSpriteReferences: ['src/baz.twig'] });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /external sprite references remain in src\/baz\.twig/);
+  });
+
+  test('missing icons (referenced but not in manifest) produce error sorted alphabetically', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
+      manifestNames: new Set(['home']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['zebra', 'home', 'apple']) });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /missing manifest icons: apple, zebra/);
+  });
+
+  test('missing includes dynamic icons not in manifest', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
+      manifestNames: new Set(['home']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['home']) });
+    const errors = computeIconErrors(theme, md, sd, new Set(['mystery']));
+    assert.match(errors[0], /missing manifest icons: mystery/);
+  });
+
+  test('unused icons (in manifest but not referenced) produce error', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'home', variant: 'outline', dynamic: false }],
+      manifestNames: new Set(['home']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set() });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.match(errors[0], /unused manifest icons: home/);
+  });
+
+  test('unused does not flag dynamic manifest icons', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'dyn', variant: 'outline', dynamic: true }],
+      manifestNames: new Set(['dyn']),
+      dynamicManifestNames: new Set(['dyn']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set() });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    assert.deepEqual(errors, []);
+  });
+
+  test('undocumented dynamic icons produce error', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'undocumented', variant: 'outline', dynamic: false }],
+      declaredDynamicManifestNames: new Set(),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['undocumented']) });
+    const errors = computeIconErrors(theme, md, sd, new Set(['undocumented']));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /dynamic icons should be marked in the manifest: undocumented/);
+  });
+
+  test('declared dynamic icons do not trigger undocumented error', () => {
+    const theme = mockTheme();
+    const md = mockManifestData({
+      manifestIcons: [{ name: 'declared', variant: 'outline', dynamic: true }],
+      declaredDynamicManifestNames: new Set(['declared']),
+    });
+    const sd = mockScanData({ referencedIcons: new Set(['declared']) });
+    const errors = computeIconErrors(theme, md, sd, new Set(['declared']));
+    assert.deepEqual(errors, []);
+  });
+
+  test('multiple error types at once', () => {
+    const theme = mockTheme({ disallowFilled: true });
+    const md = mockManifestData({
+      manifestIcons: [
+        { name: 'filled-icon', variant: 'filled', dynamic: false },
+        { name: 'unused-icon', variant: 'outline', dynamic: false },
+      ],
+      manifestNames: new Set(['filled-icon', 'unused-icon']),
+    });
+    const sd = mockScanData({
+      referencedIcons: new Set(['missing-icon']),
+      legacyReferences: ['legacy.twig'],
+      externalSpriteReferences: ['sprite.twig'],
+    });
+    const dynamicIcons = new Set(['undocumented-dyn']);
+    const errors = computeIconErrors(theme, md, sd, dynamicIcons);
+    assert.ok(errors.length >= 5);
+    const joined = errors.join('\n');
+    assert.ok(joined.includes('filled variant'));
+    assert.ok(joined.includes('legacy xlink:href'));
+    assert.ok(joined.includes('external sprite'));
+    assert.ok(joined.includes('missing manifest icons'));
+    assert.ok(joined.includes('unused manifest icons'));
+    assert.ok(joined.includes('dynamic icons should be marked'));
+  });
+
+  test('all error messages include theme code prefix', () => {
+    const theme = mockTheme({ code: 'huraga' });
+    const md = mockManifestData();
+    const sd = mockScanData({ legacyReferences: ['x.twig'] });
+    const errors = computeIconErrors(theme, md, sd, new Set());
+    for (const e of errors) {
+      assert.ok(e.startsWith('huraga: '), `expected prefix "huraga: " in "${e}"`);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "npm run check-js-syntax && npm run check-icons",
     "check-js-syntax": "node ./frontend/tools/check-js-syntax.mjs",
     "check-icons": "node ./frontend/tools/check-icons.mjs",
+    "test:js": "node --test 'frontend/core/tests/**/*.test.mjs'",
     "cy:open": "npm exec --yes cypress@15.15.0 -- open",
     "cy:run": "npm exec --yes cypress@15.15.0 -- run",
     "cy:run:record": "npm exec --yes cypress@15.15.0 -- run --record"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check": "npm run check-js-syntax && npm run check-icons",
     "check-js-syntax": "node ./frontend/tools/check-js-syntax.mjs",
     "check-icons": "node ./frontend/tools/check-icons.mjs",
-    "test:js": "node --test 'frontend/core/tests/**/*.test.mjs'",
+    "test:js": "node --test 'frontend/core/tests/**/*.test.mjs' 'frontend/tools/tests/**/*.test.mjs'",
     "cy:open": "npm exec --yes cypress@15.15.0 -- open",
     "cy:run": "npm exec --yes cypress@15.15.0 -- run",
     "cy:run:record": "npm exec --yes cypress@15.15.0 -- run --record"

--- a/src/library/Server/Manager/Directadmin.php
+++ b/src/library/Server/Manager/Directadmin.php
@@ -205,76 +205,8 @@ class Server_Manager_Directadmin extends Server_Manager
         } else {
             $this->getLog()->info("Using custom package values: {$packageName} does not exist on the server.");
 
-            $fields['action'] = 'customize'; // Use customize action for custom package values.
-            $fields = array_merge($fields, [
-                'aftp' => $package->getCustomValue('aftp') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be able to have anonymous ftp accounts.
-                'bandwidth' => $package->getBandwidth(), // Bandwidth quota in MB
-                'catchall' => $package->getCustomValue('catchall') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
-                'cgi' => $package->getCustomValue('cgi') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-                'cron' => $package->getCustomValue('cron') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to create cronjobs.
-                'dnscontrol' => $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be able to modify his/her dns records.
-                'domainptr' => $package->getMaxParkedDomains(), // Domain pointer quota
-                'ftp' => $package->getMaxFtp(), // FTP account quota
-                'login_keys' => $package->getCustomValue('login_keys') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have access to the Login Key system for extra account passwords.
-                'mysql' => $package->getMaxSql(), // Database quota
-                'nemailf' => $package->getMaxEmailForwarders(), // Email forwarder quota
-                'nemailml' => $package->getMaxEmailLists(), // Mailing list quota
-                'nemailr' => $package->getMaxEmailAutoresponders(), // Autoresponder quota
-                'nemails' => $package->getMaxPop(), // Email account quota
-                'nsubdomains' => $package->getMaxSubdomains(), // Subdomain quota
-                'php' => $package->getCustomValue('php') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run php scripts.
-                'quota' => $package->getQuota(), // Disk space quota in MB
-                'spam' => $package->getCustomValue('spam') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run scan email with SpamAssassin.
-                'ssh' => $package->getCustomValue('ssh') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have an ssh account.
-                'ssl' => $package->getCustomValue('ssl') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to access their websites through secure https://.
-                'suspend_at_limit' => $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be suspended if their User bandwidth limit is exceeded.
-                'sysinfo' => $package->getCustomValue('sysinfo') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have access to a page that shows the system information.
-                'vdomains' => $package->getMaxDomains(), // Domain quota
-            ]);
-
-            if ($package->getBandwidth() == 'unlimited') {
-                $fields['ubandwidth'] = 'ON'; // ON or OFF. If ON, bandwidth is ignored and no limit is set
-            }
-
-            if ($package->getQuota() == 'unlimited') {
-                $fields['uquota'] = 'ON'; // ON or OFF. If ON, quota is ignored and no limit is set
-            }
-
-            if ($package->getMaxDomains() == 'unlimited') {
-                $fields['uvdomains'] = 'ON'; // ON or OFF. If ON, vdomains is ignored and no limit is set
-            }
-
-            if ($package->getMaxSubdomains() == 'unlimited') {
-                $fields['unsubdomains'] = 'ON'; // ON or OFF. If ON, nsubdomains is ignored and no limit is set
-            }
-
-            if ($package->getMaxParkedDomains() == 'unlimited') {
-                $fields['udomainptr'] = 'ON'; // ON or OFF Unlimited option for domainptr
-            }
-
-            if ($package->getMaxPop() == 'unlimited') {
-                $fields['unemails'] = 'ON'; // ON or OFF Unlimited option for nemails
-            }
-
-            if ($package->getMaxSql() == 'unlimited') {
-                $fields['umysql'] = 'ON'; // ON or OFF Unlimited option for mysql
-            }
-
-            if ($package->getMaxFtp() == 'unlimited') {
-                $fields['uftp'] = 'ON'; // ON or OFF Unlimited option for ftp
-            }
-
-            if ($fields['nemailf'] == 'unlimited') {
-                $fields['unemailf'] = 'ON'; // ON or OFF Unlimited option for nemailf
-            }
-
-            if ($fields['nemailml'] == 'unlimited') {
-                $fields['unemailml'] = 'ON'; // ON or OFF Unlimited option for nemailml
-            }
-
-            if ($fields['nemailr'] == 'unlimited') {
-                $fields['unemailr'] = 'ON'; // ON or OFF Unlimited option for nemailr
-            }
+            $fields['action'] = 'customize';
+            $fields = array_merge($fields, $this->getCustomPackageFields($package));
         }
 
         $this->request('API_MODIFY_USER', $fields);
@@ -363,75 +295,7 @@ class Server_Manager_Directadmin extends Server_Manager
         } else {
             $this->getLog()->info("Using custom package values: {$packageName} does not exist on the server.");
 
-            $fields = array_merge($fields, [
-                'aftp' => $package->getCustomValue('aftp') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be able to have anonymous ftp accounts.
-                'bandwidth' => $package->getBandwidth(), // Bandwidth quota in MB
-                'catchall' => $package->getCustomValue('catchall') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to enable and customize a catch-all email (*@domain.com).
-                'cgi' => $package->getCustomValue('cgi') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run cgi scripts in their cgi-bin.
-                'cron' => $package->getCustomValue('cron') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to create cronjobs.
-                'dnscontrol' => $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be able to modify his/her dns records.
-                'domainptr' => $package->getMaxParkedDomains(), // Domain pointer quota
-                'ftp' => $package->getMaxFtp(), // FTP account quota
-                'login_keys' => $package->getCustomValue('login_keys') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have access to the Login Key system for extra account passwords.
-                'mysql' => $package->getMaxSql(), // Database quota
-                'nemailf' => $package->getMaxEmailForwarders(), // Email forwarder quota
-                'nemailml' => $package->getMaxEmailLists(), // Mailing list quota
-                'nemailr' => $package->getMaxEmailAutoresponders(), // Autoresponder quota
-                'nemails' => $package->getMaxPop(), // Email account quota
-                'nsubdomains' => $package->getMaxSubdomains(), // Subdomain quota
-                'php' => $package->getCustomValue('php') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run php scripts.
-                'quota' => $package->getQuota(), // Disk space quota in MB
-                'spam' => $package->getCustomValue('spam') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to run scan email with SpamAssassin.
-                'ssh' => $package->getCustomValue('ssh') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have an ssh account.
-                'ssl' => $package->getCustomValue('ssl') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have the ability to access their websites through secure https://.
-                'suspend_at_limit' => $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will be suspended if their User bandwidth limit is exceeded.
-                'sysinfo' => $package->getCustomValue('sysinfo') ? 'ON' : 'OFF', // ON or OFF. If ON, the User will have access to a page that shows the system information.
-                'vdomains' => $package->getMaxDomains(), // Domain quota
-            ]);
-
-            if ($package->getBandwidth() == 'unlimited') {
-                $fields['ubandwidth'] = 'ON'; // ON or OFF. If ON, bandwidth is ignored and no limit is set
-            }
-
-            if ($package->getQuota() == 'unlimited') {
-                $fields['uquota'] = 'ON'; // ON or OFF. If ON, quota is ignored and no limit is set
-            }
-
-            if ($package->getMaxDomains() == 'unlimited') {
-                $fields['uvdomains'] = 'ON'; // ON or OFF. If ON, vdomains is ignored and no limit is set
-            }
-
-            if ($package->getMaxSubdomains() == 'unlimited') {
-                $fields['unsubdomains'] = 'ON'; // ON or OFF. If ON, nsubdomains is ignored and no limit is set
-            }
-
-            if ($package->getMaxParkedDomains() == 'unlimited') {
-                $fields['udomainptr'] = 'ON'; // ON or OFF Unlimited option for domainptr
-            }
-
-            if ($package->getMaxPop() == 'unlimited') {
-                $fields['unemails'] = 'ON'; // ON or OFF Unlimited option for nemails
-            }
-
-            if ($package->getMaxSql() == 'unlimited') {
-                $fields['umysql'] = 'ON'; // ON or OFF Unlimited option for mysql
-            }
-
-            if ($package->getMaxFtp() == 'unlimited') {
-                $fields['uftp'] = 'ON'; // ON or OFF Unlimited option for ftp
-            }
-
-            if ($fields['nemailf'] == 'unlimited') {
-                $fields['unemailf'] = 'ON'; // ON or OFF Unlimited option for nemailf
-            }
-
-            if ($fields['nemailml'] == 'unlimited') {
-                $fields['unemailml'] = 'ON'; // ON or OFF Unlimited option for nemailml
-            }
-
-            if ($fields['nemailr'] == 'unlimited') {
-                $fields['unemailr'] = 'ON'; // ON or OFF Unlimited option for nemailr
-            }
+            $fields = array_merge($fields, $this->getCustomPackageFields($package));
         }
 
         $command = 'API_ACCOUNT_USER';
@@ -856,6 +720,88 @@ class Server_Manager_Directadmin extends Server_Manager
         $results = $this->request('API_SHOW_RESELLER_IPS');
 
         return $results['list'] ?? [];
+    }
+
+    /**
+     * Builds the custom package fields array for DirectAdmin API requests.
+     *
+     * @param Server_Package $package the package to extract custom fields from
+     *
+     * @return array the custom package fields including unlimited flags
+     */
+    private function getCustomPackageFields(Server_Package $package): array
+    {
+        $fields = [
+            'aftp' => $package->getCustomValue('aftp') ? 'ON' : 'OFF',
+            'bandwidth' => $package->getBandwidth(),
+            'catchall' => $package->getCustomValue('catchall') ? 'ON' : 'OFF',
+            'cgi' => $package->getCustomValue('cgi') ? 'ON' : 'OFF',
+            'cron' => $package->getCustomValue('cron') ? 'ON' : 'OFF',
+            'dnscontrol' => $package->getCustomValue('dnscontrol') ? 'ON' : 'OFF',
+            'domainptr' => $package->getMaxParkedDomains(),
+            'ftp' => $package->getMaxFtp(),
+            'login_keys' => $package->getCustomValue('login_keys') ? 'ON' : 'OFF',
+            'mysql' => $package->getMaxSql(),
+            'nemailf' => $package->getMaxEmailForwarders(),
+            'nemailml' => $package->getMaxEmailLists(),
+            'nemailr' => $package->getMaxEmailAutoresponders(),
+            'nemails' => $package->getMaxPop(),
+            'nsubdomains' => $package->getMaxSubdomains(),
+            'php' => $package->getCustomValue('php') ? 'ON' : 'OFF',
+            'quota' => $package->getQuota(),
+            'spam' => $package->getCustomValue('spam') ? 'ON' : 'OFF',
+            'ssh' => $package->getCustomValue('ssh') ? 'ON' : 'OFF',
+            'ssl' => $package->getCustomValue('ssl') ? 'ON' : 'OFF',
+            'suspend_at_limit' => $package->getCustomValue('suspend_at_limit') ? 'ON' : 'OFF',
+            'sysinfo' => $package->getCustomValue('sysinfo') ? 'ON' : 'OFF',
+            'vdomains' => $package->getMaxDomains(),
+        ];
+
+        if ($package->getBandwidth() == 'unlimited') {
+            $fields['ubandwidth'] = 'ON';
+        }
+
+        if ($package->getQuota() == 'unlimited') {
+            $fields['uquota'] = 'ON';
+        }
+
+        if ($package->getMaxDomains() == 'unlimited') {
+            $fields['uvdomains'] = 'ON';
+        }
+
+        if ($package->getMaxSubdomains() == 'unlimited') {
+            $fields['unsubdomains'] = 'ON';
+        }
+
+        if ($package->getMaxParkedDomains() == 'unlimited') {
+            $fields['udomainptr'] = 'ON';
+        }
+
+        if ($package->getMaxPop() == 'unlimited') {
+            $fields['unemails'] = 'ON';
+        }
+
+        if ($package->getMaxSql() == 'unlimited') {
+            $fields['umysql'] = 'ON';
+        }
+
+        if ($package->getMaxFtp() == 'unlimited') {
+            $fields['uftp'] = 'ON';
+        }
+
+        if ($fields['nemailf'] == 'unlimited') {
+            $fields['unemailf'] = 'ON';
+        }
+
+        if ($fields['nemailml'] == 'unlimited') {
+            $fields['unemailml'] = 'ON';
+        }
+
+        if ($fields['nemailr'] == 'unlimited') {
+            $fields['unemailr'] = 'ON';
+        }
+
+        return $fields;
     }
 
     /**

--- a/src/modules/Formbuilder/assets/css/bootstrap-form.css
+++ b/src/modules/Formbuilder/assets/css/bootstrap-form.css
@@ -109,6 +109,7 @@ input,
 textarea,
 .uneditable-input {
   width: 206px;
+  margin-left: 0;
 }
 textarea {
   height: auto;
@@ -307,11 +308,7 @@ textarea[class*="span"],
 .row-fluid .input-append [class*="span"] {
   display: inline-block;
 }
-input,
-textarea,
-.uneditable-input {
-  margin-left: 0;
-}
+
 .controls-row [class*="span"] + [class*="span"] {
   margin-left: 20px;
 }

--- a/src/modules/Support/Api/Client.php
+++ b/src/modules/Support/Api/Client.php
@@ -105,11 +105,6 @@ class Client extends \FOSSBilling\Api\AbstractApi
         $data['content'] = \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']);
 
         $client = $this->getIdentity();
-
-        $bindings = [
-            ':id' => $data['id'],
-            ':client_id' => $client->id,
-        ];
         $ticket = $this->getService()->getSupportTicketRepository()->findOneByClient((int) $client->id, (int) $data['id']);
 
         if (!$ticket instanceof SupportTicket) {

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -252,8 +252,13 @@
         </div>
     {% endif %}
 
-    {{ include('partial_dashboard_invoices_card.html.twig') }}
-    {{ include('partial_dashboard_orders_card.html.twig') }}
+    {% if admin.system_is_allowed({ 'mod': 'invoice' }) %}
+        {{ include('partial_dashboard_invoices_card.html.twig') }}
+    {% endif %}
+
+    {% if admin.system_is_allowed({ 'mod': 'order' }) %}
+        {{ include('partial_dashboard_orders_card.html.twig') }}
+    {% endif %}
 
     {% if admin.system_is_allowed({ 'mod': 'stats' }) %}
         {{ include('partial_dashboard_product_sales_card.html.twig') }}

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -8,9 +8,9 @@
     {% set dashboardSection = request.dashboard_section|default('') %}
 
     {% if request.ajax and dashboardSection in ['invoices', 'orders', 'product-sales'] %}
-        {% if dashboardSection == 'invoices' %}
+        {% if dashboardSection == 'invoices' and admin.system_is_allowed({ 'mod': 'invoice' }) %}
             {{ include('partial_dashboard_invoices_card.html.twig') }}
-        {% elseif dashboardSection == 'orders' %}
+        {% elseif dashboardSection == 'orders' and admin.system_is_allowed({ 'mod': 'order' }) %}
             {{ include('partial_dashboard_orders_card.html.twig') }}
         {% elseif dashboardSection == 'product-sales' and admin.system_is_allowed({ 'mod': 'stats' }) %}
             {{ include('partial_dashboard_product_sales_card.html.twig') }}


### PR DESCRIPTION
Introduces new core frontend utility modules (`api-helpers.mjs`, `link-helpers.mjs`, and `parse-data-attr.mjs`) to standardise and improve API interaction, link action handling, and data attribute parsing/validation. Each module is accompanied by comprehensive unit tests to ensure correctness and reliability. The changes focus on modularising logic for API requests, link behaviours, and robust attribute parsing, making the codebase more maintainable and testable.