### PR TITLE
Fix undefined method error in UpdatePatcher after Doctrine migration

### DIFF
--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use Box\Mod\Extension\Entity\Extension;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -656,8 +657,8 @@ class UpdatePatcher implements InjectionAwareInterface
             }
 
             // If the Kb extension exists, uninstall it.
-            $kb_ext = $ext_service->findExtension('mod', 'kb');
-            if ($kb_ext instanceof \Model_Extension) {
+            $kb_ext = $ext_service->getExtensionRepository()->findOneByTypeAndName('mod', 'kb');
+            if ($kb_ext instanceof Extension) {
                 $ext_service->deactivate($kb_ext);
                 $ext_service->uninstall('mod', 'kb');
             }
@@ -679,8 +680,8 @@ class UpdatePatcher implements InjectionAwareInterface
         try {
             $ext_service = $this->di['mod_service']('extension');
             // If the queue extension exists, uninstall it.
-            $queue_ext = $ext_service->findExtension('mod', 'queue');
-            if ($queue_ext instanceof \Model_Extension) {
+            $queue_ext = $ext_service->getExtensionRepository()->findOneByTypeAndName('mod', 'queue');
+            if ($queue_ext instanceof Extension) {
                 $ext_service->deactivate($queue_ext);
                 $ext_service->uninstall('mod', 'queue');
             }
@@ -1112,8 +1113,8 @@ class UpdatePatcher implements InjectionAwareInterface
 
             $this->executeSql("DELETE FROM extension_meta WHERE extension = 'mod_spamchecker' AND meta_key = 'config'");
 
-            $spamcheckerExt = $extService->findExtension('mod', 'spamchecker');
-            if ($spamcheckerExt instanceof \Model_Extension) {
+            $spamcheckerExt = $extService->getExtensionRepository()->findOneByTypeAndName('mod', 'spamchecker');
+            if ($spamcheckerExt instanceof Extension) {
                 $extService->deactivate($spamcheckerExt);
                 $extService->uninstall('mod', 'spamchecker');
             }


### PR DESCRIPTION
## Summary

Users upgrading from 0.6.x hit:

```
Call to undefined method Box\Mod\Extension\Service::findExtension() at /home/control/public/library/FOSSBilling/UpdatePatcher.php : 1115
```

[PR #3863](https://github.com/FOSSBilling/FOSSBilling/pull/3863) migrated the Extension module from RedBeanPHP to Doctrine and removed `Service::findExtension()`, replacing its internal call sites with `getExtensionRepository()->findOneByTypeAndName()`. It missed three call sites in `UpdatePatcher.php` (used by the `patch36`/`patch37` update patches and the Spamchecker → Anti-Spam migration patch) that still called the removed method. Since update patches only run once during a version upgrade, this went unnoticed until a user actually upgraded across the affected versions.

- Replaced the three `$ext_service->findExtension('mod', $name)` calls with `$ext_service->getExtensionRepository()->findOneByTypeAndName('mod', $name)`
- Updated the corresponding `instanceof \Model_Extension` checks to `instanceof Extension` (the Doctrine entity)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/FOSSBilling/FOSSBilling/pull/3949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

