### PR TITLE
Add separate billing email for invoice notifications

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','88',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','89',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -224,6 +224,7 @@ CREATE TABLE `client` (
   `role` varchar(30) NOT NULL DEFAULT 'client' COMMENT 'client',
   `auth_type` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
+  `billing_email` varchar(255) DEFAULT NULL,
   `pass` varchar(255) DEFAULT NULL,
   `salt` varchar(255) DEFAULT NULL,
   `status` varchar(30) DEFAULT 'active' COMMENT 'active, suspended, canceled',

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -498,6 +498,7 @@ class UpdatePatcher implements InjectionAwareInterface
             86 => 'patch86',
             87 => 'patch87',
             88 => 'patch88',
+            89 => 'patch89',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2347,6 +2348,15 @@ class UpdatePatcher implements InjectionAwareInterface
         // @see https://github.com/FOSSBilling/FOSSBilling/issues/3963
         if (!$this->tableHasIndex('invoice', 'invoice_status_approved_due_at_idx')) {
             $this->executeSql('ALTER TABLE `invoice` ADD INDEX `invoice_status_approved_due_at_idx` (`status`, `approved`, `due_at`)');
+        }
+    }
+
+    private function patch89(): void
+    {
+        // Allows invoice notifications to be sent to an address separate from the client's login email.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/3833
+        if (!$this->tableHasColumn('client', 'billing_email')) {
+            $this->executeSql('ALTER TABLE `client` ADD COLUMN `billing_email` varchar(255) DEFAULT NULL AFTER `email`');
         }
     }
 

--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -107,6 +107,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * Creates new client.
      *
      * @optional string $password - client password
+     * @optional string $billing_email - optional address for invoice notifications
      * @optional string $auth_type - client authorization type. Default null
      * @optional string $last_name - client last name
      * @optional string $aid - Custom client ID. If you import clients from other systems you can use this field to store the existing customer ID.
@@ -160,6 +161,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $validator = $this->getDi()['validator'];
         $data['email'] = $this->getDi()['tools']->validateAndSanitizeEmail($data['email']);
+        if (array_key_exists('billing_email', $data)) {
+            $data['billing_email'] = empty($data['billing_email'])
+                ? null
+                : $this->getDi()['tools']->validateAndSanitizeEmail($data['billing_email']);
+        }
         $data['send_welcome_email'] = Tools::normalizeBoolean($data['send_welcome_email'] ?? true, true);
 
         $service = $this->getService();
@@ -213,6 +219,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * Update client profile.
      *
      * @optional string $email - client email
+     * @optional string $billing_email - optional address for invoice notifications
      * @optional string $first_name - client first_name
      * @optional string $last_name - client last_name
      * @optional string $status - client status
@@ -272,6 +279,12 @@ class Admin extends \FOSSBilling\Api\AbstractApi
             }
         }
 
+        if (array_key_exists('billing_email', $data)) {
+            $data['billing_email'] = empty($data['billing_email'])
+                ? null
+                : $this->getDi()['tools']->validateAndSanitizeEmail($data['billing_email']);
+        }
+
         if (!empty($data['birthday'])) {
             $this->getDi()['validator']->isBirthdayValid($data['birthday']);
         }
@@ -327,6 +340,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         foreach ($allowedFields as $field) {
             $client->{$field} = $data[$field] ?? $client->{$field};
+        }
+        if (array_key_exists('billing_email', $data)) {
+            $client->billing_email = $data['billing_email'];
         }
 
         if ($client->status !== \Model_Client::ACTIVE) {

--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -466,6 +466,10 @@ class Service implements InjectionAwareInterface
             'timezone' => $model->timezone,
         ];
 
+        if ($isAdmin || ($identity instanceof \Model_Client && (int) $identity->id === (int) $model->id)) {
+            $details['billing_email'] = $model->billing_email;
+        }
+
         if ($deep) {
             $details['balance'] = $this->getClientBalance($model);
         }
