### PR TITLE
Fix Stripe webhook routing across shared accounts

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -522,6 +522,16 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         $keepTransaction = false;
 
         try {
+            // A Stripe account can deliver the same event to multiple webhook
+            // endpoints. Only the FOSSBilling gateway which created the Stripe
+            // object may process it; otherwise two gateway records configured
+            // for one Stripe account can both credit the same payment.
+            if (!$this->eventBelongsToGateway($event, $gateway_id)) {
+                $this->di['db']->trash($tx);
+
+                return;
+            }
+
             $keepTransaction = match ($event->type) {
                 'customer.subscription.created' => $this->handleSubscriptionCreated($api_admin, $tx, $event, $gateway_id),
                 'customer.subscription.updated' => $this->handleSubscriptionUpdated($api_admin, $tx, $event),
@@ -554,6 +564,77 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
         $tx->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($tx);
+    }
+
+    private function eventBelongsToGateway(object $event, int $gatewayId): bool
+    {
+        $stripeObject = $event->data->object ?? null;
+        if (!is_object($stripeObject)) {
+            return false;
+        }
+
+        $eventGatewayId = $this->getGatewayIdFromStripeObject($stripeObject);
+
+        // Older Stripe objects predate gateway_id metadata. Resolve them via
+        // their local invoice/subscription association so upgrades do not
+        // break in-flight payments or existing recurring subscriptions.
+        if ($eventGatewayId === null) {
+            $eventGatewayId = $this->getInvoiceGatewayId($stripeObject->metadata->invoice_id ?? null);
+        }
+
+        if ($eventGatewayId === null && str_starts_with((string) ($event->type ?? ''), 'customer.subscription.')) {
+            $eventGatewayId = $this->getLocalSubscriptionGatewayId($stripeObject->id ?? null);
+        }
+
+        if ($eventGatewayId === null && str_starts_with((string) ($event->type ?? ''), 'invoice')) {
+            $stripeInvoice = $this->resolveStripeInvoice($stripeObject);
+            $subscriptionId = $this->extractSubscriptionId($stripeInvoice);
+            if ($subscriptionId !== null) {
+                $eventGatewayId = $this->getLocalSubscriptionGatewayId($subscriptionId);
+                if ($eventGatewayId === null) {
+                    $stripeSubscription = $this->stripe->subscriptions->retrieve($subscriptionId, []);
+                    $eventGatewayId = $this->getGatewayIdFromStripeObject($stripeSubscription)
+                        ?? $this->getInvoiceGatewayId($stripeSubscription->metadata->invoice_id ?? null);
+                }
+            }
+        }
+
+        return $eventGatewayId === $gatewayId;
+    }
+
+    private function getGatewayIdFromStripeObject(object $stripeObject): ?int
+    {
+        $gatewayId = $stripeObject->metadata->gateway_id
+            ?? $stripeObject->parent->subscription_details->metadata->gateway_id
+            ?? $stripeObject->subscription_details->metadata->gateway_id
+            ?? $stripeObject->lines->data[0]->metadata->gateway_id
+            ?? null;
+
+        return is_numeric($gatewayId) && (int) $gatewayId > 0 ? (int) $gatewayId : null;
+    }
+
+    private function getInvoiceGatewayId(mixed $invoiceId): ?int
+    {
+        if (!is_numeric($invoiceId) || (int) $invoiceId <= 0) {
+            return null;
+        }
+
+        $invoice = $this->di['db']->findOne('Invoice', 'id = :id', [':id' => (int) $invoiceId]);
+
+        return $invoice instanceof Model_Invoice && !empty($invoice->gateway_id) ? (int) $invoice->gateway_id : null;
+    }
+
+    private function getLocalSubscriptionGatewayId(mixed $subscriptionId): ?int
+    {
+        if (!is_string($subscriptionId) || $subscriptionId === '') {
+            return null;
+        }
+
+        $subscription = $this->di['db']->findOne('Subscription', 'sid = :sid', [':sid' => $subscriptionId]);
+
+        return $subscription instanceof Model_Subscription && !empty($subscription->pay_gateway_id)
+            ? (int) $subscription->pay_gateway_id
+            : null;
     }
 
     private function handleSubscriptionCreated($api_admin, Model_Transaction $tx, object $event, int $gateway_id): bool
@@ -1139,6 +1220,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             'metadata' => [
                 'invoice_id' => $invoice->id,
                 'client_id' => $invoice->client_id,
+                'gateway_id' => (string) $this->config['gateway_id'],
             ],
         ], ['idempotency_key' => 'sub_invoice_' . $invoice->id]);
     }
@@ -1247,16 +1329,11 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             'metadata' => [
                 'client_id' => (string) $invoice->client_id,
                 'invoice_id' => (string) $invoice->id,
+                'gateway_id' => (string) $this->config['gateway_id'],
             ],
         ]);
 
         $pubKey = ($this->config['test_mode']) ? $this->config['test_pub_key'] : $this->config['pub_key'];
