### PR TITLE
Allow invoice generation for zero-price orders

### DIFF
--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -225,9 +225,6 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('invoice', 'manage_invoices');
 
         $model = $this->getDi()['db']->getExistingModelById('ClientOrder', $data['id'], 'Order not found');
-        if ($model->price <= 0) {
-            throw new InformationException('Order :id is free. No need to generate invoice.', [':id' => $model->id]);
-        }
 
         return $this->getService()->renewInvoice($model, $data);
     }

--- a/src/modules/Invoice/Api/Client.php
+++ b/src/modules/Invoice/Api/Client.php
@@ -76,9 +76,6 @@ class Client extends \FOSSBilling\Api\AbstractApi
         if (!$model instanceof \Model_ClientOrder) {
             throw new \FOSSBilling\InformationException('Order not found');
         }
-        if ($model->price <= 0) {
-            throw new \FOSSBilling\InformationException('Order :id is free. No need to generate invoice.', [':id' => $model->id]);
-        }
         $service = $this->getService();
         $invoice = $service->generateForOrder($model);
         $service->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1307,8 +1307,8 @@ class Service implements InjectionAwareInterface
             }
         }
 
-        if (($price * ($line['quantity'] ?? 1)) <= 0) {
-            throw new InformationException('Invoices are not generated for 0 amount orders.');
+        if (($price * ($line['quantity'] ?? 1)) < 0) {
+            throw new InformationException('Invoices are not generated for negative amount orders.');
         }
 
         $client = $this->di['db']->getExistingModelById('Client', $order->client_id, 'Client not found');

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -904,6 +904,13 @@ class Service implements InjectionAwareInterface
                 $this->di['logger']->setChannel('billing')->info("Setting invoice {$invoice->id} as paid with credits for the amount of {$required}.");
             }
 
+            if ($required <= $epsilon) {
+                // Nothing was actually charged against the client's balance, so don't record a $0 credit transaction.
+                $this->markAsPaid($invoice, false, true);
+
+                return true;
+            }
+
             $balanceTransaction = $this->di['db']->dispense('ClientBalance');
             $balanceTransaction->client_id = $client->id;
             $balanceTransaction->type = 'invoice';

--- a/src/modules/Invoice/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/AdminTest.php
@@ -328,11 +328,16 @@ test('creates renewal invoice', function (): void {
     expect($result)->toBeInt()->toBe($newInvoiceId);
 });
 
