### PR TITLE
Fix ClientBalance single-payment gateway flags

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','90',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','91',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -500,6 +500,7 @@ class UpdatePatcher implements InjectionAwareInterface
             88 => 'patch88',
             89 => 'patch89',
             90 => 'patch90',
+            91 => 'patch91',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2423,6 +2424,17 @@ class UpdatePatcher implements InjectionAwareInterface
         ];
 
         $this->restoreLegacyDefaultEmailTemplates($brokenV072TemplateHashes);
+    }
+
+    private function patch91(): void
+    {
+        // ClientBalance did not declare its one-time payment capability, so the gateway
+        // settings form hid the option and persisted allow_single = 0 whenever it was saved.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/3989
+        $this->executeSql(
+            'UPDATE pay_gateway SET allow_single = 1 WHERE gateway = :gateway AND allow_single = 0',
+            ['gateway' => 'ClientBalance']
+        );
     }
 
     private function generateDownloadableStoredFilename(): string

--- a/src/library/Payment/Adapter/ClientBalance.php
+++ b/src/library/Payment/Adapter/ClientBalance.php
@@ -29,6 +29,8 @@ class Payment_Adapter_ClientBalance implements FOSSBilling\InjectionAwareInterfa
     public static function getConfig(): array
     {
         return [
+            'supports_one_time_payments' => true,
+            'supports_subscriptions' => false,
             'logo' => [
                 'logo' => 'clientbalance.png',
                 'height' => '50px',

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -6,11 +6,32 @@ use FOSSBilling\UpdatePatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-test('legacy email template repair follows patch 89', function (): void {
+test('client balance gateway repair follows the legacy email template repair', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 89);
 
     expect($patches)->toHaveKey(90)
-        ->and($patches[90][1])->toBe('patch90');
+        ->and($patches[90][1])->toBe('patch90')
+        ->and($patches)->toHaveKey(91)
+        ->and($patches[91][1])->toBe('patch91');
+});
+
+test('client balance gateway patch restores one-time payments', function (): void {
+    $statement = Mockery::mock(PDOStatement::class);
+    $statement->expects('execute')
+        ->with(['gateway' => 'ClientBalance'])
+        ->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with('UPDATE pay_gateway SET allow_single = 1 WHERE gateway = :gateway AND allow_single = 0')
+        ->andReturn($statement);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch91'))->invoke($patcher);
 });
 
 test('legacy email patch restores untouched 0.7.2 defaults without replacing customizations', function (): void {

--- a/tests/Unit/Payment/Adapter/ClientBalanceTest.php
+++ b/tests/Unit/Payment/Adapter/ClientBalanceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+declare(strict_types=1);
+
+test('declares support for one-time payments only', function (): void {
+    $config = Payment_Adapter_ClientBalance::getConfig();
+
+    expect($config)
+        ->toHaveKey('supports_one_time_payments', true)
+        ->toHaveKey('supports_subscriptions', false);
+});


### PR DESCRIPTION
Addresses an issue where the `ClientBalance` payment gateway did not properly declare support for one-time payments, causing the related option to be hidden and incorrectly persisted in the settings. 

Resolves #3989.