### PR TITLE
Fix guest invoice redirect

### DIFF
--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -54,6 +54,7 @@
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             const publicPaths = [
+                '/invoice/',
                 '/news',
                 '/tos',
                 '/privacy-policy'


### PR DESCRIPTION
## What changed

- Allow guest-accessible invoice hash routes through Huraga's guest-login redirect guard.
- Keep the authenticated `/invoice` list protected by matching only the `/invoice/` prefix.

Resolves #3988.