### PR TITLE
Fix duplicate Stripe one-time payment transactions

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -962,19 +962,27 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     private function withPaymentIntentLock(string $paymentIntentId, int $gatewayId, callable $callback): mixed
     {
         $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
-        $acquired = (int) $this->di['db']->getCell(
+        $waitStartedAt = hrtime(true);
+        $acquired = (int) $this->di['dbal']->fetchOne(
             'SELECT GET_LOCK(:lock_name, 10)',
-            [':lock_name' => $lockName]
+            ['lock_name' => $lockName]
         );
 
         if ($acquired !== 1) {
+            $waitDurationMs = (hrtime(true) - $waitStartedAt) / 1_000_000;
+            $this->di['logger']->warning(
+                'Timed out after %.1f ms waiting for Stripe PaymentIntent lock %s',
+                $waitDurationMs,
+                $lockName
+            );
+
             throw new FOSSBilling\Exception('Timed out waiting to process this Stripe payment');
         }
 
         try {
             return $callback();
         } finally {
-            $this->di['db']->getCell('SELECT RELEASE_LOCK(:lock_name)', [':lock_name' => $lockName]);
+            $this->di['dbal']->fetchOne('SELECT RELEASE_LOCK(:lock_name)', ['lock_name' => $lockName]);
         }
     }
 

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -271,8 +271,18 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
     private function processPaymentIntent(Model_Transaction $tx, ?Model_Invoice $invoice, array $data): void
     {
-        $invoiceService = $this->di['mod_service']('Invoice');
         $charge = $this->stripe->paymentIntents->retrieve($data['get']['payment_intent'], []);
+
+        $this->withPaymentIntentLock(
+            $charge->id,
+            (int) $tx->gateway_id,
+            fn () => $this->processPaymentIntentUnderLock($tx, $invoice, $charge)
+        );
+    }
+
+    private function processPaymentIntentUnderLock(Model_Transaction $tx, ?Model_Invoice $invoice, object $charge): void
+    {
+        $invoiceService = $this->di['mod_service']('Invoice');
 
         $tx->txn_status = $charge->status;
         $tx->txn_id = $charge->id;
@@ -879,6 +889,15 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     {
         $paymentIntent = $event->data->object;
 
+        return $this->withPaymentIntentLock(
+            $paymentIntent->id,
+            $gateway_id,
+            fn (): bool => $this->handlePaymentIntentSucceededWebhookUnderLock($tx, $paymentIntent, $gateway_id)
+        );
+    }
+
+    private function handlePaymentIntentSucceededWebhookUnderLock(Model_Transaction $tx, object $paymentIntent, int $gateway_id): bool
+    {
         // Set transaction metadata from the PaymentIntent
         $tx->txn_id = $paymentIntent->id;
         $tx->txn_status = $paymentIntent->status;
@@ -892,8 +911,14 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         // redirect flow is mid-processing when the webhook arrives.
         $existing = $this->di['db']->findOne(
             'Transaction',
-            'txn_id = :txn_id AND status IN (:s1, :s2)',
-            [':txn_id' => $paymentIntent->id, ':s1' => Model_Transaction::STATUS_PROCESSING, ':s2' => Model_Transaction::STATUS_PROCESSED]
+            'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2)',
+            [
+                ':txn_id' => $paymentIntent->id,
+                ':gateway_id' => $gateway_id,
+                ':id' => $tx->id,
+                ':s1' => Model_Transaction::STATUS_PROCESSING,
+                ':s2' => Model_Transaction::STATUS_PROCESSED,
+            ]
         );
         if ($existing instanceof Model_Transaction) {
             $tx->invoice_id = $existing->invoice_id;
@@ -916,8 +941,11 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
         if ($invoiceId) {
             $tx->invoice_id = (int) $invoiceId;
-            $this->di['db']->store($tx);
         }
+
+        // Persist the PaymentIntent ID while the lock is held so a redirect
+        // waiting on the same key observes this transaction after release.
+        $this->di['db']->store($tx);
 
         if ($paymentIntent->status !== 'succeeded') {
             return false;
@@ -929,6 +957,25 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         $this->applyOneTimePayment($tx, $invoice, $paymentIntent);
 
         return true;
+    }
+
+    private function withPaymentIntentLock(string $paymentIntentId, int $gatewayId, callable $callback): mixed
+    {
+        $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
+        $acquired = (int) $this->di['db']->getCell(
+            'SELECT GET_LOCK(:lock_name, 10)',
+            [':lock_name' => $lockName]
+        );
+
+        if ($acquired !== 1) {
+            throw new FOSSBilling\Exception('Timed out waiting to process this Stripe payment');
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->di['db']->getCell('SELECT RELEASE_LOCK(:lock_name)', [':lock_name' => $lockName]);
+        }
     }
 
     private function handlePaymentIntentFailedWebhook($api_admin, Model_Transaction $tx, object $event): bool

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -1355,7 +1355,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
     protected function _generateForm(Model_Invoice $invoice): string
     {
-        $intent = $this->stripe->paymentIntents->create([
+        $intentParams = [
             'amount' => $this->getAmountInMinorUnits($invoice),
             'currency' => $invoice->currency,
             'description' => $this->getInvoiceTitle($invoice),
@@ -1366,7 +1366,14 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                 'invoice_id' => (string) $invoice->id,
                 'gateway_id' => (string) $this->config['gateway_id'],
             ],
-        ], ['idempotency_key' => sprintf('one_time_invoice_%d_gateway_%d', $invoice->id, $this->config['gateway_id'])]);
+        ];
+        $idempotencyKey = sprintf(
+            'one_time_invoice_%d_gateway_%d_%s',
+            $invoice->id,
+            $this->config['gateway_id'],
+            hash('sha256', json_encode($intentParams, JSON_THROW_ON_ERROR))
+        );
+        $intent = $this->stripe->paymentIntents->create($intentParams, ['idempotency_key' => $idempotencyKey]);
 
         $pubKey = ($this->config['test_mode']) ? $this->config['test_pub_key'] : $this->config['pub_key'];
 

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -280,6 +280,26 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         $tx->currency = $charge->currency;
         $tx->type = Payment_Transaction::TXTYPE_PAYMENT;
 
+        // Stripe may deliver the webhook before redirecting the customer.
+        // Keep that transaction instead of recording the PaymentIntent twice.
+        $existing = $this->di['db']->findOne(
+            'Transaction',
+            'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2, :s3)',
+            [
+                ':txn_id' => $charge->id,
+                ':gateway_id' => $tx->gateway_id,
+                ':id' => $tx->id,
+                ':s1' => Model_Transaction::STATUS_RECEIVED,
+                ':s2' => Model_Transaction::STATUS_PROCESSING,
+                ':s3' => Model_Transaction::STATUS_PROCESSED,
+            ]
+        );
+        if ($existing instanceof Model_Transaction) {
+            $this->di['db']->trash($tx);
+
+            return;
+        }
+
         if ($charge->status === 'succeeded') {
             if ($tx->status === Model_Transaction::STATUS_PROCESSED && empty($tx->error)) {
                 $tx->updated_at = date('Y-m-d H:i:s');
@@ -1346,7 +1366,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                 'invoice_id' => (string) $invoice->id,
                 'gateway_id' => (string) $this->config['gateway_id'],
             ],
-        ]);
+        ], ['idempotency_key' => sprintf('one_time_invoice_%d_gateway_%d', $invoice->id, $this->config['gateway_id'])]);
 
         $pubKey = ($this->config['test_mode']) ? $this->config['test_pub_key'] : $this->config['pub_key'];
 

--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -1404,7 +1404,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     {
         $intentParams = [
             'amount' => $this->getAmountInMinorUnits($invoice),
-            'currency' => $invoice->currency,
+            'currency' => strtolower($invoice->currency),
             'description' => $this->getInvoiceTitle($invoice),
             'automatic_payment_methods' => ['enabled' => true],
             'receipt_email' => $invoice->buyer_email,

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -1327,7 +1327,10 @@ describe('Stripe webhook gateway ownership', function (): void {
             ->once()
             ->withArgs(fn (array $params, array $options): bool => $params['metadata']['gateway_id'] === '3'
                 && $params['metadata']['invoice_id'] === '15'
-                && $options['idempotency_key'] === 'one_time_invoice_15_gateway_3')
+                && $options['idempotency_key'] === sprintf(
+                    'one_time_invoice_15_gateway_3_%s',
+                    hash('sha256', json_encode($params, JSON_THROW_ON_ERROR))
+                ))
             ->andReturn(Stripe\PaymentIntent::constructFrom([
                 'id' => 'pi_gateway_3',
                 'client_secret' => 'pi_gateway_3_secret',

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -91,6 +91,19 @@ function setPrivateProperty(object $obj, string $property, mixed $value): void
     $prop->setValue($obj, $value);
 }
 
+function expectPaymentIntentLock(Mockery\MockInterface $dbMock, string $paymentIntentId, int $gatewayId): void
+{
+    $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
+    $dbMock->shouldReceive('getCell')
+        ->once()
+        ->with('SELECT GET_LOCK(:lock_name, 10)', [':lock_name' => $lockName])
+        ->andReturn(1);
+    $dbMock->shouldReceive('getCell')
+        ->once()
+        ->with('SELECT RELEASE_LOCK(:lock_name)', [':lock_name' => $lockName])
+        ->andReturn(1);
+}
+
 function signStripeWebhookPayload(string $payload, string $secret = TEST_WEBHOOK_SECRET): string
 {
     $timestamp = time();
@@ -889,8 +902,15 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
         $existingTx->invoice_id = 10;
 
         $dbMock = Mockery::mock('\Box_Database');
+        expectPaymentIntentLock($dbMock, 'pi_existing', 1);
         $dbMock->shouldReceive('findOne')
-            ->with('Transaction', 'txn_id = :txn_id AND status IN (:s1, :s2)', Mockery::any())
+            ->with(
+                'Transaction',
+                'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2)',
+                Mockery::on(fn (array $params): bool => $params[':txn_id'] === 'pi_existing'
+                    && $params[':gateway_id'] === 1
+                    && $params[':id'] === 200)
+            )
             ->andReturn($existingTx);
         $dbMock->shouldReceive('store')->andReturn($tx->id);
 
@@ -931,6 +951,7 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
         $invoiceModel->client_id = 7;
 
         $dbMock = Mockery::mock('\Box_Database');
+        expectPaymentIntentLock($dbMock, 'pi_new', 1);
         $dbMock->shouldReceive('findOne')
             ->andReturn(null);
         $dbMock->shouldReceive('store')->andReturn($tx->id);
@@ -1007,6 +1028,7 @@ describe('processPaymentIntent', function (): void {
         setPrivateProperty($this->adapter, 'stripe', $stripeMock);
 
         $dbMock = Mockery::mock('\Box_Database');
+        expectPaymentIntentLock($dbMock, 'pi_webhook_first', 4);
         $dbMock->shouldReceive('findOne')
             ->once()
             ->with('Transaction', 'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2, :s3)', Mockery::on(fn (array $params): bool => $params[':txn_id'] === 'pi_webhook_first'
@@ -1027,6 +1049,21 @@ describe('processPaymentIntent', function (): void {
 
         expect($tx->txn_id)->toBe('pi_webhook_first');
     });
+});
+
+test('releases the PaymentIntent lock when processing fails', function (): void {
+    $dbMock = Mockery::mock('\\Box_Database');
+    expectPaymentIntentLock($dbMock, 'pi_failure', 2);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $this->adapter->setDi($di);
+
+    expect(fn () => invokePrivateMethod($this->adapter, 'withPaymentIntentLock', [
+        'pi_failure',
+        2,
+        fn () => throw new RuntimeException('Processing failed'),
+    ]))->toThrow(RuntimeException::class, 'Processing failed');
 });
 
 describe('handleSetupIntentSucceededWebhook', function (): void {

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -91,16 +91,16 @@ function setPrivateProperty(object $obj, string $property, mixed $value): void
     $prop->setValue($obj, $value);
 }
 
-function expectPaymentIntentLock(Mockery\MockInterface $dbMock, string $paymentIntentId, int $gatewayId): void
+function expectPaymentIntentLock(Mockery\MockInterface $dbalMock, string $paymentIntentId, int $gatewayId): void
 {
     $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
-    $dbMock->shouldReceive('getCell')
+    $dbalMock->shouldReceive('fetchOne')
         ->once()
-        ->with('SELECT GET_LOCK(:lock_name, 10)', [':lock_name' => $lockName])
+        ->with('SELECT GET_LOCK(:lock_name, 10)', ['lock_name' => $lockName])
         ->andReturn(1);
-    $dbMock->shouldReceive('getCell')
+    $dbalMock->shouldReceive('fetchOne')
         ->once()
-        ->with('SELECT RELEASE_LOCK(:lock_name)', [':lock_name' => $lockName])
+        ->with('SELECT RELEASE_LOCK(:lock_name)', ['lock_name' => $lockName])
         ->andReturn(1);
 }
 
@@ -902,7 +902,8 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
         $existingTx->invoice_id = 10;
 
         $dbMock = Mockery::mock('\Box_Database');
-        expectPaymentIntentLock($dbMock, 'pi_existing', 1);
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectPaymentIntentLock($dbalMock, 'pi_existing', 1);
         $dbMock->shouldReceive('findOne')
             ->with(
                 'Transaction',
@@ -916,6 +917,7 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
 
         $di = container();
         $di['db'] = $dbMock;
+        $di['dbal'] = $dbalMock;
         $this->adapter->setDi($di);
 
         invokePrivateMethod($this->adapter, 'handlePaymentIntentSucceededWebhook', [
@@ -951,7 +953,8 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
         $invoiceModel->client_id = 7;
 
         $dbMock = Mockery::mock('\Box_Database');
-        expectPaymentIntentLock($dbMock, 'pi_new', 1);
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectPaymentIntentLock($dbalMock, 'pi_new', 1);
         $dbMock->shouldReceive('findOne')
             ->andReturn(null);
         $dbMock->shouldReceive('store')->andReturn($tx->id);
@@ -982,6 +985,7 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
 
         $di = container();
         $di['db'] = $dbMock;
+        $di['dbal'] = $dbalMock;
         $di['mod_service'] = $di->protect(fn ($module, $service = null) => match (true) {
             $service === 'Transaction' => $transactionService,
             $module === 'client' => $clientService,
@@ -1028,7 +1032,8 @@ describe('processPaymentIntent', function (): void {
         setPrivateProperty($this->adapter, 'stripe', $stripeMock);
 
         $dbMock = Mockery::mock('\Box_Database');
-        expectPaymentIntentLock($dbMock, 'pi_webhook_first', 4);
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectPaymentIntentLock($dbalMock, 'pi_webhook_first', 4);
         $dbMock->shouldReceive('findOne')
             ->once()
             ->with('Transaction', 'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2, :s3)', Mockery::on(fn (array $params): bool => $params[':txn_id'] === 'pi_webhook_first'
@@ -1039,6 +1044,7 @@ describe('processPaymentIntent', function (): void {
 
         $di = container();
         $di['db'] = $dbMock;
+        $di['dbal'] = $dbalMock;
         $this->adapter->setDi($di);
 
         invokePrivateMethod($this->adapter, 'processPaymentIntent', [
@@ -1052,11 +1058,11 @@ describe('processPaymentIntent', function (): void {
 });
 
 test('releases the PaymentIntent lock when processing fails', function (): void {
-    $dbMock = Mockery::mock('\\Box_Database');
-    expectPaymentIntentLock($dbMock, 'pi_failure', 2);
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    expectPaymentIntentLock($dbalMock, 'pi_failure', 2);
 
     $di = container();
-    $di['db'] = $dbMock;
+    $di['dbal'] = $dbalMock;
     $this->adapter->setDi($di);
 
     expect(fn () => invokePrivateMethod($this->adapter, 'withPaymentIntentLock', [
@@ -1064,6 +1070,31 @@ test('releases the PaymentIntent lock when processing fails', function (): void 
         2,
         fn () => throw new RuntimeException('Processing failed'),
     ]))->toThrow(RuntimeException::class, 'Processing failed');
+});
+
+test('logs PaymentIntent lock timeouts with lock context', function (): void {
+    $lockName = 'fb:stripe:' . substr(hash('sha256', '2:pi_timeout'), 0, 54);
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('fetchOne')
+        ->once()
+        ->with('SELECT GET_LOCK(:lock_name, 10)', ['lock_name' => $lockName])
+        ->andReturn(0);
+
+    $logger = new Tests\Helpers\TestLogger();
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $di['logger'] = $logger;
+    $this->adapter->setDi($di);
+
+    expect(fn () => invokePrivateMethod($this->adapter, 'withPaymentIntentLock', [
+        'pi_timeout',
+        2,
+        fn () => null,
+    ]))->toThrow(FOSSBilling\Exception::class, 'Timed out waiting to process this Stripe payment')
+        ->and($logger->calls)->toHaveCount(1)
+        ->and($logger->calls[0]['method'])->toBe('warning')
+        ->and($logger->calls[0]['params'][0])->toContain('Timed out after')
+        ->and($logger->calls[0]['params'][2])->toBe($lockName);
 });
 
 describe('handleSetupIntentSucceededWebhook', function (): void {
@@ -1364,6 +1395,7 @@ describe('Stripe webhook gateway ownership', function (): void {
             ->once()
             ->withArgs(fn (array $params, array $options): bool => $params['metadata']['gateway_id'] === '3'
                 && $params['metadata']['invoice_id'] === '15'
+                && $params['currency'] === 'usd'
                 && $options['idempotency_key'] === sprintf(
                     'one_time_invoice_15_gateway_3_%s',
                     hash('sha256', json_encode($params, JSON_THROW_ON_ERROR))

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -981,6 +981,54 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
     });
 });
 
+describe('processPaymentIntent', function (): void {
+    test('deletes the redirect transaction when the webhook already recorded the PaymentIntent', function (): void {
+        $tx = buildTransaction();
+        $tx->id = 401;
+        $tx->gateway_id = 4;
+
+        $existingTx = buildTransaction();
+
+        $paymentIntent = Stripe\PaymentIntent::constructFrom([
+            'id' => 'pi_webhook_first',
+            'status' => 'succeeded',
+            'amount' => 2500,
+            'currency' => 'usd',
+        ]);
+
+        $paymentIntentsMock = Mockery::mock();
+        $paymentIntentsMock->shouldReceive('retrieve')
+            ->once()
+            ->with('pi_webhook_first', [])
+            ->andReturn($paymentIntent);
+
+        $stripeMock = Mockery::mock(StripeClient::class);
+        $stripeMock->paymentIntents = $paymentIntentsMock;
+        setPrivateProperty($this->adapter, 'stripe', $stripeMock);
+
+        $dbMock = Mockery::mock('\Box_Database');
+        $dbMock->shouldReceive('findOne')
+            ->once()
+            ->with('Transaction', 'txn_id = :txn_id AND gateway_id = :gateway_id AND id != :id AND status IN (:s1, :s2, :s3)', Mockery::on(fn (array $params): bool => $params[':txn_id'] === 'pi_webhook_first'
+                && $params[':gateway_id'] === 4
+                && $params[':id'] === 401))
+            ->andReturn($existingTx);
+        $dbMock->shouldReceive('trash')->once()->with($tx);
+
+        $di = container();
+        $di['db'] = $dbMock;
+        $this->adapter->setDi($di);
+
+        invokePrivateMethod($this->adapter, 'processPaymentIntent', [
+            $tx,
+            null,
+            ['get' => ['payment_intent' => 'pi_webhook_first']],
+        ]);
+
+        expect($tx->txn_id)->toBe('pi_webhook_first');
+    });
+});
+
 describe('handleSetupIntentSucceededWebhook', function (): void {
     test('skips processing when setup already handled via redirect flow', function (): void {
         $tx = buildTransaction();
@@ -1277,8 +1325,9 @@ describe('Stripe webhook gateway ownership', function (): void {
         $paymentIntentsMock = Mockery::mock();
         $paymentIntentsMock->shouldReceive('create')
             ->once()
-            ->withArgs(fn (array $params): bool => $params['metadata']['gateway_id'] === '3'
-                && $params['metadata']['invoice_id'] === '15')
+            ->withArgs(fn (array $params, array $options): bool => $params['metadata']['gateway_id'] === '3'
+                && $params['metadata']['invoice_id'] === '15'
+                && $options['idempotency_key'] === 'one_time_invoice_15_gateway_3')
             ->andReturn(Stripe\PaymentIntent::constructFrom([
                 'id' => 'pi_gateway_3',
                 'client_secret' => 'pi_gateway_3_secret',


### PR DESCRIPTION
## Summary

- discard a later Stripe redirect transaction when the webhook has already recorded the same PaymentIntent
- use a gateway- and invoice-scoped Stripe idempotency key when creating one-time PaymentIntents
- add regression coverage for webhook-first processing and PaymentIntent creation options