### PR TITLE
Standardise FOSSBilling cookie names

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -320,7 +320,6 @@
         "tailwindcss",
         "flexbox",
         "juoda",
-        "fb_sid",
         "texgt",
         "Domaincan",
         "datagrid",

--- a/frontend/core/api.ts
+++ b/frontend/core/api.ts
@@ -66,7 +66,8 @@ const Tools = {
    * @returns {string|null} The CSRF token from cookie, or null if not found.
    */
   getCSRFToken: function () {
-    const match = document.cookie.match(/csrf_token=([^;]*)/);
+    const match = document.cookie.match(/(?:^|;\s*)fossbilling_csrf=([^;]*)/)
+      || document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
     return match ? decodeURIComponent(match[1]) : null;
   },
 

--- a/frontend/core/fossbilling.ts
+++ b/frontend/core/fossbilling.ts
@@ -12,6 +12,10 @@
   const editorsByElement = new WeakMap();
   const editorsByName = new Map();
   const adapters = new Map();
+  const cookieNames = Object.freeze({
+    locale: 'fossbilling_locale',
+    timezone: 'fossbilling_timezone',
+  });
 
   function runReadyCallback(callback) {
     try {
@@ -38,6 +42,7 @@
     while (readyCallbacks.length > 0) {
       runReadyCallback(readyCallbacks.shift());
     }
+    migrateCookie(cookieNames.locale, 'fb_locale', 365);
     initTimezone();
   });
 
@@ -86,6 +91,22 @@
     return null;
   };
 
+  function migrateCookie(name, legacyName, days) {
+    const currentValue = FOSSBilling.cookieRead(name);
+    const legacyValue = FOSSBilling.cookieRead(legacyName);
+
+    if (!currentValue && legacyValue) {
+      FOSSBilling.cookieCreate(name, legacyValue, days);
+    }
+    if (legacyValue !== null) {
+      FOSSBilling.cookieCreate(legacyName, '', -1);
+    }
+
+    return currentValue || legacyValue;
+  }
+
+  FOSSBilling.cookieNames = cookieNames;
+
   // Returns the IANA timezone identifier the browser is running in, or null.
   // Used by signup and the public layout so guests see dates in their own zone.
   FOSSBilling.detectTimezone = FOSSBilling.detectTimezone || function () {
@@ -101,7 +122,7 @@
     return null;
   };
 
-  // Seeds the `fb_timezone` cookie and pre-selects the detected timezone on any
+  // Seeds the `fossbilling_timezone` cookie and pre-selects the detected timezone on any
   // `<select data-timezone-select>` that doesn't already have a value. Lets the
   // server pre-fill a stored timezone without being clobbered by the auto-detect.
   function initTimezone() {
@@ -110,8 +131,8 @@
       return;
     }
 
