### PR TITLE
Fix client sessions, form fields, and error pages

### DIFF
--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -57,6 +57,11 @@ class Box_AppClient extends Box_App
             $ext = substr((string) $page, strpos((string) $page, '.') + 1);
             $page = substr((string) $page, 0, strpos((string) $page, '.'));
         }
+
+        if ($page === 'login' && $this->di['auth']->isClientLoggedIn()) {
+            return $this->redirect('/');
+        }
+
         $page = str_replace('/', '_', $page);
         $tpl = 'mod_page_' . $page;
 

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -16,8 +16,11 @@ class Box_AppClient extends Box_App
 {
     protected function init(): void
     {
-        $m = $this->di['mod']($this->mod);
-        $m->registerClientRoutes($this);
+        // Paths without letters can resolve to custom pages, but cannot identify modules.
+        if (preg_match('/[a-zA-Z]/', $this->mod) === 1) {
+            $m = $this->di['mod']($this->mod);
+            $m->registerClientRoutes($this);
+        }
 
         if ($this->mod == 'api') {
             define('API_MODE', true);

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -110,13 +110,15 @@ class Session implements InjectionAwareInterface
         switch ($type) {
             case 'admin':
                 $this->delete('admin');
+                $this->regenerateId(0);
 
-                break;
+                return true;
             case 'client':
                 $this->delete('client');
                 $this->delete('client_id');
+                $this->regenerateId(0);
 
-                break;
+                return true;
         }
 
         return session_destroy();

--- a/src/modules/Formbuilder/Service.php
+++ b/src/modules/Formbuilder/Service.php
@@ -187,7 +187,7 @@ class Service implements InjectionAwareInterface
 
     public function updateField(array $field): int
     {
-        $fieldId = $field['id'];
+        $fieldId = (int) $field['id'];
         $label = $field['label'] ?? 'New field';
         $name = $this->slugify($field['name']);
 

--- a/src/modules/Formbuilder/tests/Unit/ServiceTest.php
+++ b/src/modules/Formbuilder/tests/Unit/ServiceTest.php
@@ -106,11 +106,11 @@ test('adds a new field', function (): void {
     expect($result)->toBeInt()->toBe($newFieldId);
 });
 
-test('updates a field', function (string $fieldType): void {
+test('updates a field', function (string $fieldType, int|string $fieldId): void {
     $service = new Service();
     $updateFieldId = 2;
     $data = [
-        'id' => $updateFieldId,
+        'id' => $fieldId,
         'form_id' => 1,
         'type' => $fieldType,
         'default_value' => 'defaultTestValue',
@@ -149,8 +149,9 @@ test('updates a field', function (string $fieldType): void {
     $result = $service->updateField($data);
     expect($result)->toBeInt()->toBe($updateFieldId);
 })->with([
-    ['select'],
-    ['textarea'],
+    ['select', 2],
+    ['radio', '2'],
+    ['textarea', 2],
 ]);
 
 test('throws exception when updating field with existing name', function (): void {

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -50,7 +50,7 @@
 {{ render_widgets('client.theme.body.start') }}
 
 {% block body %}
-{% if not client and settings.require_login %}
+{% if not client and settings.require_login and exception is not defined %}
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             const publicPaths = [

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
  * callback, so the get_custom_page catch-block logic can be exercised
  * without spinning up a Twig environment.
  */
-function appClientWithRender(callable $render): Box_AppClient
+function appClientWithRender(callable $render, bool $clientLoggedIn = false): Box_AppClient
 {
     $app = new class($render) extends Box_AppClient {
         /** @var callable */
@@ -58,6 +58,10 @@ function appClientWithRender(callable $render): Box_AppClient
     };
     $di['request'] = Request::create('http://localhost/test');
     $di['mod_service'] = $di->protect(static fn (): object => $extensionService);
+    $di['auth'] = Mockery::mock(Box_Authorization::class)
+        ->shouldReceive('isClientLoggedIn')->andReturn($clientLoggedIn)->getMock();
+    $di['url'] = Mockery::mock(Box_Url::class)
+        ->shouldReceive('link')->andReturnArg(0)->getMock();
     $app->setDi($di);
     $app->setUrl('/test');
 
@@ -81,6 +85,18 @@ test('get_custom_page returns XML content type for sitemap', function (): void {
     expect($response->getStatusCode())->toBe(200)
         ->and($response->headers->get('Content-Type'))->toContain('application/xml')
         ->and($response->getContent())->toBe('<urlset></urlset>');
+});
+
+test('get_custom_page redirects authenticated clients away from login', function (): void {
+    $app = appClientWithRender(
+        static fn (): never => throw new RuntimeException('The login page should not be rendered.'),
+        clientLoggedIn: true,
+    );
+
+    $response = $app->get_custom_page('login');
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toBe('/');
 });
 
 test('get_custom_page returns 500 (not 404) when the template throws a RuntimeError (regression for #3818)', function (): void {

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -25,6 +25,7 @@ function appClientWithRender(callable $render): Box_AppClient
 
         public function __construct(callable $render)
         {
+            parent::__construct();
             $this->renderCallback = $render;
         }
 
@@ -49,7 +50,14 @@ function appClientWithRender(callable $render): Box_AppClient
         {
         }
     };
+    $extensionService = new class {
+        public function isExtensionActive(): bool
+        {
+            return false;
+        }
+    };
     $di['request'] = Request::create('http://localhost/test');
+    $di['mod_service'] = $di->protect(static fn (): object => $extensionService);
     $app->setDi($di);
     $app->setUrl('/test');
 
@@ -129,4 +137,20 @@ test('get_custom_page still returns 404 when the top-level template is missing',
     $response = $app->get_custom_page('signup');
 
     expect($response->getStatusCode())->toBe(404);
+});
+
+test('numeric custom page paths return a themed 404', function (): void {
+    $app = appClientWithRender(static function (string $fileName): string {
+        if ($fileName === 'error') {
+            return 'error body';
+        }
+
+        throw new FOSSBilling\InformationException('Page not found', null, 404);
+    });
+    $app->setUrl('/12345');
+
+    $response = $app->run();
+
+    expect($response->getStatusCode())->toBe(404)
+        ->and($response->getContent())->toBe('error body');
 });

--- a/tests/Unit/FOSSBilling/SessionTest.php
+++ b/tests/Unit/FOSSBilling/SessionTest.php
@@ -21,6 +21,10 @@ function invokePrivate(object $instance, string $method, array $args = []): mixe
     return $methodReflection->invokeArgs($instance, $args);
 }
 
+afterEach(function (): void {
+    $_SESSION = [];
+});
+
 test('obsolete session is detected', function (): void {
     $session = createSession();
 
@@ -56,4 +60,32 @@ test('obsolete session expiry honors grace window', function (): void {
 
     expect($active)->toBeFalse();
     expect($expired)->toBeTrue();
+});
+
+test('destroying a client login preserves the admin login', function (): void {
+    $_SESSION = [
+        'admin' => ['id' => 1],
+        'client' => ['id' => 2],
+        'client_id' => 2,
+    ];
+
+    $result = createSession()->destroy('client');
+
+    expect($result)->toBeTrue()
+        ->and($_SESSION)->toHaveKey('admin')
+        ->not->toHaveKeys(['client', 'client_id']);
+});
+
+test('destroying an admin login preserves the client login', function (): void {
+    $_SESSION = [
+        'admin' => ['id' => 1],
+        'client' => ['id' => 2],
+        'client_id' => 2,
+    ];
+
+    $result = createSession()->destroy('admin');
+
+    expect($result)->toBeTrue()
+        ->and($_SESSION)->not->toHaveKey('admin')
+        ->and($_SESSION)->toHaveKeys(['client', 'client_id']);
 });


### PR DESCRIPTION
## Summary

- normalize Formbuilder field IDs before returning them from `updateField()`
- keep admin and client authentication independent when either account logs out
- redirect authenticated clients away from the client login page
- prevent Huraga's guest-dashboard redirect from replacing rendered error pages
- route numeric custom-page paths through the normal themed 404 handling

Fixes #4006.
Fixes #4007.
Fixes #4009.
Fixes #4010.