### PR TITLE
Fix GROUP BY issue in product category query

### DIFF
--- a/src/modules/Product/Repository/ProductCategoryRepository.php
+++ b/src/modules/Product/Repository/ProductCategoryRepository.php
@@ -39,16 +39,32 @@ class ProductCategoryRepository extends EntityRepository
 
     public function getEnabledVisibleSearchQueryBuilder(): QueryBuilder
     {
-        return $this->createQueryBuilder('c')
-            ->innerJoin(Product::class, 'p', 'WITH', 'p.productCategoryId = c.id')
+        // Arbitrary joins are treated as additional roots by Doctrine's paginator, which adds
+        // their identifiers to the SELECT and breaks this aggregate under ONLY_FULL_GROUP_BY.
+        $productFilter = $this->getEntityManager()->createQueryBuilder()
+            ->select('1')
+            ->from(Product::class, 'p')
+            ->andWhere('p.productCategoryId = c.id')
             ->andWhere('p.status = :status')
             ->andWhere('p.hidden = :hidden')
-            ->andWhere('p.isAddon = :isAddon')
+            ->andWhere('p.isAddon = :isAddon');
+
+        $maximumPriority = $this->getEntityManager()->createQueryBuilder()
+            ->select('MAX(priorityProduct.priority)')
+            ->from(Product::class, 'priorityProduct')
+            ->andWhere('priorityProduct.productCategoryId = c.id')
+            ->andWhere('priorityProduct.status = :status')
+            ->andWhere('priorityProduct.hidden = :hidden')
+            ->andWhere('priorityProduct.isAddon = :isAddon');
+
+        $queryBuilder = $this->createQueryBuilder('c');
+
+        return $queryBuilder
+            ->andWhere($queryBuilder->expr()->exists($productFilter->getDQL()))
             ->setParameter('status', 'enabled')
             ->setParameter('hidden', false)
             ->setParameter('isAddon', false)
-            ->addSelect('MAX(p.priority) AS HIDDEN maxPriority')
-            ->groupBy('c.id')
+            ->addSelect(sprintf('(%s) AS HIDDEN maxPriority', $maximumPriority->getDQL()))
             ->orderBy('maxPriority', 'ASC');
     }
 

--- a/src/modules/Product/Repository/ProductCategoryRepository.php
+++ b/src/modules/Product/Repository/ProductCategoryRepository.php
@@ -41,21 +41,19 @@ class ProductCategoryRepository extends EntityRepository
     {
         // Arbitrary joins are treated as additional roots by Doctrine's paginator, which adds
         // their identifiers to the SELECT and breaks this aggregate under ONLY_FULL_GROUP_BY.
-        $productFilter = $this->getEntityManager()->createQueryBuilder()
-            ->select('1')
-            ->from(Product::class, 'p')
-            ->andWhere('p.productCategoryId = c.id')
-            ->andWhere('p.status = :status')
-            ->andWhere('p.hidden = :hidden')
-            ->andWhere('p.isAddon = :isAddon');
+        $productFilter = $this->applyEnabledVisibleProductFilters(
+            $this->getEntityManager()->createQueryBuilder()
+                ->select('1')
+                ->from(Product::class, 'p'),
+            'p',
+        );
 
-        $maximumPriority = $this->getEntityManager()->createQueryBuilder()
-            ->select('MAX(priorityProduct.priority)')
-            ->from(Product::class, 'priorityProduct')
-            ->andWhere('priorityProduct.productCategoryId = c.id')
-            ->andWhere('priorityProduct.status = :status')
-            ->andWhere('priorityProduct.hidden = :hidden')
-            ->andWhere('priorityProduct.isAddon = :isAddon');
+        $maximumPriority = $this->applyEnabledVisibleProductFilters(
+            $this->getEntityManager()->createQueryBuilder()
+                ->select('MAX(priorityProduct.priority)')
+                ->from(Product::class, 'priorityProduct'),
+            'priorityProduct',
+        );
 
         $queryBuilder = $this->createQueryBuilder('c');
 
@@ -66,6 +64,15 @@ class ProductCategoryRepository extends EntityRepository
             ->setParameter('isAddon', false)
             ->addSelect(sprintf('(%s) AS HIDDEN maxPriority', $maximumPriority->getDQL()))
             ->orderBy('maxPriority', 'ASC');
+    }
+
+    private function applyEnabledVisibleProductFilters(QueryBuilder $queryBuilder, string $alias): QueryBuilder
+    {
+        return $queryBuilder
+            ->andWhere(sprintf('%s.productCategoryId = c.id', $alias))
+            ->andWhere(sprintf('%s.status = :status', $alias))
+            ->andWhere(sprintf('%s.hidden = :hidden', $alias))
+            ->andWhere(sprintf('%s.isAddon = :isAddon', $alias));
     }
 
     public function findById(int $id): ?ProductCategory

