### PR TITLE
Fix Twig currency locale formatting

### DIFF
--- a/src/library/Box/Translate.php
+++ b/src/library/Box/Translate.php
@@ -88,6 +88,8 @@ class Box_Translate
             throw new Exception('Unable to set up FOSSBilling translation functionality, locale was undefined.');
         }
 
+        Locale::setDefault($locale);
+
         $codeset = 'UTF-8';
         // set locale
         if (!defined('LC_MESSAGES')) {

--- a/tests/Unit/Box/TranslateTest.php
+++ b/tests/Unit/Box/TranslateTest.php
@@ -39,3 +39,21 @@ test('translate', function (): void {
 
     expect($result)->toEqual($text);
 });
+
+test('setup configures the default locale used by Twig Intl filters', function (): void {
+    $defaultLocale = Locale::getDefault();
+    Locale::setDefault('en_US_POSIX');
+
+    try {
+        $translateObj = new Box_Translate();
+        $translateObj->setLocale('en_US');
+        $translateObj->setup();
+
+        $intlExtension = new Twig\Extra\Intl\IntlExtension();
+
+        expect(Locale::getDefault())->toBe('en_US')
+            ->and($intlExtension->formatCurrency(5, 'USD'))->toBe('$5.00');
+    } finally {
+        Locale::setDefault($defaultLocale);
+    }
+});


### PR DESCRIPTION
## Summary

- synchronize PHP Intl's default locale with FOSSBilling's active translation locale
- keep using Twig's stock `IntlExtension` directly
- add regression coverage for the `en_US_POSIX` fallback that rendered `$ 5.00`

Fixes #3994.