### PR TITLE
Reset existing built-in email templates directly

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -993,46 +993,24 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function templateBatchRegenerate(): bool
     {
-        $extensionService = $this->di['mod_service']('extension');
-        $templatesByCode = [];
-        foreach ($this->getTemplateRepository()->findAll() as $template) {
-            $templatesByCode[$template->getActionCode()] = $template;
-        }
-
         $regenerated = 0;
-        $created = 0;
 
-        $finder = new Finder();
-        $finder = $finder->files()->in(PATH_MODS . '/*/templates/email/')->name('*.html.twig');
+        foreach ($this->getTemplateRepository()->findAll() as $template) {
+            if ($this->isCustomTemplate($template)) {
+                continue;
+            }
 
-        foreach ($finder as $file) {
-            $code = $file->getBasename('.html.twig');
-            $default = $this->getDefaultTemplate($code, ['code' => $code]);
+            $default = $this->getDefaultTemplate($template->getActionCode());
             if ($default === null) {
                 continue;
             }
 
-            $template = $templatesByCode[$code] ?? null;
-            if ($template instanceof EmailTemplate) {
-                if ($this->isCustomTemplate($template)) {
-                    continue;
-                }
-
-                $this->resetBuiltinTemplate($template, $default);
-                ++$regenerated;
-
-                continue;
-            }
-
-            $module = strtolower(Path::getFilenameWithoutExtension(Path::getDirectory(Path::getDirectory($file->getPath()))));
-            if ($extensionService->isExtensionActive('mod', $module)) {
-                $this->createBuiltinTemplateRecord($code, $default);
-                ++$created;
-            }
+            $this->resetBuiltinTemplate($template, $default);
+            ++$regenerated;
         }
 
         $this->di['em']->flush();
-        $this->di['logger']->info(sprintf('Regenerated %d and created %d file-backed email templates.', $regenerated, $created));
+        $this->di['logger']->info(sprintf('Regenerated %d existing file-backed email templates.', $regenerated));
 
         return true;
     }

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -1065,7 +1065,7 @@ test('templateCreate creates new template', function (): void {
     expect($result->getActionCode())->toBe($data['action_code']);
 });
 
-test('templateBatchRegenerate resets existing built-in templates skipped by active module sync', function (): void {
+test('templateBatchRegenerate resets existing built-in templates without module discovery', function (): void {
     $template = emailTemplate('mod_invoice_created', 1, [
         'subject' => 'Legacy subject',
         'content' => '{{ invoice.total|money(invoice.currency) }}',
@@ -1084,13 +1084,9 @@ test('templateBatchRegenerate resets existing built-in templates skipped by acti
     $em = emailBuildEm(templateRepo: $templateRepository);
     $em->shouldReceive('flush')->once();
 
-    $extensionService = Mockery::mock(Box\Mod\Extension\Service::class);
-    $extensionService->shouldReceive('isExtensionActive')->andReturnFalse();
-
     $di = container();
     $di['em'] = $em;
     $di['logger'] = new Tests\Helpers\TestLogger();
-    $di['mod_service'] = $di->protect(moduleService(['extension' => $extensionService]));
 
     $service = new Box\Mod\Email\Service();
     $service->setDi($di);
@@ -1105,7 +1101,7 @@ test('templateBatchRegenerate resets existing built-in templates skipped by acti
     $logMessages = array_map(static fn (array $call): string => $call['params'][0], $di['logger']->calls);
     expect($logMessages)
         ->not->toContain('Synced file-backed email templates for installed modules.')
-        ->toContain('Regenerated 1 and created 0 file-backed email templates.');
+        ->toContain('Regenerated 1 existing file-backed email templates.');
 });
 
 test('templateBatchDisable disables all templates', function (): void {


### PR DESCRIPTION
Follow-up to #3985, #4008, and #4018.

## What changed

- Regenerate existing built-in email template rows directly from each action code's file-backed default.
- Skip custom templates and built-ins whose default no longer exists.
- Remove filesystem discovery, module activation checks, and missing-template creation from the explicit regeneration action.
- Keep missing-template creation in the existing synchronization workflow.
- Retain one flush and report the number of existing templates regenerated.