### PR TITLE
Fix incomplete custom field configuration

### DIFF
--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -313,7 +313,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             $customFields[$fieldName] = $field;
         }
 
-        uasort($customFields, fn ($a, $b): int => strnatcasecmp((string) ($a['title'] ?? ''), (string) ($b['title'] ?? '')));
+        uasort($customFields, fn ($a, $b): int => strnatcasecmp($a['title'], $b['title']));
 
         return $customFields;
     }

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -301,6 +301,17 @@ class Guest extends \FOSSBilling\Api\AbstractApi
     {
         $config = $this->getDi()['mod_config']('client');
         $customFields = $config['custom_fields'] ?? [];
+        $customFields = is_array($customFields) ? $customFields : [];
+
+        foreach ($customFields as $fieldName => $field) {
+            $field = is_array($field) ? $field : [];
+            $title = $field['title'] ?? '';
+
+            $field['title'] = is_scalar($title) ? (string) $title : '';
+            $field['active'] = Tools::normalizeBoolean($field['active'] ?? false);
+            $field['required'] = Tools::normalizeBoolean($field['required'] ?? false);
+            $customFields[$fieldName] = $field;
+        }
 
         uasort($customFields, fn ($a, $b): int => strnatcasecmp((string) ($a['title'] ?? ''), (string) ($b['title'] ?? '')));
 

--- a/src/modules/Client/templates/admin/mod_client_settings.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_settings.html.twig
@@ -129,10 +129,12 @@
                                             <input class="form-control mb-3" id="custom-field-title-{{ i }}" type="text" placeholder="{{ 'Field title'|trans }}" name="custom_fields[{{ field_name }}][title]" value="{{ custom_field.title|default('') }}">
                                             <div class="d-flex flex-column gap-2">
                                                 <label class="form-check form-switch form-switch-2">
+                                                    <input type="hidden" name="custom_fields[{{ field_name }}][active]" value="0">
                                                     <input class="form-check-input" id="checkboxActive-{{ field_name }}" type="checkbox" name="custom_fields[{{ field_name }}][active]" value="1"{% if custom_field.active|default(false) %} checked{% endif %}>
                                                     <span class="form-check-label">{{ 'Active'|trans }}</span>
                                                 </label>
                                                 <label class="form-check form-switch form-switch-2">
+                                                    <input type="hidden" name="custom_fields[{{ field_name }}][required]" value="0">
                                                     <input class="form-check-input" id="checkboxRequired-{{ field_name }}" type="checkbox" name="custom_fields[{{ field_name }}][required]" value="1"{% if custom_field.required|default(false) %} checked{% endif %}>
                                                     <span class="form-check-label">{{ 'Required'|trans }}</span>
                                                 </label>

--- a/src/modules/Client/templates/client/mod_client_profile.html.twig
+++ b/src/modules/Client/templates/client/mod_client_profile.html.twig
@@ -168,10 +168,10 @@
                                 </div>
                             </div>
                             {% for custom, current in guest.client_custom_fields|default({}) %}
-                                {% if current.active %}
+                                {% if current.active|default(false) %}
                                     <div class="mb-3">
-                                        <label class="form-label" for="{{ custom }}">{{ current.title }}</label>
-                                        <input type="text" class="form-control" name="{{ custom }}" id="{{ custom }}" value="{{ profile[custom] }}" {% if current.required %} required {% endif %}>
+                                        <label class="form-label" for="{{ custom }}">{{ current.title|default('') is not empty ? current.title : custom|capitalize }}</label>
+                                        <input type="text" class="form-control" name="{{ custom }}" id="{{ custom }}" value="{{ profile[custom]|default('') }}" {% if current.required|default(false) %} required {% endif %}>
                                     </div>
                                 {% endif %}
                             {% endfor %}

--- a/src/modules/Client/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Client/tests/Unit/Api/GuestTest.php
@@ -374,3 +374,46 @@ test('custom_fields returns fields sorted alphabetically by title', function ():
     $result = $guestClient->custom_fields();
     expect(array_keys($result))->toBe(['custom_3', 'custom_1', 'custom_2']);
 });
+
+test('custom_fields normalizes incomplete and malformed field configuration', function (): void {
+    $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());
+    $configArr = [
+        'custom_fields' => [
+            'custom_1' => ['title' => 'Optional field'],
+            'custom_2' => ['active' => '1', 'required' => '0', 'title' => 'Required flags'],
+            'custom_3' => null,
+        ],
+    ];
+
+    $di = container();
+    $di['mod_config'] = $di->protect(fn ($name): array => $configArr);
+
+    $guestClient->setDi($di);
+
+    $result = $guestClient->custom_fields();
+    expect($result['custom_1'])->toBe([
+        'title' => 'Optional field',
+        'active' => false,
+        'required' => false,
+    ]);
+    expect($result['custom_2'])->toBe([
+        'active' => true,
+        'required' => false,
+        'title' => 'Required flags',
+    ]);
+    expect($result['custom_3'])->toBe([
+        'title' => '',
+        'active' => false,
+        'required' => false,
+    ]);
+});
+
+test('custom_fields returns an empty array when custom field configuration is malformed', function (): void {
+    $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());
+    $di = container();
+    $di['mod_config'] = $di->protect(fn ($name): array => ['custom_fields' => 'invalid']);
+
+    $guestClient->setDi($di);
+
+    expect($guestClient->custom_fields())->toBe([]);
+});

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_client.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_client.html.twig
@@ -214,14 +214,14 @@
 
                             {% set custom_fields = guest.client_custom_fields %}
                             {% for field_name, field in custom_fields %}
