### PR TITLE
Fix escaped invoice PDF font styles

### DIFF
--- a/src/modules/Invoice/templates/pdf/default-invoice.twig
+++ b/src/modules/Invoice/templates/pdf/default-invoice.twig
@@ -34,7 +34,7 @@
 		<meta http-equiv='Content-Type' content='text/html; charset=utf-8'/>
 		<title>{{ invoice.serie_nr }}</title>
 		<style>
-			{{ css }}
+			{{ css|raw }}
 		</style>
 	</head>
 	<body>

--- a/src/modules/Invoice/tests/Unit/PdfFontTest.php
+++ b/src/modules/Invoice/tests/Unit/PdfFontTest.php
@@ -14,11 +14,21 @@ use Dompdf\Dompdf;
 use Dompdf\Options;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 test('default PDF fonts cover Thai and Lao text', function (): void {
     $filesystem = new Filesystem();
     $templatePath = Path::join(PATH_ROOT, 'modules', 'Invoice', 'templates', 'pdf');
     $css = $filesystem->readFile(Path::join($templatePath, 'default-invoice.css'));
+    $template = $filesystem->readFile(Path::join($templatePath, 'default-invoice.twig'));
+
+    preg_match('/<style>.*?<\/style>/s', $template, $styleBlock);
+    expect($styleBlock)->toHaveCount(1);
+
+    $twig = new Environment(new ArrayLoader(['style' => $styleBlock[0]]), ['autoescape' => 'html']);
+    $renderedStyle = $twig->render('style', ['css' => $css]);
+    expect($renderedStyle)->not->toContain('&quot;');
 
     $fontCachePath = Path::join(sys_get_temp_dir(), 'fossbilling-pdf-font-test-' . bin2hex(random_bytes(6)));
     $filesystem->mkdir($fontCachePath);
@@ -31,7 +41,7 @@ test('default PDF fonts cover Thai and Lao text', function (): void {
 
         $pdf = new Dompdf($options);
         $pdf->setBasePath($templatePath);
-        $pdf->loadHtml("<style>{$css}</style><p>ภูเก็ต ພູເກັດ</p>");
+        $pdf->loadHtml("{$renderedStyle}<p>ภูเก็ต ພູເກັດ</p>");
         $pdf->render();
 
         $cases = [


### PR DESCRIPTION
## Summary

- render the trusted local invoice stylesheet without Twig HTML escaping
- exercise the actual Twig style block in the Thai/Lao PDF font regression test
- verify that auto-escaping no longer converts quoted CSS values to `&quot;`

Follow-up to #4012 and #3157.