### PR TITLE
Fix footer link checkbox state persistence

### DIFF
--- a/src/modules/Theme/templates/admin/mod_theme_preset.html.twig
+++ b/src/modules/Theme/templates/admin/mod_theme_preset.html.twig
@@ -217,7 +217,7 @@
                             }
                             break;
                         case 'checkbox':
-                            el.checked = value === '1' || value === 1 || value === true || value === 'true';
+                            el.checked = value === '1' || value === 1 || value === true || value === 'true' || value === 'on';
                             break;
                         default:
                             el.value = value;

--- a/src/modules/Theme/tests/Unit/Controller/AdminTest.php
+++ b/src/modules/Theme/tests/Unit/Controller/AdminTest.php
@@ -10,7 +10,48 @@
 
 declare(strict_types=1);
 
+use Box\Mod\Theme\Model\Theme;
+use FOSSBilling\Sanitizer\BrowserHtmlSanitizer;
+use FOSSBilling\Twig\SandboxedStringRenderer;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\TwigFilter;
+
 use function Tests\Helpers\container;
+
+/**
+ * @param array<string, mixed> $settings
+ *
+ * @return list<DOMElement>
+ */
+function renderHuragaFooterLinkCheckboxes(array $settings): array
+{
+    $twig = new Environment(new ArrayLoader(), ['strict_variables' => true]);
+    $twig->addFilter(new TwigFilter('trans', static fn (mixed $value): string => (string) $value));
+
+    $theme = new Theme('huraga');
+    $html = SandboxedStringRenderer::render(
+        $twig,
+        $theme->getSettingsPageHtml(),
+        ['settings' => $settings],
+        'Theme settings template',
+    );
+    $html = BrowserHtmlSanitizer::sanitizeThemeSettingsHtml($html);
+
+    $document = new DOMDocument();
+    $previousLibxmlErrorsSetting = libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?><html><body>' . $html . '</body></html>');
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousLibxmlErrorsSetting);
+
+    $checkboxes = (new DOMXPath($document))->query('//input[@type="checkbox" and starts-with(@name, "footer_link_")]');
+    assert($checkboxes instanceof DOMNodeList);
+
+    return array_values(array_filter(
+        iterator_to_array($checkboxes),
+        static fn (DOMNode $node): bool => $node instanceof DOMElement,
+    ));
+}
 
 test('getDi returns dependency injection container', function (): void {
     $controller = new Box\Mod\Theme\Controller\Admin();
@@ -44,7 +85,7 @@ test('getTheme renders theme preset', function (): void {
         ->andReturn('Rendering ...');
 
     // Create theme mock first
-    $themeMock = Mockery::mock(Box\Mod\Theme\Model\Theme::class);
+    $themeMock = Mockery::mock(Theme::class);
     $themeMock->shouldReceive('getName')
         ->atLeast()
         ->once()
@@ -108,7 +149,7 @@ test('save theme settings reads body from request and strips preset control keys
     $controller = new Box\Mod\Theme\Controller\Admin();
     $di = container();
 
-    $themeMock = Mockery::mock(Box\Mod\Theme\Model\Theme::class);
+    $themeMock = Mockery::mock(Theme::class);
     $themeMock->shouldReceive('getName')->andReturn('huraga');
     $themeMock->shouldReceive('isAssetsPathWritable')->andReturn(true);
 
@@ -160,22 +201,26 @@ test('save theme settings reads body from request and strips preset control keys
 });
 
 test('huraga footer link checkboxes submit canonical enabled values', function (): void {
-    $settingsTemplate = file_get_contents(PATH_THEMES . '/huraga/config/settings.html.twig');
+    $checkboxes = renderHuragaFooterLinkCheckboxes([]);
 
-    expect($settingsTemplate)->not->toBeFalse();
-
-    for ($index = 1; $index <= 5; ++$index) {
-        expect($settingsTemplate)->toContain(sprintf(
-            'type="checkbox" name="footer_link_%d_enabled" value="1"',
-            $index,
-        ));
+    expect($checkboxes)->toHaveCount(5);
+    foreach ($checkboxes as $index => $checkbox) {
+        expect($checkbox->getAttribute('name'))->toBe(sprintf('footer_link_%d_enabled', $index + 1))
+            ->and($checkbox->getAttribute('value'))->toBe('1')
+            ->and($checkbox->hasAttribute('checked'))->toBeFalse();
     }
 });
 
 test('theme settings restore checkbox values saved with the browser default', function (): void {
-    $presetTemplate = file_get_contents(PATH_MODS . '/Theme/templates/admin/mod_theme_preset.html.twig');
+    $settings = [];
+    for ($index = 1; $index <= 5; ++$index) {
+        $settings['footer_link_' . $index . '_enabled'] = 'on';
+    }
 
-    expect($presetTemplate)
-        ->not->toBeFalse()
-        ->toContain("value === 'on'");
+    $checkboxes = renderHuragaFooterLinkCheckboxes($settings);
+
+    expect($checkboxes)->toHaveCount(5);
+    foreach ($checkboxes as $checkbox) {
+        expect($checkbox->hasAttribute('checked'))->toBeTrue();
+    }
 });

--- a/src/modules/Theme/tests/Unit/Controller/AdminTest.php
+++ b/src/modules/Theme/tests/Unit/Controller/AdminTest.php
@@ -158,3 +158,24 @@ test('save theme settings reads body from request and strips preset control keys
     $response = $controller->save_theme_settings($boxAppMock, 'huraga');
     expect($response)->toBeInstanceOf(Symfony\Component\HttpFoundation\RedirectResponse::class);
 });
+
+test('huraga footer link checkboxes submit canonical enabled values', function (): void {
+    $settingsTemplate = file_get_contents(PATH_THEMES . '/huraga/config/settings.html.twig');
+
+    expect($settingsTemplate)->not->toBeFalse();
+
+    for ($index = 1; $index <= 5; ++$index) {
+        expect($settingsTemplate)->toContain(sprintf(
+            'type="checkbox" name="footer_link_%d_enabled" value="1"',
+            $index,
+        ));
+    }
+});
+
+test('theme settings restore checkbox values saved with the browser default', function (): void {
+    $presetTemplate = file_get_contents(PATH_MODS . '/Theme/templates/admin/mod_theme_preset.html.twig');
+
+    expect($presetTemplate)
+        ->not->toBeFalse()
+        ->toContain("value === 'on'");
+});

--- a/src/themes/huraga/config/settings.html.twig
+++ b/src/themes/huraga/config/settings.html.twig
@@ -245,7 +245,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_1_enabled">
+                    <input class="form-check-input" type="checkbox" name="footer_link_1_enabled" value="1">
                 </label>
             </div>
             <div class="col-lg-4">
@@ -261,7 +261,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_2_enabled">
+                    <input class="form-check-input" type="checkbox" name="footer_link_2_enabled" value="1">
                 </label>
             </div>
             <div class="col-lg-4">
@@ -277,7 +277,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_3_enabled">
+                    <input class="form-check-input" type="checkbox" name="footer_link_3_enabled" value="1">
                 </label>
             </div>
             <div class="col-lg-4">
@@ -293,7 +293,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_4_enabled">
+                    <input class="form-check-input" type="checkbox" name="footer_link_4_enabled" value="1">
                 </label>
             </div>
             <div class="col-lg-4">
@@ -309,7 +309,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_5_enabled">
+                    <input class="form-check-input" type="checkbox" name="footer_link_5_enabled" value="1">
                 </label>
             </div>
             <div class="col-lg-4">

--- a/src/themes/huraga/config/settings.html.twig
+++ b/src/themes/huraga/config/settings.html.twig
@@ -245,7 +245,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_1_enabled" value="1">
+                    <input class="form-check-input" type="checkbox" name="footer_link_1_enabled" value="1"{% if settings.footer_link_1_enabled|default('0') in ['1', 1, true, 'true', 'on'] %} checked{% endif %}>
                 </label>
             </div>
             <div class="col-lg-4">
@@ -261,7 +261,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_2_enabled" value="1">
+                    <input class="form-check-input" type="checkbox" name="footer_link_2_enabled" value="1"{% if settings.footer_link_2_enabled|default('0') in ['1', 1, true, 'true', 'on'] %} checked{% endif %}>
                 </label>
             </div>
             <div class="col-lg-4">
@@ -277,7 +277,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_3_enabled" value="1">
+                    <input class="form-check-input" type="checkbox" name="footer_link_3_enabled" value="1"{% if settings.footer_link_3_enabled|default('0') in ['1', 1, true, 'true', 'on'] %} checked{% endif %}>
                 </label>
             </div>
             <div class="col-lg-4">
@@ -293,7 +293,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_4_enabled" value="1">
+                    <input class="form-check-input" type="checkbox" name="footer_link_4_enabled" value="1"{% if settings.footer_link_4_enabled|default('0') in ['1', 1, true, 'true', 'on'] %} checked{% endif %}>
                 </label>
             </div>
             <div class="col-lg-4">
@@ -309,7 +309,7 @@
             </div>
             <div class="col-auto">
                 <label class="form-check mb-0">
-                    <input class="form-check-input" type="checkbox" name="footer_link_5_enabled" value="1">
+                    <input class="form-check-input" type="checkbox" name="footer_link_5_enabled" value="1"{% if settings.footer_link_5_enabled|default('0') in ['1', 1, true, 'true', 'on'] %} checked{% endif %}>
                 </label>
             </div>
             <div class="col-lg-4">


### PR DESCRIPTION
## What changed

- submit Huraga footer-link checkboxes with the canonical value `1`
- recognize the browser-default checkbox value `on` when restoring saved theme settings
- add regression coverage for canonical submissions and legacy saved values

Fixes #3992.