-    if (!FOSSBilling.cookieRead('fb_timezone')) {
-      FOSSBilling.cookieCreate('fb_timezone', detected, 365);
+    if (!migrateCookie(cookieNames.timezone, 'fb_timezone', 365)) {
+      FOSSBilling.cookieCreate(cookieNames.timezone, detected, 365);
     }
 
     const selects = document.querySelectorAll('select[data-timezone-select]');

--- a/frontend/types/globals.d.ts
+++ b/frontend/types/globals.d.ts
@@ -55,6 +55,10 @@ interface FOSSBillingRuntime {
   charts?: {
     renderTimeSeriesSparkline: (target: HTMLElement | string, data: unknown, options?: Record<string, unknown>) => unknown;
   };
+  cookieNames?: {
+    locale: string;
+    timezone: string;
+  };
   cookieCreate?: (name: string, value: string, days?: number) => void;
   cookieRead?: (name: string) => string | null;
   detectTimezone?: () => string;

--- a/src/install/session.php
+++ b/src/install/session.php
@@ -1,6 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
+use FOSSBilling\Http\CookieNames;
+
 class Session
 {
     private $_handler;
@@ -49,7 +52,7 @@ class Box_SessionFile
     {
         if (!isset(self::$instance)) {
             self::$instance = new self();
-            session_name('fossbilling_session');
+            session_name(CookieNames::SESSION);
             if (!self::$instance->sessionExists() && !headers_sent()) {
                 self::$instance->sessionState = session_start();
             }

--- a/src/install/session.php
+++ b/src/install/session.php
@@ -49,8 +49,8 @@ class Box_SessionFile
     {
         if (!isset(self::$instance)) {
             self::$instance = new self();
+            session_name('fossbilling_session');
             if (!self::$instance->sessionExists() && !headers_sent()) {
-                session_name('fb_sid');
                 self::$instance->sessionState = session_start();
             }
         }

--- a/src/library/FOSSBilling/Fingerprint.php
+++ b/src/library/FOSSBilling/Fingerprint.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use FOSSBilling\Http\CookieNames;
 use Symfony\Component\HttpFoundation\Request;
 
 class Fingerprint
@@ -169,7 +170,7 @@ class Fingerprint
 
         // If fingerprint debugging is enabled and it failed, print some debug info to the log
         if (!$valid && Config::getProperty('security.debug_fingerprint', false)) {
-            $ID = $this->request->cookies->get('PHPSESSID');
+            $ID = session_id() ?: $this->request->cookies->get(CookieNames::SESSION);
             if (!$ID) {
                 return $valid;
             }

--- a/src/library/FOSSBilling/Http/CookieNames.php
+++ b/src/library/FOSSBilling/Http/CookieNames.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling\Http;
+
+final class CookieNames
+{
+    public const string SESSION = 'fossbilling_session';
+    public const string CSRF = 'fossbilling_csrf';
+    public const string LOCALE = 'fossbilling_locale';
+    public const string TIMEZONE = 'fossbilling_timezone';
+
+    public const string LEGACY_CSRF = 'csrf_token';
+    public const string LEGACY_LOCALE = 'fb_locale';
+    public const string LEGACY_BOX_LOCALE = 'BBLANG';
+    public const string LEGACY_TIMEZONE = 'fb_timezone';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use FOSSBilling\Http\CookieNames;
+
 class Session implements InjectionAwareInterface
 {
     private const string OBSOLETE_FLAG = 'fb_session_obsolete';
@@ -18,6 +20,7 @@ class Session implements InjectionAwareInterface
     private const int DEFAULT_REGENERATION_GRACE_PERIOD = 300;
 
     private ?\Pimple\Container $di = null;
+    private ?string $legacySessionCookie = null;
 
     public function setDi(\Pimple\Container $di): void
     {
@@ -39,6 +42,7 @@ class Session implements InjectionAwareInterface
             return;
         }
 
+        $this->configureCookieName();
         $this->canUseSession();
 
         if (!headers_sent()) {
@@ -64,6 +68,7 @@ class Session implements InjectionAwareInterface
 
         session_set_cookie_params($cookieParams);
         session_start();
+        $this->expireLegacySessionCookies();
 
         $this->handleObsoleteSession();
         $this->updateFingerprint();
@@ -241,6 +246,53 @@ class Session implements InjectionAwareInterface
         $sessionName = session_name();
 
         return $sessionName !== false ? ($_COOKIE[$sessionName] ?? '') : '';
+    }
+
+    private function configureCookieName(): void
+    {
+        $previousName = session_name();
+
+        session_name(CookieNames::SESSION);
+
+        if (
+            $previousName === false
+            || $previousName === CookieNames::SESSION
+            || !isset($_COOKIE[$previousName])
+        ) {
+            return;
+        }
+
+        $this->legacySessionCookie = $previousName;
+        if (isset($_COOKIE[CookieNames::SESSION])) {
+            return;
+        }
+
+        $sessionId = $_COOKIE[$previousName];
+        if (
+            is_string($sessionId)
+            && $sessionId !== ''
+            && preg_match('/^[A-Za-z0-9,-]+$/D', $sessionId) === 1
+        ) {
+            session_id($sessionId);
+        }
+    }
+
+    private function expireLegacySessionCookies(): void
+    {
+        if ($this->legacySessionCookie === null || headers_sent()) {
+            return;
+        }
+
+        $params = session_get_cookie_params();
+        setcookie($this->legacySessionCookie, '', [
+            'expires' => time() - 3600,
+            'path' => $params['path'],
+            'domain' => $params['domain'],
+            'secure' => $params['secure'],
+            'httponly' => $params['httponly'],
+            'samesite' => $params['samesite'],
+        ]);
+        unset($_COOKIE[$this->legacySessionCookie]);
     }
 
     private function handleObsoleteSession(): void

--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -184,17 +184,8 @@ class Session implements InjectionAwareInterface
             } catch (\Doctrine\DBAL\Exception) {
                 // The cookie is still expired below so the unusable session is not reused.
             }
-            $cookieParams = session_get_cookie_params();
-            $cookieOptions = [
-                'expires' => time() - 3600,
-                'path' => $cookieParams['path'],
-                'domain' => $cookieParams['domain'],
-                'secure' => $cookieParams['secure'],
-                'httponly' => $cookieParams['httponly'],
-            ];
-            $cookieOptions['samesite'] = $cookieParams['samesite'];
             if ($sessionName !== false) {
-                setcookie($sessionName, '', $cookieOptions);
+                setcookie($sessionName, '', $this->getSessionCookieOptions(time() - 3600));
                 unset($_COOKIE[$sessionName]);
             }
         }
@@ -283,15 +274,7 @@ class Session implements InjectionAwareInterface
             return;
         }
 
-        $params = session_get_cookie_params();
-        setcookie($this->legacySessionCookie, '', [
-            'expires' => time() - 3600,
-            'path' => $params['path'],
-            'domain' => $params['domain'],
-            'secure' => $params['secure'],
-            'httponly' => $params['httponly'],
-            'samesite' => $params['samesite'],
-        ]);
+        setcookie($this->legacySessionCookie, '', $this->getSessionCookieOptions(time() - 3600));
         unset($_COOKIE[$this->legacySessionCookie]);
     }
 
@@ -317,19 +300,27 @@ class Session implements InjectionAwareInterface
         $sessionName = session_name();
         $sessionId = session_id();
         if ($sessionId !== '') {
-            $params = session_get_cookie_params();
-
-            setcookie($sessionName, $sessionId, [
-                'expires' => 0,
-                'path' => $params['path'],
-                'domain' => $params['domain'],
-                'secure' => $params['secure'],
-                'httponly' => $params['httponly'],
-                'samesite' => $params['samesite'],
-            ]);
+            setcookie($sessionName, $sessionId, $this->getSessionCookieOptions(0));
 
             $_COOKIE[$sessionName] = $sessionId;
         }
+    }
+
+    /**
+     * @return array{expires: int, path: string, domain: string, secure: bool, httponly: bool, samesite: string}
+     */
+    private function getSessionCookieOptions(int $expires): array
+    {
+        $params = session_get_cookie_params();
+
+        return [
+            'expires' => $expires,
+            'path' => $params['path'],
+            'domain' => $params['domain'],
+            'secure' => $params['secure'],
+            'httponly' => $params['httponly'],
+            'samesite' => $params['samesite'],
+        ];
     }
 
     private function clearAuthenticationData(): void

--- a/src/library/FOSSBilling/Twig/TwigFactory.php
+++ b/src/library/FOSSBilling/Twig/TwigFactory.php
@@ -15,6 +15,7 @@ use Box\Mod\Currency\Entity\Currency;
 use DebugBar\Bridge\Twig\NamespacedTwigProfileCollector;
 use DebugBar\StandardDebugBar;
 use FOSSBilling\Config;
+use FOSSBilling\Http\CookieNames;
 use FOSSBilling\Http\RequestFactory;
 use FOSSBilling\i18n;
 use FOSSBilling\Tools;
@@ -80,7 +81,7 @@ class TwigFactory
             }
         }
 
-        return i18n::getActiveTimezone($this->di['request'], $clientTimezone, $adminTimezone);
+        return i18n::getActiveTimezone($this->di['request'], $clientTimezone, $adminTimezone, $this->di['cookie_queue']);
     }
 
     /**
@@ -470,7 +471,7 @@ class TwigFactory
     {
         $csrfToken = $this->getCsrfToken();
         $this->di['cookie_queue']->queue(
-            'csrf_token',
+            CookieNames::CSRF,
             $csrfToken,
             0,
             '/',

--- a/src/library/FOSSBilling/Twig/TwigFactory.php
+++ b/src/library/FOSSBilling/Twig/TwigFactory.php
@@ -470,16 +470,31 @@ class TwigFactory
     public function configureCsrf(): void
     {
         $csrfToken = $this->getCsrfToken();
+        $request = $this->di['request'];
+        $secure = $request->isSecure();
         $this->di['cookie_queue']->queue(
             CookieNames::CSRF,
             $csrfToken,
             0,
             '/',
             null,
-            $this->di['request']->isSecure(),
+            $secure,
             false,
             'Strict',
         );
+
+        if ($request->cookies->has(CookieNames::LEGACY_CSRF)) {
+            $this->di['cookie_queue']->queue(
+                CookieNames::LEGACY_CSRF,
+                '',
+                time() - 3600,
+                '/',
+                null,
+                $secure,
+                false,
+                'Strict',
+            );
+        }
     }
 
     private function getCsrfToken(): string

--- a/src/library/FOSSBilling/i18n.php
+++ b/src/library/FOSSBilling/i18n.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use FOSSBilling\Http\CookieNames;
 use FOSSBilling\Http\CookieQueue;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -40,8 +41,9 @@ class i18n
     {
         $locale = null;
 
-        $cookieLocale = $request->cookies->get('fb_locale');
-        $cookieBBLANG = $request->cookies->get('BBLANG');
+        $cookieLocale = $request->cookies->get(CookieNames::LOCALE);
+        $legacyCookieLocale = $request->cookies->get(CookieNames::LEGACY_LOCALE);
+        $cookieBBLANG = $request->cookies->get(CookieNames::LEGACY_BOX_LOCALE);
 
         /*
          * If the locale cookie is set and it's one of the enabled locales, use that.
@@ -49,13 +51,17 @@ class i18n
          */
         if (!empty($cookieLocale) && in_array($cookieLocale, self::getLocales())) {
             $locale = $cookieLocale;
+        } elseif (!empty($legacyCookieLocale) && in_array($legacyCookieLocale, self::getLocales())) {
+            $locale = $legacyCookieLocale;
+            $cookies?->queue(CookieNames::LOCALE, (string) $locale, strtotime('+1 month'), '/');
         } elseif (!empty($cookieBBLANG) && in_array($cookieBBLANG, self::getLocales())) {
             $locale = $cookieBBLANG;
-            $cookies?->queue('fb_locale', (string) $locale, strtotime('+1 month'), '/');
-            $cookies?->queue('BBLANG', '', time() - 3600, '/');
+            $cookies?->queue(CookieNames::LOCALE, (string) $locale, strtotime('+1 month'), '/');
         } elseif ($autoDetect && self::isBrowserLocaleDetectionEnabled()) {
             $locale = self::getBrowserLocale($request, $cookies);
         }
+
+        self::expireLegacyLocaleCookies($request, $cookies);
 
         // If we somehow still don't have a locale, use the default / fallback.
         if (!$locale) {
@@ -107,14 +113,14 @@ class i18n
             }
             foreach (self::getLocales() as $locale) {
                 if (str_starts_with((string) $locale, substr($detectedLocale, 0, 2))) {
-                    $cookies?->queue('fb_locale', (string) $locale, strtotime('+1 month'), '/');
+                    $cookies?->queue(CookieNames::LOCALE, (string) $locale, strtotime('+1 month'), '/');
 
                     return $locale;
                 }
             }
         }
 
