### PR TITLE
Fix bulk email template regeneration

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -448,7 +448,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $this->createTemplateRecordFromData($code, $data);
     }
 
-    private function syncBuiltinTemplate(EmailTemplate $template, array $default, bool $resetOverride = false): void
+    private function syncBuiltinTemplate(EmailTemplate $template, array $default): void
     {
         $updated = false;
 
@@ -462,7 +462,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $updated = true;
         }
 
-        if ($resetOverride || !$template->isOverridden()) {
+        if (!$template->isOverridden()) {
             if ($template->getSubject() !== $default['subject']) {
                 $template->setSubject($default['subject']);
                 $updated = true;
@@ -473,19 +473,17 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             }
         }
 
-        if ($resetOverride && $template->isOverridden()) {
-            $template->setIsOverridden(false);
-            $updated = true;
-        }
-
-        if ($resetOverride && $template->hasError()) {
-            $template->clearError();
-            $updated = true;
-        }
-
         if ($updated) {
             $this->di['em']->flush();
         }
+    }
+
+    private function resetBuiltinTemplate(EmailTemplate $template, array $default): void
+    {
+        $template->setSubject($default['subject'])
+            ->setContent($default['content'])
+            ->setIsOverridden(false)
+            ->clearError();
     }
 
     private function getEffectiveTemplateParts(EmailTemplate $template): array
@@ -860,9 +858,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             throw new \FOSSBilling\Exception('Custom email template :code cannot be reset to a default', [':code' => $code]);
         }
 
-        $template->setSubject($default['subject'])
-            ->setContent($default['content'])
-            ->setIsOverridden(false);
+        $this->resetBuiltinTemplate($template, $default);
         $this->di['em']->flush();
         $this->di['logger']->info('Reset email template: %s', $template->getActionCode());
 
@@ -899,15 +895,33 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function templateBatchGenerate(): bool
     {
-        return $this->syncFileBackedTemplates(false);
+        return $this->syncFileBackedTemplates();
     }
 
     public function templateBatchRegenerate(): bool
     {
-        return $this->syncFileBackedTemplates(true);
+        $this->templateBatchGenerate();
+        $regenerated = 0;
+
+        foreach ($this->getTemplateRepository()->findAll() as $template) {
+            if ($this->isCustomTemplate($template)) {
+                continue;
+            }
+
+            $default = $this->getDefaultTemplate($template->getActionCode());
+            if ($default !== null) {
+                $this->resetBuiltinTemplate($template, $default);
+                ++$regenerated;
+            }
+        }
+
+        $this->di['em']->flush();
+        $this->di['logger']->info(sprintf('Regenerated %d file-backed email templates.', $regenerated));
+
+        return true;
     }
 
-    private function syncFileBackedTemplates(bool $resetOverrides): bool
+    private function syncFileBackedTemplates(): bool
     {
         $extensionService = $this->di['mod_service']('extension');
 
@@ -936,14 +950,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             }
 
             if (!$this->isCustomTemplate($template)) {
-                $this->syncBuiltinTemplate($template, $default, $resetOverrides);
+                $this->syncBuiltinTemplate($template, $default);
             }
         }
 
-        $message = $resetOverrides
-            ? 'Regenerated file-backed email templates for installed modules.'
-            : 'Synced file-backed email templates for installed modules.';
-        $this->di['logger']->info($message);
+        $this->di['logger']->info('Synced file-backed email templates for installed modules.');
 
         return true;
     }

--- a/src/modules/Email/templates/admin/mod_email_settings.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_settings.html.twig
@@ -60,7 +60,7 @@
                            modal: {
                                type: 'confirm',
                                title: 'Regenerate built-in templates?'|trans,
-                               content: 'This will replace the subject and content of every built-in email template for active modules. Custom templates will not be affected.'|trans,
+                               content: 'This will replace the subject and content of every existing built-in email template. Custom templates will not be affected.'|trans,
                            },
                            reload: true,
                        }) }}>

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -1029,7 +1029,7 @@ test('templateCreate creates new template', function (): void {
     expect($result->getActionCode())->toBe($data['action_code']);
 });
 
-test('templateBatchRegenerate resets overridden built-in templates', function (): void {
+test('templateBatchRegenerate resets existing built-in templates skipped by active module sync', function (): void {
     $template = emailTemplate('mod_invoice_created', 1, [
         'subject' => 'Legacy subject',
         'content' => '{{ invoice.total|money(invoice.currency) }}',
@@ -1041,23 +1041,19 @@ test('templateBatchRegenerate resets overridden built-in templates', function ()
         'is_custom' => true,
     ]);
 
-    $templateRepository = Mockery::mock(Box\Mod\Email\Repository\EmailTemplateRepository::class)->shouldIgnoreMissing();
-    $templateRepository->shouldReceive('findOneByActionCode')
-        ->andReturnUsing(static fn (string $code): EmailTemplate => match ($code) {
-            'mod_invoice_created' => $template,
-            'mod_invoice_paid' => $customTemplate,
-            default => emailTemplate($code, null, ['is_custom' => true]),
-        });
+    $templateRepository = Mockery::mock(Box\Mod\Email\Repository\EmailTemplateRepository::class);
+    $templateRepository->shouldReceive('findOneByActionCode')->never();
+    $templateRepository->shouldReceive('findAll')->once()->andReturn([$template, $customTemplate]);
 
     $em = emailBuildEm(templateRepo: $templateRepository);
     $em->shouldReceive('flush')->once();
 
     $extensionService = Mockery::mock(Box\Mod\Extension\Service::class);
-    $extensionService->shouldReceive('isExtensionActive')
-        ->andReturnUsing(static fn (string $type, string $module): bool => $type === 'mod' && $module === 'invoice');
+    $extensionService->shouldReceive('isExtensionActive')->andReturnFalse();
 
     $di = container();
     $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
     $di['mod_service'] = $di->protect(moduleService(['extension' => $extensionService]));
 
     $service = new Box\Mod\Email\Service();
@@ -1069,6 +1065,9 @@ test('templateBatchRegenerate resets overridden built-in templates', function ()
         ->and($template->getContent())->not->toContain('|money')
         ->and($template->hasError())->toBeFalse()
         ->and($customTemplate->getContent())->toBe('Custom template content');
+
+    $logMessages = array_map(static fn (array $call): string => $call['params'][0], $di['logger']->calls);
+    expect($logMessages)->toContain('Regenerated 1 file-backed email templates.');
 });
 
 test('templateBatchDisable disables all templates', function (): void {


### PR DESCRIPTION
Follow-up to #3985 and #4002.

## What changed

- Keep active-module synchronization for discovering and creating missing templates.
- Regenerate every existing built-in template that has a file-backed default.
- Share the same reset operation between individual and bulk resets.
- Preserve custom templates and clear stale validation errors.
- Log the number of templates regenerated.
- Add regression coverage for an existing template skipped by active-module synchronization.