### PR TITLE
Add 'Brien' to cspell.json dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -528,7 +528,8 @@
         "seti",
         "unassigns",
         "docstrings",
-        "tablesort"
+        "tablesort",
+        "Brien"
     ],
     "ignorePaths": [
         "node_modules/**",


### PR DESCRIPTION
Added `"Brien"` to the `words` list in `cspell.json` to ensure it is not flagged as a spelling error.