@@ -594,6 +598,8 @@ class Service implements InjectionAwareInterface
 
         $client->auth_type = $data['auth_type'] ?? null;
         $client->email = strtolower(trim((string) ($data['email'] ?? null)));
+        $billingEmail = trim((string) ($data['billing_email'] ?? ''));
+        $client->billing_email = $billingEmail !== '' ? strtolower($billingEmail) : null;
         $client->first_name = ucwords((string) ($data['first_name'] ?? null));
         $client->pass = $this->di['password']->hashIt($password);
 

--- a/src/modules/Client/templates/admin/mod_client_manage.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_manage.html.twig
@@ -268,6 +268,11 @@
                                     <label class="form-label">{{ 'Email'|trans }}</label>
                                     <input class="form-control" type="email" name="email" value="{{ client.email }}" required>
                                 </div>
+                                <div class="col-xl-6">
+                                    <label class="form-label">{{ 'Billing Email'|trans }}</label>
+                                    <input class="form-control" type="email" name="billing_email" value="{{ client.billing_email }}" placeholder="{{ client.email }}">
+                                    <small class="form-hint">{{ 'Invoice notifications are sent here. Leave blank to use the account email.'|trans }}</small>
+                                </div>
                                 <div class="col-xl-3">
                                     <label class="form-label">{{ 'First Name'|trans }}</label>
                                     <input class="form-control" type="text" name="first_name" value="{{ client.first_name }}" required>

--- a/src/modules/Client/templates/admin/mod_client_new_form.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_new_form.html.twig
@@ -26,6 +26,11 @@
                             <input id="new-client-email" type="email" name="email" class="form-control" placeholder="client@fossbilling.org" required>
                         </div>
                         <div class="col-12">
+                            <label class="form-label" for="new-client-billing-email">{{ 'Billing Email Address'|trans }}</label>
+                            <input id="new-client-billing-email" type="email" name="billing_email" class="form-control" placeholder="billing@fossbilling.org">
+                            <div class="form-text">{{ 'Invoice notifications are sent here. Leave blank to use the account email.'|trans }}</div>
+                        </div>
+                        <div class="col-12">
                             <label class="form-label" for="new-client-aid">{{ 'Custom Client ID'|trans }}</label>
                             <input id="new-client-aid" type="text" name="aid" class="form-control" placeholder="{{ 'Existing customer ID from another system'|trans }}">
                         </div>

--- a/src/modules/Client/templates/client/mod_client_profile.html.twig
+++ b/src/modules/Client/templates/client/mod_client_profile.html.twig
@@ -68,6 +68,13 @@
                                 </div>
                             </div>
                             <div class="row">
+                                <div class="mb-3 col-md-10">
+                                    <label class="form-label" for="billing_email">{{ 'Billing Email Address'|trans }}</label>
+                                    <input type="email" class="form-control" id="billing_email" name="billing_email" value="{{ profile.billing_email }}" placeholder="{{ profile.email }}">
+                                    <small class="form-hint text-muted">{{ 'Invoice notifications are sent here. Leave blank to use your account email.'|trans }}</small>
+                                </div>
+                            </div>
+                            <div class="row">
                                 <div class="mb-3 col-md-5">
                                     <label class="form-label" for="birthday">{{ 'Birthdate'|trans }}</label>
                                     <input type="date" class="form-control" id="birthday" name="birthday"

