### PR TITLE
Standardise Twig URL filter arguments

### DIFF
--- a/src/modules/Activity/templates/admin/mod_activity_index.html.twig
+++ b/src/modules/Activity/templates/admin/mod_activity_index.html.twig
@@ -203,14 +203,14 @@
                 <td>
                     {% if event.client_id %}
                         <a href='{{ "client/manage/#{event.client_id}"|url }}'>{{ event.client.name|default('') }}</a>
-                        <a href="{{ request_path|url(request_query|merge({ 'client_id': event.client_id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this client'|trans }}">
+                        <a href="{{ request_path|url(query: request_query|merge({ 'client_id': event.client_id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this client'|trans }}">
                             <svg class="icon icon-sm text-muted">
                                 <use href="#filter" />
                             </svg>
                         </a>
                     {% elseif event.staff_id %}
                         <a href='{{ "staff/manage/#{event.staff_id}"|url }}'>{{ event.staff.name|default('') }}</a>
-                        <a href="{{ request_path|url(request_query|merge({ 'admin_id': event.staff_id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this admin'|trans }}">
+                        <a href="{{ request_path|url(query: request_query|merge({ 'admin_id': event.staff_id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this admin'|trans }}">
                             <svg class="icon icon-sm text-muted">
                                 <use href="#filter" />
                             </svg>
@@ -245,7 +245,7 @@
                     <div class="d-inline-flex align-items-center gap-1 flex-nowrap">
                         {{ mf.ip_lookup_link(event.ip) }}
                         {% if event.ip %}
-                        <a href="{{ request_path|url(request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this IP address'|trans }}">
+                        <a href="{{ request_path|url(query: request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all activity from this IP address'|trans }}">
                             <svg class="icon icon-sm text-muted">
                                 <use href="#filter" />
                             </svg>

--- a/src/modules/Client/templates/admin/mod_client_login_history.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_login_history.html.twig
@@ -113,7 +113,7 @@
                 </td>
                 <td>
                     <a href='{{ "client/manage/#{event.client.id}"|url }}'>{{ event.client.first_name }} {{ event.client.last_name }}</a>
-                    <a href="{{ request_path|url(request_query|merge({ 'client_id': event.client.id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events for this client'|trans }}">
+                    <a href="{{ request_path|url(query: request_query|merge({ 'client_id': event.client.id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events for this client'|trans }}">
                         <svg class="icon icon-sm text-muted">
                             <use href="#filter" />
                         </svg>
@@ -123,7 +123,7 @@
                     <div class="d-inline-flex align-items-center gap-1 flex-nowrap">
                         {{ mf.ip_lookup_link(event.ip) }}
                         {% if event.ip %}
-                        <a href="{{ request_path|url(request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events from this IP address'|trans }}">
+                        <a href="{{ request_path|url(query: request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events from this IP address'|trans }}">
                             <svg class="icon icon-sm text-muted">
                                 <use href="#filter" />
                             </svg>

--- a/src/modules/Email/templates/admin/mod_email_settings.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_settings.html.twig
@@ -329,7 +329,7 @@
                                 </div>
                             </div>
                             <div class="d-flex justify-content-end gap-2 mt-3">
-                                <a class="btn btn-outline-secondary" href="{{ request_path|url({ tab: 'queue' }) }}">{{ 'Reset'|trans }}</a>
+                                <a class="btn btn-outline-secondary" href="{{ request_path|url(query: { tab: 'queue' }) }}">{{ 'Reset'|trans }}</a>
                                 <button class="btn btn-primary" type="submit">
                                     <svg class="icon">
                                         <use href="#filter" />

--- a/src/modules/Staff/templates/admin/mod_staff_login_history.html.twig
+++ b/src/modules/Staff/templates/admin/mod_staff_login_history.html.twig
@@ -113,7 +113,7 @@
                     <a href='{{ "staff/manage/#{event.staff.id}"|url }}'>
                         {{ event.staff.name }}
                     </a>
