### PR TITLE
Fix email template variable previews

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -148,7 +148,100 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $vars['invoice'] = $invoice;
         }
 
+        $defaults = $this->getTemplateVarDefaults($template->getActionCode());
+        if ($defaults !== []) {
+            $vars = array_replace_recursive($defaults, $vars);
+        }
+
         return $vars;
+    }
+
+    private function getTemplateVarDefaults(string $actionCode): array
+    {
+        $staff = [
+            'id' => 1,
+            'email' => 'staff@example.com',
+            'name' => 'Staff Member',
+            'signature' => '',
+        ];
+        $client = [
+            'id' => 1,
+            'email' => 'client@example.com',
+            'email_approved' => true,
+            'type' => 'individual',
+            'company' => '',
+            'company_vat' => '',
+            'company_number' => '',
+            'first_name' => 'Example',
+            'last_name' => 'Client',
+            'gender' => '',
+            'birthday' => '',
+            'phone_cc' => '',
+            'phone' => '',
+            'address_1' => '',
+            'address_2' => '',
+            'city' => '',
+            'state' => '',
+            'postcode' => '',
+            'country' => '',
+            'currency' => '',
+            'lang' => '',
+            'timezone' => '',
+        ];
+        $message = [
+            'id' => 1,
+            'content' => 'Example ticket message',
+            'attachment' => '',
+            'created_at' => '',
+            'updated_at' => '',
+            'author' => [
+                'name' => 'Example Client',
+                'role' => 'client',
+            ],
+        ];
+        $ticket = [
+            'id' => 1,
+            'subject' => 'Example support ticket',
+            'status' => 'open',
+            'created_at' => '',
+            'updated_at' => '',
+            'replies' => 0,
+            'first' => $message,
+            'helpdesk' => [
+                'id' => 1,
+                'name' => 'Support',
+                'can_reopen' => true,
+            ],
+            'author' => [
+                'id' => 1,
+                'name' => 'Example Client',
+                'first_name' => 'Example',
+                'last_name' => 'Client',
+                'email' => 'client@example.com',
+                'role' => 'client',
+            ],
+            'client' => [
+                'id' => 1,
+                'first_name' => 'Example',
+                'last_name' => 'Client',
+            ],
+            'messages' => [$message],
+        ];
+        $staffTicket = $ticket;
+        $staffTicket['priority'] = 100;
+        $staffTicket['client'] = $client;
+
+        return match ($actionCode) {
+            'mod_support_ticket_staff_open',
+            'mod_support_ticket_staff_close',
+            'mod_support_ticket_staff_reply' => ['c' => $client, 'ticket' => $ticket],
+            'mod_staff_ticket_open',
+            'mod_staff_ticket_reply',
+            'mod_staff_ticket_close' => ['staff' => $staff, 'ticket' => $staffTicket],
+            'mod_staff_password_reset_approve' => ['c' => $staff],
+            'mod_staff_client_signup' => ['c' => $client, 'staff' => $staff],
+            default => [],
+        };
     }
 
     public function sendTemplate($data)

--- a/src/modules/Email/templates/admin/mod_email_template.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_template.html.twig
@@ -5,23 +5,6 @@
 {% set can_manage_settings = has_permission('email', 'manage_settings') %}
 {% set can_manage_templates = has_permission('email', 'manage_templates') %}
 
-{% macro render_vars(vars, prefix = '') %}
-    {% for key, value in vars %}
-        {% set path = prefix is empty ? key : prefix ~ '.' ~ key %}
-        {% if value is sequence and value|length > 0 %}
-            {# Every item in a list has the same shape; one example avoids duplicate rows. #}
-            {{ _self.render_vars(value|slice(0, 1), path) }}
-        {% elseif value is iterable and value|length > 0 %}
-            {{ _self.render_vars(value, path) }}
-        {% else %}
-            <tr>
-                <td>{{ '{{' }} {{ path }} {{ '}}' }}</td>
-                <td>{{ value is iterable ? 'Array [ ]' : value }}</td>
-            </tr>
-        {% endif %}
-    {% endfor %}
-{% endmacro render_vars %}
-
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item">
@@ -234,6 +217,7 @@
                         card_class: 'm-3'
                     } %}
                         {% block section_content %}
+                        {% import 'partial_email_template_macros.html.twig' as email_template %}
                         <div class="table-responsive">
                             <table class="table card-table table-vcenter table-striped text-nowrap">
                                 <thead>
