### PR TITLE
Fix staff signup email template variables

### DIFF
--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -345,7 +345,8 @@ class Service implements InjectionAwareInterface
             $email = [];
             $email['to_staff'] = true;
             $email['code'] = 'mod_staff_client_signup';
-            $email['c'] = $clientService->get(['id' => $params['id']]);
+            $client = $clientService->get(['id' => $params['id']]);
+            $email['c'] = $clientService->toApiArray($client);
             $emailService = $di['mod_service']('email');
             $emailService->sendTemplate($email);
         } catch (\Exception $exc) {

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -594,18 +594,35 @@ test('onAfterClientReplyTicket handles guest email exception', function (): void
     $service->onAfterClientReplyTicket($eventMock);
 });
 
-test('onAfterClientSignUp sends email notification', function (): void {
+test('onAfterClientSignUp sends sanitized client details in the email variables', function (): void {
     $eventMock = Mockery::mock('\Box_Event');
+    $clientId = 42;
+    $client = Mockery::mock(Model_Client::class);
+    $clientDetails = [
+        'id' => $clientId,
+        'email' => 'new-client@example.com',
+        'first_name' => 'New',
+        'last_name' => 'Client',
+    ];
 
     $clientMock = Mockery::mock(Box\Mod\Client\Service::class);
-    $clientMock->shouldReceive('get')->atLeast()->once()
-        ->andReturn([]);
+    $clientMock->shouldReceive('get')->once()
+        ->with(['id' => $clientId])
+        ->andReturn($client);
+    $clientMock->shouldReceive('toApiArray')->once()
+        ->with($client)
+        ->andReturn($clientDetails);
 
     $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
-    $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once();
+    $emailServiceMock->shouldReceive('sendTemplate')->once()
+        ->with([
+            'to_staff' => true,
+            'code' => 'mod_staff_client_signup',
+            'c' => $clientDetails,
+        ]);
 
-    $eventMock->shouldReceive('getparameters')->atLeast()->once()
-        ->andReturn(['id' => random_int(1, 100)]);
+    $eventMock->shouldReceive('getParameters')->once()
+        ->andReturn(['id' => $clientId]);
 
     $service = new Service();
 
@@ -627,17 +644,23 @@ test('onAfterClientSignUp sends email notification', function (): void {
 
 test('onAfterClientSignUp handles email exception', function (): void {
     $eventMock = Mockery::mock('\Box_Event');
+    $clientId = 42;
+    $client = Mockery::mock(Model_Client::class);
 
     $clientMock = Mockery::mock(Box\Mod\Client\Service::class);
-    $clientMock->shouldReceive('get')->atLeast()->once()
+    $clientMock->shouldReceive('get')->once()
+        ->with(['id' => $clientId])
+        ->andReturn($client);
+    $clientMock->shouldReceive('toApiArray')->once()
+        ->with($client)
         ->andReturn([]);
 
     $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
-    $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once()
+    $emailServiceMock->shouldReceive('sendTemplate')->once()
         ->andThrow(new Exception('PHPunit controlled Exception'));
 
-    $eventMock->shouldReceive('getparameters')->atLeast()->once()
-        ->andReturn(['id' => random_int(1, 100)]);
+    $eventMock->shouldReceive('getParameters')->once()
+        ->andReturn(['id' => $clientId]);
 
     $service = new Service();
 


### PR DESCRIPTION
## Summary

- convert the newly signed-up client model to its sanitized API representation before sending the staff notification
- preserve the existing `c.*` email-template interface while making client details available in the Variables tab
- strengthen the Staff service regression tests with deterministic, exact payload expectations

Fixes #4014.