### PR TITLE
Prevent email template regeneration timeouts

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -900,23 +900,46 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function templateBatchRegenerate(): bool
     {
-        $this->templateBatchGenerate();
-        $regenerated = 0;
-
+        $extensionService = $this->di['mod_service']('extension');
+        $templatesByCode = [];
         foreach ($this->getTemplateRepository()->findAll() as $template) {
-            if ($this->isCustomTemplate($template)) {
+            $templatesByCode[$template->getActionCode()] = $template;
+        }
+
+        $regenerated = 0;
+        $created = 0;
+
+        $finder = new Finder();
+        $finder = $finder->files()->in(PATH_MODS . '/*/templates/email/')->name('*.html.twig');
+
+        foreach ($finder as $file) {
+            $code = $file->getBasename('.html.twig');
+            $default = $this->getDefaultTemplate($code, ['code' => $code]);
+            if ($default === null) {
                 continue;
             }
 
-            $default = $this->getDefaultTemplate($template->getActionCode());
-            if ($default !== null) {
+            $template = $templatesByCode[$code] ?? null;
+            if ($template instanceof EmailTemplate) {
+                if ($this->isCustomTemplate($template)) {
+                    continue;
+                }
+
                 $this->resetBuiltinTemplate($template, $default);
                 ++$regenerated;
+
+                continue;
+            }
+
+            $module = strtolower(Path::getFilenameWithoutExtension(Path::getDirectory(Path::getDirectory($file->getPath()))));
+            if ($extensionService->isExtensionActive('mod', $module)) {
+                $this->createBuiltinTemplateRecord($code, $default);
+                ++$created;
             }
         }
 
         $this->di['em']->flush();
-        $this->di['logger']->info(sprintf('Regenerated %d file-backed email templates.', $regenerated));
+        $this->di['logger']->info(sprintf('Regenerated %d and created %d file-backed email templates.', $regenerated, $created));
 
         return true;
     }

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -947,6 +947,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     private function syncFileBackedTemplates(): bool
     {
         $extensionService = $this->di['mod_service']('extension');
+        $templatesByCode = [];
+        foreach ($this->getTemplateRepository()->findAll() as $template) {
+            $templatesByCode[$template->getActionCode()] = $template;
+        }
 
         $finder = new Finder();
         $finder = $finder->files()->in(PATH_MODS . '/*/templates/email/')->name('*.html.twig');
@@ -960,7 +964,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
                 continue;
             }
 
-            $template = $this->getTemplateRepository()->findOneByActionCode($code);
+            $template = $templatesByCode[$code] ?? null;
             $default = $this->getDefaultTemplate($code, ['code' => $code]);
             if ($default === null) {
                 continue;

--- a/src/modules/Email/templates/admin/mod_email_settings.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_settings.html.twig
@@ -63,6 +63,8 @@
                                content: 'This will replace the subject and content of every existing built-in email template. Custom templates will not be affected.'|trans,
                            },
                            reload: true,
+                           timeoutMs: 120000,
+                           timeoutMessage: 'Email template regeneration timed out after two minutes.'|trans,
                        }) }}>
                         <svg class="icon me-1"><use href="#mail" /></svg>
                         {{ 'Regenerate Built-in Templates'|trans }}

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -1067,7 +1067,9 @@ test('templateBatchRegenerate resets existing built-in templates skipped by acti
         ->and($customTemplate->getContent())->toBe('Custom template content');
 
     $logMessages = array_map(static fn (array $call): string => $call['params'][0], $di['logger']->calls);
-    expect($logMessages)->toContain('Regenerated 1 file-backed email templates.');
+    expect($logMessages)
+        ->not->toContain('Synced file-backed email templates for installed modules.')
+        ->toContain('Regenerated 1 and created 0 file-backed email templates.');
 });
 
 test('templateBatchDisable disables all templates', function (): void {


### PR DESCRIPTION
Follow-up to #3985 and #4008.

## What changed

- Regenerate file-backed email templates in a single pass instead of running synchronization followed by a second full pass.
- Reset existing built-in templates regardless of module activation state.
- Check module activation only when a missing template needs to be created.
- Increase the browser timeout for the explicit regeneration action to two minutes.
- Log separate regenerated and created template counts.
- Extend the regression test to ensure the preliminary synchronization pass is not invoked.