### PR TITLE
Limit daily batch invoice reminders and adjust cron job order

### DIFF
--- a/src/cron.php
+++ b/src/cron.php
@@ -35,7 +35,7 @@ try {
     if (Environment::isCLI()) {
         echo $success
             ? "\e[32mSuccessfully ran the cron jobs.\e[0m"
-            : "\e[31mCron jobs finished with failures. Check the logs for details.\e[0m";
+            : "\e[31mCron jobs finished with failures. Check the logs for details.\e[0m" . PHP_EOL;
     }
 }
 

--- a/src/cron.php
+++ b/src/cron.php
@@ -17,6 +17,8 @@ $di = include Path::join(PATH_ROOT, 'di.php');
 
 $di['translate']();
 
+$success = false;
+
 try {
     $interval = $argv[1] ?? null;
     $service = $di['mod_service']('cron');
@@ -26,11 +28,19 @@ try {
         echo "\e[34mLast executed: {$service->getLastExecutionTime()}.\e[0m";
     }
 
-    $service->runCrons($interval);
+    $success = $service->runCrons($interval);
 } catch (Exception $exception) {
     throw new Exception($exception->getMessage(), $exception->getCode(), $exception);
 } finally {
     if (Environment::isCLI()) {
-        echo "\e[32mSuccessfully ran the cron jobs.\e[0m";
+        echo $success
+            ? "\e[32mSuccessfully ran the cron jobs.\e[0m"
+            : "\e[31mCron jobs finished with failures. Check the logs for details.\e[0m";
     }
+}
+
+// Surface partial failures (e.g. an isolated cron task that threw) via a non-zero exit code so
+// system cron monitors relying on the process exit status can detect them.
+if (Environment::isCLI() && !$success) {
+    exit(1);
 }

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','87',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','88',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -618,7 +618,8 @@ CREATE TABLE `invoice` (
   `hash_expires_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `hash` (`hash`),
-  KEY `client_id_idx` (`client_id`)
+  KEY `client_id_idx` (`client_id`),
+  KEY `invoice_status_approved_due_at_idx` (`status`, `approved`, `due_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -497,6 +497,7 @@ class UpdatePatcher implements InjectionAwareInterface
             85 => 'patch85',
             86 => 'patch86',
             87 => 'patch87',
+            88 => 'patch88',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2336,6 +2337,16 @@ class UpdatePatcher implements InjectionAwareInterface
 
         if (!$this->tableHasColumn('activity_client_email', 'attachment_mime')) {
             $this->executeSql('ALTER TABLE `activity_client_email` ADD COLUMN `attachment_mime` varchar(100) DEFAULT NULL');
+        }
+    }
+
+    private function patch88(): void
+    {
+        // Invoice reminder batches now query unpaid/approved invoices by due date on every cron
+        // run (instead of once a day), so index the columns those queries filter on.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/3963
+        if (!$this->tableHasIndex('invoice', 'invoice_status_approved_due_at_idx')) {
+            $this->executeSql('ALTER TABLE `invoice` ADD INDEX `invoice_status_approved_due_at_idx` (`status`, `approved`, `due_at`)');
         }
     }
 

--- a/src/modules/Cron/Commands/Run.php
+++ b/src/modules/Cron/Commands/Run.php
@@ -54,12 +54,19 @@ class Run extends Command implements \FOSSBilling\InjectionAwareInterface
         ]);
 
         try {
-            $service->runCrons($interval);
+            $success = $service->runCrons($interval);
         } catch (\Exception $e) {
             $output->writeln("<error>An error occurred: {$e->getMessage()}</error>");
 
             return Command::FAILURE;
         }
+
+        if (!$success) {
+            $output->writeln('<error>Cron jobs finished with failures. Check the logs for details.</error>');
+
+            return Command::FAILURE;
+        }
+
         $output->writeln('<info>Successfully ran the cron jobs.</info>');
 
         return Command::SUCCESS;

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -95,7 +95,14 @@ class Service
                     $this->_exec($api, $method);
                 } catch (\Throwable $exception) {
                     $failedTasks[] = $method;
-                    $this->di['logger']->setChannel('cron')->error("Failed to run cron task {$method}: {$exception}");
+                    $this->di['logger']->setChannel('cron')->error(sprintf(
+                        'Failed to run cron task %s: %s: %s in %s:%d',
+                        $method,
+                        $exception::class,
+                        $exception->getMessage(),
+                        $exception->getFile(),
+                        $exception->getLine()
+                    ));
                 }
             }
 

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -89,11 +89,13 @@ class Service
                 'cart_batch_expire',
                 'email_batch_sendmail',
             ];
+            $failedTasks = [];
             foreach ($isolatedTasks as $method) {
                 try {
                     $this->_exec($api, $method);
                 } catch (\Throwable $exception) {
-                    $this->di['logger']->setChannel('cron')->error("Failed to run cron task {$method}: {$exception->getMessage()}");
+                    $failedTasks[] = $method;
+                    $this->di['logger']->setChannel('cron')->error("Failed to run cron task {$method}: {$exception}");
                 }
             }
 
@@ -105,6 +107,13 @@ class Service
             $this->di['logger']->setChannel('cron')->info("Cleared {$count} outdated sessions from the database.");
 
             $this->di['events_manager']->fire(['event' => 'onAfterAdminCronRun']);
+
+            if ($failedTasks !== []) {
+                $this->di['logger']->setChannel('cron')->warning('Finished executing cron jobs, but the following tasks failed: ' . implode(', ', $failedTasks) . '.');
+
+                return false;
+            }
+
             $this->di['logger']->setChannel('cron')->info('Finished executing cron jobs.');
 
             return true;

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -78,8 +78,8 @@ class Service
 
             $this->_exec($api, 'invoice_batch_pay_with_credits');
             $this->_exec($api, 'invoice_batch_activate_paid');
-            $this->_exec($api, 'invoice_batch_send_reminders');
             $this->_exec($api, 'invoice_batch_generate');
+            $this->_exec($api, 'invoice_batch_send_reminders');
             $this->_exec($api, 'invoice_batch_invoke_due_event');
             $this->_exec($api, 'order_batch_suspend_expired');
             $this->_exec($api, 'order_batch_cancel_suspended');

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -93,7 +93,7 @@ class Service
                 try {
                     $this->_exec($api, $method);
                 } catch (\Throwable $exception) {
-                    $this->di['logger']->error("Failed to run cron task {$method}: {$exception->getMessage()}");
+                    $this->di['logger']->setChannel('cron')->error("Failed to run cron task {$method}: {$exception->getMessage()}");
                 }
             }
 

--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -78,15 +78,24 @@ class Service
 
             $this->_exec($api, 'invoice_batch_pay_with_credits');
             $this->_exec($api, 'invoice_batch_activate_paid');
-            $this->_exec($api, 'invoice_batch_generate');
-            $this->_exec($api, 'invoice_batch_send_reminders');
-            $this->_exec($api, 'invoice_batch_invoke_due_event');
-            $this->_exec($api, 'order_batch_suspend_expired');
-            $this->_exec($api, 'order_batch_cancel_suspended');
-            $this->_exec($api, 'support_batch_ticket_auto_close');
-            $this->_exec($api, 'client_batch_expire_password_reminders');
-            $this->_exec($api, 'cart_batch_expire');
-            $this->_exec($api, 'email_batch_sendmail');
+            $isolatedTasks = [
+                'invoice_batch_generate',
+                'invoice_batch_send_reminders',
+                'invoice_batch_invoke_due_event',
+                'order_batch_suspend_expired',
+                'order_batch_cancel_suspended',
+                'support_batch_ticket_auto_close',
+                'client_batch_expire_password_reminders',
+                'cart_batch_expire',
+                'email_batch_sendmail',
+            ];
+            foreach ($isolatedTasks as $method) {
+                try {
+                    $this->_exec($api, $method);
+                } catch (\Throwable $exception) {
+                    $this->di['logger']->error("Failed to run cron task {$method}: {$exception->getMessage()}");
+                }
+            }
 
             // Update the last time cron was executed
             $this->di['mod_service']('system')->setParamValue('last_cron_exec', date('Y-m-d H:i:s'), true);