-test('throws exception when creating renewal invoice for free order', function (): void {
+test('creates renewal invoice for free order', function (): void {
     $api = apiEndpoint(new Admin());
     $data = [
         'id' => 1,
     ];
+    $newInvoiceId = 3;
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('renewInvoice')
+        ->atLeast()->once()
+        ->andReturn($newInvoiceId);
 
     $dbMock = Mockery::mock('\Box_Database');
     $model = new Model_ClientOrder();
@@ -347,9 +352,10 @@ test('throws exception when creating renewal invoice for free order', function (
     $di['db'] = $dbMock;
 
     $api->setDi($di);
+    $api->setService($serviceMock);
 
-    expect(fn () => $api->renewal_invoice($data))
-        ->toThrow(FOSSBilling\Exception::class, sprintf('Order %d is free. No need to generate invoice.', $model->id));
+    $result = $api->renewal_invoice($data);
+    expect($result)->toBeInt()->toBe($newInvoiceId);
 });
 
 test('processes batch pay with credits', function (): void {

--- a/src/modules/Invoice/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/ClientTest.php
@@ -112,8 +112,19 @@ test('creates renewal invoice', function (): void {
     expect($result)->toBeString()->toBe($generatedHash);
 });
 
-test('throws exception when creating renewal invoice for free order', function (): void {
+test('creates renewal invoice for free order', function (): void {
     $api = apiEndpoint(new Client());
+    $generatedHash = 'generatedHashString';
+
+    $serviceMock = Mockery::mock(Service::class);
+    $model = new Model_Invoice();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+    $model->hash = $generatedHash;
+    $serviceMock->shouldReceive('generateForOrder')
+        ->atLeast()->once()
+        ->andReturn($model);
+    $serviceMock->shouldReceive('approveInvoice');
+
     $dbMock = Mockery::mock('\Box_Database');
     $clientOrder = new Model_ClientOrder();
     $clientOrder->loadBean(new Tests\Helpers\DummyBean());
@@ -129,14 +140,14 @@ test('throws exception when creating renewal invoice for free order', function (
     $di['logger'] = new Tests\Helpers\TestLogger();
 
     $api->setDi($di);
+    $api->setService($serviceMock);
     $identity = new Model_Admin();
     $identity->loadBean(new Tests\Helpers\DummyBean());
     $api->setIdentity($identity);
 
     $data['order_id'] = 1;
-
-    expect(fn () => $api->renewal_invoice($data))
-        ->toThrow(FOSSBilling\Exception::class, sprintf('Order %d is free. No need to generate invoice.', $clientOrder->id));
+    $result = $api->renewal_invoice($data);
+    expect($result)->toBeString()->toBe($generatedHash);
 });
 
 test('throws exception when creating renewal invoice for order not found', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1669,14 +1669,55 @@ test('generates invoice for active order using the order price, not the product 
     expect($result)->toBeInstanceOf(Model_Invoice::class);
 });
 
-test('throws exception when generating invoice for zero amount order', function (): void {
+test('generates invoice for zero amount order', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('setInvoiceDefaults')
+        ->once();
+
+    $orderModel = new Model_ClientOrder();
+    $orderModel->loadBean(new Tests\Helpers\DummyBean());
+    $orderModel->price = 0;
+    $orderModel->quantity = 1;
+    $orderModel->currency = 'USD';
+
+    $clientModel = new Model_Client();
+    $clientModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $invoiceModel = new Model_Invoice();
+    $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('getExistingModelById')
+        ->atLeast()->once()
+        ->andReturn($clientModel);
+    $dbMock->shouldReceive('dispense')
+        ->atLeast()->once()
+        ->andReturn($invoiceModel);
+    $dbMock->shouldReceive('store')
+        ->atLeast()->once();
+
+    $invoiceItemServiceMock = Mockery::mock(ServiceInvoiceItem::class);
+    $invoiceItemServiceMock->shouldReceive('generateFromOrder')
+        ->atLeast()->once();
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $invoiceItemServiceMock);
+
+    $serviceMock->setDi($di);
+    $result = $serviceMock->generateForOrder($orderModel);
+    expect($result)->toBeInstanceOf(Model_Invoice::class);
+});
+
+test('throws exception when generating invoice for negative amount order', function (): void {
     $service = new Service();
     $clientOrder = new Model_ClientOrder();
     $clientOrder->loadBean(new Tests\Helpers\DummyBean());
-    $clientOrder->price = 0;
+    $clientOrder->price = -1;
+    $clientOrder->quantity = 1;
 
     expect(fn () => $service->generateForOrder($clientOrder))
-        ->toThrow(FOSSBilling\Exception::class, 'Invoices are not generated for 0 amount orders');
+        ->toThrow(FOSSBilling\Exception::class, 'Invoices are not generated for negative amount orders.');
 });
 
 test('returns true when no expiring orders found', function (): void {

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -802,7 +802,14 @@ class Service implements InjectionAwareInterface
 
             if ($invoiceOption == 'issue-invoice') {
                 $invoiceService = $this->di['mod_service']('invoice');
-                $invoice = $invoiceService->generateForOrder($order);
+
+                try {
+                    $invoice = $invoiceService->generateForOrder($order);
+                } catch (InformationException $e) {
+                    // Order price resolved to a negative amount (e.g. via a misconfigured
+                    // pricing rule); don't let a failed invoice attempt roll back order creation.
+                    $this->di['logger']->warning($e->getMessage());
+                }
             }
 
             return $id;

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -800,7 +800,7 @@ class Service implements InjectionAwareInterface
                 }
             }
 
-            if ($invoiceOption == 'issue-invoice' && $order->price > 0) {
+            if ($invoiceOption == 'issue-invoice') {
                 $invoiceService = $this->di['mod_service']('invoice');
                 $invoice = $invoiceService->generateForOrder($order);
             }

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -2607,3 +2607,94 @@ test('createOrder generates an invoice for a zero-price order with issue-invoice
 
     expect($result)->toBe($newId);
 });
+
+test('createOrder does not roll back when invoice generation fails for a negative resolved price', function (): void {
+    $modelClient = new Model_Client();
+    $modelClient->loadBean(new Tests\Helpers\DummyBean());
+    $modelClient->currency = 'USD';
+
+    $modelProduct = orderServiceCreateProductEntity(1, 'custom');
+
+    $currencyModel = Mockery::mock(Box\Mod\Currency\Entity\Currency::class)->shouldIgnoreMissing();
+
+    $currencyRepositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $currencyRepositoryMock->shouldReceive('findOneByCode')->atLeast()->once()->andReturn($currencyModel);
+    $currencyRepositoryMock->shouldReceive('getRateByCode')->atLeast()->once()->andReturn(1.0);
+
+    $currencyServiceMock = Mockery::mock(Box\Mod\Currency\Service::class);
+    $currencyServiceMock->shouldReceive('getCurrencyRepository')->atLeast()->once()->andReturn($currencyRepositoryMock);
+
+    $cartServiceMock = Mockery::mock(Box\Mod\Cart\Service::class);
+    $cartServiceMock->shouldReceive('isStockAvailable')
+        ->atLeast()->once()
+        ->with($modelProduct, Mockery::any())
+        ->andReturn(true);
+
+    $eventMock = Mockery::mock(Box_EventManager::class);
+    $eventMock->shouldReceive('fire')->atLeast()->once();
+
+    $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
+    $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
+    $pricingServiceMock->shouldReceive('getProductOrderLineConfig')
+        ->atLeast()->once()
+        ->andReturn(['price' => -5.0, 'quantity' => 1]);
+
+    $clientOrderModel = new Model_ClientOrder();
+    $clientOrderModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('generateForOrder')
+        ->once()
+        ->with($clientOrderModel)
+        ->andThrow(new FOSSBilling\InformationException('Invoices are not generated for negative amount orders.'));
+    $invoiceServiceMock->shouldReceive('approveInvoice')->never();
+
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('transaction')
+        ->once()
+        ->andReturnUsing(fn (callable $callback) => $callback());
+    $dbMock->shouldReceive('dispense')->atLeast()->once()->with('ClientOrder')->andReturn($clientOrderModel);
+
+    $newId = 1;
+    $dbMock->shouldReceive('store')->atLeast()->once()->with($clientOrderModel)->andReturn($newId);
+    $dbMock->shouldReceive('getExistingModelById')
+        ->atLeast()->once()
+        ->with('ClientOrder', $newId, 'Order not found')
+        ->andReturn($clientOrderModel);
+
+    $periodMock = Mockery::mock(Box_Period::class);
+    $periodMock->shouldReceive('getCode')->atLeast()->once()->andReturn('1Y');
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($cartServiceMock, $currencyServiceMock, $invoiceServiceMock, $productServiceMock, $pricingServiceMock) {
+        if ($serviceName == 'currency') {
+            return $currencyServiceMock;
+        }
+        if ($serviceName == 'cart') {
+            return $cartServiceMock;
+        }
+        if ($serviceName == 'Product') {
+            return $pricingServiceMock;
+        }
+        if ($serviceName == 'invoice') {
+            return $invoiceServiceMock;
+        }
+        if ($serviceName == 'servicecustom') {
+            return $productServiceMock;
+        }
+    });
+    $di['events_manager'] = $eventMock;
+    $di['db'] = $dbMock;
+    $di['period'] = $di->protect(fn (): Mockery\MockInterface => $periodMock);
+    $di['logger'] = new Box_Log();
+
+    $svc = new Service();
+    $svc->setDi($di);
+
+    $result = $svc->createOrder($modelClient, $modelProduct, [
+        'period' => '1Y',
+        'invoice_option' => 'issue-invoice',
+    ]);
+
+    expect($result)->toBe($newId);
+});

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -2511,3 +2511,99 @@ test('updateOrder rejects a negative price', function (): void {
     expect(fn () => $service->updateOrder($order, ['price' => -1]))
         ->toThrow(FOSSBilling\InformationException::class, 'Price cannot be negative');
 });
+
+test('createOrder generates an invoice for a zero-price order with issue-invoice', function (): void {
+    $modelClient = new Model_Client();
+    $modelClient->loadBean(new Tests\Helpers\DummyBean());
+    $modelClient->currency = 'USD';
+
+    $modelProduct = orderServiceCreateProductEntity(1, 'custom');
+
+    $currencyModel = Mockery::mock(Box\Mod\Currency\Entity\Currency::class)->shouldIgnoreMissing();
+
+    $currencyRepositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $currencyRepositoryMock->shouldReceive('findOneByCode')->atLeast()->once()->andReturn($currencyModel);
+
+    $currencyServiceMock = Mockery::mock(Box\Mod\Currency\Service::class);
+    $currencyServiceMock->shouldReceive('getCurrencyRepository')->atLeast()->once()->andReturn($currencyRepositoryMock);
+
+    $cartServiceMock = Mockery::mock(Box\Mod\Cart\Service::class);
+    $cartServiceMock->shouldReceive('isStockAvailable')
+        ->atLeast()->once()
+        ->with($modelProduct, Mockery::any())
+        ->andReturn(true);
+
+    $eventMock = Mockery::mock(Box_EventManager::class);
+    $eventMock->shouldReceive('fire')->atLeast()->once();
+
+    $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
+    $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
+    $pricingServiceMock->shouldReceive('getProductOrderLineConfig')->never();
+
+    $clientOrderModel = new Model_ClientOrder();
+    $clientOrderModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $invoiceModel = new Model_Invoice();
+    $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
+    $invoiceModel->id = 10;
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('generateForOrder')
+        ->once()
+        ->with($clientOrderModel)
+        ->andReturn($invoiceModel);
+    $invoiceServiceMock->shouldReceive('approveInvoice')
+        ->once()
+        ->with($invoiceModel, ['id' => $invoiceModel->id, 'use_credits' => true])
+        ->andReturn(true);
+
+    $dbMock = Mockery::mock(Box_Database::class);
+    $dbMock->shouldReceive('transaction')
+        ->once()
+        ->andReturnUsing(fn (callable $callback) => $callback());
+    $dbMock->shouldReceive('dispense')->atLeast()->once()->with('ClientOrder')->andReturn($clientOrderModel);
+
+    $newId = 1;
+    $dbMock->shouldReceive('store')->atLeast()->once()->with($clientOrderModel)->andReturn($newId);
+    $dbMock->shouldReceive('getExistingModelById')
+        ->atLeast()->once()
+        ->with('ClientOrder', $newId, 'Order not found')
+        ->andReturn($clientOrderModel);
+
+    $periodMock = Mockery::mock(Box_Period::class);
+    $periodMock->shouldReceive('getCode')->atLeast()->once()->andReturn('1Y');
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($cartServiceMock, $currencyServiceMock, $invoiceServiceMock, $productServiceMock, $pricingServiceMock) {
+        if ($serviceName == 'currency') {
+            return $currencyServiceMock;
+        }
+        if ($serviceName == 'cart') {
+            return $cartServiceMock;
+        }
+        if ($serviceName == 'Product') {
+            return $pricingServiceMock;
+        }
+        if ($serviceName == 'invoice') {
+            return $invoiceServiceMock;
+        }
+        if ($serviceName == 'servicecustom') {
+            return $productServiceMock;
+        }
+    });
+    $di['events_manager'] = $eventMock;
+    $di['db'] = $dbMock;
+    $di['period'] = $di->protect(fn (): Mockery\MockInterface => $periodMock);
+    $di['logger'] = new Box_Log();
+
+    $svc = new Service();
+    $svc->setDi($di);
+
+    $result = $svc->createOrder($modelClient, $modelProduct, [
+        'period' => '1Y',
+        'price' => 0,
+        'invoice_option' => 'issue-invoice',
+    ]);
+
+    expect($result)->toBe($newId);
+});


### PR DESCRIPTION
Update invoice generation logic to allow invoices to be created for zero-price (free) orders, while still preventing invoice creation for orders with negative amounts.