@@ -244,7 +228,7 @@
                                 </thead>
                                 <tbody>
                                 {% if template.vars|length > 0 %}
-                                    {{ _self.render_vars(template.vars) }}
+                                    {{ email_template.render_vars(template.vars) }}
                                 {% else %}
                                     <tr>
                                         <td class="text-muted" colspan="2">{{ 'This template has no known parameters, you may need to take an action to trigger its sending before they become known.'|trans }}</td>

--- a/src/modules/Email/templates/admin/partial_email_template_macros.html.twig
+++ b/src/modules/Email/templates/admin/partial_email_template_macros.html.twig
@@ -1,0 +1,16 @@
+{% macro render_vars(vars, prefix = '') %}
+    {% for key, value in vars %}
+        {% set path = prefix is empty ? key : prefix ~ '.' ~ key %}
+        {% if value is sequence and value|length > 0 %}
+            {# Every item in a list has the same shape; one example avoids duplicate rows. #}
+            {{ _self.render_vars(value|slice(0, 1), path) }}
+        {% elseif value is iterable and value|length > 0 %}
+            {{ _self.render_vars(value, path) }}
+        {% else %}
+            <tr>
+                <td>{{ '{{' }} {{ path }} {{ '}}' }}</td>
+                <td>{{ value is iterable ? 'Array [ ]' : value }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+{% endmacro render_vars %}

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -237,6 +237,42 @@ test('getVars supplies the default currency for invoice template previews', func
     ]);
 });
 