-        $cookies?->queue('fb_locale', (string) $matchingLocale, strtotime('+1 month'), '/');
+        $cookies?->queue(CookieNames::LOCALE, (string) $matchingLocale, strtotime('+1 month'), '/');
 
         return $matchingLocale;
     }
@@ -122,14 +128,33 @@ class i18n
     /**
      * Returns the timezone the current request should be rendered in.
      *
-     * Resolves in order: client -> admin -> `fb_timezone` cookie -> `i18n.timezone` config -> `UTC`.
+     * Resolves in order: client -> admin -> `fossbilling_timezone` cookie -> `i18n.timezone` config -> `UTC`.
      * Invalid values are silently dropped so a stale cookie or corrupt DB value can't crash the date formatter.
      */
-    public static function getActiveTimezone(Request $request, ?string $clientTimezone = null, ?string $adminTimezone = null): string
-    {
+    public static function getActiveTimezone(
+        Request $request,
+        ?string $clientTimezone = null,
+        ?string $adminTimezone = null,
+        ?CookieQueue $cookies = null,
+    ): string {
         $valid = self::getTimezoneList();
+        $cookieTimezone = $request->cookies->get(CookieNames::TIMEZONE);
+        $legacyCookieTimezone = $request->cookies->get(CookieNames::LEGACY_TIMEZONE);
 
-        foreach ([$clientTimezone, $adminTimezone, $request->cookies->get('fb_timezone')] as $candidate) {
+        if ($request->cookies->has(CookieNames::LEGACY_TIMEZONE)) {
+            if (
+                (!is_string($cookieTimezone) || !in_array($cookieTimezone, $valid, true))
+                && is_string($legacyCookieTimezone)
+                && in_array($legacyCookieTimezone, $valid, true)
+            ) {
+                $cookies?->queue(CookieNames::TIMEZONE, $legacyCookieTimezone, strtotime('+1 year'), '/');
+                $cookieTimezone = $legacyCookieTimezone;
+            }
+
+            $cookies?->queue(CookieNames::LEGACY_TIMEZONE, '', time() - 3600, '/');
+        }
+
+        foreach ([$clientTimezone, $adminTimezone, $cookieTimezone] as $candidate) {
             if (is_string($candidate) && $candidate !== '' && in_array($candidate, $valid, true)) {
                 return $candidate;
             }
@@ -141,6 +166,15 @@ class i18n
         }
 
         return 'UTC';
+    }
+
+    private static function expireLegacyLocaleCookies(Request $request, ?CookieQueue $cookies): void
+    {
+        foreach ([CookieNames::LEGACY_LOCALE, CookieNames::LEGACY_BOX_LOCALE] as $name) {
+            if ($request->cookies->has($name)) {
+                $cookies?->queue($name, '', time() - 3600, '/');
+            }
+        }
     }
 
     /**

--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -465,7 +465,8 @@ class Client implements InjectionAwareInterface
             $data = new \stdClass();
         }
 
-        $cookieToken = $this->di['request']->cookies->get('csrf_token');
+        $cookieToken = $this->di['request']->cookies->get(\FOSSBilling\Http\CookieNames::CSRF)
+            ?? $this->di['request']->cookies->get(\FOSSBilling\Http\CookieNames::LEGACY_CSRF);
         $headerToken = $this->di['request']->headers->get('X-CSRF-TOKEN');
 
         $token = $data->CSRFToken

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Box\Mod\Client\Api;
 
+use FOSSBilling\Http\CookieNames;
 use FOSSBilling\Security\RandomizedTimeFloor;
 use FOSSBilling\Tools;
 use FOSSBilling\Validation\Api\RequiredParams;
@@ -146,7 +147,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             $this->getDi()['session']->delete('redirect_uri');
 
             if (!empty($client->lang)) {
-                $this->getDi()['cookie_queue']->queue('fb_locale', (string) $client->lang, strtotime('+1 month'), '/');
+                $this->getDi()['cookie_queue']->queue(CookieNames::LOCALE, (string) $client->lang, strtotime('+1 month'), '/');
             }
 
             $this->getDi()['mod_service']('cart')->transferFromOtherSession($oldSession);

--- a/src/themes/admin_default/assets/js/tomselect.ts
+++ b/src/themes/admin_default/assets/js/tomselect.ts
@@ -18,7 +18,8 @@ const createTomSelectTemplate = (data, escape, options = {}) => {
 export default function initTomSelectControls() {
   const localeSelectorEl = document.querySelector('.js-locale-selector');
   if (localeSelectorEl !== null) {
-    const selectedLang = FOSSBilling.cookieRead("fb_locale") || localeSelectorEl.value;
+    const localeCookie = FOSSBilling.cookieNames?.locale || "fossbilling_locale";
+    const selectedLang = FOSSBilling.cookieRead(localeCookie) || localeSelectorEl.value;
     const localeSelector = new TomSelect(".js-locale-selector", {
       copyClassesToDropdown: false,
       controlClass: "ts-control locale",
@@ -33,7 +34,7 @@ export default function initTomSelectControls() {
     });
 
     localeSelector.on("change", (value) => {
-      FOSSBilling.cookieCreate("fb_locale", value, 365);
+      FOSSBilling.cookieCreate(localeCookie, value, 365);
       window.location.reload();
     });
   }

--- a/src/themes/admin_default/assets/js/utils.ts
+++ b/src/themes/admin_default/assets/js/utils.ts
@@ -13,7 +13,8 @@
  * @returns {string|null} CSRF token or null if not found
  */
 export function getCSRFToken(): string | null {
-  const match = document.cookie.match(/csrf_token=([^;]*)/);
+  const match = document.cookie.match(/(?:^|;\s*)fossbilling_csrf=([^;]*)/)
+    || document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
 }
 

--- a/src/themes/huraga/assets/js/tomselect.ts
+++ b/src/themes/huraga/assets/js/tomselect.ts
@@ -36,7 +36,8 @@ export default function initLanguageSelector() {
     return;
   }
 
-  const selectedLang = FOSSBilling.cookieRead('fb_locale') || localeSelectorEl.value;
+  const localeCookie = FOSSBilling.cookieNames?.locale || 'fossbilling_locale';
+  const selectedLang = FOSSBilling.cookieRead(localeCookie) || localeSelectorEl.value;
 
   new TomSelect('.js-locale-selector', {
     copyClassesToDropdown: false,
@@ -50,7 +51,7 @@ export default function initLanguageSelector() {
       option: (data, escape) => localeSelectorTemplate(data, escape),
     },
     onItemAdd: (value) => {
-      FOSSBilling.cookieCreate('fb_locale', value, 365);
+      FOSSBilling.cookieCreate(localeCookie, value, 365);
       window.location.reload();
     },
   });

--- a/tests/E2E/Cypress/specs/admin/admin-auth-api.cy.js
+++ b/tests/E2E/Cypress/specs/admin/admin-auth-api.cy.js
@@ -12,7 +12,7 @@ describe('admin auth and API protections', () => {
   it('allows authenticated admin profile API requests', () => {
     cy.loginAsAdmin();
 
-    cy.getCookie('csrf_token').should('exist').then((cookie) => {
+    cy.getCookie('fossbilling_csrf').should('exist').then((cookie) => {
       cy.request({
         url: '/api/admin/profile/get',
         qs: { CSRFToken: cookie.value },

--- a/tests/E2E/Cypress/specs/client/client-auth.cy.js
+++ b/tests/E2E/Cypress/specs/client/client-auth.cy.js
@@ -22,7 +22,7 @@ describe('client authentication', () => {
     });
 
     cy.location('pathname', { timeout: 10000 }).should('eq', '/');
-    cy.getCookie('csrf_token').should('exist').then((cookie) => {
+    cy.getCookie('fossbilling_csrf').should('exist').then((cookie) => {
       cy.request({
         url: '/api/client/profile/get',
         qs: { CSRFToken: cookie.value },

--- a/tests/E2E/Cypress/specs/client/client-support.cy.js
+++ b/tests/E2E/Cypress/specs/client/client-support.cy.js
@@ -63,7 +63,7 @@ describe('client support tickets', () => {
     cy.contains('button', 'Close Ticket').should('not.exist');
 
     cy.then(() => {
-      cy.getCookie('csrf_token').should('exist').then((cookie) => {
+      cy.getCookie('fossbilling_csrf').should('exist').then((cookie) => {
         cy.request({
           url: '/api/client/support/ticket_get',
           qs: {

--- a/tests/E2E/Cypress/support/e2e.js
+++ b/tests/E2E/Cypress/support/e2e.js
@@ -158,7 +158,7 @@ Cypress.Commands.add('loginAsClient', (client) => {
   }, {
     cacheAcrossSpecs: true,
     validate() {
-      cy.getCookie('csrf_token').should('exist').then((cookie) => {
+      cy.getCookie('fossbilling_csrf').should('exist').then((cookie) => {
         cy.request({
           url: '/api/client/profile/get',
           qs: { CSRFToken: cookie.value },

--- a/tests/Unit/FOSSBilling/SessionTest.php
+++ b/tests/Unit/FOSSBilling/SessionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Doctrine\DBAL\Connection;
+use FOSSBilling\Http\CookieNames;
 use Symfony\Component\HttpFoundation\Request;
 
 function createSession(): FOSSBilling\Session
@@ -57,10 +58,30 @@ function invokePrivate(object $instance, string $method, array $args = []): mixe
 
 afterEach(function (): void {
     $_SESSION = [];
-    $sessionName = session_name();
-    if ($sessionName !== false) {
+    foreach ([
+        CookieNames::SESSION,
+        'PHPSESSID',
+    ] as $sessionName) {
         unset($_COOKIE[$sessionName]);
     }
+    if (session_status() === PHP_SESSION_NONE) {
+        session_id('');
+        session_name('PHPSESSID');
+    }
+});
+
+test('session cookie name migrates and expires the previous session cookie', function (): void {
+    $_COOKIE['PHPSESSID'] = 'legacy-session';
+    $session = createSession();
+
+    invokePrivate($session, 'configureCookieName');
+
+    expect(session_name())->toBe(CookieNames::SESSION)
+        ->and(session_id())->toBe('legacy-session');
+
+    invokePrivate($session, 'expireLegacySessionCookies');
+
+    expect($_COOKIE)->not->toHaveKey('PHPSESSID');
 });
 
 test('session validation ignores a missing database record', function (): void {

--- a/tests/Unit/FOSSBilling/Twig/TwigFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Twig/TwigFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use FOSSBilling\Http\CookieNames;
+use FOSSBilling\Http\CookieQueue;
+use FOSSBilling\Twig\TwigFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+test('configureCsrf expires the legacy cookie with matching attributes', function (): void {
+    $di = Tests\Helpers\container();
+    $request = Request::create('https://localhost/');
+    $request->cookies->set(CookieNames::LEGACY_CSRF, 'legacy-token');
+    $di['request'] = $request;
+    $di['cookie_queue'] = new CookieQueue();
+
+    $session = Mockery::mock(FOSSBilling\Session::class);
+    $session->shouldReceive('get')->once()->with('csrf_token')->andReturn('current-token');
+    $di['session'] = $session;
+
+    (new TwigFactory($di))->configureCsrf();
+
+    $response = new Response();
+    $di['cookie_queue']->applyToResponse($response);
+    $cookies = [];
+    foreach ($response->headers->getCookies() as $cookie) {
+        $cookies[$cookie->getName()] = $cookie;
+    }
+
+    expect($cookies[CookieNames::CSRF]->getValue())->toBe('current-token')
+        ->and($cookies[CookieNames::LEGACY_CSRF]->getExpiresTime())->toBeLessThan(time())
+        ->and($cookies[CookieNames::LEGACY_CSRF]->isSecure())->toBeTrue()
+        ->and($cookies[CookieNames::LEGACY_CSRF]->isHttpOnly())->toBeFalse()
+        ->and($cookies[CookieNames::LEGACY_CSRF]->getSameSite())->toBe($cookies[CookieNames::CSRF]->getSameSite());
+});

--- a/tests/Unit/FOSSBilling/i18nTest.php
+++ b/tests/Unit/FOSSBilling/i18nTest.php
@@ -11,8 +11,11 @@
 declare(strict_types=1);
 
 use FOSSBilling\Config;
+use FOSSBilling\Http\CookieNames;
+use FOSSBilling\Http\CookieQueue;
 use FOSSBilling\i18n;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 beforeEach(function (): void {
     Config::setProperty('i18n.timezone', 'UTC');
@@ -24,11 +27,11 @@ afterEach(function (): void {
     Config::setProperty('i18n.locale', 'en_US');
 });
 
-function requestWithTimezoneCookie(?string $timezone = null): Request
+function requestWithTimezoneCookie(?string $timezone = null, string $cookieName = CookieNames::TIMEZONE): Request
 {
     $request = Request::create('/');
     if ($timezone !== null) {
-        $request->cookies->set('fb_timezone', $timezone);
+        $request->cookies->set($cookieName, $timezone);
     }
 
     return $request;
@@ -94,13 +97,13 @@ test('getActiveTimezone prefers the client timezone over the admin timezone', fu
     expect(i18n::getActiveTimezone(Request::create('/'), 'America/New_York', 'Asia/Tokyo'))->toBe('America/New_York');
 });
 
-test('getActiveTimezone reads the fb_timezone cookie when set and valid', function (): void {
+test('getActiveTimezone reads the namespaced timezone cookie when set and valid', function (): void {
     $request = requestWithTimezoneCookie('Europe/Berlin');
 
     expect(i18n::getActiveTimezone($request))->toBe('Europe/Berlin');
 });
 
-test('getActiveTimezone prefers explicit client/admin arguments over a valid fb_timezone cookie', function (): void {
+test('getActiveTimezone prefers explicit client/admin arguments over a valid timezone cookie', function (): void {
     $request = requestWithTimezoneCookie('Europe/Berlin');
 
     expect(i18n::getActiveTimezone($request, 'America/New_York', 'Asia/Tokyo'))->toBe('America/New_York');
@@ -109,13 +112,13 @@ test('getActiveTimezone prefers explicit client/admin arguments over a valid fb_
     expect(i18n::getActiveTimezone($request, null, null))->toBe('Europe/Berlin');
 });
 
-test('getActiveTimezone ignores an invalid fb_timezone cookie', function (): void {
+test('getActiveTimezone ignores an invalid timezone cookie', function (): void {
     $request = requestWithTimezoneCookie('Definitely/Not_Real');
 
     expect(i18n::getActiveTimezone($request))->toBe('UTC');
 });
 
-test('getActiveTimezone ignores an invalid fb_timezone cookie when explicit arguments are valid', function (): void {
+test('getActiveTimezone ignores an invalid timezone cookie when explicit arguments are valid', function (): void {
     $request = requestWithTimezoneCookie('Definitely/Not_Real');
 
     expect(i18n::getActiveTimezone($request, 'America/New_York', 'Asia/Tokyo'))->toBe('America/New_York');
@@ -123,7 +126,7 @@ test('getActiveTimezone ignores an invalid fb_timezone cookie when explicit argu
     expect(i18n::getActiveTimezone($request, null, 'Asia/Tokyo'))->toBe('Asia/Tokyo');
 });
 
-test('getActiveTimezone falls back to valid fb_timezone cookie when client timezone is invalid', function (): void {
+test('getActiveTimezone falls back to a valid timezone cookie when client timezone is invalid', function (): void {
     $request = requestWithTimezoneCookie('Europe/Berlin');
 
     expect(i18n::getActiveTimezone($request, 'Mars/Olympus_Mons', null))->toBe('Europe/Berlin');
@@ -171,20 +174,20 @@ test('validateTimezone throws InformationException for invalid timezone identifi
     }
 });
 
-test('getActiveLocale returns the fb_locale cookie when it matches an enabled locale', function (): void {
+test('getActiveLocale returns the namespaced locale cookie when it matches an enabled locale', function (): void {
     // Only en_US is guaranteed to be installed (translations are not fetched in CI),
     // so use a different config default to prove the cookie takes precedence.
     Config::setProperty('i18n.locale', 'de_DE');
 
     $request = Request::create('/');
-    $request->cookies->set('fb_locale', 'en_US');
+    $request->cookies->set(CookieNames::LOCALE, 'en_US');
 
     expect(i18n::getActiveLocale($request, false))->toBe('en_US');
 });
 
-test('getActiveLocale ignores an invalid fb_locale cookie and falls back to config default', function (): void {
+test('getActiveLocale ignores an invalid locale cookie and falls back to config default', function (): void {
     $request = Request::create('/');
-    $request->cookies->set('fb_locale', 'xx_XX');
+    $request->cookies->set(CookieNames::LOCALE, 'xx_XX');
 
     expect(i18n::getActiveLocale($request, false))->toBe('en_US');
 });
@@ -205,4 +208,39 @@ test('getActiveLocale auto-detects locale from Accept-Language header when enabl
 
 test('getActiveLocale returns the configured default when no cookie and no Accept-Language header', function (): void {
     expect(i18n::getActiveLocale(Request::create('/'), false))->toBe('en_US');
+});
+
+test('getActiveTimezone migrates and expires the legacy timezone cookie', function (): void {
+    $request = requestWithTimezoneCookie('Europe/Berlin', CookieNames::LEGACY_TIMEZONE);
+    $cookies = new CookieQueue();
+
+    expect(i18n::getActiveTimezone($request, cookies: $cookies))->toBe('Europe/Berlin');
+
+    $response = new Response();
+    $cookies->applyToResponse($response);
+    $queued = [];
+    foreach ($response->headers->getCookies() as $cookie) {
+        $queued[$cookie->getName()] = $cookie;
+    }
+
+    expect($queued[CookieNames::TIMEZONE]->getValue())->toBe('Europe/Berlin')
+        ->and($queued[CookieNames::LEGACY_TIMEZONE]->getExpiresTime())->toBeLessThan(time());
+});
+
+test('getActiveLocale migrates and expires the legacy locale cookie', function (): void {
+    $request = Request::create('/');
+    $request->cookies->set(CookieNames::LEGACY_LOCALE, 'en_US');
+    $cookies = new CookieQueue();
+
+    expect(i18n::getActiveLocale($request, false, $cookies))->toBe('en_US');
+
+    $response = new Response();
+    $cookies->applyToResponse($response);
+    $queued = [];
+    foreach ($response->headers->getCookies() as $cookie) {
+        $queued[$cookie->getName()] = $cookie;
+    }
+
+    expect($queued[CookieNames::LOCALE]->getValue())->toBe('en_US')
+        ->and($queued[CookieNames::LEGACY_LOCALE]->getExpiresTime())->toBeLessThan(time());
 });


### PR DESCRIPTION
## Summary

- standardise FOSSBilling-owned cookies under the `fossbilling_` namespace
- migrate existing locale, timezone, and application session cookies to their new names
- update CSRF handling, both themes, installer session handling, and browser tests
- centralise server-side cookie names to prevent future inconsistencies

Closes #4041.