-                    <a href="{{ request_path|url(request_query|merge({ 'admin_id': event.staff.id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events for this staff member'|trans }}">
+                    <a href="{{ request_path|url(query: request_query|merge({ 'admin_id': event.staff.id, 'page': null })) }}" class="ms-1" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events for this staff member'|trans }}">
                         <svg class="icon icon-sm text-muted">
                             <use href="#filter" />
                         </svg>
@@ -123,7 +123,7 @@
                     <div class="d-inline-flex align-items-center gap-1 flex-nowrap">
                         {{ mf.ip_lookup_link(event.ip) }}
                         {% if event.ip %}
-                        <a href="{{ request_path|url(request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events from this IP address'|trans }}">
+                        <a href="{{ request_path|url(query: request_query|merge({ 'ip': event.ip, 'page': null })) }}" data-bs-toggle="tooltip" data-bs-title="{{ 'Show all login events from this IP address'|trans }}">
                             <svg class="icon icon-sm text-muted">
                                 <use href="#filter" />
                             </svg>

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -130,7 +130,7 @@
 
 {% macro ip_lookup_link(ip) %}
     {% if ip is not empty %}
-        <a href="{{ 'security/iplookup'|url({'ip': ip }) }}" target="_blank" class='ip_lookup_link'>{{ ip }}</a>
+        <a href="{{ 'security/iplookup'|url(query: {'ip': ip }) }}" target="_blank" class='ip_lookup_link'>{{ ip }}</a>
     {% else %}
         {{ ip }}
     {% endif %}

--- a/src/themes/admin_default/html/partial_pagination.html.twig
+++ b/src/themes/admin_default/html/partial_pagination.html.twig
@@ -41,7 +41,7 @@
             {% set recordSelectorOptions = recordSelectorOptions|merge([{
                 value: pageSize,
                 active: pageSize == currentPerPage,
-                href: url|url(filteredRequest|merge({ (pageParam): 1, (perPageParam): pageSize })) ~ hash
+                href: url|url(query: filteredRequest|merge({ (pageParam): 1, (perPageParam): pageSize })) ~ hash
             }]) %}
         {% endfor %}
     {% endif %}
@@ -59,7 +59,7 @@
                 <ul class="pagination m-0">
                     {% if paginator.currentpage != 1 %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ url|url(filteredRequest|merge({ (pageParam): currentPage - 1, (perPageParam): currentPerPage })) ~ hash }}">
+                        <a class="page-link" href="{{ url|url(query: filteredRequest|merge({ (pageParam): currentPage - 1, (perPageParam): currentPerPage })) ~ hash }}">
                             <svg class="icon">
                                 <use href="#chevron-left" />
                             </svg>
@@ -68,7 +68,7 @@
                     {% endif %}
                     {% if (paginator.range.0 != 1) %}
                         <li class="page-item">
-                            <a class="page-link" href="{{ url|url(filteredRequest|merge({ (pageParam): 1, (perPageParam): currentPerPage })) ~ hash }}">1</a>
+                            <a class="page-link" href="{{ url|url(query: filteredRequest|merge({ (pageParam): 1, (perPageParam): currentPerPage })) ~ hash }}">1</a>
                         </li>
                     {% endif %}
                     {% for i in paginator.start..paginator.end %}
@@ -82,7 +82,7 @@
                             </li>
                         {% else %}
                             <li class="page-item">
-                                <a class="page-link" href="{{ url|url(filteredRequest|merge({ (pageParam): i, (perPageParam): currentPerPage })) ~ hash }}"> {{ i }}</a>
+                                <a class="page-link" href="{{ url|url(query: filteredRequest|merge({ (pageParam): i, (perPageParam): currentPerPage })) ~ hash }}"> {{ i }}</a>
                             </li>
                         {% endif %}
                     {% endfor %}