-                                {% if field.active %}
+                                {% if field.active|default(false) %}
                                     <div class="row">
                                         <div class="form-floating col-md-7 mb-3">
                                             <input class="form-control form-control-sm" type="text" name="{{ field_name }}" id="{{ field_name }}"
-                                                   value="{{ request.(field_name) }}"
-                                                   {% if field.required %}required="required"{% endif %}
+                                                   value="{{ request.(field_name)|default('') }}"
+                                                   {% if field.required|default(false) %}required="required"{% endif %}
                                                    placeholder="{{ field_name|capitalize }}">
-                                            <label class="ms-2" for="{{ field_name }}">{% if field.title is not empty %}{{ field.title }}{% else %} {{ field_name|capitalize }} {% endif %}</label>
+                                            <label class="ms-2" for="{{ field_name }}">{% if field.title|default('') is not empty %}{{ field.title }}{% else %} {{ field_name|capitalize }} {% endif %}</label>
                                         </div>
                                     </div>
                                 {% endif %}

--- a/src/modules/Page/templates/client/mod_page_signup.html.twig
+++ b/src/modules/Page/templates/client/mod_page_signup.html.twig
@@ -154,13 +154,13 @@
 
                             {% set custom_fields = guest.client_custom_fields %}
                             {% for field_name, field in custom_fields %}
-                                {% if field.active %}
+                                {% if field.active|default(false) %}
                                     <div class="mb-3">
                                         <label class="form-label"
-                                               for="{{ field_name }}">{{ field.title is not empty ? field.title : field_name|capitalize }}</label>
+                                               for="{{ field_name }}">{{ field.title|default('') is not empty ? field.title : field_name|capitalize }}</label>
                                         <input class="form-control" id="{{ field_name }}" type="text"
-                                               name="{{ field_name }}" value="{{ request.(field_name) }}"
-                                               {% if field.required %}required="required"{% endif %} />
+                                               name="{{ field_name }}" value="{{ request.(field_name)|default('') }}"
+                                               {% if field.required|default(false) %}required="required"{% endif %} />
                                     </div>
                                 {% endif %}
                             {% endfor %}

--- a/src/modules/Page/templates/client/mod_page_signup.html.twig
+++ b/src/modules/Page/templates/client/mod_page_signup.html.twig
@@ -157,7 +157,7 @@
                                 {% if field.active|default(false) %}
                                     <div class="mb-3">
                                         <label class="form-label"
-                                               for="{{ field_name }}">{{ field.title|default('') is not empty ? field.title : field_name|capitalize }}</label>
+                                               for="{{ field_name }}">{{ field.title|default(field_name|capitalize) }}</label>
                                         <input class="form-control" id="{{ field_name }}" type="text"
                                                name="{{ field_name }}" value="{{ request.(field_name)|default('') }}"
                                                {% if field.required|default(false) %}required="required"{% endif %} />

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+use Tests\Support\PermissiveStub;
 use Tests\Support\StrictTemplateRenderer;
 
 test('cron settings renders when module config has not been saved', function (): void {
@@ -168,6 +169,26 @@ test('orderbutton checkout renders for guests under strict_variables', function 
         ->and($html)->toContain('Subscription Gateway')
         ->and($html)->toContain('id="order-gateway-2" value="2" autocomplete="off" checked')
         ->and($html)->not->toContain('id="order-gateway-3" value="3" autocomplete="off" checked');
+});
+
+test('orderbutton client form renders incomplete custom field configuration under strict_variables', function (): void {
+    $renderer = new StrictTemplateRenderer();
+
+    $html = $renderer->renderTemplate(PATH_MODS . '/Orderbutton/templates/client/mod_orderbutton_client.html.twig', [
+        'client' => null,
+        'request' => new PermissiveStub(['checkout' => true]),
+        'settings' => new PermissiveStub(['signup_tos' => 'disabled']),
+        'guest' => new PermissiveStub([
+            'client_custom_fields' => [
+                'custom_1' => ['title' => 'Inactive field'],
+                'custom_2' => ['title' => 'Active field', 'active' => true],
+            ],
+        ]),
+    ]);
+
+    expect($html)
+        ->not->toContain('id="custom_1"')
+        ->toContain('id="custom_2"');
 });
 
 /*


### PR DESCRIPTION
## Summary

- normalize incomplete and malformed client custom-field configuration returned by the guest API
- persist explicit false values for unchecked `active` and `required` settings
- guard custom-field rendering in checkout, signup, and profile templates under strict Twig variables
- add API normalization and strict-rendering regression coverage