### PR TITLE
Add priority to support ticket email previews

### DIFF
--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -203,6 +203,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             'id' => 1,
             'subject' => 'Example support ticket',
             'status' => 'open',
+            'priority' => 100,
             'created_at' => '',
             'updated_at' => '',
             'replies' => 0,
@@ -228,7 +229,6 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             'messages' => [$message],
         ];
         $staffTicket = $ticket;
-        $staffTicket['priority'] = 100;
         $staffTicket['client'] = $client;
 
         return match ($actionCode) {

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -242,8 +242,12 @@ test('getVars supplies preview variables for support and staff templates before 
 
     $supportVars = $service->getVars(emailTemplate('mod_support_ticket_staff_open'));
     expect($supportVars)
-        ->toHaveKeys(['c.email', 'ticket.subject', 'ticket.client.first_name', 'ticket.messages.0.content'])
-        ->not->toHaveKeys(['ticket.priority', 'ticket.client.email', 'ticket.messages.0.author.email']);
+        ->toHaveKeys(['c.email', 'ticket.subject', 'ticket.priority', 'ticket.client.first_name', 'ticket.messages.0.content'])
+        ->not->toHaveKeys(['ticket.client.email', 'ticket.messages.0.author.email']);
+
+    foreach (['mod_support_ticket_staff_open', 'mod_support_ticket_staff_close', 'mod_support_ticket_staff_reply'] as $actionCode) {
+        expect($service->getVars(emailTemplate($actionCode))['ticket']['priority'])->toBe(100);
+    }
 
     $staffVars = $service->getVars(emailTemplate('mod_staff_ticket_open'));
     expect($staffVars)


### PR DESCRIPTION
## What changed

- expose `ticket.priority` in previews for `mod_support_ticket_staff_open`
- expose `ticket.priority` in previews for `mod_support_ticket_staff_close`
- keep the equivalent reply template consistent
- add regression assertions covering all three action codes

Follow-up to #4017.