-
-        $dataAmount = $this->getAmountInMinorUnits($invoice);
-
-        $settingService = $this->di['mod_service']('System');
-
-        $title = $this->getInvoiceTitle($invoice);
 
         $form = '<form id="payment-form" data-secret=":intent_secret">
                 <div class="loading" style="display:none;"><span>{% trans \'Loading ...\' %}</span></div>
@@ -1322,18 +1399,12 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                   </script>
                 </form>';
 
-        $payGatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
-        $payGateway = $this->di['db']->findOne('PayGateway', 'gateway = "Stripe"');
         $bindings = [
             ':pub_key' => $pubKey,
             ':intent_secret' => $intent->client_secret,
-            ':amount' => $dataAmount,
-            ':currency' => $invoice->currency,
-            ':description' => $title,
             ':buyer_email' => htmlspecialchars((string) $invoice->buyer_email, ENT_QUOTES, 'UTF-8'),
             ':buyer_name' => htmlspecialchars(trim($invoice->buyer_first_name . ' ' . $invoice->buyer_last_name), ENT_QUOTES, 'UTF-8'),
-            ':callbackUrl' => $payGatewayService->getCallbackUrl($payGateway, $invoice),
-            ':redirectUrl' => $this->di['tools']->url('invoice/' . $invoice->hash),
+            ':callbackUrl' => $this->config['notify_url'],
             ':invoice_hash' => $invoice->hash,
         ];
 
@@ -1353,13 +1424,11 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             'metadata' => [
                 'invoice_id' => $invoice->id,
                 'price_id' => $price->id,
+                'gateway_id' => (string) $this->config['gateway_id'],
             ],
         ]);
 
         $pubKey = ($this->config['test_mode']) ? $this->config['test_pub_key'] : $this->config['pub_key'];
-
-        $payGatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
-        $payGateway = $this->di['db']->findOne('PayGateway', 'gateway = "Stripe"');
 
         $form = '<form id="subscription-form" data-secret=":setup_intent_secret">
                 <div class="loading" style="display:none;"><span>{% trans \'Loading ...\' %}</span></div>
@@ -1419,7 +1488,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             ':setup_intent_secret' => $setupIntent->client_secret,
             ':buyer_email' => htmlspecialchars($invoice->buyer_email ?? '', ENT_QUOTES, 'UTF-8'),
             ':buyer_name' => htmlspecialchars(trim($invoice->buyer_first_name . ' ' . $invoice->buyer_last_name), ENT_QUOTES, 'UTF-8'),
-            ':callbackUrl' => $payGatewayService->getCallbackUrl($payGateway, $invoice),
+            ':callbackUrl' => $this->config['notify_url'],
             ':invoice_hash' => $invoice->hash,
         ];
 

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -619,9 +619,12 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             return null;
         }
 
-        $invoice = $this->di['db']->findOne('Invoice', 'id = :id', [':id' => (int) $invoiceId]);
+        $gatewayId = $this->di['dbal']->fetchOne(
+            'SELECT gateway_id FROM invoice WHERE id = :id',
+            ['id' => (int) $invoiceId]
+        );
 
-        return $invoice instanceof Model_Invoice && !empty($invoice->gateway_id) ? (int) $invoice->gateway_id : null;
+        return is_numeric($gatewayId) && (int) $gatewayId > 0 ? (int) $gatewayId : null;
     }
 
     private function getLocalSubscriptionGatewayId(mixed $subscriptionId): ?int
@@ -630,11 +633,12 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             return null;
         }
 
-        $subscription = $this->di['db']->findOne('Subscription', 'sid = :sid', [':sid' => $subscriptionId]);
+        $gatewayId = $this->di['dbal']->fetchOne(
+            'SELECT pay_gateway_id FROM subscription WHERE sid = :sid',
+            ['sid' => $subscriptionId]
+        );
 
-        return $subscription instanceof Model_Subscription && !empty($subscription->pay_gateway_id)
-            ? (int) $subscription->pay_gateway_id
-            : null;
+        return is_numeric($gatewayId) && (int) $gatewayId > 0 ? (int) $gatewayId : null;
     }
 
     private function handleSubscriptionCreated($api_admin, Model_Transaction $tx, object $event, int $gateway_id): bool

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -336,6 +336,7 @@ class ServicePayGateway implements InjectionAwareInterface
         $config = json_decode($pg->config ?? '', true) ?? [];
         $defaults = [];
         $defaults['auto_redirect'] = false;
