### PR TITLE
Fix support email template variables

### DIFF
--- a/src/modules/Email/templates/admin/mod_email_template.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_template.html.twig
@@ -5,6 +5,23 @@
 {% set can_manage_settings = has_permission('email', 'manage_settings') %}
 {% set can_manage_templates = has_permission('email', 'manage_templates') %}
 
+{% macro render_vars(vars, prefix = '') %}
+    {% for key, value in vars %}
+        {% set path = prefix is empty ? key : prefix ~ '.' ~ key %}
+        {% if value is sequence and value|length > 0 %}
+            {# Every item in a list has the same shape; one example avoids duplicate rows. #}
+            {{ _self.render_vars(value|slice(0, 1), path) }}
+        {% elseif value is iterable and value|length > 0 %}
+            {{ _self.render_vars(value, path) }}
+        {% else %}
+            <tr>
+                <td>{{ '{{' }} {{ path }} {{ '}}' }}</td>
+                <td>{{ value is iterable ? 'Array [ ]' : value }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+{% endmacro render_vars %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item">
@@ -226,41 +243,13 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                {% for k,var in template.vars %}
-                                    {% if var is iterable %}
-                                        {% for subkey,subvalue in var %}
-                                            {% if subvalue is iterable %}
-                                                {% for subsubkey,subsubvalue in var %}
-                                                    {% if subsubvalue is not iterable %}
-                                                        <tr>
-                                                            <td>{{ '{{' }} {{ k }}.{{ subkey }}.{{ subsubkey }}{{ '}}' }}</td>
-                                                            <td>{{ subsubvalue }}</td>
-                                                        </tr>
-                                                    {% else %}
-                                                        <tr>
-                                                            <td>{{ '{{' }} {{ k }}.{{ subkey }}.{{ subsubkey }}{{ '}}' }}</td>
-                                                            <td>Array [ ]</td>
-                                                        </tr>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            {% else %}
-                                                <tr>
-                                                    <td>{{ '{{' }} {{ k }}.{{ subkey }} {{ '}}' }}</td>
-                                                    <td>{{ subvalue }}</td>
-                                                </tr>
-                                            {% endif %}
-                                        {% endfor %}
-                                    {% else %}
-                                        <tr>
-                                            <td>{{ '{{' }} {{ k }} {{ '}}' }}</td>
-                                            <td>{{ var }}</td>
-                                        </tr>
-                                    {% endif %}
+                                {% if template.vars|length > 0 %}
+                                    {{ _self.render_vars(template.vars) }}
                                 {% else %}
                                     <tr>
                                         <td class="text-muted" colspan="2">{{ 'This template has no known parameters, you may need to take an action to trigger its sending before they become known.'|trans }}</td>
                                     </tr>
-                                {% endfor %}
+                                {% endif %}
                                 </tbody>
                             </table>
                         </div>

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -267,6 +267,7 @@ class Service implements InjectionAwareInterface
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
             $ticket = $supportTicketService->toApiArray($ticketModel, true);
+            $ticket['priority'] = $ticketModel->getPriority();
 
             $helpdeskId = $ticketModel->getSupportHelpdeskId();
             $helpdeskModel = $helpdeskId !== null ? $di['em']->getRepository(Helpdesk::class)->find($helpdeskId) : null;
@@ -300,6 +301,7 @@ class Service implements InjectionAwareInterface
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
             $ticket = $supportTicketService->toApiArray($ticketModel, true);
+            $ticket['priority'] = $ticketModel->getPriority();
 
             $email = [];
             $email['to_staff'] = true;
@@ -322,6 +324,7 @@ class Service implements InjectionAwareInterface
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
             $ticket = $supportTicketService->toApiArray($ticketModel, true);
+            $ticket['priority'] = $ticketModel->getPriority();
             $email = [];
             $email['to_staff'] = true;
             $email['code'] = 'mod_staff_ticket_close';

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -324,19 +324,30 @@ test('hasPermission returns false for staff without method permission', function
 
 test('onAfterClientReplyTicket sends email notification', function (): void {
     $eventMock = Mockery::mock('\Box_Event');
+    $ticketId = 42;
+    $ticketModel = (new Box\Mod\Support\Entity\SupportTicket())->setPriority(25);
 
     $supportServiceMock = Mockery::mock(Box\Mod\Support\Service::class);
-    $supportServiceMock->shouldReceive('getTicketById')->atLeast()->once()
-        ->andReturn(new Box\Mod\Support\Entity\SupportTicket());
-    $supportServiceMock->shouldReceive('toApiArray')->atLeast()->once()
-        ->andReturn([]);
+    $supportServiceMock->shouldReceive('getTicketById')->once()
+        ->with($ticketId)
+        ->andReturn($ticketModel);
+    $supportServiceMock->shouldReceive('toApiArray')->once()
+        ->with($ticketModel, true)
+        ->andReturn(['subject' => 'Example ticket']);
 
     $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
-    $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once()
-        ->with(Mockery::on(fn ($email): bool => $email['code'] === 'mod_staff_ticket_reply'));
+    $emailServiceMock->shouldReceive('sendTemplate')->once()
+        ->with([
+            'to_staff' => true,
+            'code' => 'mod_staff_ticket_reply',
+            'ticket' => [
+                'subject' => 'Example ticket',
+                'priority' => 25,
+            ],
+        ]);
 
-    $eventMock->shouldReceive('getparameters')->atLeast()->once()
-        ->andReturn(['id' => random_int(1, 100)]);
+    $eventMock->shouldReceive('getParameters')->once()
+        ->andReturn(['id' => $ticketId]);
 
     $service = new Service();
 
@@ -735,7 +746,7 @@ test('onAfterClientOpenTicket sends mod_staff_ticket_open email', function (): v
     $emailConfig = [
         'to_staff' => true,
         'code' => 'mod_staff_ticket_open',
-        'ticket' => $supportTicketArray,
+        'ticket' => ['priority' => 100],
     ];
     $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once()
         ->with($emailConfig)
@@ -797,7 +808,7 @@ test('onAfterClientOpenTicket sends mod_support_helpdesk_ticket_open email', fun
     $emailConfig = [
         'to' => $helpdeskModel->getEmail(),
         'code' => 'mod_support_helpdesk_ticket_open',
-        'ticket' => $supportTicketArray,
+        'ticket' => ['priority' => 100],
     ];
     $emailServiceMock->shouldReceive('sendTemplate')->atLeast()->once()
         ->with($emailConfig)


### PR DESCRIPTION
## Summary

- render nested email-template variables recursively in the Variables tab
- show one representative entry for list-shaped values to avoid duplicate rows
- include `ticket.priority` in staff-facing ticket open, reply, and close notifications
- strengthen the Staff service payload expectations

Fixes #4017.