--- a/src/modules/Product/tests/Unit/Repository/ProductCategoryRepositoryTest.php
+++ b/src/modules/Product/tests/Unit/Repository/ProductCategoryRepositoryTest.php
@@ -13,23 +13,23 @@ declare(strict_types=1);
 use Box\Mod\Product\Entity\Product;
 use Box\Mod\Product\Entity\ProductCategory;
 use Box\Mod\Product\Repository\ProductCategoryRepository;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\QueryBuilder;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
 
 function productCategoryRepositoryCreateRepository(): ProductCategoryRepository
 {
-    $entityManager = Mockery::mock(EntityManagerInterface::class);
-    $classMetadata = Mockery::mock(ClassMetadata::class);
-    $classMetadata->name = ProductCategory::class;
-    $classMetadata->shouldReceive('getName')->andReturn(ProductCategory::class);
+    $config = ORMSetup::createAttributeMetadataConfig(
+        paths: [dirname(__DIR__, 3) . '/Entity'],
+        isDevMode: true,
+    );
+    $config->setProxyDir(sys_get_temp_dir());
+    $config->setProxyNamespace('FOSSBillingTestProxies');
 
-    $entityManager->shouldReceive('createQueryBuilder')
-        ->andReturnUsing(static fn (): QueryBuilder => new QueryBuilder($entityManager));
-    $entityManager->shouldReceive('getExpressionBuilder')->andReturn(new Expr());
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $entityManager = new EntityManager($connection, $config);
 
-    return new ProductCategoryRepository($entityManager, $classMetadata);
+    return new ProductCategoryRepository($entityManager, $entityManager->getClassMetadata(ProductCategory::class));
 }
 
 test('enabled visible category query avoids a joined product paginator root', function (): void {
@@ -42,4 +42,8 @@ test('enabled visible category query avoids a joined product paginator root', fu
         ->toContain(sprintf('(SELECT MAX(priorityProduct.priority) FROM %s priorityProduct', Product::class))
         ->not->toContain('GROUP BY');
     expect($queryBuilder->getParameters()->toArray())->toHaveCount(3);
+
+    expect($queryBuilder->getQuery()->getSQL())
+        ->toBeString()
+        ->not->toBeEmpty();
 });

--- a/src/modules/Product/tests/Unit/Repository/ProductCategoryRepositoryTest.php
+++ b/src/modules/Product/tests/Unit/Repository/ProductCategoryRepositoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+declare(strict_types=1);
+
+use Box\Mod\Product\Entity\Product;
+use Box\Mod\Product\Entity\ProductCategory;
+use Box\Mod\Product\Repository\ProductCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+
+function productCategoryRepositoryCreateRepository(): ProductCategoryRepository
+{
+    $entityManager = Mockery::mock(EntityManagerInterface::class);
+    $classMetadata = Mockery::mock(ClassMetadata::class);
+    $classMetadata->name = ProductCategory::class;
+    $classMetadata->shouldReceive('getName')->andReturn(ProductCategory::class);
+
+    $entityManager->shouldReceive('createQueryBuilder')
+        ->andReturnUsing(static fn (): QueryBuilder => new QueryBuilder($entityManager));
+    $entityManager->shouldReceive('getExpressionBuilder')->andReturn(new Expr());
+
+    return new ProductCategoryRepository($entityManager, $classMetadata);
+}
+
+test('enabled visible category query avoids a joined product paginator root', function (): void {
+    $queryBuilder = productCategoryRepositoryCreateRepository()->getEnabledVisibleSearchQueryBuilder();
+    $dql = $queryBuilder->getDQL();
+
+    expect($queryBuilder->getDQLPart('join'))->toBe([]);
+    expect($dql)
+        ->toContain(sprintf('EXISTS(SELECT 1 FROM %s p', Product::class))
+        ->toContain(sprintf('(SELECT MAX(priorityProduct.priority) FROM %s priorityProduct', Product::class))
+        ->not->toContain('GROUP BY');
+    expect($queryBuilder->getParameters()->toArray())->toHaveCount(3);
+});


### PR DESCRIPTION
This pull request refactors the `getEnabledVisibleSearchQueryBuilder` method in the `ProductCategoryRepository` to avoid issues with Doctrine's paginator when using SQL aggregate functions under `ONLY_FULL_GROUP_BY` mode. The change replaces a direct join and group by with subqueries, ensuring compatibility and correctness.