### PR TITLE
Add end-of-period subscription cancellation

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -144,6 +144,16 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         $this->stripe->subscriptions->cancel($subscriptionId, []);
     }
 
+    public function cancelSubscriptionAtPeriodEnd(string $subscriptionId): void
+    {
+        $subscription = $this->stripe->subscriptions->retrieve($subscriptionId, []);
+        if ($subscription->status === Stripe\Subscription::STATUS_CANCELED || ($subscription->cancel_at_period_end ?? false)) {
+            return;
+        }
+
+        $this->stripe->subscriptions->update($subscriptionId, ['cancel_at_period_end' => true]);
+    }
+
     public function getAmountInCents(Model_Invoice $invoice): int
     {
         return $this->getAmountInMinorUnits($invoice);
@@ -667,12 +677,14 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     {
         $stripeSubscription = $event->data->object;
 
-        $status = match ($stripeSubscription->status) {
-            'active' => 'active',
-            'trialing' => 'active',
-            'past_due' => 'active',
-            default => 'canceled',
-        };
+        $status = ($stripeSubscription->cancel_at_period_end ?? false)
+            ? Box\Mod\Invoice\ServiceSubscription::STATUS_PENDING_CANCELLATION
+            : match ($stripeSubscription->status) {
+                'active' => 'active',
+                'trialing' => 'active',
+                'past_due' => 'active',
+                default => 'canceled',
+            };
 
         try {
             $this->updateSubscriptionStatusFromGateway($api_admin, $stripeSubscription->id, $status);
@@ -688,14 +700,13 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     private function handleSubscriptionDeleted($api_admin, Model_Transaction $tx, object $event): bool
     {
         $stripeSubscription = $event->data->object;
-
-        try {
-            $this->updateSubscriptionStatusFromGateway($api_admin, $stripeSubscription->id, 'canceled');
-        } catch (Exception $e) {
-            if (DEBUG) {
-                error_log('Stripe subscription deleted webhook: ' . $e->getMessage());
-            }
+        $subscriptionService = $this->di['mod_service']('Invoice', 'Subscription');
+        $subscriptionId = $subscriptionService->findIdBySid($stripeSubscription->id);
+        if ($subscriptionId === null) {
+            return false;
         }
+
+        $subscriptionService->finalizeCancellationFromGateway($subscriptionId);
 
         return false;
     }

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -430,7 +430,41 @@ class Service implements InjectionAwareInterface
             'total' => $total - $items_discount,
             'items' => $items,
             'currency' => $currency->toApiArray(),
+            'subscribable' => $this->getSubscriptionPeriodFromItems($items) !== null,
         ];
+    }
+
+    private function getSubscriptionPeriodFromItems(array $items): ?string
+    {
+        $subscriptionPeriod = null;
+
+        foreach ($items as $item) {
+            $netSetupPrice = (float) ($item['setup_price'] ?? 0) - (float) ($item['discount_setup'] ?? 0);
+            if ($netSetupPrice > 0) {
+                return null;
+            }
+
+            if ((float) ($item['total'] ?? 0) <= 0) {
+                continue;
+            }
+
+            $period = $item['period'] ?? null;
+            if (empty($period)) {
+                return null;
+            }
+
+            if ($subscriptionPeriod === null) {
+                $subscriptionPeriod = $period;
+
+                continue;
+            }
+
+            if ($subscriptionPeriod !== $period) {
+                return null;
+            }
+        }
+
+        return $subscriptionPeriod;
     }
 
     public function isClientAbleToUsePromo(\Model_Client $client, Promo $promo)

--- a/src/modules/Cart/tests/Unit/ServiceTest.php
+++ b/src/modules/Cart/tests/Unit/ServiceTest.php
@@ -1334,6 +1334,7 @@ test('toApiArray returns expected structure', function (): void {
         'total' => 1,
         'setup_price' => 0,
         'discount' => 0,
+        'period' => '1M',
     ];
     $serviceMock->shouldReceive('cartProductToApiArray')->atLeast()->once()->andReturn($cartProductApiArray);
 
@@ -1363,9 +1364,40 @@ test('toApiArray returns expected structure', function (): void {
         'items' => [$cartProductApiArray],
         'currency' => [],
         'subtotal' => 1,
+        'subscribable' => true,
     ];
     expect($result)->toBeArray();
     expect($result)->toEqual($expected);
+});
+
+test('cart is not subscribable when items use different billing periods', function (): void {
+    $cartModel = new Model_Cart();
+    $cartModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $cartProducts = [new Model_CartProduct(), new Model_CartProduct()];
+    foreach ($cartProducts as $cartProduct) {
+        $cartProduct->loadBean(new Tests\Helpers\DummyBean());
+    }
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('getCartProducts')->once()->andReturn($cartProducts);
+    $serviceMock->shouldReceive('cartProductToApiArray')->andReturn(
+        ['total' => 10, 'setup_price' => 0, 'discount' => 0, 'period' => '1M'],
+        ['total' => 10, 'setup_price' => 0, 'discount' => 0, 'period' => '1Y'],
+    );
+
+    $currency = Mockery::mock(Currency::class);
+    $currency->shouldReceive('toApiArray')->once()->andReturn([]);
+    $currencyRepository = Mockery::mock(CurrencyRepository::class);
+    $currencyRepository->shouldReceive('find')->once()->andReturn($currency);
+    $currencyService = Mockery::mock(CurrencyService::class);
+    $currencyService->shouldReceive('getCurrencyRepository')->once()->andReturn($currencyRepository);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $currencyService);
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->toApiArray($cartModel)['subscribable'])->toBeFalse();
 });
 
 test('getProductDiscount returns discount array', function (): void {

--- a/src/modules/Invoice/ServiceSubscription.php
+++ b/src/modules/Invoice/ServiceSubscription.php
@@ -15,6 +15,8 @@ use FOSSBilling\InjectionAwareInterface;
 
 class ServiceSubscription implements InjectionAwareInterface
 {
+    public const STATUS_PENDING_CANCELLATION = 'pending_cancellation';
+
     protected ?\Pimple\Container $di = null;
 
     public function setDi(\Pimple\Container $di): void
@@ -223,6 +225,22 @@ class ServiceSubscription implements InjectionAwareInterface
         $this->unsubscribe($model);
     }
 
+    public function scheduleCancellation(\Model_Subscription $model): void
+    {
+        $subscriptionId = trim((string) $model->sid);
+        if ($subscriptionId === '') {
+            throw new \FOSSBilling\InformationException('The subscription cannot be canceled at the end of its billing period because it has no gateway ID.');
+        }
+
+        $adapter = $this->getGatewayAdapter($model);
+        if (!method_exists($adapter, 'cancelSubscriptionAtPeriodEnd')) {
+            throw new \FOSSBilling\InformationException('The payment gateway does not support cancellation at the end of the billing period.');
+        }
+
+        $adapter->cancelSubscriptionAtPeriodEnd($subscriptionId);
+        $this->persistUpdate($model, ['status' => self::STATUS_PENDING_CANCELLATION]);
+    }
+
     private function cancelAtGateway(\Model_Subscription $model, ?string $subscriptionId = null): void
     {
         $subscriptionId = trim($subscriptionId ?? (string) $model->sid);
@@ -230,19 +248,118 @@ class ServiceSubscription implements InjectionAwareInterface
             return;
         }
 
-        $gateway = $this->di['db']->getExistingModelById('PayGateway', $model->pay_gateway_id, 'Payment gateway not found');
-        $payGatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
-        $adapter = $payGatewayService->getPaymentAdapter($gateway);
+        $adapter = $this->getGatewayAdapter($model);
 
         if (method_exists($adapter, 'cancelSubscription')) {
             $adapter->cancelSubscription($subscriptionId);
         }
     }
 
-    public function cancelForOrder(\Model_ClientOrder $order): void
+    private function getGatewayAdapter(\Model_Subscription $model): object
+    {
+        $gateway = $this->di['db']->getExistingModelById('PayGateway', $model->pay_gateway_id, 'Payment gateway not found');
+        $payGatewayService = $this->di['mod_service']('Invoice', 'PayGateway');
+
+        return $payGatewayService->getPaymentAdapter($gateway);
+    }
+
+    public function cancelForOrder(\Model_ClientOrder $order): int
+    {
+        $canceledSubscriptions = 0;
+        foreach ($this->getSubscriptionsForOrder($order) as $subscription) {
+            $this->cancel($subscription);
+            ++$canceledSubscriptions;
+        }
+
+        return $canceledSubscriptions;
+    }
+
+    public function scheduleCancellationForOrder(\Model_ClientOrder $order): int
+    {
+        $scheduledSubscriptions = 0;
+        foreach ($this->getSubscriptionsForOrder($order, 'active') as $subscription) {
+            $this->scheduleCancellation($subscription);
+            ++$scheduledSubscriptions;
+        }
+
+        return $scheduledSubscriptions;
+    }
+
+    public function finalizeCancellationFromGateway(int $id): bool
+    {
+        $subscription = $this->di['db']->getExistingModelById('Subscription', $id, 'Subscription not found');
+
+        if ($subscription->status === self::STATUS_PENDING_CANCELLATION && $subscription->rel_type === 'invoice') {
+            $query = $this->di['dbal']->createQueryBuilder();
+            $orderIds = $query
+                ->select('DISTINCT ii.rel_id')
+                ->from('invoice_item', 'ii')
+                ->innerJoin('ii', 'client_order_meta', 'com', 'com.client_order_id = ii.rel_id')
+                ->where('ii.invoice_id = :invoice_id')
+                ->andWhere('ii.type = :item_type')
+                ->andWhere('com.name = :meta_name')
+                ->andWhere('com.value = :meta_value')
+                ->setParameter('invoice_id', $subscription->rel_id)
+                ->setParameter('item_type', \Model_InvoiceItem::TYPE_ORDER)
+                ->setParameter('meta_name', \Box\Mod\Order\Service::META_CANCEL_AT_PERIOD_END)
+                ->setParameter('meta_value', '1')
+                ->executeQuery()
+                ->fetchFirstColumn();
+
+            $orderService = $this->di['mod_service']('Order');
+            foreach ($orderIds as $orderId) {
+                $order = $this->di['db']->getExistingModelById('ClientOrder', (int) $orderId, 'Order not found');
+                if (in_array($order->status, [\Model_ClientOrder::STATUS_CANCELED, \Model_ClientOrder::STATUS_PENDING_SETUP, \Model_ClientOrder::STATUS_FAILED_SETUP], true)) {
+                    continue;
+                }
+
+                $orderService->finalizeCancellationFromGateway($order, 'Subscription ended at the payment gateway');
+            }
+        }
+
+        return $this->persistUpdate($subscription, ['status' => 'canceled']);
+    }
+
+    public function canCancelAtPeriodEndForOrder(\Model_ClientOrder $order): bool
+    {
+        $subscriptions = $this->getSubscriptionsForOrder($order, 'active');
+        if ($subscriptions === []) {
+            return false;
+        }
+
+        foreach ($subscriptions as $subscription) {
+            if (trim((string) $subscription->sid) === '') {
+                return false;
+            }
+
+            try {
+                $adapter = $this->getGatewayAdapter($subscription);
+            } catch (\Exception) {
+                return false;
+            }
+
+            if (!method_exists($adapter, 'cancelSubscriptionAtPeriodEnd')) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function findIdBySid(string $sid): ?int
+    {
+        $id = $this->di['dbal']->fetchOne('SELECT id FROM subscription WHERE sid = :sid', ['sid' => $sid]);
+
+        return is_numeric($id) ? (int) $id : null;
+    }
+
+    /**
+     * @return list<\Model_Subscription>
+     */
+    private function getSubscriptionsForOrder(\Model_ClientOrder $order, ?string $status = null): array
     {
         $query = $this->di['dbal']->createQueryBuilder();
-        $subscriptions = $query
+        $query
             ->select('DISTINCT s.id')
             ->from('subscription', 's')
             ->innerJoin('s', 'invoice_item', 'ii', 'ii.invoice_id = s.rel_id')
@@ -251,14 +368,18 @@ class ServiceSubscription implements InjectionAwareInterface
             ->andWhere('ii.rel_id = :order_id')
             ->setParameter('rel_type', 'invoice')
             ->setParameter('item_type', \Model_InvoiceItem::TYPE_ORDER)
-            ->setParameter('order_id', $order->id)
-            ->executeQuery()
-            ->fetchAllAssociative();
+            ->setParameter('order_id', $order->id);
 
-        foreach ($subscriptions as $subscriptionData) {
-            $subscription = $this->di['db']->getExistingModelById('Subscription', (int) $subscriptionData['id'], 'Subscription not found');
-            $this->cancel($subscription);
+        if ($status !== null) {
+            $query->andWhere('s.status = :status')->setParameter('status', $status);
         }
+
+        $subscriptionIds = $query->executeQuery()->fetchFirstColumn();
+
+        return array_map(
+            fn (mixed $id): \Model_Subscription => $this->di['db']->getExistingModelById('Subscription', (int) $id, 'Subscription not found'),
+            $subscriptionIds,
+        );
     }
 
     private function getSubscriptionPeriodByInvoiceId(int $invoiceId): ?string

--- a/src/modules/Invoice/templates/admin/mod_invoice_subscription.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_subscription.html.twig
@@ -129,6 +129,9 @@
                                                 <span class="form-check-label">{{ 'Canceled'|trans }}</span>
                                             </label>
                                         </div>
+                                        {% if subscription.status == 'pending_cancellation' %}
+                                            <div class="form-hint">{{ 'Cancellation is scheduled at the payment gateway. Select a different status only to override the synchronized state.'|trans }}</div>
+                                        {% endif %}
                                     </div>
                                     <div class="col-xl-6">
                                         <label class="form-label">{{ 'Period'|trans }}</label>

--- a/src/modules/Invoice/templates/admin/mod_invoice_subscriptions.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_subscriptions.html.twig
@@ -87,6 +87,7 @@
                                 <select class="form-select" id="subscription-status" name="status">
                                     <option value="">{{ 'All Statuses'|trans }}</option>
                                     <option value="active"{% if request.status == 'active' %} selected{% endif %}>{{ 'Active'|trans }}</option>
+                                    <option value="pending_cancellation"{% if request.status == 'pending_cancellation' %} selected{% endif %}>{{ 'Pending Cancellation'|trans }}</option>
                                     <option value="canceled"{% if request.status == 'canceled' %} selected{% endif %}>{{ 'Canceled'|trans }}</option>
                                 </select>
                             </div>

--- a/src/modules/Invoice/tests/Unit/ServiceSubscriptionTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceSubscriptionTest.php
@@ -13,8 +13,22 @@ declare(strict_types=1);
 use Box\Mod\Client\Service as ClientService;
 use Box\Mod\Invoice\ServicePayGateway;
 use Box\Mod\Invoice\ServiceSubscription;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
 
 use function Tests\Helpers\container;
+
+function createSubscriptionDbal(): Connection
+{
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $connection->executeStatement('CREATE TABLE subscription (id INTEGER PRIMARY KEY, rel_type TEXT, rel_id INTEGER, status TEXT, sid TEXT)');
+    $connection->executeStatement('CREATE TABLE invoice_item (invoice_id INTEGER, type TEXT, rel_id INTEGER)');
+    $connection->executeStatement('CREATE TABLE client_order_meta (client_order_id INTEGER, name TEXT, value TEXT)');
+    $connection->executeStatement("INSERT INTO subscription (id, rel_type, rel_id, status, sid) VALUES (7, 'invoice', 25, 'active', 'sub_123')");
+    $connection->executeStatement("INSERT INTO invoice_item (invoice_id, type, rel_id) VALUES (25, 'order', 10), (25, 'order', 11)");
+
+    return $connection;
+}
 
 test('gets dependency injection container', function (): void {
     $service = new ServiceSubscription();
@@ -150,6 +164,44 @@ test('does not call the gateway when canceling a subscription without a sid', fu
         ->and($subscriptionModel->status)->toBe('canceled');
 });
 
+test('schedules a subscription cancellation at the gateway', function (): void {
+    $subscription = new Model_Subscription();
+    $subscription->loadBean(new Tests\Helpers\DummyBean());
+    $subscription->sid = 'sub_123';
+    $subscription->pay_gateway_id = 2;
+
+    $gateway = new Model_PayGateway();
+    $gateway->loadBean(new Tests\Helpers\DummyBean());
+
+    $adapter = new class {
+        public ?string $scheduledSubscriptionId = null;
+
+        public function cancelSubscriptionAtPeriodEnd(string $subscriptionId): void
+        {
+            $this->scheduledSubscriptionId = $subscriptionId;
+        }
+    };
+
+    $payGatewayService = Mockery::mock(ServicePayGateway::class);
+    $payGatewayService->shouldReceive('getPaymentAdapter')->once()->with($gateway)->andReturn($adapter);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('getExistingModelById')->once()->with('PayGateway', 2, 'Payment gateway not found')->andReturn($gateway);
+    $db->shouldReceive('store')->once()->with($subscription)->andReturn(1);
+
+    $di = container();
+    $di['db'] = $db;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod_service'] = $di->protect(fn () => $payGatewayService);
+
+    $service = new ServiceSubscription();
+    $service->setDi($di);
+    $service->scheduleCancellation($subscription);
+
+    expect($adapter->scheduledSubscriptionId)->toBe('sub_123')
+        ->and($subscription->status)->toBe(ServiceSubscription::STATUS_PENDING_CANCELLATION);
+});
+
 test('updates subscription status from a gateway without calling the adapter', function (): void {
     $service = new ServiceSubscription();
     $subscriptionModel = new Model_Subscription();
@@ -184,24 +236,6 @@ test('cancels subscriptions linked to an order', function (): void {
     $orderModel->loadBean(new Tests\Helpers\DummyBean());
     $orderModel->id = 10;
 
-    $resultMock = Mockery::mock();
-    $resultMock->shouldReceive('fetchAllAssociative')->once()->andReturn([['id' => 7]]);
-
-    $queryMock = Mockery::mock();
-    $queryMock->shouldReceive('select')->once()->with('DISTINCT s.id')->andReturnSelf();
-    $queryMock->shouldReceive('from')->once()->with('subscription', 's')->andReturnSelf();
-    $queryMock->shouldReceive('innerJoin')->once()->with('s', 'invoice_item', 'ii', 'ii.invoice_id = s.rel_id')->andReturnSelf();
-    $queryMock->shouldReceive('where')->once()->with('s.rel_type = :rel_type')->andReturnSelf();
-    $queryMock->shouldReceive('andWhere')->once()->with('ii.type = :item_type')->andReturnSelf();
-    $queryMock->shouldReceive('andWhere')->once()->with('ii.rel_id = :order_id')->andReturnSelf();
-    $queryMock->shouldReceive('setParameter')->once()->with('rel_type', 'invoice')->andReturnSelf();
-    $queryMock->shouldReceive('setParameter')->once()->with('item_type', Model_InvoiceItem::TYPE_ORDER)->andReturnSelf();
-    $queryMock->shouldReceive('setParameter')->once()->with('order_id', 10)->andReturnSelf();
-    $queryMock->shouldReceive('executeQuery')->once()->andReturn($resultMock);
-
-    $dbalMock = Mockery::mock();
-    $dbalMock->shouldReceive('createQueryBuilder')->once()->andReturn($queryMock);
-
     $dbMock = Mockery::mock('\Box_Database');
     $dbMock->shouldReceive('getExistingModelById')
         ->once()
@@ -212,10 +246,109 @@ test('cancels subscriptions linked to an order', function (): void {
     $service->shouldReceive('cancel')->once()->with($subscriptionModel);
     $di = container();
     $di['db'] = $dbMock;
-    $di['dbal'] = $dbalMock;
+    $di['dbal'] = createSubscriptionDbal();
     $service->setDi($di);
 
     $service->cancelForOrder($orderModel);
+});
+
+test('finalizes a scheduled cancellation by canceling its order and service', function (): void {
+    $subscription = new Model_Subscription();
+    $subscription->loadBean(new Tests\Helpers\DummyBean());
+    $subscription->status = ServiceSubscription::STATUS_PENDING_CANCELLATION;
+    $subscription->rel_type = 'invoice';
+    $subscription->rel_id = 25;
+
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+    $order->status = Model_ClientOrder::STATUS_ACTIVE;
+
+    $dbal = createSubscriptionDbal();
+    $dbal->insert('client_order_meta', [
+        'client_order_id' => 10,
+        'name' => Box\Mod\Order\Service::META_CANCEL_AT_PERIOD_END,
+        'value' => '1',
+    ]);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('getExistingModelById')->once()->with('Subscription', 7, 'Subscription not found')->andReturn($subscription);
+    $db->shouldReceive('getExistingModelById')->once()->with('ClientOrder', 10, 'Order not found')->andReturn($order);
+    $db->shouldReceive('store')->once()->with($subscription)->andReturn(7);
+
+    $orderService = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderService->shouldReceive('finalizeCancellationFromGateway')
+        ->once()
+        ->with($order, 'Subscription ended at the payment gateway')
+        ->andReturn(true);
+
+    $di = container();
+    $di['db'] = $db;
+    $di['dbal'] = $dbal;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod_service'] = $di->protect(fn () => $orderService);
+
+    $service = new ServiceSubscription();
+    $service->setDi($di);
+
+    expect($service->finalizeCancellationFromGateway(7))->toBeTrue()
+        ->and($subscription->status)->toBe('canceled');
+});
+
+test('reports end-of-period cancellation support for active gateway subscriptions', function (): void {
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+    $order->id = 10;
+
+    $subscription = new Model_Subscription();
+    $subscription->loadBean(new Tests\Helpers\DummyBean());
+    $subscription->sid = 'sub_123';
+    $subscription->pay_gateway_id = 2;
+
+    $gateway = new Model_PayGateway();
+    $gateway->loadBean(new Tests\Helpers\DummyBean());
+    $adapter = new class {
+        public function cancelSubscriptionAtPeriodEnd(string $subscriptionId): void
+        {
+        }
+    };
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('getExistingModelById')->once()->with('Subscription', 7, 'Subscription not found')->andReturn($subscription);
+    $db->shouldReceive('getExistingModelById')->once()->with('PayGateway', 2, 'Payment gateway not found')->andReturn($gateway);
+
+    $gatewayService = Mockery::mock(ServicePayGateway::class);
+    $gatewayService->shouldReceive('getPaymentAdapter')->once()->with($gateway)->andReturn($adapter);
+
+    $di = container();
+    $di['db'] = $db;
+    $di['dbal'] = createSubscriptionDbal();
+    $di['mod_service'] = $di->protect(fn () => $gatewayService);
+
+    $service = new ServiceSubscription();
+    $service->setDi($di);
+
+    expect($service->canCancelAtPeriodEndForOrder($order))->toBeTrue();
+});
+
+test('finds a subscription ID by gateway SID without throwing for missing records', function (): void {
+    $dbal = Mockery::mock();
+    $dbal->shouldReceive('fetchOne')
+        ->once()
+        ->with('SELECT id FROM subscription WHERE sid = :sid', ['sid' => 'sub_123'])
+        ->andReturn('7');
+    $dbal->shouldReceive('fetchOne')
+        ->once()
+        ->with('SELECT id FROM subscription WHERE sid = :sid', ['sid' => 'sub_missing'])
+        ->andReturn(false);
+
+    $di = container();
+    $di['dbal'] = $dbal;
+
+    $service = new ServiceSubscription();
+    $service->setDi($di);
+
+    expect($service->findIdBySid('sub_123'))->toBe(7)
+        ->and($service->findIdBySid('sub_missing'))->toBeNull();
 });
 
 test('converts to api array', function (): void {

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -208,6 +208,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * Cancel order.
      *
      * @optional bool $skip_event - Skip calling event hooks
+     * @optional bool $cancel_at_period_end - Keep the order active until its gateway subscription ends
      *
      * @return bool
      */
@@ -217,10 +218,28 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $order = $this->_getOrder($data);
         $skip_event = Tools::normalizeBoolean($data['skip_event'] ?? false);
+        $cancelAtPeriodEnd = Tools::normalizeBoolean($data['cancel_at_period_end'] ?? false);
 
         $reason = $data['reason'] ?? null;
 
+        if ($cancelAtPeriodEnd) {
+            return $this->getService()->scheduleCancellationFromOrder($order, $reason);
+        }
+
         return $this->getService()->cancelFromOrder($order, $reason, $skip_event);
+    }
+
+    /**
+     * Check whether an order's active gateway subscription supports cancellation at period end.
+     */
+    public function can_cancel_at_period_end($data): bool
+    {
+        $this->checkPermissions('order', 'view');
+
+        $order = $this->_getOrder($data);
+        $subscriptionService = $this->getDi()['mod_service']('Invoice', 'Subscription');
+
+        return $subscriptionService->canCancelAtPeriodEndForOrder($order);
     }
 
     /**

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1269,10 +1269,10 @@ class Service implements InjectionAwareInterface
             throw new InformationException('No active gateway subscription that supports cancellation at period end is linked to this order.');
         }
 
-        $this->updateOrderMeta($order, [self::META_CANCEL_AT_PERIOD_END => '1']);
         if ($subscriptionService->scheduleCancellationForOrder($order) === 0) {
             throw new InformationException('No active gateway subscription is linked to this order.');
         }
+        $this->updateOrderMeta($order, [self::META_CANCEL_AT_PERIOD_END => '1']);
 
         $order->reason = $reason;
         $order->updated_at = date('Y-m-d H:i:s');

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Service implements InjectionAwareInterface
 {
+    public const META_CANCEL_AT_PERIOD_END = 'cancel_at_period_end';
+
     protected ?\Pimple\Container $di = null;
 
     public function setDi(\Pimple\Container $di): void
@@ -1249,19 +1251,66 @@ class Service implements InjectionAwareInterface
 
     public function cancelFromOrder(\Model_ClientOrder $order, $reason = null, $skipEvent = false): bool
     {
-        if (!$skipEvent) {
-            $this->di['events_manager']->fire(['event' => 'onBeforeAdminOrderCancel', 'params' => ['id' => $order->id]]);
-        }
-
-        if (in_array($order->status, [\Model_ClientOrder::STATUS_CANCELED, \Model_ClientOrder::STATUS_PENDING_SETUP, \Model_ClientOrder::STATUS_FAILED_SETUP])) {
-            throw new \FOSSBilling\Exception('Cannot cancel ' . $order->status . ' order');
-        }
-
-        $this->_callOnService($order, \Model_ClientOrder::ACTION_CANCEL);
+        $this->assertOrderCanBeCanceled($order);
+        $this->beginCancellation($order, $skipEvent);
 
         $subscriptionService = $this->di['mod_service']('Invoice', 'Subscription');
         $subscriptionService->cancelForOrder($order);
 
+        return $this->completeCancellation($order, $reason, $skipEvent);
+    }
+
+    public function scheduleCancellationFromOrder(\Model_ClientOrder $order, $reason = null): bool
+    {
+        $this->assertOrderCanBeCanceled($order);
+
+        $subscriptionService = $this->di['mod_service']('Invoice', 'Subscription');
+        if (!$subscriptionService->canCancelAtPeriodEndForOrder($order)) {
+            throw new InformationException('No active gateway subscription that supports cancellation at period end is linked to this order.');
+        }
+
+        $this->updateOrderMeta($order, [self::META_CANCEL_AT_PERIOD_END => '1']);
+        if ($subscriptionService->scheduleCancellationForOrder($order) === 0) {
+            throw new InformationException('No active gateway subscription is linked to this order.');
+        }
+
+        $order->reason = $reason;
+        $order->updated_at = date('Y-m-d H:i:s');
+        $this->di['db']->store($order);
+        $this->saveStatusChange($order, 'Cancellation scheduled at the end of the current billing period');
+        $this->di['logger']->info('Scheduled cancellation for order #%s at the end of the current billing period', $order->id);
+
+        return true;
+    }
+
+    public function finalizeCancellationFromGateway(\Model_ClientOrder $order, $reason = null): bool
+    {
+        $this->assertOrderCanBeCanceled($order);
+        $this->beginCancellation($order, false);
+
+        return $this->completeCancellation($order, $reason, false);
+    }
+
+    private function assertOrderCanBeCanceled(\Model_ClientOrder $order): void
+    {
+        if (!in_array($order->status, [\Model_ClientOrder::STATUS_CANCELED, \Model_ClientOrder::STATUS_PENDING_SETUP, \Model_ClientOrder::STATUS_FAILED_SETUP], true)) {
+            return;
+        }
+
+        throw new \FOSSBilling\Exception('Cannot cancel ' . $order->status . ' order');
+    }
+
+    private function beginCancellation(\Model_ClientOrder $order, bool $skipEvent): void
+    {
+        if (!$skipEvent) {
+            $this->di['events_manager']->fire(['event' => 'onBeforeAdminOrderCancel', 'params' => ['id' => $order->id]]);
+        }
+
+        $this->_callOnService($order, \Model_ClientOrder::ACTION_CANCEL);
+    }
+
+    private function completeCancellation(\Model_ClientOrder $order, $reason, bool $skipEvent): bool
+    {
         $order->status = \Model_ClientOrder::STATUS_CANCELED;
         $order->reason = $reason;
         $order->canceled_at = date('Y-m-d H:i:s');
@@ -1269,6 +1318,10 @@ class Service implements InjectionAwareInterface
         $order->suspended_at = null;
         $order->updated_at = date('Y-m-d H:i:s');
         $this->di['db']->store($order);
+        $this->di['db']->exec(
+            'DELETE FROM client_order_meta WHERE client_order_id = :order_id AND name = :name',
+            [':order_id' => $order->id, ':name' => self::META_CANCEL_AT_PERIOD_END],
+        );
         $productService = $this->di['mod_service']('Product');
         $productService->releaseReservedPromoRedemptionsForOrder($order, 'order_canceled');
 

--- a/src/modules/Order/templates/admin/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_manage.html.twig
@@ -26,6 +26,9 @@
 {% if order.group_master == 1 %}
     {% set addons = admin.order_addons({ 'id': order.id }) %}
 {% endif %}
+{% if order.status == 'active' or order.status == 'failed_renew' %}
+    {% set can_cancel_at_period_end = admin.order_can_cancel_at_period_end({ 'id': order.id }) %}
+{% endif %}
 
 {% block content %}
 {% embed 'partial_admin_detail_tabs.html.twig' with {
@@ -197,13 +200,12 @@
                         <span>{{ 'Suspend'|trans }}</span>
                     </button>
                     {% endif %}
-                    <a class="btn btn-primary"
-                        {{ fb_api_link({href: 'order/cancel'|api_url(query: {'id': order.id}), modal: {type: 'prompt', title: 'Cancellation Reason'|trans, label: 'Reason for Cancellation'|trans, key: 'reason'}, reload: true}) }}>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#cancelModal">
                         <svg class="icon" width="24" height="24">
                             <use href="#x" />
                         </svg>
                         <span>{{ 'Cancel'|trans }}</span>
-                    </a>
+                    </button>
                     {% endif %}
 
                     {% if order.status == 'suspended' %}
@@ -273,6 +275,50 @@
             </div>
         </div>
         {% if order.status == 'active' or order.status == 'failed_renew' %}
+            <div class="modal modal-blur fade" id="cancelModal" tabindex="-1" aria-labelledby="cancelModalLabel" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        <form method="post" action="{{ 'order/cancel'|api_url }}" {{ fb_api_form({ reload: true }) }}>
+                            <div class="modal-status bg-danger"></div>
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="cancelModalLabel">{{ 'Cancel Order'|trans }}</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
+                            </div>
+                            <div class="modal-body">
+                                <input type="hidden" name="id" value="{{ order.id }}">
+                                <label class="form-label" for="cancellationReason">{{ 'Reason for Cancellation'|trans }}</label>
+                                <input class="form-control mb-3" id="cancellationReason" type="text" name="reason">
+
+                                {% if can_cancel_at_period_end %}
+                                <label class="form-label">{{ 'Cancellation Timing'|trans }}</label>
+                                <label class="form-check mb-2">
+                                    <input class="form-check-input" type="radio" name="cancel_at_period_end" value="0" checked>
+                                    <span class="form-check-label">
+                                        <strong>{{ 'Cancel immediately'|trans }}</strong>
+                                        <span class="d-block text-muted">{{ 'Cancel the order, service, and linked subscription now.'|trans }}</span>
+                                    </span>
+                                </label>
+                                <label class="form-check">
+                                    <input class="form-check-input" type="radio" name="cancel_at_period_end" value="1">
+                                    <span class="form-check-label">
+                                        <strong>{{ 'Cancel at the end of the current billing period'|trans }}</strong>
+                                        <span class="d-block text-muted">{{ 'Keep the order and service active until the payment gateway ends the subscription.'|trans }}</span>
+                                    </span>
+                                </label>
+                                {% else %}
+                                <input type="hidden" name="cancel_at_period_end" value="0">
+                                <p class="text-muted mb-0">{{ 'This order does not have an active gateway subscription that supports cancellation at the end of the billing period.'|trans }}</p>
+                                {% endif %}
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'Close'|trans }}</button>
+                                <button type="submit" class="btn btn-danger">{{ 'Confirm Cancellation'|trans }}</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
             {% set params = admin.extension_config_get({ 'ext': 'mod_order' }) %}
             {% if params.suspend_reason_list|default('')|trim is not empty %}
                 <div class="modal modal-blur fade" id="suspendModal" tabindex="-1" aria-labelledby="suspendModalLabel" aria-hidden="true">

--- a/src/modules/Order/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Order/tests/Unit/Api/AdminTest.php
@@ -391,6 +391,25 @@ test('cancels an order', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('cancels an order immediately when cancellation timing is omitted', function (): void {
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+
+    $api = apiEndpoint(Mockery::mock(Admin::class)->makePartial());
+    $api->shouldAllowMockingProtectedMethods();
+    $api->shouldReceive('_getOrder')->once()->andReturn($order);
+
+    $service = Mockery::mock(Service::class);
+    $service->shouldReceive('cancelFromOrder')
+        ->once()
+        ->with($order, 'Customer request', false)
+        ->andReturn(true);
+
+    $api->setService($service);
+
+    expect($api->cancel(['reason' => 'Customer request']))->toBeTrue();
+});
+
 test('checks whether an order supports cancellation at period end', function (): void {
     $order = new Model_ClientOrder();
     $order->loadBean(new Tests\Helpers\DummyBean());

--- a/src/modules/Order/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Order/tests/Unit/Api/AdminTest.php
@@ -376,16 +376,40 @@ test('cancels an order', function (): void {
     $apiMock->shouldReceive('_getOrder')->atLeast()->once()->andReturn($order);
 
     $serviceMock = Mockery::mock(Service::class);
-    $serviceMock->shouldReceive('cancelFromOrder')->atLeast()->once()->andReturn(true);
+    $serviceMock->shouldReceive('scheduleCancellationFromOrder')
+        ->once()
+        ->with($order, 'Customer request')
+        ->andReturn(true);
 
     $di = container();
     $apiMock->setDi($di);
     $apiMock->setService($serviceMock);
 
-    $data = [];
+    $data = ['reason' => 'Customer request', 'cancel_at_period_end' => '1'];
     $result = $apiMock->cancel($data);
 
     expect($result)->toBeTrue();
+});
+
+test('checks whether an order supports cancellation at period end', function (): void {
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+
+    $api = apiEndpoint(Mockery::mock(Admin::class)->makePartial());
+    $api->shouldAllowMockingProtectedMethods();
+    $api->shouldReceive('_getOrder')->once()->andReturn($order);
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('canCancelAtPeriodEndForOrder')->once()->with($order)->andReturn(true);
+
+    $staffService = Mockery::mock(Box\Mod\Staff\Service::class);
+    $staffService->shouldReceive('checkPermissionsAndThrowException')->once()->andReturn(true);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (string $module) => strtolower($module) === 'staff' ? $staffService : $subscriptionService);
+    $api->setDi($di);
+
+    expect($api->can_cancel_at_period_end(['id' => 1]))->toBeTrue();
 });
 
 test('uncancels a canceled order', function (): void {

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -2141,6 +2141,26 @@ test('scheduleCancellationFromOrder keeps the service active', function (): void
         ->and($order->reason)->toBe('Customer request');
 });
 
+test('scheduleCancellationFromOrder does not mark the order when no subscription was scheduled', function (): void {
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+    $order->status = Model_ClientOrder::STATUS_ACTIVE;
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('canCancelAtPeriodEndForOrder')->once()->with($order)->andReturn(true);
+    $subscriptionService->shouldReceive('scheduleCancellationForOrder')->once()->with($order)->andReturn(0);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldNotReceive('updateOrderMeta');
+    $service->setDi($di);
+
+    expect(fn () => $service->scheduleCancellationFromOrder($order))
+        ->toThrow(FOSSBilling\InformationException::class, 'No active gateway subscription is linked to this order.');
+});
+
 test('cancelFromOrder does not cancel subscriptions when service cancellation fails', function (): void {
     $clientOrderModel = new Model_ClientOrder();
     $clientOrderModel->loadBean(new Tests\Helpers\DummyBean());

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -2060,8 +2060,10 @@ test('cancelFromOrder cancels linked subscriptions', function (): void {
     $subscriptionService->shouldReceive('cancelForOrder')
         ->once()
         ->with($clientOrderModel)
-        ->andReturnUsing(function () use (&$calls): void {
+        ->andReturnUsing(function () use (&$calls): int {
             $calls[] = 'subscriptions';
+
+            return 1;
         });
 
     $productService = Mockery::mock(Box\Mod\Product\Service::class);
@@ -2071,6 +2073,12 @@ test('cancelFromOrder cancels linked subscriptions', function (): void {
 
     $dbMock = Mockery::mock(Box_Database::class);
     $dbMock->shouldReceive('store')->once()->with($clientOrderModel);
+    $dbMock->shouldReceive('exec')
+        ->once()
+        ->with(
+            'DELETE FROM client_order_meta WHERE client_order_id = :order_id AND name = :name',
+            [':order_id' => $clientOrderModel->id, ':name' => Service::META_CANCEL_AT_PERIOD_END],
+        );
 
     $di = container();
     $di['db'] = $dbMock;
@@ -2096,6 +2104,41 @@ test('cancelFromOrder cancels linked subscriptions', function (): void {
     expect($serviceMock->cancelFromOrder($clientOrderModel, skipEvent: true))->toBeTrue()
         ->and($clientOrderModel->status)->toBe(Model_ClientOrder::STATUS_CANCELED)
         ->and($calls)->toBe(['service', 'subscriptions']);
+});
+
+test('scheduleCancellationFromOrder keeps the service active', function (): void {
+    $order = new Model_ClientOrder();
+    $order->loadBean(new Tests\Helpers\DummyBean());
+    $order->id = 10;
+    $order->status = Model_ClientOrder::STATUS_ACTIVE;
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('canCancelAtPeriodEndForOrder')->once()->with($order)->andReturn(true);
+    $subscriptionService->shouldReceive('scheduleCancellationForOrder')->once()->with($order)->andReturn(1);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('store')->once()->with($order);
+
+    $di = container();
+    $di['db'] = $db;
+    $di['logger'] = new Box_Log();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldNotReceive('_callOnService');
+    $service->shouldReceive('updateOrderMeta')
+        ->once()
+        ->with($order, [Service::META_CANCEL_AT_PERIOD_END => '1'])
+        ->andReturn(2);
+    $service->shouldReceive('saveStatusChange')
+        ->once()
+        ->with($order, 'Cancellation scheduled at the end of the current billing period');
+    $service->setDi($di);
+
+    expect($service->scheduleCancellationFromOrder($order, 'Customer request'))->toBeTrue()
+        ->and($order->status)->toBe(Model_ClientOrder::STATUS_ACTIVE)
+        ->and($order->reason)->toBe('Customer request');
 });
 
 test('cancelFromOrder does not cancel subscriptions when service cancellation fails', function (): void {

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
@@ -170,11 +170,12 @@
                                     <div class="control-group">
                                         <p class="small text-muted mb-2">{{ 'Choose a payment method to continue with your order.'|trans }}</p>
                                         <div class="d-flex flex-wrap gap-3">
+                                        {% set gateway_selected = false %}
                                         {% for gtw in guest.invoice_gateways %}
                                             {% if cart.currency.code in gtw.accepted_currencies and (gtw.allow_single or (cart.subscribable|default(false) and gtw.allow_recurrent)) %}
                                                 {% set gateway_input_id = 'order-gateway-' ~ gtw.id %}
                                                 <div class="invoice-gateway rounded-2 p-2">
-                                                    <input type="radio" class="btn-check border-0" name="gateway_id" id="{{ gateway_input_id }}" value="{{ gtw.id }}" autocomplete="off" {{ loop.first ? 'checked' : '' }}/>
+                                                    <input type="radio" class="btn-check border-0" name="gateway_id" id="{{ gateway_input_id }}" value="{{ gtw.id }}" autocomplete="off" {{ not gateway_selected ? 'checked' : '' }}/>
                                                     {% if gtw.logo.logo %}
                                                         <label class="btn" for="{{ gateway_input_id }}"
                                                             style="background: transparent url('{{ gtw.logo.logo }}') no-repeat center center; background-size: contain; height:{{ gtw.logo.height }}; width:{{ gtw.logo.width }};"
@@ -184,6 +185,7 @@
                                                         <label class="btn text-nowrap" for="{{ gateway_input_id }}">{{ gtw.title }}</label>
                                                     {% endif %}
                                                 </div>
+                                                {% set gateway_selected = true %}
                                             {% endif %}
                                         {% endfor %}
                                         </div>

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
@@ -171,7 +171,7 @@
                                         <p class="small text-muted mb-2">{{ 'Choose a payment method to continue with your order.'|trans }}</p>
                                         <div class="d-flex flex-wrap gap-3">
                                         {% for gtw in guest.invoice_gateways %}
-                                            {% if cart.currency.code in gtw.accepted_currencies and gtw.allow_single %}
+                                            {% if cart.currency.code in gtw.accepted_currencies and (gtw.allow_single or (cart.subscribable|default(false) and gtw.allow_recurrent)) %}
                                                 {% set gateway_input_id = 'order-gateway-' ~ gtw.id %}
                                                 <div class="invoice-gateway rounded-2 p-2">
                                                     <input type="radio" class="btn-check border-0" name="gateway_id" id="{{ gateway_input_id }}" value="{{ gtw.id }}" autocomplete="off" {{ loop.first ? 'checked' : '' }}/>

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -294,6 +294,7 @@
         },
         'subscription': {
             'active': 'text-bg-success',
+            'pending_cancellation': 'text-bg-warning',
             'canceled': 'text-bg-secondary',
             'past_due': 'text-bg-danger',
         },

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -126,6 +126,7 @@ test('orderbutton checkout renders for guests under strict_variables', function 
                 'discount' => 0,
                 'subtotal' => 10,
                 'total' => 10,
+                'subscribable' => true,
                 'currency' => [
                     'code' => 'USD',
                 ],
@@ -134,11 +135,21 @@ test('orderbutton checkout renders for guests under strict_variables', function 
                 'code' => 'USD',
                 'conversion_rate' => 1,
             ],
-            'invoice_gateways' => [],
+            'invoice_gateways' => [
+                [
+                    'id' => 1,
+                    'title' => 'Subscription Gateway',
+                    'accepted_currencies' => ['USD'],
+                    'allow_single' => false,
+                    'allow_recurrent' => true,
+                    'logo' => ['logo' => null, 'height' => 0, 'width' => 0],
+                ],
+            ],
         ],
     ]);
 
-    expect($html)->toContain('You must first login / create an account before you can checkout.');
+    expect($html)->toContain('You must first login / create an account before you can checkout.')
+        ->and($html)->toContain('Subscription Gateway');
 });
 
 /*

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -138,10 +138,26 @@ test('orderbutton checkout renders for guests under strict_variables', function 
             'invoice_gateways' => [
                 [
                     'id' => 1,
+                    'title' => 'Unsupported Gateway',
+                    'accepted_currencies' => ['EUR'],
+                    'allow_single' => true,
+                    'allow_recurrent' => false,
+                    'logo' => ['logo' => null, 'height' => 0, 'width' => 0],
+                ],
+                [
+                    'id' => 2,
                     'title' => 'Subscription Gateway',
                     'accepted_currencies' => ['USD'],
                     'allow_single' => false,
                     'allow_recurrent' => true,
+                    'logo' => ['logo' => null, 'height' => 0, 'width' => 0],
+                ],
+                [
+                    'id' => 3,
+                    'title' => 'Secondary Gateway',
+                    'accepted_currencies' => ['USD'],
+                    'allow_single' => true,
+                    'allow_recurrent' => false,
                     'logo' => ['logo' => null, 'height' => 0, 'width' => 0],
                 ],
             ],
@@ -149,7 +165,9 @@ test('orderbutton checkout renders for guests under strict_variables', function 
     ]);
 
     expect($html)->toContain('You must first login / create an account before you can checkout.')
-        ->and($html)->toContain('Subscription Gateway');
+        ->and($html)->toContain('Subscription Gateway')
+        ->and($html)->toContain('id="order-gateway-2" value="2" autocomplete="off" checked')
+        ->and($html)->not->toContain('id="order-gateway-3" value="3" autocomplete="off" checked');
 });
 
 /*

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -52,6 +52,38 @@ test('does not cancel an already canceled Stripe subscription again', function (
     $this->adapter->cancelSubscription('sub_123');
 });
 
+test('schedules a Stripe subscription cancellation at period end', function (): void {
+    $subscriptionsMock = Mockery::mock();
+    $subscriptionsMock->shouldReceive('retrieve')
+        ->once()
+        ->with('sub_123', [])
+        ->andReturn((object) ['status' => 'active', 'cancel_at_period_end' => false]);
+    $subscriptionsMock->shouldReceive('update')
+        ->once()
+        ->with('sub_123', ['cancel_at_period_end' => true]);
+
+    $stripeMock = Mockery::mock(StripeClient::class);
+    $stripeMock->subscriptions = $subscriptionsMock;
+    setPrivateProperty($this->adapter, 'stripe', $stripeMock);
+
+    $this->adapter->cancelSubscriptionAtPeriodEnd('sub_123');
+});
+
+test('does not reschedule a Stripe subscription already ending at period end', function (): void {
+    $subscriptionsMock = Mockery::mock();
+    $subscriptionsMock->shouldReceive('retrieve')
+        ->once()
+        ->with('sub_123', [])
+        ->andReturn((object) ['status' => 'active', 'cancel_at_period_end' => true]);
+    $subscriptionsMock->shouldReceive('update')->never();
+
+    $stripeMock = Mockery::mock(StripeClient::class);
+    $stripeMock->subscriptions = $subscriptionsMock;
+    setPrivateProperty($this->adapter, 'stripe', $stripeMock);
+
+    $this->adapter->cancelSubscriptionAtPeriodEnd('sub_123');
+});
+
 function setPrivateProperty(object $obj, string $property, mixed $value): void
 {
     $reflection = new ReflectionClass($obj);
@@ -311,6 +343,120 @@ test('syncs subscription webhook status through the internal service path', func
     $this->adapter->setDi($di);
 
     expect(invokePrivateMethod($this->adapter, 'handleSubscriptionUpdated', [
+        $apiAdmin,
+        buildTransaction(),
+        $event,
+    ]))->toBeFalse();
+});
+
+test('syncs end-of-period cancellation state from Stripe', function (): void {
+    $event = (object) ['data' => (object) ['object' => (object) [
+        'id' => 'sub_123',
+        'status' => 'active',
+        'cancel_at_period_end' => true,
+    ]]];
+
+    $apiAdmin = Mockery::mock();
+    $apiAdmin->shouldReceive('invoice_subscription_get')->once()->andReturn(['id' => 42]);
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('updateStatusFromGateway')
+        ->once()
+        ->with(42, Box\Mod\Invoice\ServiceSubscription::STATUS_PENDING_CANCELLATION);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+    $this->adapter->setDi($di);
+
+    expect(invokePrivateMethod($this->adapter, 'handleSubscriptionUpdated', [
+        $apiAdmin,
+        buildTransaction(),
+        $event,
+    ]))->toBeFalse();
+});
+
+test('finalizes local cancellation when Stripe deletes a subscription', function (): void {
+    $event = (object) ['data' => (object) ['object' => (object) ['id' => 'sub_123']]];
+
+    $apiAdmin = Mockery::mock();
+    $apiAdmin->shouldNotReceive('invoice_subscription_get');
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('findIdBySid')->once()->with('sub_123')->andReturn(42);
+    $subscriptionService->shouldReceive('finalizeCancellationFromGateway')->once()->with(42);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+    $this->adapter->setDi($di);
+
+    expect(invokePrivateMethod($this->adapter, 'handleSubscriptionDeleted', [
+        $apiAdmin,
+        buildTransaction(),
+        $event,
+    ]))->toBeFalse();
+});
+
+test('propagates local cancellation failures so Stripe retries the webhook', function (): void {
+    $event = (object) ['data' => (object) ['object' => (object) ['id' => 'sub_123']]];
+
+    $apiAdmin = Mockery::mock();
+    $apiAdmin->shouldNotReceive('invoice_subscription_get');
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('findIdBySid')->once()->with('sub_123')->andReturn(42);
+    $subscriptionService->shouldReceive('finalizeCancellationFromGateway')
+        ->once()
+        ->with(42)
+        ->andThrow(new RuntimeException('Service cancellation failed'));
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+    $this->adapter->setDi($di);
+
+    expect(fn () => invokePrivateMethod($this->adapter, 'handleSubscriptionDeleted', [
+        $apiAdmin,
+        buildTransaction(),
+        $event,
+    ]))->toThrow(RuntimeException::class, 'Service cancellation failed');
+});
+
+test('propagates subscription lookup failures so Stripe retries the webhook', function (): void {
+    $event = (object) ['data' => (object) ['object' => (object) ['id' => 'sub_123']]];
+
+    $apiAdmin = Mockery::mock();
+    $apiAdmin->shouldNotReceive('invoice_subscription_get');
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('findIdBySid')
+        ->once()
+        ->with('sub_123')
+        ->andThrow(new RuntimeException('Database unavailable'));
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+    $this->adapter->setDi($di);
+
+    expect(fn () => invokePrivateMethod($this->adapter, 'handleSubscriptionDeleted', [
+        $apiAdmin,
+        buildTransaction(),
+        $event,
+    ]))->toThrow(RuntimeException::class, 'Database unavailable');
+});
+
+test('ignores deleted Stripe subscriptions without a local record', function (): void {
+    $event = (object) ['data' => (object) ['object' => (object) ['id' => 'sub_missing']]];
+
+    $apiAdmin = Mockery::mock();
+    $apiAdmin->shouldNotReceive('invoice_subscription_get');
+
+    $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+    $subscriptionService->shouldReceive('findIdBySid')->once()->with('sub_missing')->andReturn(null);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn () => $subscriptionService);
+    $this->adapter->setDi($di);
+
+    expect(invokePrivateMethod($this->adapter, 'handleSubscriptionDeleted', [
         $apiAdmin,
         buildTransaction(),
         $event,
@@ -1087,11 +1233,14 @@ describe('processWebhookEvent noise filtering', function (): void {
         $dbMock->shouldReceive('store')->andReturn($tx->id);
 
         $apiAdmin = Mockery::mock();
-        $apiAdmin->shouldReceive('invoice_subscription_get')
-            ->andThrow(new Exception('Not found'));
+        $apiAdmin->shouldNotReceive('invoice_subscription_get');
+
+        $subscriptionService = Mockery::mock(Box\Mod\Invoice\ServiceSubscription::class);
+        $subscriptionService->shouldReceive('findIdBySid')->once()->with('sub_nonexistent')->andReturn(null);
 
         $di = container();
         $di['db'] = $dbMock;
+        $di['mod_service'] = $di->protect(fn () => $subscriptionService);
         $this->adapter->setDi($di);
 
         $data = [


### PR DESCRIPTION
## Summary

- add an admin choice between immediate cancellation and cancellation at the end of the current billing period
- keep the order and service active while Stripe has `cancel_at_period_end` set, then finalize cancellation from the subscription deletion webhook
- scope webhook finalization to orders explicitly marked for scheduled cancellation
- expose the pending-cancellation subscription state in the admin UI
- allow subscription-only gateways to appear during checkout when the cart is eligible for recurring billing