### PR TITLE
Invalidate user sessions after password reset

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -263,6 +263,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             $c->pass = $this->getDi()['password']->hashIt($data['password']);
             $this->getDi()['db']->store($c);
 
+            $profileService = $this->getDi()['mod_service']('profile');
+            $profileService->invalidateSessions('client', (int) $c->id);
+
             $this->getDi()['logger']->setChannel('security')->info('Client password reset completed for client #%s from IP %s', $c->id, $this->getIp());
 
             // send email

--- a/src/modules/Client/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Client/tests/Unit/Api/GuestTest.php
@@ -302,13 +302,16 @@ test('updatePassword returns true', function (): void {
     $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
     $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once();
 
+    $profileServiceMock = Mockery::mock(Box\Mod\Profile\Service::class);
+    $profileServiceMock->shouldReceive('invalidateSessions')->atLeast()->once();
+
     $di = container();
     $di['db'] = $dbMock;
     $di['events_manager'] = $eventMock;
     $di['logger'] = new Tests\Helpers\TestLogger();
     $di['password'] = $passwordMock;
     $di['logger'] = new Tests\Helpers\TestLogger();
-    $di['mod_service'] = $di->protect(moduleService(['email' => $emailServiceMock]));
+    $di['mod_service'] = $di->protect(moduleService(['email' => $emailServiceMock, 'profile' => $profileServiceMock]));
 
     $guestClient->setDi($di);
 

--- a/src/modules/Staff/Api/Guest.php
+++ b/src/modules/Staff/Api/Guest.php
@@ -102,6 +102,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             $admin->pass = $this->getDi()['password']->hashIt($data['password']);
             $this->getDi()['db']->store($admin);
 
+            $profileService = $this->getDi()['mod_service']('profile');
+            $profileService->invalidateSessions('admin', (int) $admin->id);
+
             $this->getDi()['logger']->setChannel('security')->info('Staff password reset completed for admin #%s from IP %s', $admin->id, $this->getIp());
 
             $this->getDi()['events_manager']->fire(['event' => 'onAfterPasswordResetStaff', 'params' => ['id' => $admin->id]]);

--- a/src/modules/Staff/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Staff/tests/Unit/Api/GuestTest.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use function Tests\Helpers\container;
+use function Tests\Helpers\moduleService;
 
 test('get di', function (): void {
     $api = apiEndpoint(new Box\Mod\Staff\Api\Guest());
@@ -105,4 +106,54 @@ test('login check ip exception', function (): void {
     ];
     expect(fn () => $guestApi->login($data))
         ->toThrow(FOSSBilling\Exception::class, 'You are not allowed to login to admin area from this IP address.');
+});
+
+test('updatePassword invalidates existing sessions', function (): void {
+    $guestApi = apiEndpoint(new Box\Mod\Staff\Api\Guest());
+
+    $modMock = Mockery::mock('\\' . FOSSBilling\Module::class);
+    $modMock->shouldReceive('getConfig')->atLeast()->once()->andReturn([]);
+
+    $modelPasswordReset = new Model_AdminPasswordReset();
+    $modelPasswordReset->loadBean(new Tests\Helpers\DummyBean());
+    $modelPasswordReset->created_at = date('Y-m-d H:i:s', time() - 300);
+
+    $admin = new Model_Admin();
+    $admin->loadBean(new Tests\Helpers\DummyBean());
+    $admin->id = 1;
+    $admin->status = Model_Admin::STATUS_ACTIVE;
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('findOne')->atLeast()->once()->andReturn($modelPasswordReset);
+    $dbMock->shouldReceive('getExistingModelById')->atLeast()->once()->andReturn($admin);
+    $dbMock->shouldReceive('store')->atLeast()->once();
+    $dbMock->shouldReceive('trash')->atLeast()->once();
+
+    $eventMock = Mockery::mock('\Box_EventManager');
+    $eventMock->shouldReceive('fire')->times(2);
+
+    $passwordMock = Mockery::mock(FOSSBilling\PasswordManager::class);
+    $passwordMock->shouldReceive('hashIt')->atLeast()->once();
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once();
+
+    $profileServiceMock = Mockery::mock(Box\Mod\Profile\Service::class);
+    $profileServiceMock->shouldReceive('invalidateSessions')->atLeast()->once();
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['events_manager'] = $eventMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['password'] = $passwordMock;
+    $di['mod_service'] = $di->protect(moduleService(['email' => $emailServiceMock, 'profile' => $profileServiceMock]));
+
+    $guestApi->setMod($modMock);
+    $guestApi->setDi($di);
+
+    $guestApi->update_password([
+        'code' => 'hashedString',
+        'password' => 'NewPassword1',
+        'password_confirm' => 'NewPassword1',
+    ]);
 });

--- a/tests/Unit/FOSSBilling/Validation/PriceValidatorTest.php
+++ b/tests/Unit/FOSSBilling/Validation/PriceValidatorTest.php
@@ -41,6 +41,7 @@ dataset('flooredQuantities', fn (): array => [
     'negative int' => [-5, 1],
     'negative float' => [-1.5, 1],
     'positive float' => [1.5, 1],
+    'positive float above one' => [2.7, 2],
 ]);
 
 dataset('invalidQuantities', fn (): array => [

--- a/tests/Unit/FOSSBilling/Validation/PriceValidatorTest.php
+++ b/tests/Unit/FOSSBilling/Validation/PriceValidatorTest.php
@@ -93,6 +93,11 @@ test('validateSignedAmount rejects non-numeric values', function (): void {
         ->toThrow(InformationException::class, 'Price must be a valid number.');
 });
 
+test('validateSignedAmount uses custom field name in error', function (): void {
+    expect(fn (): float => PriceValidator::validateSignedAmount('not-a-price', 'Adjustment'))
+        ->toThrow(InformationException::class, 'Adjustment must be a valid number.');
+});
+
 test('validateQuantity accepts valid quantities', function (mixed $input, int $expected): void {
     $result = PriceValidator::validateQuantity($input);
 


### PR DESCRIPTION
This pull request introduces improved session security by ensuring that all active sessions are invalidated when a client or staff member resets their password.