--- a/src/modules/Client/tests/Unit/ServiceTest.php
+++ b/src/modules/Client/tests/Unit/ServiceTest.php
@@ -707,6 +707,7 @@ test('toApiArray returns array', function (): void {
     $model = new Model_Client();
     $model->loadBean(new Tests\Helpers\DummyBean());
     $model->custom_1 = 'custom field';
+    $model->billing_email = 'billing@example.com';
 
     $clientGroup = new Model_ClientGroup();
     $clientGroup->loadBean(new Tests\Helpers\DummyBean());
@@ -731,6 +732,10 @@ test('toApiArray returns array', function (): void {
 
     $result = $serviceMock->toApiArray($model, true, new Model_Admin());
     expect($result)->toBeArray();
+    expect($result['billing_email'])->toBe('billing@example.com');
+
+    $publicResult = $serviceMock->toApiArray($model);
+    expect($publicResult)->not->toHaveKey('billing_email');
 });
 
 test('toApiArray includes custom fields beyond the original cap of 10', function (): void {

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -237,7 +237,9 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $to_name = $oneStaff['name'];
             $sent = $this->sendMail($to, $from, $subject, $content, $to_name, $from_name, $oneStaff['id'], null, $send_now, $throw_exceptions, $attachment);
         } elseif (isset($customer)) {
-            $to = $customer['email'];
+            // Supplying both keeps the email associated with the client while allowing a
+            // purpose-specific recipient, such as the client's billing address.
+            $to = $data['to'] ?? $customer['email'];
             $to_name = $customer['first_name'] . ' ' . $customer['last_name'];
             $sent = $this->sendMail($to, $from, $subject, $content, $to_name, $from_name, $customer['id'], null, $send_now, $throw_exceptions, $attachment);
         } else {

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -428,6 +428,7 @@ dataset('sendTemplateExistsStaffProvider', fn (): array => [
         ],
         'never',
         'atLeastOnce',
+        'staff@fossbilling.org',
     ],
     [
         [
@@ -440,10 +441,11 @@ dataset('sendTemplateExistsStaffProvider', fn (): array => [
         ],
         'atLeastOnce',
         'never',
+        'example@example.com',
     ],
 ]);
 
-test('sendTemplate handles to_staff and to_client options', function (array $data, string $clientGetExpects, string $staffResolveExpects): void {
+test('sendTemplate handles to_staff and to_client options', function (array $data, string $clientGetExpects, string $staffResolveExpects, string $expectedRecipient): void {
     $service = new Box\Mod\Email\Service();
 
     $di = container();
@@ -456,7 +458,18 @@ test('sendTemplate handles to_staff and to_client options', function (array $dat
     $templateGroupRepo = Mockery::mock(Box\Mod\Email\Repository\EmailTemplateGroupRepository::class);
     $templateGroupRepo->shouldReceive('getGroupIdsForTemplate')->andReturn([3]);
 
+    /** @var Box\Mod\Email\Entity\QueuedEmail|null $persistedQueue */
+    $persistedQueue = null;
     $em = emailBuildEm(null, $templateRepo, null, true, $templateGroupRepo);
+    $em->shouldReceive('persist')
+        ->atLeast()->once()
+        ->with(Mockery::on(function ($entity) use (&$persistedQueue): bool {
+            if ($entity instanceof Box\Mod\Email\Entity\QueuedEmail) {
+                $persistedQueue = $entity;
+            }
+
+            return true;
+        }));
 
     $system = Mockery::mock(Box\Mod\System\Service::class);
     $system->shouldReceive('getParamValue')
@@ -551,6 +564,8 @@ test('sendTemplate handles to_staff and to_client options', function (array $dat
     $result = $service->sendTemplate($data);
 
     expect($result)->toBeTrue();
+    expect($persistedQueue)->not->toBeNull();
+    expect($persistedQueue->getRecipient())->toBe($expectedRecipient);
 })->with('sendTemplateExistsStaffProvider');
 
 test('sendTemplate does not send to staff when template has no assigned groups', function (): void {

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -187,7 +187,7 @@ class Service implements InjectionAwareInterface
         return [$sql, $params];
     }
 
-    public function toApiArray(\Model_Invoice $invoice, $deep = true, $identity = null): array
+    public function toApiArray(\Model_Invoice $invoice, $deep = true, $identity = null, bool $includeClientBillingEmail = false): array
     {
         $this->ensureValidHash($invoice);
         $row = $this->di['db']->toArray($invoice);
@@ -307,6 +307,9 @@ class Service implements InjectionAwareInterface
         $clientService = $this->di['mod_service']('client');
         if ($client instanceof \Model_Client) {
             $result['client'] = $clientService->toApiArray($client);
+            if ($includeClientBillingEmail) {
+                $result['client']['billing_email'] = $client->billing_email;
+            }
         } else {
             $result['client'] = null;
         }
@@ -388,7 +391,7 @@ class Service implements InjectionAwareInterface
 
         try {
             $invoiceModel = $di['db']->load('Invoice', $params['id'] ?? 0);
-            $invoice = $service->toApiArray($invoiceModel, true);
+            $invoice = $service->toApiArray($invoiceModel, true, null, true);
             if (($invoice['total'] ?? 0) > 0) {
                 $service->sendInvoiceEmail($invoiceModel, $invoice, 'mod_invoice_paid');
             }
@@ -407,7 +410,7 @@ class Service implements InjectionAwareInterface
 
         try {
             $invoiceModel = $di['db']->load('Invoice', $params['id']);
-            $invoice = $service->toApiArray($invoiceModel, true);
+            $invoice = $service->toApiArray($invoiceModel, true, null, true);
             $service->sendInvoiceEmail($invoiceModel, $invoice, 'mod_invoice_created');
         } catch (\Exception $exc) {
             $di['logger']->setChannel('email')->error('Failed to send email for invoice creation', ['exception' => $exc->getMessage()]);
@@ -453,6 +456,7 @@ class Service implements InjectionAwareInterface
             'code' => $templateCode,
             'invoice' => $invoiceData,
         ];
+        $email = $this->withBillingRecipient($email, $invoiceData);
 
         $attachment = $this->getInvoicePdfAttachment($invoice);
         if ($attachment !== null) {
@@ -474,11 +478,12 @@ class Service implements InjectionAwareInterface
                 return;
             }
 
-            $invoice = $service->toApiArray($invoiceModel, true);
+            $invoice = $service->toApiArray($invoiceModel, true, null, true);
             $email = [];
             $email['to_client'] = $invoiceModel->client_id;
             $email['code'] = 'mod_invoice_payment_reminder';
             $email['invoice'] = $invoice;
+            $email = $service->withBillingRecipient($email, $invoice);
             $attachment = $service->getInvoicePdfAttachment($invoiceModel);
             if ($attachment !== null) {
                 $email['attachment'] = $attachment;
@@ -577,7 +582,7 @@ class Service implements InjectionAwareInterface
                 return;
             }
 
-            $invoice = $service->toApiArray($invoiceModel, true);
+            $invoice = $service->toApiArray($invoiceModel, true, null, true);
             if (!isset($invoice['client']) || !is_array($invoice['client']) || !isset($invoice['client']['id'])) {
                 throw new \FOSSBilling\Exception('Invoice client data is unavailable.');
             }
@@ -587,6 +592,7 @@ class Service implements InjectionAwareInterface
             $email['code'] = 'mod_invoice_due_after';
             $email['days_passed'] = $params['days_passed'];
             $email['invoice'] = $invoice;
+            $email = $service->withBillingRecipient($email, $invoice);
             $attachment = $service->getInvoicePdfAttachment($invoiceModel);
             if ($attachment !== null) {
                 $email['attachment'] = $attachment;
@@ -603,6 +609,20 @@ class Service implements InjectionAwareInterface
             }
             $di['logger']->setChannel('email')->error('Failed to send overdue invoice email', ['id' => $params['id'] ?? null, 'exception' => $exc->getMessage()]);
         }
+    }
+
+    /**
+     * Route invoice notifications to the client's optional billing address while retaining
+     * to_client so templates, timezone handling, and client email history keep working.
+     */
+    public function withBillingRecipient(array $email, array $invoice): array
+    {
+        $billingEmail = trim((string) ($invoice['client']['billing_email'] ?? ''));
+        if ($billingEmail !== '') {
+            $email['to'] = $billingEmail;
+        }
+
+        return $email;
     }
 
     public function markAsPaid(\Model_Invoice $invoice, $charge = true, $execute = false): bool
@@ -901,7 +921,7 @@ class Service implements InjectionAwareInterface
             $this->tryPayWithCredits($invoice);
         }
 
-        $this->di['events_manager']->fire(['event' => 'onAfterAdminInvoiceApprove', 'params' => $this->toApiArray($invoice)]);
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminInvoiceApprove', 'params' => $this->toApiArray($invoice, true, null, true)]);
 
         $this->di['logger']->info("Approved invoice {$invoice->id}.");
 

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -582,6 +582,19 @@ test('handles after admin cron run event', function (): void {
     $service->onAfterAdminCronRun($eventMock);
 });
 
+test('uses the client billing email for invoice notifications', function (): void {
+    $service = new Service();
+    $email = ['to_client' => 42, 'code' => 'mod_invoice_created'];
+    $invoice = ['client' => ['billing_email' => ' billing@example.com ']];
+
+    expect($service->withBillingRecipient($email, $invoice))->toBe([
+        'to_client' => 42,
+        'code' => 'mod_invoice_created',
+        'to' => 'billing@example.com',
+    ]);
+    expect($service->withBillingRecipient($email, ['client' => ['billing_email' => null]]))->toBe($email);
+});
+
 test('handles event after invoice is due', function (): void {
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $arr = [

--- a/src/modules/Profile/Api/Client.php
+++ b/src/modules/Profile/Api/Client.php
@@ -33,6 +33,7 @@ class Client extends \FOSSBilling\Api\AbstractApi
      * Update currently logged in client details.
      *
      * @optional string $email - new client email. Must not exist on system
+     * @optional string $billing_email - optional address for invoice notifications
      * @optional string $last_name - last name
      * @optional string $aid - Alternative id. Usually used by import tools.
      * @optional string $gender - Gender - values: male|female|nonbinary|other
@@ -81,6 +82,12 @@ class Client extends \FOSSBilling\Api\AbstractApi
     {
         if (!is_null($data['email'] ?? null)) {
             $data['email'] = $this->getDi()['tools']->validateAndSanitizeEmail($data['email']);
+        }
+
+        if (array_key_exists('billing_email', $data)) {
+            $data['billing_email'] = empty($data['billing_email'])
+                ? null
+                : $this->getDi()['tools']->validateAndSanitizeEmail($data['billing_email']);
         }
 
         return $this->getService()->updateClient($this->getIdentity(), $data);

--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -160,6 +160,9 @@ class Service implements InjectionAwareInterface
         }
 
         $client->first_name = $data['first_name'] ?? $client->first_name;
+        if (array_key_exists('billing_email', $data)) {
+            $client->billing_email = $data['billing_email'];
+        }
         $client->last_name = $data['last_name'] ?? $client->last_name;
         $client->gender = ClientValidator::validateGender($data['gender'] ?? $client->gender);
         $client->birthday = ClientValidator::validateBirthday($data['birthday'] ?? $client->birthday);

--- a/src/modules/Profile/tests/Unit/ServiceTest.php
+++ b/src/modules/Profile/tests/Unit/ServiceTest.php
@@ -158,6 +158,7 @@ test('updates client', function (): void {
 
     $data = [
         'email' => 'email@example.com',
+        'billing_email' => 'billing@example.com',
         'first_name' => 'string',
         'last_name' => 'string',
         'gender' => 'other',
@@ -202,6 +203,7 @@ test('updates client', function (): void {
     $service->setDi($di);
     $result = $service->updateClient($model, $data);
     expect($result)->toBeTrue();
+    expect($model->billing_email)->toBe('billing@example.com');
 });
 
 test('throws exception when email change is not allowed', function (): void {


### PR DESCRIPTION
## Summary

- add an optional billing email address to client records, APIs, and admin/client profile forms
- route invoice created, paid, reminder, and overdue notifications to the billing address when configured
- retain the account email as the fallback and keep all non-billing messages unchanged
- preserve client-linked email history and avoid exposing the billing address through public client serialization
- add database patch 89 and update the installation schema and seeded patch level

Closes #3833.