### PR TITLE
Fix invoice approval discarding unsaved changes

### DIFF
--- a/frontend/core/api.ts
+++ b/frontend/core/api.ts
@@ -400,6 +400,10 @@ const API = {
           event.preventDefault();
 
           const formData = new FormData(formElement);
+          const submitter = event.submitter;
+          if (submitter?.name) {
+            formData.append(submitter.name, submitter.value);
+          }
 
           if (FOSSBilling.editor) {
             if (!FOSSBilling.editor.validateForm(formElement)) {

--- a/src/modules/Invoice/Api/Admin.php
+++ b/src/modules/Invoice/Api/Admin.php
@@ -166,6 +166,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * @optional string $buyer_zip - Buyer zip
      * @optional string $buyer_phone - Buyer phone
      * @optional string $buyer_email - Buyer email
+     * @optional bool $approve - approve the invoice after saving the supplied changes
      *
      * @return bool
      */
@@ -174,8 +175,13 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('invoice', 'manage_invoices');
 
         $model = $this->_getInvoice($data);
+        $result = $this->getService()->updateInvoice($model, $data);
 
-        return $this->getService()->updateInvoice($model, $data);
+        if ($result && !empty($data['approve'])) {
+            return $this->getService()->approveInvoice($model, $data);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/modules/Invoice/templates/admin/mod_invoice_invoice.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_invoice.html.twig
@@ -276,17 +276,16 @@
                         </tfoot>
                     </table>
                     <div class="card-footer d-flex justify-content-end gap-2">
+                        <input type="hidden" name="id" value="{{ invoice.id }}">
+                        <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary">
                         {% if not invoice.approved %}
-                        <a class="btn btn-success" href="{{ 'invoice/approve'|api_url(query: { 'id': invoice.id }) }}"
-                            {{ fb_api_link({redirect: 'invoice'|url}) }}>
+                        <button class="btn btn-success" type="submit" name="approve" value="1">
                             <svg class="icon">
                                 <use href="#check" />
                             </svg>
                             {{ 'Approve'|trans }}
-                        </a>
+                        </button>
                         {% endif %}
-                        <input type="hidden" name="id" value="{{ invoice.id }}">
-                        <input type="submit" value="{{ 'Update'|trans }}" class="btn btn-primary">
                     </div>
                 </form>
                 {% else %}

--- a/src/modules/Invoice/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/AdminTest.php
@@ -243,6 +243,47 @@ test('updates an invoice', function (): void {
     expect($result)->toBeBool()->toBeTrue();
 });
 
+test('updates an invoice before approving it', function (): void {
+    $api = apiEndpoint(new Admin());
+    $data = [
+        'id' => 1,
+        'approve' => 1,
+        'new_item' => [
+            'title' => 'Hosting',
+            'quantity' => 1,
+            'price' => '10.00',
+        ],
+    ];
+    $model = new Model_Invoice();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('updateInvoice')
+        ->once()
+        ->ordered()
+        ->with($model, $data)
+        ->andReturn(true);
+    $serviceMock->shouldReceive('approveInvoice')
+        ->once()
+        ->ordered()
+        ->with($model, $data)
+        ->andReturn(true);
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('getExistingModelById')
+        ->once()
+        ->andReturn($model);
+
+    $di = container();
+    $di['db'] = $dbMock;
+
+    $api->setDi($di);
+    $api->setService($serviceMock);
+
+    $result = $api->update($data);
+    expect($result)->toBeTrue();
+});
+
 test('deletes an invoice item', function (): void {
     $api = apiEndpoint(new Admin());
     $data = [


### PR DESCRIPTION
## What changed

- submit the invoice edit form when **Approve** is clicked
- preserve the clicked submit button in API form payloads
- save invoice changes before invoking the existing approval service and events
- add a regression test covering save-before-approve ordering

Fixes #3991.