### PR TITLE
Fix duplicate domain activation from stale order object during checkout

### DIFF
--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -879,6 +879,9 @@ class Service implements InjectionAwareInterface
 
     public function activateOrder(\Model_ClientOrder $order, $data = []): bool
     {
+        // re-fetch in case the caller's order object is stale (e.g. already activated by another code path)
+        $order = $this->di['db']->load('ClientOrder', $order->id);
+
         $statues = [
             \Model_ClientOrder::STATUS_PENDING_SETUP,
             \Model_ClientOrder::STATUS_FAILED_SETUP,

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -880,7 +880,11 @@ class Service implements InjectionAwareInterface
     public function activateOrder(\Model_ClientOrder $order, $data = []): bool
     {
         // re-fetch in case the caller's order object is stale (e.g. already activated by another code path)
-        $order = $this->di['db']->load('ClientOrder', $order->id);
+        $orderId = $order->id;
+        $order = $this->di['db']->load('ClientOrder', $orderId);
+        if (!$order instanceof \Model_ClientOrder) {
+            throw new \FOSSBilling\Exception('Order :id not found', [':id' => $orderId]);
+        }
         $force = !empty($data['force']);
 
         // Already active and not a forced re-activation: nothing to do.

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -881,15 +881,19 @@ class Service implements InjectionAwareInterface
     {
         // re-fetch in case the caller's order object is stale (e.g. already activated by another code path)
         $order = $this->di['db']->load('ClientOrder', $order->id);
+        $force = !empty($data['force']);
+
+        // Already active and not a forced re-activation: nothing to do.
+        if ($order->status === \Model_ClientOrder::STATUS_ACTIVE && !$force) {
+            return true;
+        }
 
         $statues = [
             \Model_ClientOrder::STATUS_PENDING_SETUP,
             \Model_ClientOrder::STATUS_FAILED_SETUP,
         ];
-        if (!in_array($order->status, $statues)) {
-            if (!isset($data['force']) || !$data['force']) {
-                throw new \FOSSBilling\Exception('Only pending setup or failed orders can be activated');
-            }
+        if (!in_array($order->status, $statues) && !$force) {
+            throw new \FOSSBilling\Exception('Only pending setup or failed orders can be activated');
         }
 
         $event_params = ['id' => $order->id];

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1711,7 +1711,7 @@ test('activateOrder activates pending order', function (): void {
     expect($result)->toBeTrue();
 });
 
-test('activateOrder is idempotent when order was already activated by a stale reference', function (): void {
+test('activateOrder is a no-op when order was already activated by a stale reference', function (): void {
     $staleOrderModel = new Model_ClientOrder();
     $staleOrderModel->loadBean(new Tests\Helpers\DummyBean());
     $staleOrderModel->status = Model_ClientOrder::STATUS_PENDING_SETUP;
@@ -1727,11 +1727,45 @@ test('activateOrder is idempotent when order was already activated by a stale re
     $di = container();
     $di['db'] = $dbMock;
 
-    $svc = new Service();
-    $svc->setDi($di);
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('createFromOrder')->never();
+    $serviceMock->shouldReceive('activateOrderAddons')->never();
 
-    expect(fn (): bool => $svc->activateOrder($staleOrderModel))
-        ->toThrow(FOSSBilling\Exception::class, 'Only pending setup or failed orders can be activated');
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->activateOrder($staleOrderModel);
+
+    expect($result)->toBeTrue();
+});
+
+test('activateOrder force re-activates an already active order', function (): void {
+    $activeOrderModel = new Model_ClientOrder();
+    $activeOrderModel->loadBean(new Tests\Helpers\DummyBean());
+    $activeOrderModel->status = Model_ClientOrder::STATUS_ACTIVE;
+    $activeOrderModel->group_master = 1;
+
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('load')->atLeast()->once()->with('ClientOrder', Mockery::any())->andReturn($activeOrderModel);
+
+    $eventMock = Mockery::mock(Box_EventManager::class);
+    $eventMock->shouldReceive('fire')->atLeast()->once();
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['events_manager'] = $eventMock;
+    $di['logger'] = new Box_Log();
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('createFromOrder')->atLeast()->once()->andReturn([]);
+    $serviceMock->shouldReceive('activateOrderAddons')->atLeast()->once();
+
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->activateOrder($activeOrderModel, ['force' => true]);
+
+    expect($result)->toBeTrue();
 });
 
 test('activateOrderAddons activates addons', function (): void {

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1669,7 +1669,14 @@ test('activateOrder throws for non-pending order', function (): void {
     $clientOrderModel->loadBean(new Tests\Helpers\DummyBean());
     $clientOrderModel->status = Model_ClientOrder::STATUS_CANCELED;
 
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('load')->atLeast()->once()->with('ClientOrder', Mockery::any())->andReturn($clientOrderModel);
+
+    $di = container();
+    $di['db'] = $dbMock;
+
     $svc = new Service();
+    $svc->setDi($di);
 
     expect(fn (): bool => $svc->activateOrder($clientOrderModel))
         ->toThrow(FOSSBilling\Exception::class, 'Only pending setup or failed orders can be activated');
@@ -1681,10 +1688,14 @@ test('activateOrder activates pending order', function (): void {
     $clientOrderModel->status = Model_ClientOrder::STATUS_PENDING_SETUP;
     $clientOrderModel->group_master = 1;
 
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('load')->atLeast()->once()->with('ClientOrder', Mockery::any())->andReturn($clientOrderModel);
+
     $eventMock = Mockery::mock(Box_EventManager::class);
     $eventMock->shouldReceive('fire')->atLeast()->once();
 
     $di = container();
+    $di['db'] = $dbMock;
     $di['events_manager'] = $eventMock;
     $di['logger'] = new Box_Log();
 
@@ -1698,6 +1709,29 @@ test('activateOrder activates pending order', function (): void {
     $result = $serviceMock->activateOrder($clientOrderModel);
 
     expect($result)->toBeTrue();
+});
+
+test('activateOrder is idempotent when order was already activated by a stale reference', function (): void {
+    $staleOrderModel = new Model_ClientOrder();
+    $staleOrderModel->loadBean(new Tests\Helpers\DummyBean());
+    $staleOrderModel->status = Model_ClientOrder::STATUS_PENDING_SETUP;
+
+    $activeOrderModel = new Model_ClientOrder();
+    $activeOrderModel->loadBean(new Tests\Helpers\DummyBean());
+    $activeOrderModel->status = Model_ClientOrder::STATUS_ACTIVE;
+    $activeOrderModel->group_master = 1;
+
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('load')->atLeast()->once()->with('ClientOrder', Mockery::any())->andReturn($activeOrderModel);
+
+    $di = container();
+    $di['db'] = $dbMock;
+
+    $svc = new Service();
+    $svc->setDi($di);
+
+    expect(fn (): bool => $svc->activateOrder($staleOrderModel))
+        ->toThrow(FOSSBilling\Exception::class, 'Only pending setup or failed orders can be activated');
 });
 
 test('activateOrderAddons activates addons', function (): void {


### PR DESCRIPTION
## Summary

- On 0.8.3, checking out a cart whose invoice is fully paid via account credit could activate the same order twice, causing EPP-backed domain products to attempt domain registration a second time and fail with "Domain is not available: In use".
- Root cause: `Invoice::approveInvoice()` → `tryPayWithCredits()` → `markAsPaid($invoice, false, true)` synchronously activates the order (via a freshly-loaded `ClientOrder`) when the invoice is settled entirely by balance. `Cart::checkoutCart()` then re-checks `$invoiceModel->status == STATUS_PAID` and calls `activateOrder()` again using its own, now-stale, in-memory `$order` object (still `STATUS_PENDING_SETUP` with `service_id = null`), which bypasses `activateOrder()`'s status guard and re-creates/re-activates the service.
- Fix: `Order\Service::activateOrder()` now re-fetches the order from the database before evaluating its status, so it always acts on current state regardless of which caller's in-memory copy triggered it. The existing `force` flag (documented in the admin `order/activate` endpoint for reactivating an already-active order) still works, since the reload feeds into the existing guard rather than short-circuiting.

Credit to @getpinga for reporting this.