### PR TITLE
Fix invoice email template preview variables

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Box\Mod\Email;
 
+use Box\Mod\Currency\Entity\Currency;
 use Box\Mod\Email\Entity\ActivityClientEmail;
 use Box\Mod\Email\Entity\EmailTemplate;
 use Box\Mod\Email\Entity\EmailTemplateGroup;
@@ -126,13 +127,28 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function getVars(EmailTemplate $template): array
     {
-        if ($template->getVars() === null || $template->getVars() === '') {
-            return [];
+        $vars = [];
+        if ($template->getVars() !== null && $template->getVars() !== '') {
+            $json = $this->di['crypt']->decrypt($template->getVars(), Config::getProperty('info.salt'));
+            $decoded = is_string($json) ? json_decode($json, true) : null;
+            $vars = is_array($decoded) ? $decoded : [];
         }
 
-        $json = $this->di['crypt']->decrypt($template->getVars(), Config::getProperty('info.salt'));
+        // Invoice templates must remain previewable before an invoice email has
+        // populated the stored example variables.
+        if (str_starts_with($template->getActionCode(), 'mod_invoice_')) {
+            $invoice = is_array($vars['invoice'] ?? null) ? $vars['invoice'] : [];
+            $invoice['total'] ??= 0;
+            if (empty($invoice['currency'])) {
+                $currency = $this->di['mod_service']('currency')->getCurrencyRepository()->findDefault();
+                if ($currency instanceof Currency) {
+                    $invoice['currency'] = $currency->getCode();
+                }
+            }
+            $vars['invoice'] = $invoice;
+        }
 
-        return is_string($json) ? json_decode($json, true) : [];
+        return $vars;
     }
 
     public function sendTemplate($data)

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+use Box\Mod\Currency\Entity\Currency;
 use Box\Mod\Email\Entity\EmailTemplate;
 
 use function Tests\Helpers\container;
@@ -212,6 +213,28 @@ test('getVars decrypts and returns variables', function (): void {
     $result = $service->getVars($t);
     expect($result)->toBeArray();
     expect($result)->toBe($expected);
+});
+
+test('getVars supplies the default currency for invoice template previews', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $currencyRepository = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $currencyRepository->shouldReceive('findDefault')->once()->andReturn(new Currency('USD'));
+    $currencyService = Mockery::mock(Box\Mod\Currency\Service::class);
+    $currencyService->shouldReceive('getCurrencyRepository')->once()->andReturn($currencyRepository);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(moduleService(['currency' => $currencyService]));
+    $service->setDi($di);
+
+    $template = emailTemplate('mod_invoice_paid');
+
+    expect($service->getVars($template))->toBe([
+        'invoice' => [
+            'total' => 0,
+            'currency' => 'USD',
+        ],
+    ]);
 });
 
 test('sendTemplate returns false when template does not exist', function (): void {


### PR DESCRIPTION
## Summary

- provide safe example values for invoice email templates before a real invoice email has populated the stored variables
- use `0` for the example total and the configured default currency for `invoice.currency`
- preserve existing stored invoice values when they are available

Fixes #3996.