+test('getVars supplies preview variables for support and staff templates before their first send', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $supportVars = $service->getVars(emailTemplate('mod_support_ticket_staff_open'));
+    expect($supportVars)
+        ->toHaveKeys(['c.email', 'ticket.subject', 'ticket.client.first_name', 'ticket.messages.0.content'])
+        ->not->toHaveKeys(['ticket.priority', 'ticket.client.email', 'ticket.messages.0.author.email']);
+
+    $staffVars = $service->getVars(emailTemplate('mod_staff_ticket_open'));
+    expect($staffVars)
+        ->toHaveKeys(['staff.email', 'ticket.priority', 'ticket.client.email', 'ticket.messages.0.content']);
+
+    $passwordResetVars = $service->getVars(emailTemplate('mod_staff_password_reset_approve'));
+    expect($passwordResetVars)->toHaveKeys(['c.id', 'c.email', 'c.name']);
+
+    $signupVars = $service->getVars(emailTemplate('mod_staff_client_signup'));
+    expect($signupVars)->toHaveKeys(['c.email', 'c.first_name', 'c.last_name', 'staff.email']);
+});
+
+test('getVars merges stored examples over preview defaults', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $cryptMock = Mockery::mock('\Box_Crypt');
+    $cryptMock->shouldReceive('decrypt')->once()->andReturn('{"ticket":{"subject":"Stored subject"}}');
+
+    $di = container();
+    $di['crypt'] = $cryptMock;
+    $service->setDi($di);
+
+    $template = emailTemplate('mod_staff_ticket_reply', data: ['vars' => 'encrypted']);
+    $vars = $service->getVars($template);
+
+    expect($vars['ticket']['subject'])->toBe('Stored subject')
+        ->and($vars)->toHaveKeys(['staff.email', 'ticket.priority', 'ticket.client.email']);
+});
+
 test('sendTemplate returns false when template does not exist', function (): void {
     $service = new Box\Mod\Email\Service();
     $di = container();

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -16,6 +16,7 @@ use Box\Mod\Staff\Entity\AdminGroupMember;
 use Box\Mod\Staff\Repository\AdminGroupMemberRepository;
 use Box\Mod\Staff\Repository\AdminGroupRepository;
 use Box\Mod\Support\Entity\Helpdesk;
+use Box\Mod\Support\Entity\SupportTicket;
 use FOSSBilling\i18n;
 use FOSSBilling\InjectionAwareInterface;
 use FOSSBilling\PaginationOptions;
@@ -266,8 +267,7 @@ class Service implements InjectionAwareInterface
         try {
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
-            $ticket = $supportTicketService->toApiArray($ticketModel, true);
-            $ticket['priority'] = $ticketModel->getPriority();
+            $ticket = self::getTicketEmailVars($di, $ticketModel);
 
             $helpdeskId = $ticketModel->getSupportHelpdeskId();
             $helpdeskModel = $helpdeskId !== null ? $di['em']->getRepository(Helpdesk::class)->find($helpdeskId) : null;
@@ -300,8 +300,7 @@ class Service implements InjectionAwareInterface
         try {
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
-            $ticket = $supportTicketService->toApiArray($ticketModel, true);
-            $ticket['priority'] = $ticketModel->getPriority();
+            $ticket = self::getTicketEmailVars($di, $ticketModel);
 
             $email = [];
             $email['to_staff'] = true;
@@ -323,8 +322,7 @@ class Service implements InjectionAwareInterface
         try {
             $supportTicketService = $di['mod_service']('support');
             $ticketModel = $supportTicketService->getTicketById((int) $params['id']);
-            $ticket = $supportTicketService->toApiArray($ticketModel, true);
-            $ticket['priority'] = $ticketModel->getPriority();
+            $ticket = self::getTicketEmailVars($di, $ticketModel);
             $email = [];
             $email['to_staff'] = true;
             $email['code'] = 'mod_staff_ticket_close';
@@ -335,6 +333,26 @@ class Service implements InjectionAwareInterface
         } catch (\Exception $exc) {
             $di['logger']->setChannel('email')->error('Failed to send staff ticket close notification email', ['exception' => $exc->getMessage()]);
         }
+    }
+
+    private static function getTicketEmailVars(\Pimple\Container $di, SupportTicket $ticketModel): array
+    {
+        $ticket = $di['mod_service']('support')->toApiArray($ticketModel, true);
+        $ticket['priority'] = $ticketModel->getPriority();
+
+        $clientId = $ticketModel->getClientId();
+        if ($clientId !== null) {
+            $clientService = $di['mod_service']('client');
+
+            try {
+                $client = $clientService->get(['id' => $clientId]);
+            } catch (\FOSSBilling\InformationException) {
+                return $ticket;
+            }
+            $ticket['client'] = $clientService->toApiArray($client);
+        }
+
+        return $ticket;
     }
 
     public static function onAfterClientSignUp(\Box_Event $event): bool

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -325,7 +325,17 @@ test('hasPermission returns false for staff without method permission', function
 test('onAfterClientReplyTicket sends email notification', function (): void {
     $eventMock = Mockery::mock('\Box_Event');
     $ticketId = 42;
-    $ticketModel = (new Box\Mod\Support\Entity\SupportTicket())->setPriority(25);
+    $clientId = 7;
+    $ticketModel = (new Box\Mod\Support\Entity\SupportTicket())
+        ->setClientId($clientId)
+        ->setPriority(25);
+    $clientModel = Mockery::mock(Model_Client::class);
+    $clientDetails = [
+        'id' => $clientId,
+        'email' => 'client@example.com',
+        'first_name' => 'Example',
+        'last_name' => 'Client',
+    ];
 
     $supportServiceMock = Mockery::mock(Box\Mod\Support\Service::class);
     $supportServiceMock->shouldReceive('getTicketById')->once()
@@ -334,6 +344,71 @@ test('onAfterClientReplyTicket sends email notification', function (): void {
     $supportServiceMock->shouldReceive('toApiArray')->once()
         ->with($ticketModel, true)
         ->andReturn(['subject' => 'Example ticket']);
+
+    $clientServiceMock = Mockery::mock(Box\Mod\Client\Service::class);
+    $clientServiceMock->shouldReceive('get')->once()
+        ->with(['id' => $clientId])
+        ->andReturn($clientModel);
+    $clientServiceMock->shouldReceive('toApiArray')->once()
+        ->with($clientModel)
+        ->andReturn($clientDetails);
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->once()
+        ->with([
+            'to_staff' => true,
+            'code' => 'mod_staff_ticket_reply',
+            'ticket' => [
+                'subject' => 'Example ticket',
+                'priority' => 25,
+                'client' => $clientDetails,
+            ],
+        ]);
+
+    $eventMock->shouldReceive('getParameters')->once()
+        ->andReturn(['id' => $ticketId]);
+
+    $service = new Service();
+
+    $di = container();
+    $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $clientServiceMock, $emailServiceMock) {
+        if ($name == 'support') {
+            return $supportServiceMock;
+        }
+        if ($name == 'client') {
+            return $clientServiceMock;
+        }
+        if ($name == 'email') {
+            return $emailServiceMock;
+        }
+    });
+
+    $eventMock->shouldReceive('getDi')->atLeast()->once()
+        ->andReturn($di);
+    $service->setDi($di);
+    $service->onAfterClientReplyTicket($eventMock);
+});
+
+test('onAfterClientReplyTicket still sends when its client no longer exists', function (): void {
+    $eventMock = Mockery::mock('\\Box_Event');
+    $ticketId = 42;
+    $clientId = 7;
+    $ticketModel = (new Box\Mod\Support\Entity\SupportTicket())
+        ->setClientId($clientId)
+        ->setPriority(25);
+
+    $supportServiceMock = Mockery::mock(Box\Mod\Support\Service::class);
+    $supportServiceMock->shouldReceive('getTicketById')->once()
+        ->with($ticketId)
+        ->andReturn($ticketModel);
+    $supportServiceMock->shouldReceive('toApiArray')->once()
+        ->with($ticketModel, true)
+        ->andReturn(['subject' => 'Example ticket']);
+
+    $clientServiceMock = Mockery::mock(Box\Mod\Client\Service::class);
+    $clientServiceMock->shouldReceive('get')->once()
+        ->with(['id' => $clientId])
+        ->andThrow(new FOSSBilling\InformationException('Client not found'));
 
     $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
     $emailServiceMock->shouldReceive('sendTemplate')->once()
@@ -346,25 +421,19 @@ test('onAfterClientReplyTicket sends email notification', function (): void {
             ],
         ]);
 
-    $eventMock->shouldReceive('getParameters')->once()
-        ->andReturn(['id' => $ticketId]);
-
-    $service = new Service();
-
     $di = container();
-    $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $emailServiceMock) {
-        if ($name == 'support') {
-            return $supportServiceMock;
-        }
-        if ($name == 'email') {
-            return $emailServiceMock;
-        }
+    $di['mod_service'] = $di->protect(function ($name) use ($supportServiceMock, $clientServiceMock, $emailServiceMock) {
+        return match ($name) {
+            'support' => $supportServiceMock,
+            'client' => $clientServiceMock,
+            'email' => $emailServiceMock,
+        };
     });
 
-    $eventMock->shouldReceive('getDi')->atLeast()->once()
-        ->andReturn($di);
-    $service->setDi($di);
-    $service->onAfterClientReplyTicket($eventMock);
+    $eventMock->shouldReceive('getParameters')->once()->andReturn(['id' => $ticketId]);
+    $eventMock->shouldReceive('getDi')->once()->andReturn($di);
+
+    Service::onAfterClientReplyTicket($eventMock);
 });
 
 test('onAfterClientReplyTicket handles email exception', function (): void {

--- a/tests/Unit/FOSSBilling/Twig/EdgeCaseRenderingTest.php
+++ b/tests/Unit/FOSSBilling/Twig/EdgeCaseRenderingTest.php
@@ -161,6 +161,41 @@ test('email template example renders without calling email globals in admin cont
         ->not->toContain('{% endapply %}');
 });
 
+test('email template variable macro renders nested variables inside an embed', function (): void {
+    $macro = file_get_contents(PATH_MODS . '/Email/templates/admin/partial_email_template_macros.html.twig');
+    expect($macro)->not->toBeFalse();
+
+    $twig = new Environment(new ArrayLoader([
+        'page' => <<<'TWIG'
+            {% embed 'section' %}
+                {% block content %}
+                    {% import 'macros' as email_template %}
+                    {{ email_template.render_vars(vars) }}
+                {% endblock %}
+            {% endembed %}
+            TWIG,
+        'section' => '{% block content %}{% endblock %}',
+        'macros' => $macro,
+    ]), [
+        'strict_variables' => true,
+        'cache' => false,
+    ]);
+
+    $html = $twig->render('page', [
+        'vars' => [
+            'ticket' => [
+                'client' => [
+                    'email' => 'client@example.com',
+                ],
+            ],
+        ],
+    ]);
+
+    expect($html)
+        ->toContain('{{ ticket.client.email }}')
+        ->toContain('client@example.com');
+});
+
 test('orderbutton product configuration renders a hosting product', function (): void {
     $html = (new StrictTemplateRenderer())->renderTemplate(
         PATH_MODS . '/Orderbutton/templates/client/mod_orderbutton_product_configuration.html.twig',


### PR DESCRIPTION
## What changed

- provide realistic preview variables for the support and staff email templates reported in #4017
- merge previously stored examples over the preview defaults
- include sanitized client details and ticket priority in staff ticket notifications
- move the recursive variable renderer into an explicitly imported Twig macro
- keep staff notifications sendable when a ticket references a missing client

Fixes #4017.
