### PR TITLE
Fix checkout rendering for one-time products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /src/config.old.php
 /src/data/log/*
 /src/data/cache/*
+/src/data/uploads/*
 /src/data/update-finalization.json
 !/src/data/cache/.gitkeep
 /src/public/assets

--- a/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
+++ b/src/modules/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig
@@ -28,7 +28,7 @@
                                     x {{ item.quantity }}
                                 {% endif %}
 
-                                {% if item.period %}
+                                {% if item.period|default(false) %}
                                     ({{ item.period|period_title }})
                                 {% endif %}
                             </td>

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -96,7 +96,7 @@ test('all templates render under strict_variables', function (): void {
     }
 });
 
-test('orderbutton checkout renders for guests under strict_variables', function (): void {
+test('orderbutton checkout renders one-time items without a period under strict_variables', function (): void {
     $renderer = new StrictTemplateRenderer();
 
     $html = $renderer->renderTemplate(PATH_MODS . '/Orderbutton/templates/client/mod_orderbutton_checkout.html.twig', [
@@ -115,7 +115,6 @@ test('orderbutton checkout renders for guests under strict_variables', function 
                         'id' => 1,
                         'title' => 'Test product',
                         'quantity' => 1,
-                        'period' => null,
                         'discount_price' => 0,
                         'total' => 10,
                         'setup_price' => 0,

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -126,7 +126,7 @@ test('orderbutton checkout renders one-time items without a period under strict_
                 'discount' => 0,
                 'subtotal' => 10,
                 'total' => 10,
-                'subscribable' => true,
+                'subscribable' => false,
                 'currency' => [
                     'code' => 'USD',
                 ],
@@ -165,9 +165,9 @@ test('orderbutton checkout renders one-time items without a period under strict_
     ]);
 
     expect($html)->toContain('You must first login / create an account before you can checkout.')
-        ->and($html)->toContain('Subscription Gateway')
-        ->and($html)->toContain('id="order-gateway-2" value="2" autocomplete="off" checked')
-        ->and($html)->not->toContain('id="order-gateway-3" value="3" autocomplete="off" checked');
+        ->and($html)->toContain('Secondary Gateway')
+        ->and($html)->toContain('id="order-gateway-3" value="3" autocomplete="off" checked')
+        ->and($html)->not->toContain('Subscription Gateway');
 });
 
 test('orderbutton client form renders incomplete custom field configuration under strict_variables', function (): void {


### PR DESCRIPTION
## Summary
- treat the cart item's billing period as optional in the checkout template
- update the strict-Twig checkout regression fixture to match one-time cart items, which omit `period`
- ignore runtime uploads under `src/data/uploads/` while retaining the tracked placeholder