@@ -90,13 +90,13 @@
                     {% if paginator.range|length > 0 and paginator.range|last < paginator.numpages and paginator.end == paginator.range|last %}
                         ...
                         <li class="page-item">
-                            <a class="page-link" href="{{ url|url(filteredRequest|merge({ (pageParam): paginator.numpages, (perPageParam): currentPerPage })) ~ hash }}"> {{ paginator.numpages }}</a>
+                            <a class="page-link" href="{{ url|url(query: filteredRequest|merge({ (pageParam): paginator.numpages, (perPageParam): currentPerPage })) ~ hash }}"> {{ paginator.numpages }}</a>
                         </li>
                     {% endif %}
 
                     {% if paginator.currentpage != paginator.numpages %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ url|url(filteredRequest|merge({ (pageParam): currentPage + 1, (perPageParam): currentPerPage })) ~ hash }}">
+                        <a class="page-link" href="{{ url|url(query: filteredRequest|merge({ (pageParam): currentPage + 1, (perPageParam): currentPerPage })) ~ hash }}">
                             <svg class="icon">
                                 <use href="#chevron-right" />
                             </svg>

--- a/src/themes/huraga/html/partial_pagination.html.twig
+++ b/src/themes/huraga/html/partial_pagination.html.twig
@@ -18,7 +18,7 @@
         <ul class="pagination justify-content-center mb-0">
             <li class="page-item{% if currentPage == 1 %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url|url(filteredRequest|merge({ (pageParam): 1 })) ~ hash }}"
+                   href="{{ url|url(query: filteredRequest|merge({ (pageParam): 1 })) ~ hash }}"
                    aria-label="{{ 'First'|trans }}">
                     <svg class="icon"><use href="#chevrons-left" /></svg>
                 </a>
@@ -26,7 +26,7 @@
 
             <li class="page-item{% if currentPage == 1 %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url|url(filteredRequest|merge({ (pageParam): currentPage - 1 })) ~ hash }}"
+                   href="{{ url|url(query: filteredRequest|merge({ (pageParam): currentPage - 1 })) ~ hash }}"
                    aria-label="{{ 'Previous'|trans }}" rel="prev">
                     <svg class="icon"><use href="#chevron-left" /></svg>
                 </a>
@@ -38,14 +38,14 @@
                         <span class="page-link" aria-current="page">{{ i }}</span>
                     {% else %}
                         <a class="page-link"
-                           href="{{ url|url(filteredRequest|merge({ (pageParam): i })) ~ hash }}">{{ i }}</a>
+                           href="{{ url|url(query: filteredRequest|merge({ (pageParam): i })) ~ hash }}">{{ i }}</a>
                     {% endif %}
                 </li>
             {% endfor %}
 
             <li class="page-item{% if currentPage == list.pages %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url|url(filteredRequest|merge({ (pageParam): currentPage + 1 })) ~ hash }}"
+                   href="{{ url|url(query: filteredRequest|merge({ (pageParam): currentPage + 1 })) ~ hash }}"
                    aria-label="{{ 'Next'|trans }}" rel="next">
                     <svg class="icon"><use href="#chevron-right" /></svg>
                 </a>
@@ -53,7 +53,7 @@
 
             <li class="page-item{% if currentPage == list.pages %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url|url(filteredRequest|merge({ (pageParam): list.pages })) ~ hash }}"
+                   href="{{ url|url(query: filteredRequest|merge({ (pageParam): list.pages })) ~ hash }}"
                    aria-label="{{ 'Last'|trans }}">
                     <svg class="icon"><use href="#chevrons-right" /></svg>
                 </a>


### PR DESCRIPTION
## What changed

- name every query argument passed to the Twig `url` filter explicitly as `query:`
- keep cross-area links explicit with the existing `area:` named argument
- normalize pagination, activity, login history, email settings, and IP lookup templates

Related documentation report: FOSSBilling/docs#73.