+        $defaults['gateway_id'] = (int) $pg->id;
         $defaults['test_mode'] = $pg->test_mode;
         $defaults['return_url'] = $this->getReturnUrl($pg, $model);
         $defaults['cancel_url'] = $this->getCancelUrl($pg, $model);

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -16,6 +16,7 @@ beforeEach(function (): void {
         'test_api_key' => 'sk_test_dummy',
         'test_pub_key' => 'pk_test_dummy',
         'test_webhook_secret' => TEST_WEBHOOK_SECRET,
+        'gateway_id' => 1,
     ]);
 });
 
@@ -1070,7 +1071,10 @@ describe('processWebhookEvent noise filtering', function (): void {
         $rawBody = json_encode([
             'type' => 'customer.subscription.deleted',
             'id' => 'evt_life_1',
-            'data' => ['object' => ['id' => 'sub_nonexistent']],
+            'data' => ['object' => [
+                'id' => 'sub_nonexistent',
+                'metadata' => ['gateway_id' => '1'],
+            ]],
         ]);
 
         $trashCalled = false;
@@ -1107,6 +1111,147 @@ describe('processWebhookEvent noise filtering', function (): void {
         // Subscription lifecycle events don't represent payments — their
         // transactions should be deleted to keep the list clean.
         expect($trashCalled)->toBeTrue();
+    });
+});
+
+describe('Stripe webhook gateway ownership', function (): void {
+    test('tags one-time payments and uses the selected gateway callback', function (): void {
+        $adapter = new Payment_Adapter_Stripe([
+            'test_mode' => true,
+            'test_api_key' => 'sk_test_dummy',
+            'test_pub_key' => 'pk_test_dummy',
+            'test_webhook_secret' => TEST_WEBHOOK_SECRET,
+            'gateway_id' => 3,
+            'notify_url' => 'https://billing.example/ipn.php?gateway_id=3&invoice_id=15',
+        ]);
+
+        $paymentIntentsMock = Mockery::mock();
+        $paymentIntentsMock->shouldReceive('create')
+            ->once()
+            ->withArgs(fn (array $params): bool => $params['metadata']['gateway_id'] === '3'
+                && $params['metadata']['invoice_id'] === '15')
+            ->andReturn(Stripe\PaymentIntent::constructFrom([
+                'id' => 'pi_gateway_3',
+                'client_secret' => 'pi_gateway_3_secret',
+            ]));
+
+        $stripeMock = Mockery::mock(StripeClient::class);
+        $stripeMock->paymentIntents = $paymentIntentsMock;
+        setPrivateProperty($adapter, 'stripe', $stripeMock);
+
+        $invoice = new Model_Invoice();
+        $invoice->loadBean(new DummyBean());
+        $invoice->id = 15;
+        $invoice->client_id = 7;
+        $invoice->currency = 'USD';
+        $invoice->buyer_email = 'client@example.com';
+        $invoice->buyer_first_name = 'Test';
+        $invoice->buyer_last_name = 'Client';
+        $invoice->hash = 'invoice-hash';
+        $invoice->nr = 15;
+        $invoice->serie = 'INV';
+
+        $dbMock = Mockery::mock('\\Box_Database');
+        $dbMock->shouldReceive('getAll')->once()->andReturn([['title' => 'Hosting']]);
+
+        $invoiceService = Mockery::mock();
+        $invoiceService->shouldReceive('getTotalWithTax')->once()->andReturn(15.00);
+
+        $di = container();
+        $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $invoiceService);
+        $adapter->setDi($di);
+
+        $form = invokePrivateMethod($adapter, '_generateForm', [$invoice]);
+
+        expect($form)->toContain('https://billing.example/ipn.php?gateway_id=3&invoice_id=15');
+    });
+
+    test('ignores an event created by another FOSSBilling Stripe gateway', function (): void {
+        $tx = buildTransaction();
+        $tx->id = 550;
+
+        $rawBody = json_encode([
+            'type' => 'payment_intent.succeeded',
+            'id' => 'evt_wrong_gateway',
+            'data' => ['object' => [
+                'id' => 'pi_gateway_3',
+                'status' => 'succeeded',
+                'amount' => 1500,
+                'currency' => 'usd',
+                'metadata' => [
+                    'invoice_id' => '10',
+                    'client_id' => '3',
+                    'gateway_id' => '3',
+                ],
+            ]],
+        ]);
+
+        $dbMock = Mockery::mock('\\Box_Database');
+        $dbMock->shouldReceive('trash')->once()->with($tx);
+        $dbMock->shouldNotReceive('findOne');
+        $dbMock->shouldNotReceive('store');
+
+        $di = container();
+        $di['db'] = $dbMock;
+        $this->adapter->setDi($di);
+
+        $data = [
+            'http_raw_post_data' => $rawBody,
+            'server' => ['HTTP_STRIPE_SIGNATURE' => signStripeWebhookPayload($rawBody)],
+            'get' => [],
+            'post' => [],
+        ];
+
+        invokePrivateMethod($this->adapter, 'processWebhookEvent', [
+            Mockery::mock(),
+            $tx,
+            $data,
+            10,
+        ]);
+    });
+
+    test('reads copied subscription metadata from recurring invoices', function (): void {
+        $event = (object) [
+            'type' => 'invoice.paid',
+            'data' => (object) ['object' => (object) [
+                'parent' => (object) [
+                    'subscription_details' => (object) [
+                        'metadata' => (object) ['gateway_id' => '3'],
+                    ],
+                ],
+            ]],
+        ];
+
+        expect(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 3]))->toBeTrue()
+            ->and(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 10]))->toBeFalse();
+    });
+
+    test('resolves gateway ownership from the invoice for legacy Stripe objects', function (): void {
+        $invoice = new Model_Invoice();
+        $invoice->loadBean(new DummyBean());
+        $invoice->id = 10;
+        $invoice->gateway_id = 3;
+
+        $event = (object) [
+            'type' => 'payment_intent.succeeded',
+            'data' => (object) ['object' => (object) [
+                'metadata' => (object) ['invoice_id' => '10'],
+            ]],
+        ];
+
+        $dbMock = Mockery::mock('\\Box_Database');
+        $dbMock->shouldReceive('findOne')
+            ->twice()
+            ->with('Invoice', 'id = :id', [':id' => 10])
+            ->andReturn($invoice);
+
+        $di = container();
+        $di['db'] = $dbMock;
+        $this->adapter->setDi($di);
+
+        expect(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 3]))->toBeTrue()
+            ->and(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 10]))->toBeFalse();
     });
 });
 

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -1228,11 +1228,6 @@ describe('Stripe webhook gateway ownership', function (): void {
     });
 
     test('resolves gateway ownership from the invoice for legacy Stripe objects', function (): void {
-        $invoice = new Model_Invoice();
-        $invoice->loadBean(new DummyBean());
-        $invoice->id = 10;
-        $invoice->gateway_id = 3;
-
         $event = (object) [
             'type' => 'payment_intent.succeeded',
             'data' => (object) ['object' => (object) [
@@ -1240,14 +1235,36 @@ describe('Stripe webhook gateway ownership', function (): void {
             ]],
         ];
 
-        $dbMock = Mockery::mock('\\Box_Database');
-        $dbMock->shouldReceive('findOne')
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        $dbalMock->shouldReceive('fetchOne')
             ->twice()
-            ->with('Invoice', 'id = :id', [':id' => 10])
-            ->andReturn($invoice);
+            ->with('SELECT gateway_id FROM invoice WHERE id = :id', ['id' => 10])
+            ->andReturn('3');
 
         $di = container();
-        $di['db'] = $dbMock;
+        $di['dbal'] = $dbalMock;
+        $this->adapter->setDi($di);
+
+        expect(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 3]))->toBeTrue()
+            ->and(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 10]))->toBeFalse();
+    });
+
+    test('resolves gateway ownership from a legacy local subscription', function (): void {
+        $event = (object) [
+            'type' => 'customer.subscription.updated',
+            'data' => (object) ['object' => (object) [
+                'id' => 'sub_legacy',
+            ]],
+        ];
+
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        $dbalMock->shouldReceive('fetchOne')
+            ->twice()
+            ->with('SELECT pay_gateway_id FROM subscription WHERE sid = :sid', ['sid' => 'sub_legacy'])
+            ->andReturn('3');
+
+        $di = container();
+        $di['dbal'] = $dbalMock;
         $this->adapter->setDi($di);
 
         expect(invokePrivateMethod($this->adapter, 'eventBelongsToGateway', [$event, 3]))->toBeTrue()


### PR DESCRIPTION
## Summary

- attach the originating FOSSBilling gateway ID to Stripe PaymentIntents, SetupIntents, and Subscriptions
- ignore webhook events that belong to another Stripe gateway configured against the same Stripe account
- resolve older Stripe objects through their existing invoice or subscription ownership using DBAL
- use the selected gateway's callback URL instead of looking up an arbitrary Stripe gateway

## Root cause

Stripe sends an account event to every configured endpoint that subscribes to it. FOSSBilling verified each endpoint's signing secret, but Stripe objects did not identify which local gateway created them. The Stripe payment forms also selected the first Stripe gateway record when constructing their callback URL.

Together, multiple local Stripe gateways using one Stripe account could accept and process the same payment event.

## Impact

Each Stripe event is now handled only by its originating FOSSBilling gateway. Existing PaymentIntents and subscriptions created before this change remain supported through local invoice/subscription lookup.

Closes #3967

## Validation

- focused Pest suite: 66 tests, 146 assertions
- PHPStan on the changed production files
- PHP-CS-Fixer dry run
- PHP syntax checks
- `git diff --check`
