### PR TITLE
Fix password reset confirmation page

### DIFF
--- a/src/modules/Client/Controller/Client.php
+++ b/src/modules/Client/Controller/Client.php
@@ -102,7 +102,7 @@ class Client implements \FOSSBilling\InjectionAwareInterface
         }
 
         if ($result !== false) {
-            return $app->render('mod_client_set_new_password');
+            return $app->render('mod_client_set_new_password', ['hash' => $hash]);
         }
 
         return $app->redirect('/');

--- a/src/modules/Client/templates/client/mod_client_set_new_password.html.twig
+++ b/src/modules/Client/templates/client/mod_client_set_new_password.html.twig
@@ -43,13 +43,3 @@
     </div>
 </div>
 {% endblock %}
-
-{% block js %}
-<script>
-    // Set value of hash field to last part of URL.
-    document.addEventListener('DOMContentLoaded', function() {
-        const hash = window.location.href.split('/').pop();
-        document.getElementById('hash').value = hash;
-    });
-</script>
-{% endblock %}

--- a/src/modules/Client/tests/Unit/Controller/ClientTest.php
+++ b/src/modules/Client/tests/Unit/Controller/ClientTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+declare(strict_types=1);
+
+use Box\Mod\Client\Controller\Client;
+
+use function Tests\Helpers\container;
+use function Tests\Helpers\moduleService;
+
+test('password reset confirmation passes the validated hash to the template', function (): void {
+    $hash = 'validresethash';
+
+    $service = Mockery::mock(Box\Mod\Client\Service::class);
+    $service->shouldReceive('password_reset_valid')
+        ->once()
+        ->with(['hash' => $hash])
+        ->andReturn(1);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(moduleService(['client' => $service]));
+
+    $controller = new Client();
+    $controller->setDi($di);
+
+    $boxAppMock = Mockery::mock('\Box_App');
+    $boxAppMock->shouldReceive('render')
+        ->once()
+        ->with('mod_client_set_new_password', ['hash' => $hash])
+        ->andReturn('rendered');
+
+    expect($controller->get_reset_password_confirm($boxAppMock, $hash))->toBe('rendered');
+});

--- a/src/modules/Client/tests/Unit/Controller/ClientTest.php
+++ b/src/modules/Client/tests/Unit/Controller/ClientTest.php
@@ -16,7 +16,7 @@ use function Tests\Helpers\container;
 use function Tests\Helpers\moduleService;
 
 test('password reset confirmation passes the validated hash to the template', function (): void {
-    $hash = 'validresethash';
+    $hash = 'password';
 
     $service = Mockery::mock(Box\Mod\Client\Service::class);
     $service->shouldReceive('password_reset_valid')


### PR DESCRIPTION
## What changed

- pass the validated password-reset hash to the new-password Twig template
- remove the obsolete browser-side URL parsing workaround
- add a focused controller regression test

Fixes #4037.