### PR TITLE
Fix KB article title quote encoding

### DIFF
--- a/src/library/FOSSBilling/Tools.php
+++ b/src/library/FOSSBilling/Tools.php
@@ -436,7 +436,7 @@ class Tools
 
         if (!$allowHtml) {
             // Strip all HTML tags for plain text
-            return trim(htmlspecialchars(strip_tags($content), ENT_QUOTES | ENT_HTML5, 'UTF-8', false));
+            return htmlspecialchars(self::sanitizePlainText($content), ENT_QUOTES | ENT_HTML5, 'UTF-8', false);
         }
 
         // Use Symfony's HTML Sanitizer
@@ -450,6 +450,17 @@ class Tools
         $sanitizer = new \Symfony\Component\HtmlSanitizer\HtmlSanitizer($config);
 
         return trim($sanitizer->sanitize($content));
+    }
+
+    /**
+     * Sanitize plain text for storage without HTML-encoding it.
+     *
+     * Output contexts must still escape the returned value. Encoding during input would store HTML
+     * entities as data and cause them to be displayed literally when the output is escaped again.
+     */
+    public static function sanitizePlainText(string $content = ''): string
+    {
+        return trim(strip_tags(str_replace("\0", '', $content)));
     }
 
     /**

--- a/src/modules/Support/Api/Admin.php
+++ b/src/modules/Support/Api/Admin.php
@@ -659,7 +659,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $articleCategoryId = (int) $data['kb_article_category_id'];
         $status = $data['status'] ?? KbArticle::DRAFT;
 
-        $title = \FOSSBilling\Tools::sanitizeContent($data['title'], false);
+        $title = \FOSSBilling\Tools::sanitizePlainText($data['title']);
         $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']) : null;
 
         return $this->getService()->kbCreateArticle($articleCategoryId, $title, $status, $content);
@@ -681,7 +681,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('support', 'manage_kb');
 
         $articleCategoryId = isset($data['kb_article_category_id']) ? (int) $data['kb_article_category_id'] : null;
-        $title = isset($data['title']) ? \FOSSBilling\Tools::sanitizeContent($data['title'], false) : null;
+        $title = isset($data['title']) ? \FOSSBilling\Tools::sanitizePlainText($data['title']) : null;
         $slug = $data['slug'] ?? null;
         $status = $data['status'] ?? null;
         $content = isset($data['content']) ? \FOSSBilling\Tools::sanitizeMarkdownContent($data['content']) : null;

--- a/src/modules/Support/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Support/tests/Unit/Api/AdminTest.php
@@ -1054,13 +1054,12 @@ test('kb article get not found exception', function (): void {
     expect(fn (): array => $adminApi->kb_article_get($data))->toThrow(FOSSBilling\Exception::class);
 });
 
-test('kb article create', function (): void {
-    $api = apiEndpoint(new Box\Mod\Support\Api\Admin());
+test('kb article create preserves quotes in the title', function (): void {
     $adminApi = apiEndpoint(new Box\Mod\Support\Api\Admin());
 
     $data = [
         'kb_article_category_id' => 1,
-        'title' => 'Title',
+        'title' => "What's new",
     ];
 
     $id = 1;
@@ -1070,7 +1069,8 @@ test('kb article create', function (): void {
     $kbService = Mockery::mock(Box\Mod\Support\Service::class)->makePartial();
     $kbService
     ->shouldReceive('kbCreateArticle')
-    ->atLeast()->once()
+    ->once()
+    ->with(1, "What's new", KbArticle::DRAFT, null)
     ->andReturn($id);
     $adminApi->setService($kbService);
 
@@ -1081,14 +1081,13 @@ test('kb article create', function (): void {
     expect($result)->toEqual($id);
 });
 
-test('kb article update', function (): void {
-    $api = apiEndpoint(new Box\Mod\Support\Api\Admin());
+test('kb article update preserves quotes in the title', function (): void {
     $adminApi = apiEndpoint(new Box\Mod\Support\Api\Admin());
 
     $data = [
         'id' => 1,
         'kb_article_category_id' => 1,
-        'title' => 'Title',
+        'title' => "What's new",
         'slug' => 'article-slug',
         'status' => 'active',
         'content' => 'Content',
@@ -1098,7 +1097,8 @@ test('kb article update', function (): void {
     $kbService = Mockery::mock(Box\Mod\Support\Service::class)->makePartial();
     $kbService
     ->shouldReceive('kbUpdateArticle')
-    ->atLeast()->once()
+    ->once()
+    ->with(1, 1, "What's new", 'article-slug', 'active', 'Content', 1)
     ->andReturn(true);
     $di = container();
 

--- a/tests/Unit/FOSSBilling/ToolsTest.php
+++ b/tests/Unit/FOSSBilling/ToolsTest.php
@@ -114,6 +114,13 @@ test('sanitize content preserves text content', function (): void {
     expect($result)->not->toContain('>');
 });
 
+test('sanitize plain text preserves characters without storing HTML entities', function (): void {
+    $input = " What's <strong>new</strong> & useful\0 ";
+    $result = FOSSBilling\Tools::sanitizePlainText($input);
+
+    expect($result)->toBe("What's new & useful");
+});
+
 test('sanitize markdown content preserves angle brackets as literal text', function (): void {
     $input = 'Hello <World> this text must not disappear';
     $result = FOSSBilling\Tools::sanitizeMarkdownContent($input);


### PR DESCRIPTION
## What changed

- store knowledge base article titles as plain text instead of pre-encoding HTML entities
- preserve quote and ampersand characters while retaining null-byte and HTML-tag removal
- add regression coverage for article creation and updates

Fixes #4004.