### PR TITLE
Add 'tablesort' to cspell.json dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -527,7 +527,8 @@
         "inpay",
         "seti",
         "unassigns",
-        "docstrings"
+        "docstrings",
+        "tablesort"
     ],
     "ignorePaths": [
         "node_modules/**",


### PR DESCRIPTION
Minor update to the `cspell.json` configuration file to improve spell checking coverage.