--- a/src/modules/Cron/tests/Unit/ServiceTest.php
+++ b/src/modules/Cron/tests/Unit/ServiceTest.php
@@ -18,11 +18,13 @@ class CronServiceApiDouble
 {
     public ?string $method = null;
     public mixed $params = null;
+    public array $methods = [];
 
     public function __call(string $method, array $arguments): void
     {
         $this->method = $method;
         $this->params = $arguments[0] ?? null;
+        $this->methods[] = $method;
     }
 }
 
@@ -85,6 +87,44 @@ test('exec passes empty array when cron task has no params', function (): void {
 
     expect($api->method)->toBe('invoice_batch_pay_with_credits');
     expect($api->params)->toBe([]);
+});
+
+test('runCrons generates invoices before processing reminder intervals', function (): void {
+    $updateFinalization = Mockery::mock();
+    $updateFinalization->shouldReceive('isRequired')->once()->andReturnFalse();
+
+    $eventsManager = Mockery::mock('\\Box_EventManager');
+    $eventsManager->shouldReceive('fire')->twice();
+
+    $systemService = Mockery::mock(Box\Mod\System\Service::class);
+    $systemService->shouldReceive('setParamValue')
+        ->once()
+        ->with('last_cron_exec', Mockery::type('string'), true);
+
+    $db = Mockery::mock('\\Box_Database');
+    $db->shouldReceive('exec')->once()->andReturn(0);
+
+    $api = new CronServiceApiDouble();
+    $di = container();
+    $di['api_system'] = $api;
+    $di['db'] = $db;
+    $di['events_manager'] = $eventsManager;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+    $di['update_finalization'] = $updateFinalization;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    ob_start();
+    $service->runCrons();
+    ob_end_clean();
+
+    $positions = array_flip($api->methods);
+    expect($positions['invoice_batch_generate'])
+        ->toBeLessThan($positions['invoice_batch_send_reminders'])
+        ->and($positions['invoice_batch_send_reminders'])
+        ->toBeLessThan($positions['invoice_batch_invoke_due_event']);
 });
 
 test('runCrons restores the previous cron context when update finalization interrupts execution', function (): void {

--- a/src/modules/Cron/tests/Unit/ServiceTest.php
+++ b/src/modules/Cron/tests/Unit/ServiceTest.php
@@ -122,11 +122,12 @@ test('runCrons isolates failures in core batch tasks', function (string $failedT
     $service->setDi($di);
 
     ob_start();
-    $service->runCrons();
+    $result = $service->runCrons();
     ob_end_clean();
 
     $positions = array_flip($api->methods);
-    expect($positions['invoice_batch_generate'])
+    expect($result)->toBeFalse()
+        ->and($positions['invoice_batch_generate'])
         ->toBeLessThan($positions['invoice_batch_send_reminders'])
         ->and($positions['invoice_batch_send_reminders'])
         ->toBeLessThan($positions['invoice_batch_invoke_due_event'])

--- a/src/modules/Cron/tests/Unit/ServiceTest.php
+++ b/src/modules/Cron/tests/Unit/ServiceTest.php
@@ -19,12 +19,16 @@ class CronServiceApiDouble
     public ?string $method = null;
     public mixed $params = null;
     public array $methods = [];
+    public ?string $throwOn = null;
 
     public function __call(string $method, array $arguments): void
     {
         $this->method = $method;
         $this->params = $arguments[0] ?? null;
         $this->methods[] = $method;
+        if ($method === $this->throwOn) {
+            throw new RuntimeException("Failed to run {$method}");
+        }
     }
 }
 
@@ -89,7 +93,7 @@ test('exec passes empty array when cron task has no params', function (): void {
     expect($api->params)->toBe([]);
 });
 
-test('runCrons generates invoices before processing reminder intervals', function (): void {
+test('runCrons isolates failures in core batch tasks', function (string $failedTask): void {
     $updateFinalization = Mockery::mock();
     $updateFinalization->shouldReceive('isRequired')->once()->andReturnFalse();
 
@@ -105,6 +109,7 @@ test('runCrons generates invoices before processing reminder intervals', functio
     $db->shouldReceive('exec')->once()->andReturn(0);
 
     $api = new CronServiceApiDouble();
+    $api->throwOn = $failedTask;
     $di = container();
     $di['api_system'] = $api;
     $di['db'] = $db;
@@ -124,8 +129,19 @@ test('runCrons generates invoices before processing reminder intervals', functio
     expect($positions['invoice_batch_generate'])
         ->toBeLessThan($positions['invoice_batch_send_reminders'])
         ->and($positions['invoice_batch_send_reminders'])
-        ->toBeLessThan($positions['invoice_batch_invoke_due_event']);
-});
+        ->toBeLessThan($positions['invoice_batch_invoke_due_event'])
+        ->and($api->methods)->toContain('email_batch_sendmail');
+})->with([
+    'invoice generation' => 'invoice_batch_generate',
+    'invoice reminders' => 'invoice_batch_send_reminders',
+    'invoice due events' => 'invoice_batch_invoke_due_event',
+    'order suspension' => 'order_batch_suspend_expired',
+    'order cancellation' => 'order_batch_cancel_suspended',
+    'support ticket auto-close' => 'support_batch_ticket_auto_close',
+    'password reminder expiry' => 'client_batch_expire_password_reminders',
+    'cart expiry' => 'cart_batch_expire',
+    'email queue' => 'email_batch_sendmail',
+]);
 
 test('runCrons restores the previous cron context when update finalization interrupts execution', function (): void {
     $updateFinalization = Mockery::mock()->shouldIgnoreMissing();

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -505,12 +505,8 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $queue->setAttachmentMime((string) ($attachment['mime'] ?? 'application/octet-stream'));
         }
 
-        try {
-            $em->persist($queue);
-            $em->flush();
-        } catch (\Exception $e) {
-            error_log($e->getMessage());
-        }
+        $em->persist($queue);
+        $em->flush();
 
         return $queue;
     }

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -283,11 +283,12 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
-     * Attempts the invoice due event batch (see batch_invoke_due_event()), limited to once
-     * per rolling 24-hour period. If that batch ran within the previous 24 hours, it falls
-     * back to a reminded_at-based check for invoices that became reminder-eligible afterward.
-     * Both paths claim each invoice atomically before firing its reminder event, so the same
-     * invoice is never reminded twice even across overlapping cron runs.
+     * Attempts the invoice due event batch (see batch_invoke_due_event()), limited to once per
+     * rolling 24-hour period. If that batch ran within the previous 24 hours, it falls back to
+     * dispatching the same due-date events directly so newly-eligible invoices are not missed
+     * for up to 24 hours. Either way, the built-in reminder handlers atomically claim each
+     * invoice via reminded_at before sending anything, so the same invoice is never reminded
+     * twice even across overlapping cron runs or repeated dispatch of the underlying events.
      *
      * @return bool
      */

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -283,9 +283,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
-     * Triggers the once-daily invoice due event batch (see batch_invoke_due_event()) and,
-     * if that batch already ran today, falls back to a reminded_at-based check so invoices
-     * that only became reminder-eligible after today's run are still caught.
+     * Attempts the invoice due event batch (see batch_invoke_due_event()), limited to once
+     * per rolling 24-hour period. If that batch ran within the previous 24 hours, it falls
+     * back to a reminded_at-based check for invoices that became reminder-eligible afterward.
+     * Both paths claim each invoice atomically before firing its reminder event, so the same
+     * invoice is never reminded twice even across overlapping cron runs.
      *
      * @return bool
      */

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -283,9 +283,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
-     * Legacy hook point for buyer payment reminders.
-     *
-     * Automatic reminder intervals are processed by batch_invoke_due_event().
+     * Triggers the once-daily invoice due event batch (see batch_invoke_due_event()) and,
+     * if that batch already ran today, falls back to a reminded_at-based check so invoices
+     * that only became reminder-eligible after today's run are still caught.
      *
      * @return bool
      */

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -505,6 +505,18 @@ class Service implements InjectionAwareInterface
                 return;
             }
 
+            // Atomically claim the invoice before sending anything: this is what stops the same
+            // reminder being sent twice when this event is dispatched more than once for the
+            // same invoice (overlapping cron runs, the once-daily batch and the pending-reminder
+            // fallback both firing it, etc).
+            $claimed = $di['db']->exec(
+                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
+                [':id' => $params['id'] ?? 0]
+            );
+            if (!$claimed) {
+                return;
+            }
+
             $invoiceModel = $di['db']->load('Invoice', $params['id'] ?? 0);
             if ($invoiceModel instanceof \Model_Invoice) {
                 $service->sendInvoiceReminder($invoiceModel);
@@ -537,6 +549,18 @@ class Service implements InjectionAwareInterface
 
         try {
             if (!$service->isInvoiceReminderIntervalEnabled('invoice_reminder_after_due_days', (int) ($params['days_passed'] ?? 0), '5', $params['reminder_intervals'] ?? null)) {
+                return;
+            }
+
+            // Atomically claim the invoice before sending anything: this is what stops the same
+            // reminder being sent twice when this event is dispatched more than once for the
+            // same invoice (overlapping cron runs, the once-daily batch and the pending-reminder
+            // fallback both firing it, etc).
+            $claimed = $di['db']->exec(
+                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
+                [':id' => $params['id'] ?? 0]
+            );
+            if (!$claimed) {
                 return;
             }
 
@@ -1439,81 +1463,38 @@ class Service implements InjectionAwareInterface
 
     protected function doBatchInvokePendingReminderEvents(): bool
     {
-        return $this->fireDueReminderEvents();
+        $this->fireDueReminderEvents();
+
+        return true;
     }
 
     /**
-     * Claims and fires due-reminder events for eligible invoices.
-     *
-     * Both the once-daily primary batch and the pending-reminder fallback call this, so an
-     * invoice can only be claimed by whichever cron run reaches it first, and neither path can
-     * re-send a reminder the other already recorded via reminded_at (even across a calendar day
-     * boundary).
+     * Fires the before/after due-date events for every unpaid, approved invoice in range, same
+     * as before this class started reminder-throttling. Listeners (built-in or third-party
+     * extensions) decide for themselves whether a given invoice is actionable; this method does
+     * not filter by reminder interval so it does not narrow what extensions can observe. The
+     * built-in reminder handlers (onEventBeforeInvoiceIsDue, onEventAfterInvoiceIsDue) are the
+     * ones responsible for matching the configured interval and atomically claiming the invoice
+     * via reminded_at before actually sending anything, which is what keeps overlapping cron
+     * runs and repeated dispatch of this same event from sending duplicate reminders.
      */
-    private function fireDueReminderEvents(): bool
+    private function fireDueReminderEvents(): void
     {
         $ss = $this->di['mod_service']('System');
         $beforeDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_before_due_days', ''));
         $afterDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_after_due_days', '5'));
 
-        $invokedBefore = $this->claimAndFireReminderEvents(
-            'DATEDIFF(due_at, NOW())',
-            'days_left',
-            'due_at > NOW()',
-            $beforeDueReminderIntervals,
-            'onEventBeforeInvoiceIsDue'
-        );
-
-        $invokedAfter = $this->claimAndFireReminderEvents(
-            'ABS(DATEDIFF(due_at, NOW()))',
-            'days_passed',
-            '(due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)',
-            $afterDueReminderIntervals,
-            'onEventAfterInvoiceIsDue'
-        );
-
-        return $invokedBefore || $invokedAfter;
-    }
-
-    /**
-     * Selects invoices whose due-date offset matches one of the configured reminder intervals
-     * and have not already been reminded today, atomically claims each one by updating
-     * reminded_at, and fires the reminder event only for invoices it successfully claimed. The
-     * atomic claim (rather than checking reminded_at then firing separately) is what prevents
-     * overlapping cron runs from sending the same reminder twice.
-     *
-     * @param string $dayExpression  SQL expression producing the invoice's day offset from due_at
-     * @param string $dayAlias       result column alias for $dayExpression, also used as the event param key
-     * @param string $rangeCondition SQL condition scoping the query to before-due or after-due invoices
-     * @param int[]  $intervals      configured reminder day offsets; empty means nothing is due
-     */
-    private function claimAndFireReminderEvents(string $dayExpression, string $dayAlias, string $rangeCondition, array $intervals, string $event): bool
-    {
-        if ($intervals === []) {
-            return false;
+        $beforeDueList = $this->di['db']->getAll("SELECT id, DATEDIFF(due_at, NOW()) as days_left FROM invoice WHERE status = 'unpaid' AND approved = 1 AND due_at > NOW()");
+        foreach ($beforeDueList as $params) {
+            $params['reminder_intervals'] = $beforeDueReminderIntervals;
+            $this->di['events_manager']->fire(['event' => 'onEventBeforeInvoiceIsDue', 'params' => $params]);
         }
 
-        // $intervals only ever contains ints (see parseInvoiceReminderIntervals), so it is safe to inline here.
-        $days = implode(', ', $intervals);
-        $eligibility = "status = 'unpaid' AND approved = 1 AND ({$rangeCondition}) AND {$dayExpression} IN ({$days}) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())";
-
-        $invoked = false;
-        $candidates = $this->di['db']->getAll("SELECT id, {$dayExpression} as {$dayAlias} FROM invoice WHERE {$eligibility}");
-        foreach ($candidates as $params) {
-            $claimed = $this->di['db']->exec(
-                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND {$eligibility}",
-                [':id' => $params['id']]
-            );
-            if (!$claimed) {
-                continue;
-            }
-
-            $params['reminder_intervals'] = $intervals;
-            $this->di['events_manager']->fire(['event' => $event, 'params' => $params]);
-            $invoked = true;
+        $afterDueList = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0))");
+        foreach ($afterDueList as $params) {
+            $params['reminder_intervals'] = $afterDueReminderIntervals;
+            $this->di['events_manager']->fire(['event' => 'onEventAfterInvoiceIsDue', 'params' => $params]);
         }
-
-        return $invoked;
     }
 
     public function sendInvoiceReminder(\Model_Invoice $invoice): bool

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1393,7 +1393,9 @@ class Service implements InjectionAwareInterface
     {
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminInvoiceSendReminders']);
         $result = $this->doBatchInvokeDueEvent(['once_per_day' => true]);
-        $this->di['logger']->info('Executed action to send invoice payment reminders.');
+        if ($result) {
+            $this->di['logger']->info('Executed action to send invoice payment reminders.');
+        }
 
         return $result;
     }

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1392,7 +1392,7 @@ class Service implements InjectionAwareInterface
     public function doBatchRemindersSend(): bool
     {
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminInvoiceSendReminders']);
-        $result = $this->doBatchInvokeDueEvent(['once_per_day' => false]);
+        $result = $this->doBatchInvokeDueEvent(['once_per_day' => true]);
         $this->di['logger']->info('Executed action to send invoice payment reminders.');
 
         return $result;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -551,10 +551,11 @@ class Service implements InjectionAwareInterface
             }
 
             $emailService = $di['mod_service']('email');
+            $emailService->sendTemplate($email);
+
             $invoiceModel->reminded_at = date('Y-m-d H:i:s');
             $invoiceModel->updated_at = date('Y-m-d H:i:s');
             $di['db']->store($invoiceModel);
-            $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
             $di['logger']->setChannel('email')->error('Failed to send overdue invoice email', ['exception' => $exc->getMessage()]);
         }
@@ -1450,7 +1451,7 @@ class Service implements InjectionAwareInterface
 
         $beforeDueList = $this->di['db']->getAll("SELECT id, DATEDIFF(due_at, NOW()) as days_left FROM invoice WHERE status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
         foreach ($beforeDueList as $params) {
-            if (!in_array((int) $params['days_left'], $beforeDueReminderIntervals, true)) {
+            if (!$this->isInvoiceReminderIntervalEnabled('invoice_reminder_before_due_days', (int) $params['days_left'], '', $beforeDueReminderIntervals)) {
                 continue;
             }
 
@@ -1461,7 +1462,7 @@ class Service implements InjectionAwareInterface
 
         $afterDueList = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
         foreach ($afterDueList as $params) {
-            if (!in_array((int) $params['days_passed'], $afterDueReminderIntervals, true)) {
+            if (!$this->isInvoiceReminderIntervalEnabled('invoice_reminder_after_due_days', (int) $params['days_passed'], '5', $afterDueReminderIntervals)) {
                 continue;
             }
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -510,7 +510,9 @@ class Service implements InjectionAwareInterface
                 $service->sendInvoiceReminder($invoiceModel);
             }
         } catch (\Exception $exc) {
-            $di['logger']->setChannel('email')->error('Failed to send invoice reminder email', ['exception' => $exc->getMessage()]);
+            // The invoice may already be claimed/marked as reminded by the batch that fired this
+            // event even though the send below failed, so it will not be retried automatically.
+            $di['logger']->setChannel('email')->error('Failed to send invoice reminder email; invoice may need a manual resend', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
         }
     }
 
@@ -561,7 +563,9 @@ class Service implements InjectionAwareInterface
             $invoiceModel->updated_at = date('Y-m-d H:i:s');
             $di['db']->store($invoiceModel);
         } catch (\Exception $exc) {
-            $di['logger']->setChannel('email')->error('Failed to send overdue invoice email', ['exception' => $exc->getMessage()]);
+            // The invoice may already be claimed/marked as reminded by the batch that fired this
+            // event even though the send above failed, so it will not be retried automatically.
+            $di['logger']->setChannel('email')->error('Failed to send overdue invoice email; invoice may need a manual resend', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
         }
     }
 
@@ -1425,20 +1429,7 @@ class Service implements InjectionAwareInterface
             return false;
         }
 
-        $beforeDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_before_due_days', ''));
-        $afterDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_after_due_days', '5'));
-
-        $before_due_list = $this->di['db']->getAll("SELECT id, DATEDIFF(due_at, NOW()) as days_left FROM invoice WHERE status = 'unpaid' AND approved = 1 AND due_at > NOW()");
-        foreach ($before_due_list as $params) {
-            $params['reminder_intervals'] = $beforeDueReminderIntervals;
-            $this->di['events_manager']->fire(['event' => 'onEventBeforeInvoiceIsDue', 'params' => $params]);
-        }
-
-        $after_due_list = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0 ))");
-        foreach ($after_due_list as $params) {
-            $params['reminder_intervals'] = $afterDueReminderIntervals;
-            $this->di['events_manager']->fire(['event' => 'onEventAfterInvoiceIsDue', 'params' => $params]);
-        }
+        $this->fireDueReminderEvents();
 
         $ss->setParamValue($key, date('Y-m-d H:i:s'));
         $this->di['logger']->info('Executed action to invoke invoice due event');
@@ -1448,46 +1439,77 @@ class Service implements InjectionAwareInterface
 
     protected function doBatchInvokePendingReminderEvents(): bool
     {
-        $systemService = $this->di['mod_service']('System');
-        $beforeDueReminderIntervals = $this->parseInvoiceReminderIntervals($systemService->getParamValue('invoice_reminder_before_due_days', ''));
-        $afterDueReminderIntervals = $this->parseInvoiceReminderIntervals($systemService->getParamValue('invoice_reminder_after_due_days', '5'));
-        $invoked = false;
+        return $this->fireDueReminderEvents();
+    }
 
-        $beforeDueList = $this->di['db']->getAll("SELECT id, DATEDIFF(due_at, NOW()) as days_left FROM invoice WHERE status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
-        foreach ($beforeDueList as $params) {
-            if (!$this->isInvoiceReminderIntervalEnabled('invoice_reminder_before_due_days', (int) $params['days_left'], '', $beforeDueReminderIntervals)) {
-                continue;
-            }
+    /**
+     * Claims and fires due-reminder events for eligible invoices.
+     *
+     * Both the once-daily primary batch and the pending-reminder fallback call this, so an
+     * invoice can only be claimed by whichever cron run reaches it first, and neither path can
+     * re-send a reminder the other already recorded via reminded_at (even across a calendar day
+     * boundary).
+     */
+    private function fireDueReminderEvents(): bool
+    {
+        $ss = $this->di['mod_service']('System');
+        $beforeDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_before_due_days', ''));
+        $afterDueReminderIntervals = $this->parseInvoiceReminderIntervals($ss->getParamValue('invoice_reminder_after_due_days', '5'));
 
-            $claimed = $this->di['db']->exec(
-                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
-                [':id' => $params['id']]
-            );
-            if (!$claimed) {
-                continue;
-            }
+        $invokedBefore = $this->claimAndFireReminderEvents(
+            'DATEDIFF(due_at, NOW())',
+            'days_left',
+            'due_at > NOW()',
+            $beforeDueReminderIntervals,
+            'onEventBeforeInvoiceIsDue'
+        );
 
-            $params['reminder_intervals'] = $beforeDueReminderIntervals;
-            $this->di['events_manager']->fire(['event' => 'onEventBeforeInvoiceIsDue', 'params' => $params]);
-            $invoked = true;
+        $invokedAfter = $this->claimAndFireReminderEvents(
+            'ABS(DATEDIFF(due_at, NOW()))',
+            'days_passed',
+            '(due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)',
+            $afterDueReminderIntervals,
+            'onEventAfterInvoiceIsDue'
+        );
+
+        return $invokedBefore || $invokedAfter;
+    }
+
+    /**
+     * Selects invoices whose due-date offset matches one of the configured reminder intervals
+     * and have not already been reminded today, atomically claims each one by updating
+     * reminded_at, and fires the reminder event only for invoices it successfully claimed. The
+     * atomic claim (rather than checking reminded_at then firing separately) is what prevents
+     * overlapping cron runs from sending the same reminder twice.
+     *
+     * @param string $dayExpression  SQL expression producing the invoice's day offset from due_at
+     * @param string $dayAlias       result column alias for $dayExpression, also used as the event param key
+     * @param string $rangeCondition SQL condition scoping the query to before-due or after-due invoices
+     * @param int[]  $intervals      configured reminder day offsets; empty means nothing is due
+     */
+    private function claimAndFireReminderEvents(string $dayExpression, string $dayAlias, string $rangeCondition, array $intervals, string $event): bool
+    {
+        if ($intervals === []) {
+            return false;
         }
 
-        $afterDueList = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
-        foreach ($afterDueList as $params) {
-            if (!$this->isInvoiceReminderIntervalEnabled('invoice_reminder_after_due_days', (int) $params['days_passed'], '5', $afterDueReminderIntervals)) {
-                continue;
-            }
+        // $intervals only ever contains ints (see parseInvoiceReminderIntervals), so it is safe to inline here.
+        $days = implode(', ', $intervals);
+        $eligibility = "status = 'unpaid' AND approved = 1 AND ({$rangeCondition}) AND {$dayExpression} IN ({$days}) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())";
 
+        $invoked = false;
+        $candidates = $this->di['db']->getAll("SELECT id, {$dayExpression} as {$dayAlias} FROM invoice WHERE {$eligibility}");
+        foreach ($candidates as $params) {
             $claimed = $this->di['db']->exec(
-                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
+                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND {$eligibility}",
                 [':id' => $params['id']]
             );
             if (!$claimed) {
                 continue;
             }
 
-            $params['reminder_intervals'] = $afterDueReminderIntervals;
-            $this->di['events_manager']->fire(['event' => 'onEventAfterInvoiceIsDue', 'params' => $params]);
+            $params['reminder_intervals'] = $intervals;
+            $this->di['events_manager']->fire(['event' => $event, 'params' => $params]);
             $invoked = true;
         }
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -499,6 +499,7 @@ class Service implements InjectionAwareInterface
         $params = $event->getParameters();
         $di = $event->getDi();
         $service = $di['mod_service']('invoice');
+        $claimed = false;
 
         try {
             if (!$service->isInvoiceReminderIntervalEnabled('invoice_reminder_before_due_days', (int) ($params['days_left'] ?? 0), '', $params['reminder_intervals'] ?? null)) {
@@ -509,7 +510,7 @@ class Service implements InjectionAwareInterface
             // reminder being sent twice when this event is dispatched more than once for the
             // same invoice (overlapping cron runs, the once-daily batch and the pending-reminder
             // fallback both firing it, etc).
-            $claimed = $di['db']->exec(
+            $claimed = (bool) $di['db']->exec(
                 "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
                 [':id' => $params['id'] ?? 0]
             );
@@ -522,9 +523,14 @@ class Service implements InjectionAwareInterface
                 $service->sendInvoiceReminder($invoiceModel);
             }
         } catch (\Exception $exc) {
-            // The invoice may already be claimed/marked as reminded by the batch that fired this
-            // event even though the send below failed, so it will not be retried automatically.
-            $di['logger']->setChannel('email')->error('Failed to send invoice reminder email; invoice may need a manual resend', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
+            if ($claimed) {
+                // sendInvoiceReminder()'s downstream send handler (onAfterAdminInvoiceReminderSent)
+                // catches its own failures internally, so any exception reaching here means the
+                // email was never queued. Release the claim so a later cron run retries it instead
+                // of the reminder being silently lost for the day.
+                $di['db']->exec('UPDATE invoice SET reminded_at = NULL WHERE id = :id', [':id' => $params['id'] ?? 0]);
+            }
+            $di['logger']->setChannel('email')->error('Failed to send invoice reminder email', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
         }
     }
 
@@ -546,6 +552,7 @@ class Service implements InjectionAwareInterface
         $params = $event->getParameters();
         $di = $event->getDi();
         $service = $di['mod_service']('invoice');
+        $claimed = false;
 
         try {
             if (!$service->isInvoiceReminderIntervalEnabled('invoice_reminder_after_due_days', (int) ($params['days_passed'] ?? 0), '5', $params['reminder_intervals'] ?? null)) {
@@ -555,8 +562,9 @@ class Service implements InjectionAwareInterface
             // Atomically claim the invoice before sending anything: this is what stops the same
             // reminder being sent twice when this event is dispatched more than once for the
             // same invoice (overlapping cron runs, the once-daily batch and the pending-reminder
-            // fallback both firing it, etc).
-            $claimed = $di['db']->exec(
+            // fallback both firing it, etc). The claim UPDATE already persists reminded_at and
+            // updated_at, so there's no need to store the loaded model again once sent below.
+            $claimed = (bool) $di['db']->exec(
                 "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
                 [':id' => $params['id'] ?? 0]
             );
@@ -582,14 +590,14 @@ class Service implements InjectionAwareInterface
 
             $emailService = $di['mod_service']('email');
             $emailService->sendTemplate($email);
-
-            $invoiceModel->reminded_at = date('Y-m-d H:i:s');
-            $invoiceModel->updated_at = date('Y-m-d H:i:s');
-            $di['db']->store($invoiceModel);
         } catch (\Exception $exc) {
-            // The invoice may already be claimed/marked as reminded by the batch that fired this
-            // event even though the send above failed, so it will not be retried automatically.
-            $di['logger']->setChannel('email')->error('Failed to send overdue invoice email; invoice may need a manual resend', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
+            if ($claimed) {
+                // Nothing past sendTemplate() can throw, so reaching here with a claim already
+                // made means the email was never confirmed queued. Release the claim so a later
+                // cron run retries this invoice instead of losing the reminder.
+                $di['db']->exec('UPDATE invoice SET reminded_at = NULL WHERE id = :id', [':id' => $params['id'] ?? 0]);
+            }
+            $di['logger']->setChannel('email')->error('Failed to send overdue invoice email', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
         }
     }
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -539,6 +539,10 @@ class Service implements InjectionAwareInterface
             }
 
             $invoiceModel = $di['db']->load('Invoice', $params['id']);
+            if (!$invoiceModel instanceof \Model_Invoice) {
+                return;
+            }
+
             $invoice = $service->toApiArray($invoiceModel, true);
             $email = [];
             $email['to_client'] = $invoice['client']['id'];
@@ -1455,6 +1459,14 @@ class Service implements InjectionAwareInterface
                 continue;
             }
 
+            $claimed = $this->di['db']->exec(
+                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
+                [':id' => $params['id']]
+            );
+            if (!$claimed) {
+                continue;
+            }
+
             $params['reminder_intervals'] = $beforeDueReminderIntervals;
             $this->di['events_manager']->fire(['event' => 'onEventBeforeInvoiceIsDue', 'params' => $params]);
             $invoked = true;
@@ -1463,6 +1475,14 @@ class Service implements InjectionAwareInterface
         $afterDueList = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
         foreach ($afterDueList as $params) {
             if (!$this->isInvoiceReminderIntervalEnabled('invoice_reminder_after_due_days', (int) $params['days_passed'], '5', $afterDueReminderIntervals)) {
+                continue;
+            }
+
+            $claimed = $this->di['db']->exec(
+                "UPDATE invoice SET reminded_at = NOW(), updated_at = NOW() WHERE id = :id AND status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())",
+                [':id' => $params['id']]
+            );
+            if (!$claimed) {
                 continue;
             }
 

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -551,6 +551,9 @@ class Service implements InjectionAwareInterface
             }
 
             $emailService = $di['mod_service']('email');
+            $invoiceModel->reminded_at = date('Y-m-d H:i:s');
+            $invoiceModel->updated_at = date('Y-m-d H:i:s');
+            $di['db']->store($invoiceModel);
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {
             $di['logger']->setChannel('email')->error('Failed to send overdue invoice email', ['exception' => $exc->getMessage()]);
@@ -1393,6 +1396,10 @@ class Service implements InjectionAwareInterface
     {
         $this->di['events_manager']->fire(['event' => 'onBeforeAdminInvoiceSendReminders']);
         $result = $this->doBatchInvokeDueEvent(['once_per_day' => true]);
+        if (!$result) {
+            // Pick up invoices that became reminder-eligible after today's due-event batch ran.
+            $result = $this->doBatchInvokePendingReminderEvents();
+        }
         if ($result) {
             $this->di['logger']->info('Executed action to send invoice payment reminders.');
         }
@@ -1432,6 +1439,38 @@ class Service implements InjectionAwareInterface
         $this->di['logger']->info('Executed action to invoke invoice due event');
 
         return true;
+    }
+
+    protected function doBatchInvokePendingReminderEvents(): bool
+    {
+        $systemService = $this->di['mod_service']('System');
+        $beforeDueReminderIntervals = $this->parseInvoiceReminderIntervals($systemService->getParamValue('invoice_reminder_before_due_days', ''));
+        $afterDueReminderIntervals = $this->parseInvoiceReminderIntervals($systemService->getParamValue('invoice_reminder_after_due_days', '5'));
+        $invoked = false;
+
+        $beforeDueList = $this->di['db']->getAll("SELECT id, DATEDIFF(due_at, NOW()) as days_left FROM invoice WHERE status = 'unpaid' AND approved = 1 AND due_at > NOW() AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
+        foreach ($beforeDueList as $params) {
+            if (!in_array((int) $params['days_left'], $beforeDueReminderIntervals, true)) {
+                continue;
+            }
+
+            $params['reminder_intervals'] = $beforeDueReminderIntervals;
+            $this->di['events_manager']->fire(['event' => 'onEventBeforeInvoiceIsDue', 'params' => $params]);
+            $invoked = true;
+        }
+
+        $afterDueList = $this->di['db']->getAll("SELECT id, ABS(DATEDIFF(due_at, NOW())) as days_passed FROM invoice WHERE status = 'unpaid' AND approved = 1 AND ((due_at < NOW()) OR (ABS(DATEDIFF(due_at, NOW())) = 0)) AND (reminded_at IS NULL OR DATE(reminded_at) < CURDATE())");
+        foreach ($afterDueList as $params) {
+            if (!in_array((int) $params['days_passed'], $afterDueReminderIntervals, true)) {
+                continue;
+            }
+
+            $params['reminder_intervals'] = $afterDueReminderIntervals;
+            $this->di['events_manager']->fire(['event' => 'onEventAfterInvoiceIsDue', 'params' => $params]);
+            $invoked = true;
+        }
+
+        return $invoked;
     }
 
     public function sendInvoiceReminder(\Model_Invoice $invoice): bool

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1936,6 +1936,10 @@ test('processes a newly eligible invoice after the daily due event batch', funct
     $dbMock->shouldReceive('getAll')
         ->twice()
         ->andReturn([['id' => 2, 'days_left' => 7]], []);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 2])
+        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')
@@ -1954,6 +1958,48 @@ test('processes a newly eligible invoice after the daily due event batch', funct
     $service->setDi($di);
 
     expect($service->doBatchRemindersSend())->toBeTrue();
+});
+
+test('skips a pending reminder invoice already claimed by another cron run', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('doBatchInvokeDueEvent')
+        ->once()
+        ->with(['once_per_day' => true])
+        ->andReturnFalse();
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_before_due_days', '')
+        ->andReturn('7');
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_after_due_days', '5')
+        ->andReturn('5');
+
+    $dbMock = Mockery::mock('\\Box_Database');
+    $dbMock->shouldReceive('getAll')
+        ->twice()
+        ->andReturn([['id' => 2, 'days_left' => 7]], []);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 2])
+        ->andReturn(0);
+
+    $eventManagerMock = Mockery::mock('\\Box_EventManager');
+    $eventManagerMock->shouldReceive('fire')
+        ->once()
+        ->with(['event' => 'onBeforeAdminInvoiceSendReminders']);
+    $eventManagerMock->shouldNotReceive('fire')
+        ->with(['event' => 'onEventBeforeInvoiceIsDue', 'params' => Mockery::any()]);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['events_manager'] = $eventManagerMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $service->setDi($di);
+
+    expect($service->doBatchRemindersSend())->toBeFalse();
 });
 
 test('guards both reminder cron paths across repeated runs', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -616,6 +616,10 @@ test('handles event after invoice is due', function (): void {
     $invoiceModel = new Model_Invoice();
     $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
     $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(1);
     $dbMock->shouldReceive('load')
         ->atLeast()->once()
         ->andReturn($invoiceModel);
@@ -665,10 +669,58 @@ test('handles event before invoice is due', function (): void {
     $invoiceModel = new Model_Invoice();
     $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
     $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(1);
     $dbMock->shouldReceive('load')
         ->once()
         ->with('Invoice', 1)
         ->andReturn($invoiceModel);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($serviceMock, $systemService) {
+        if ($serviceName == 'invoice') {
+            return $serviceMock;
+        }
+        if ($serviceName == 'system') {
+            return $systemService;
+        }
+    });
+    $di['db'] = $dbMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')
+        ->atLeast()->once()
+        ->andReturn($di);
+
+    $service->onEventBeforeInvoiceIsDue($eventMock);
+});
+
+test('skips before due invoice reminder when the invoice was already claimed', function (): void {
+    $service = new Service();
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('sendInvoiceReminder')
+        ->never();
+
+    $eventMock = Mockery::mock('\Box_Event');
+    $eventMock->shouldReceive('getParameters')
+        ->atLeast()->once()
+        ->andReturn(['days_left' => 7, 'id' => 1]);
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_before_due_days', '')
+        ->andReturn('14, 7, 1');
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(0);
+    $dbMock->shouldReceive('load')
+        ->never();
 
     $di = container();
     $di['mod_service'] = $di->protect(function ($serviceName) use ($serviceMock, $systemService) {
@@ -1917,7 +1969,7 @@ test('does not log reminder batch as executed when it is throttled', function ()
         ->and($logger->calls)->toBeEmpty();
 });
 
-test('processes a newly eligible invoice after the daily due event batch', function (): void {
+test('fires due events via the pending reminder fallback when the primary batch is throttled', function (): void {
     $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $service->shouldReceive('doBatchInvokeDueEvent')
         ->once()
@@ -1936,10 +1988,6 @@ test('processes a newly eligible invoice after the daily due event batch', funct
     $dbMock->shouldReceive('getAll')
         ->twice()
         ->andReturn([['id' => 2, 'days_left' => 7]], []);
-    $dbMock->shouldReceive('exec')
-        ->once()
-        ->with(Mockery::type('string'), [':id' => 2])
-        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')
@@ -1960,49 +2008,7 @@ test('processes a newly eligible invoice after the daily due event batch', funct
     expect($service->doBatchRemindersSend())->toBeTrue();
 });
 
-test('skips a pending reminder invoice already claimed by another cron run', function (): void {
-    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
-    $service->shouldReceive('doBatchInvokeDueEvent')
-        ->once()
-        ->with(['once_per_day' => true])
-        ->andReturnFalse();
-
-    $systemService = Mockery::mock(SystemService::class);
-    $systemService->shouldReceive('getParamValue')
-        ->with('invoice_reminder_before_due_days', '')
-        ->andReturn('7');
-    $systemService->shouldReceive('getParamValue')
-        ->with('invoice_reminder_after_due_days', '5')
-        ->andReturn('5');
-
-    $dbMock = Mockery::mock('\\Box_Database');
-    $dbMock->shouldReceive('getAll')
-        ->twice()
-        ->andReturn([['id' => 2, 'days_left' => 7]], []);
-    $dbMock->shouldReceive('exec')
-        ->once()
-        ->with(Mockery::type('string'), [':id' => 2])
-        ->andReturn(0);
-
-    $eventManagerMock = Mockery::mock('\\Box_EventManager');
-    $eventManagerMock->shouldReceive('fire')
-        ->once()
-        ->with(['event' => 'onBeforeAdminInvoiceSendReminders']);
-    $eventManagerMock->shouldNotReceive('fire')
-        ->with(['event' => 'onEventBeforeInvoiceIsDue', 'params' => Mockery::any()]);
-
-    $di = container();
-    $di['db'] = $dbMock;
-    $di['events_manager'] = $eventManagerMock;
-    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
-    $di['logger'] = new Tests\Helpers\TestLogger();
-
-    $service->setDi($di);
-
-    expect($service->doBatchRemindersSend())->toBeFalse();
-});
-
-test('guards both reminder cron paths across repeated runs', function (): void {
+test('guards the primary reminder batch throttle while the fallback still dispatches', function (): void {
     $lastInvocation = date('Y-m-d H:i:s');
 
     $systemService = Mockery::mock(SystemService::class);
@@ -2026,10 +2032,6 @@ test('guards both reminder cron paths across repeated runs', function (): void {
     $dbMock->shouldReceive('getAll')
         ->times(4)
         ->andReturn([['id' => 1, 'days_left' => 7]], [], [], []);
-    $dbMock->shouldReceive('exec')
-        ->once()
-        ->with(Mockery::type('string'), [':id' => 1])
-        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')
@@ -2048,9 +2050,11 @@ test('guards both reminder cron paths across repeated runs', function (): void {
     $service = new Service();
     $service->setDi($di);
 
+    // Primary batch runs, then is throttled on the direct call, then the fallback still
+    // dispatches due events (broadly, for any listener) even though the primary is throttled.
     expect($service->doBatchRemindersSend())->toBeTrue()
         ->and($service->doBatchInvokeDueEvent([]))->toBeFalse()
-        ->and($service->doBatchRemindersSend())->toBeFalse();
+        ->and($service->doBatchRemindersSend())->toBeTrue();
 });
 
 test('invokes due event in batch', function (): void {
@@ -2072,9 +2076,6 @@ test('invokes due event in batch', function (): void {
     $dbMock->shouldReceive('getAll')
         ->atLeast()->once()
         ->andReturn([['id' => 1]]);
-    $dbMock->shouldReceive('exec')
-        ->atLeast()->once()
-        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1860,11 +1860,11 @@ test('handles exception during batch paid invoice activation', function (): void
     expect($result)->toBeBool()->toBeTrue();
 });
 
-test('sends reminders in batch', function (): void {
+test('sends reminders in batch at most once per day', function (): void {
     $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $service->shouldReceive('doBatchInvokeDueEvent')
         ->once()
-        ->with(['once_per_day' => false])
+        ->with(['once_per_day' => true])
         ->andReturnTrue();
 
     $eventManagerMock = Mockery::mock('\Box_EventManager');

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -2026,6 +2026,10 @@ test('guards both reminder cron paths across repeated runs', function (): void {
     $dbMock->shouldReceive('getAll')
         ->times(4)
         ->andReturn([['id' => 1, 'days_left' => 7]], [], [], []);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')
@@ -2067,7 +2071,10 @@ test('invokes due event in batch', function (): void {
     $dbMock = Mockery::mock('\Box_Database');
     $dbMock->shouldReceive('getAll')
         ->atLeast()->once()
-        ->andReturn([[]]);
+        ->andReturn([['id' => 1]]);
+    $dbMock->shouldReceive('exec')
+        ->atLeast()->once()
+        ->andReturn(1);
 
     $eventManagerMock = Mockery::mock('\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -619,6 +619,9 @@ test('handles event after invoice is due', function (): void {
     $dbMock->shouldReceive('load')
         ->atLeast()->once()
         ->andReturn($invoiceModel);
+    $dbMock->shouldReceive('store')
+        ->once()
+        ->with($invoiceModel);
 
     $di = container();
     $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock, $systemService) {
@@ -639,6 +642,7 @@ test('handles event after invoice is due', function (): void {
         ->atLeast()->once()
         ->andReturn($di);
     $serviceMock->onEventAfterInvoiceIsDue($eventMock);
+    expect($invoiceModel->reminded_at)->not->toBeEmpty();
 });
 
 test('handles event before invoice is due', function (): void {
@@ -1892,6 +1896,9 @@ test('does not log reminder batch as executed when it is throttled', function ()
         ->once()
         ->with(['once_per_day' => true])
         ->andReturnFalse();
+    $service->shouldReceive('doBatchInvokePendingReminderEvents')
+        ->once()
+        ->andReturnFalse();
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')
@@ -1910,6 +1917,45 @@ test('does not log reminder batch as executed when it is throttled', function ()
         ->and($logger->calls)->toBeEmpty();
 });
 
+test('processes a newly eligible invoice after the daily due event batch', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('doBatchInvokeDueEvent')
+        ->once()
+        ->with(['once_per_day' => true])
+        ->andReturnFalse();
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_before_due_days', '')
+        ->andReturn('7');
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_after_due_days', '5')
+        ->andReturn('5');
+
+    $dbMock = Mockery::mock('\\Box_Database');
+    $dbMock->shouldReceive('getAll')
+        ->twice()
+        ->andReturn([['id' => 2, 'days_left' => 7]], []);
+
+    $eventManagerMock = Mockery::mock('\\Box_EventManager');
+    $eventManagerMock->shouldReceive('fire')
+        ->once()
+        ->with(['event' => 'onBeforeAdminInvoiceSendReminders']);
+    $eventManagerMock->shouldReceive('fire')
+        ->once()
+        ->with(['event' => 'onEventBeforeInvoiceIsDue', 'params' => ['id' => 2, 'days_left' => 7, 'reminder_intervals' => [7]]]);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['events_manager'] = $eventManagerMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $service->setDi($di);
+
+    expect($service->doBatchRemindersSend())->toBeTrue();
+});
+
 test('guards both reminder cron paths across repeated runs', function (): void {
     $lastInvocation = date('Y-m-d H:i:s');
 
@@ -1919,11 +1965,11 @@ test('guards both reminder cron paths across repeated runs', function (): void {
         ->with('invoice_overdue_invoked')
         ->andReturn(null, $lastInvocation, $lastInvocation);
     $systemService->shouldReceive('getParamValue')
-        ->once()
+        ->twice()
         ->with('invoice_reminder_before_due_days', '')
         ->andReturn('7');
     $systemService->shouldReceive('getParamValue')
-        ->once()
+        ->twice()
         ->with('invoice_reminder_after_due_days', '5')
         ->andReturn('5');
     $systemService->shouldReceive('setParamValue')
@@ -1932,8 +1978,8 @@ test('guards both reminder cron paths across repeated runs', function (): void {
 
     $dbMock = Mockery::mock('\\Box_Database');
     $dbMock->shouldReceive('getAll')
-        ->twice()
-        ->andReturn([['id' => 1, 'days_left' => 7]], []);
+        ->times(4)
+        ->andReturn([['id' => 1, 'days_left' => 7]], [], [], []);
 
     $eventManagerMock = Mockery::mock('\\Box_EventManager');
     $eventManagerMock->shouldReceive('fire')

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1871,13 +1871,43 @@ test('sends reminders in batch at most once per day', function (): void {
     $eventManagerMock->shouldReceive('fire')
         ->atLeast()->once();
 
+    $logger = new Tests\Helpers\TestLogger();
+
     $di = container();
     $di['events_manager'] = $eventManagerMock;
-    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['logger'] = $logger;
 
     $service->setDi($di);
     $result = $service->doBatchRemindersSend();
     expect($result)->toBeBool()->toBeTrue();
+    expect($logger->calls)->toContain([
+        'method' => 'info',
+        'params' => ['Executed action to send invoice payment reminders.'],
+    ]);
+});
+
+test('does not log reminder batch as executed when it is throttled', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('doBatchInvokeDueEvent')
+        ->once()
+        ->with(['once_per_day' => true])
+        ->andReturnFalse();
+
+    $eventManagerMock = Mockery::mock('\\Box_EventManager');
+    $eventManagerMock->shouldReceive('fire')
+        ->once()
+        ->with(['event' => 'onBeforeAdminInvoiceSendReminders']);
+
+    $logger = new Tests\Helpers\TestLogger();
+
+    $di = container();
+    $di['events_manager'] = $eventManagerMock;
+    $di['logger'] = $logger;
+
+    $service->setDi($di);
+
+    expect($service->doBatchRemindersSend())->toBeFalse()
+        ->and($logger->calls)->toBeEmpty();
 });
 
 test('guards both reminder cron paths across repeated runs', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -623,9 +623,6 @@ test('handles event after invoice is due', function (): void {
     $dbMock->shouldReceive('load')
         ->atLeast()->once()
         ->andReturn($invoiceModel);
-    $dbMock->shouldReceive('store')
-        ->once()
-        ->with($invoiceModel);
 
     $di = container();
     $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock, $systemService) {
@@ -646,7 +643,78 @@ test('handles event after invoice is due', function (): void {
         ->atLeast()->once()
         ->andReturn($di);
     $serviceMock->onEventAfterInvoiceIsDue($eventMock);
-    expect($invoiceModel->reminded_at)->not->toBeEmpty();
+});
+
+test('releases the claim when sending the overdue invoice email fails', function (): void {
+    $service = new Service();
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $arr = [
+        'total' => 1,
+        'client' => [
+            'id' => 1,
+        ],
+    ];
+    $serviceMock->shouldReceive('toApiArray')
+        ->atLeast()->once()
+        ->andReturn($arr);
+    $serviceMock->shouldReceive('getInvoicePdfAttachment')
+        ->atLeast()->once()
+        ->andReturn(null);
+
+    $eventMock = Mockery::mock('\Box_Event');
+    $params = ['days_passed' => 5, 'id' => 1];
+    $eventMock->shouldReceive('getParameters')
+        ->atLeast()->once()
+        ->andReturn($params);
+
+    $emailService = Mockery::mock(EmailService::class);
+    $emailService->shouldReceive('sendTemplate')
+        ->atLeast()->once()
+        ->andThrow(new Exception('SMTP timeout'));
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_after_due_days', '5')
+        ->andReturn('1, 5, 7');
+
+    $invoiceModel = new Model_Invoice();
+    $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(1);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with('UPDATE invoice SET reminded_at = NULL WHERE id = :id', [':id' => 1]);
+    $dbMock->shouldReceive('load')
+        ->atLeast()->once()
+        ->andReturn($invoiceModel);
+
+    $logger = new Tests\Helpers\TestLogger();
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($emailService, $serviceMock, $systemService) {
+        if ($serviceName == 'invoice') {
+            return $serviceMock;
+        }
+        if ($serviceName == 'email') {
+            return $emailService;
+        }
+        if ($serviceName == 'system') {
+            return $systemService;
+        }
+    });
+    $di['db'] = $dbMock;
+    $di['logger'] = $logger;
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')
+        ->atLeast()->once()
+        ->andReturn($di);
+    $serviceMock->onEventAfterInvoiceIsDue($eventMock);
+
+    expect($logger->calls)->not->toBeEmpty();
 });
 
 test('handles event before invoice is due', function (): void {
@@ -696,6 +764,62 @@ test('handles event before invoice is due', function (): void {
         ->andReturn($di);
 
     $service->onEventBeforeInvoiceIsDue($eventMock);
+});
+
+test('releases the claim when sending the before-due invoice reminder fails', function (): void {
+    $service = new Service();
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('sendInvoiceReminder')
+        ->once()
+        ->andThrow(new Exception('DB write failed'));
+
+    $eventMock = Mockery::mock('\Box_Event');
+    $eventMock->shouldReceive('getParameters')
+        ->atLeast()->once()
+        ->andReturn(['days_left' => 7, 'id' => 1]);
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->with('invoice_reminder_before_due_days', '')
+        ->andReturn('14, 7, 1');
+
+    $invoiceModel = new Model_Invoice();
+    $invoiceModel->loadBean(new Tests\Helpers\DummyBean());
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(Mockery::type('string'), [':id' => 1])
+        ->andReturn(1);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with('UPDATE invoice SET reminded_at = NULL WHERE id = :id', [':id' => 1]);
+    $dbMock->shouldReceive('load')
+        ->once()
+        ->with('Invoice', 1)
+        ->andReturn($invoiceModel);
+
+    $logger = new Tests\Helpers\TestLogger();
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($serviceMock, $systemService) {
+        if ($serviceName == 'invoice') {
+            return $serviceMock;
+        }
+        if ($serviceName == 'system') {
+            return $systemService;
+        }
+    });
+    $di['db'] = $dbMock;
+    $di['logger'] = $logger;
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')
+        ->atLeast()->once()
+        ->andReturn($di);
+
+    $service->onEventBeforeInvoiceIsDue($eventMock);
+
+    expect($logger->calls)->not->toBeEmpty();
 });
 
 test('skips before due invoice reminder when the invoice was already claimed', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -583,7 +583,6 @@ test('handles after admin cron run event', function (): void {
 });
 
 test('handles event after invoice is due', function (): void {
-    $service = new Service();
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $arr = [
         'total' => 1,
@@ -646,7 +645,6 @@ test('handles event after invoice is due', function (): void {
 });
 
 test('releases the claim when sending the overdue invoice email fails', function (): void {
-    $service = new Service();
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $arr = [
         'total' => 1,

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1880,6 +1880,53 @@ test('sends reminders in batch at most once per day', function (): void {
     expect($result)->toBeBool()->toBeTrue();
 });
 
+test('guards both reminder cron paths across repeated runs', function (): void {
+    $lastInvocation = date('Y-m-d H:i:s');
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->times(3)
+        ->with('invoice_overdue_invoked')
+        ->andReturn(null, $lastInvocation, $lastInvocation);
+    $systemService->shouldReceive('getParamValue')
+        ->once()
+        ->with('invoice_reminder_before_due_days', '')
+        ->andReturn('7');
+    $systemService->shouldReceive('getParamValue')
+        ->once()
+        ->with('invoice_reminder_after_due_days', '5')
+        ->andReturn('5');
+    $systemService->shouldReceive('setParamValue')
+        ->once()
+        ->with('invoice_overdue_invoked', Mockery::type('string'));
+
+    $dbMock = Mockery::mock('\\Box_Database');
+    $dbMock->shouldReceive('getAll')
+        ->twice()
+        ->andReturn([['id' => 1, 'days_left' => 7]], []);
+
+    $eventManagerMock = Mockery::mock('\\Box_EventManager');
+    $eventManagerMock->shouldReceive('fire')
+        ->twice()
+        ->with(['event' => 'onBeforeAdminInvoiceSendReminders']);
+    $eventManagerMock->shouldReceive('fire')
+        ->once()
+        ->with(['event' => 'onEventBeforeInvoiceIsDue', 'params' => ['id' => 1, 'days_left' => 7, 'reminder_intervals' => [7]]]);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['events_manager'] = $eventManagerMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect($service->doBatchRemindersSend())->toBeTrue()
+        ->and($service->doBatchInvokeDueEvent([]))->toBeFalse()
+        ->and($service->doBatchRemindersSend())->toBeFalse();
+});
+
 test('invokes due event in batch', function (): void {
     $service = new Service();
     $systemService = Mockery::mock(SystemService::class);


### PR DESCRIPTION
Improves the handling of invoice reminder batches to ensure reminders are sent at most once per day and enhances test coverage to verify this behavior. It also clarifies the execution order of invoice-related cron jobs. Resolves #3963.