### PR TITLE
Render support ticket edit history as Markdown instead of raw source

### DIFF
--- a/src/library/FOSSBilling/Twig/Markdown/FOSSBillingMarkdown.php
+++ b/src/library/FOSSBilling/Twig/Markdown/FOSSBillingMarkdown.php
@@ -22,7 +22,13 @@ class FOSSBillingMarkdown implements MarkdownInterface
 {
     private readonly MarkdownConverter $converter;
 
-    public function __construct(\Pimple\Container $di)
+    /**
+     * @param bool|null $isAdmin Which theme's Markdown attribute defaults to use. Pass explicitly
+     *                           when converting outside of an admin page render (e.g. from an API
+     *                           endpoint), where the ADMIN_AREA constant doesn't reflect the caller's
+     *                           area. Leave null to fall back to that runtime check.
+     */
+    public function __construct(\Pimple\Container $di, ?bool $isAdmin = null)
     {
         $config = [
             'html_input' => 'escape',
@@ -30,7 +36,7 @@ class FOSSBillingMarkdown implements MarkdownInterface
             'max_nesting_level' => 50,
         ];
 
-        $defaultAttributes = $di['mod_service']('theme')->getDefaultMarkdownAttributes() ?? [];
+        $defaultAttributes = $di['mod_service']('theme')->getDefaultMarkdownAttributes($isAdmin) ?? [];
         if (!empty($defaultAttributes)) {
             $config['default_attributes'] = $defaultAttributes;
         }

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -939,7 +939,9 @@ class Service implements \FOSSBilling\InjectionAwareInterface
      */
     public function getMessageHistory(SupportTicketMessage $message): array
     {
-        $markdown = new FOSSBillingMarkdown($this->di);
+        // Always render with the admin theme's Markdown defaults: this is admin-only functionality,
+        // and ADMIN_AREA isn't set to true for api/admin/... requests the way it is for admin page loads.
+        $markdown = new FOSSBillingMarkdown($this->di, isAdmin: true);
 
         $result = [];
         foreach ($this->getSupportTicketMessageHistoryRepository()->findByMessageId((int) $message->getId()) as $history) {

--- a/src/modules/Support/Service.php
+++ b/src/modules/Support/Service.php
@@ -31,6 +31,7 @@ use Box\Mod\Support\Repository\SupportTicketNoteRepository;
 use Box\Mod\Support\Repository\SupportTicketRepository;
 use FOSSBilling\InformationException;
 use FOSSBilling\Tools;
+use FOSSBilling\Twig\Markdown\FOSSBillingMarkdown;
 
 class Service implements \FOSSBilling\InjectionAwareInterface
 {
@@ -938,10 +939,16 @@ class Service implements \FOSSBilling\InjectionAwareInterface
      */
     public function getMessageHistory(SupportTicketMessage $message): array
     {
-        return array_map(
-            fn (SupportTicketMessageHistory $history): array => $history->toApiArray(),
-            $this->getSupportTicketMessageHistoryRepository()->findByMessageId((int) $message->getId()),
-        );
+        $markdown = new FOSSBillingMarkdown($this->di);
+
+        $result = [];
+        foreach ($this->getSupportTicketMessageHistoryRepository()->findByMessageId((int) $message->getId()) as $history) {
+            $data = $history->toApiArray();
+            $data['content_html'] = $markdown->convert((string) $data['content']);
+            $result[] = $data;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/modules/Support/templates/admin/mod_support_ticket.html.twig
+++ b/src/modules/Support/templates/admin/mod_support_ticket.html.twig
@@ -484,10 +484,9 @@
                         meta.className = 'text-muted small mb-1';
                         meta.textContent = revision.created_at;
 
-                        var content = document.createElement('pre');
-                        content.className = 'mb-0';
-                        content.style.whiteSpace = 'pre-wrap';
-                        content.textContent = revision.content;
+                        var content = document.createElement('article');
+                        content.className = 'markdown-body bg-transparent text-reset mb-0';
+                        content.innerHTML = revision.content_html;
 
                         entry.appendChild(meta);
                         entry.appendChild(content);

--- a/src/modules/Support/tests/Unit/ServiceTest.php
+++ b/src/modules/Support/tests/Unit/ServiceTest.php
@@ -1929,7 +1929,7 @@ test('gets message history', function (): void {
     setEntityId($history, 1);
     $history->setMessage($message);
     $history->setAdminId(7);
-    $history->setContent('Original content');
+    $history->setContent('**Original** content');
 
     $historyRepo = Mockery::mock(SupportTicketMessageHistoryRepository::class);
     $historyRepo->shouldReceive('findByMessageId')->atLeast()->once()
@@ -1942,7 +1942,7 @@ test('gets message history', function (): void {
     $service->setDi($di);
 
     $result = $service->getMessageHistory($message);
-    expect($result)->toBe([$history->toApiArray()]);
+    expect($result)->toBe([[...$history->toApiArray(), 'content_html' => "<p><strong>Original</strong> content</p>\n"]]);
 });
 
 dataset('ticketReplyProvider', function () {

--- a/src/modules/Theme/Service.php
+++ b/src/modules/Theme/Service.php
@@ -461,11 +461,12 @@ class Service implements InjectionAwareInterface
         return $this->getCurrentClientAreaTheme()->getName();
     }
 
-    public function getDefaultMarkdownAttributes(): array
+    public function getDefaultMarkdownAttributes(?bool $isAdmin = null): array
     {
-        // Runtime check for admin area - uses index.php defined constant
-        $isAdmin = ADMIN_AREA;
-        // @phpstan-ignore if.alwaysTrue
+        // Runtime check for admin area - uses index.php defined constant.
+        // API requests (e.g. api/admin/...) don't set ADMIN_AREA the way admin panel
+        // page loads do, so callers outside of an admin page render must pass $isAdmin explicitly.
+        $isAdmin ??= ADMIN_AREA;
         if ($isAdmin) {
             $config = $this->getThemeConfig(false);
         } else {


### PR DESCRIPTION
## Summary
- Follow-up to #3906 based on [feedback on #2317](https://github.com/FOSSBilling/FOSSBilling/issues/2317#issuecomment-4954119068): the admin "Edit History" modal for ticket replies was displaying the raw Markdown source in a `<pre>` block instead of rendering it, unlike the live message body.
- `Service::getMessageHistory()` now converts each history revision's content with the same Markdown converter (`FOSSBillingMarkdown`, safe `html_input: escape` config) used by the `markdown_to_html` Twig filter, adding a `content_html` field to the API response.
- The modal's JS now renders that HTML into a `.markdown-body` article, matching the styling of the rest of the conversation thread, instead of dumping raw Markdown text.