### PR TITLE
Fix domain TLD configuration handling

### DIFF
--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -177,12 +177,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     {
         $this->checkPermissions('servicedomain', 'manage_tlds');
 
-        $tld = $data['tld'];
-        if ($tld[0] != '.') {
-            $tld = '.' . $tld;
-        }
-
-        $model = $this->getService()->tldFindOneByTld($tld);
+        $model = $this->getService()->tldFindOneByTld($data['tld']);
         if (!$model instanceof \Model_Tld) {
             throw new \FOSSBilling\InformationException('TLD not found');
         }
@@ -222,12 +217,17 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     {
         $this->checkPermissions('servicedomain', 'manage_tlds');
 
-        $model = $this->getService()->tldFindOneByTld($data['tld']);
+        $normalizedTld = $this->getService()->normalizeTld($data['tld']);
+        $model = $this->getService()->tldFindOneByTld($normalizedTld);
 
         if (!$model instanceof \Model_Tld) {
             throw new \FOSSBilling\InformationException('TLD not found');
         }
-        $service_domains = $this->getDi()['db']->find('ServiceDomain', 'tld = :tld', [':tld' => $data['tld']]);
+        $service_domains = $this->getDi()['db']->find(
+            'ServiceDomain',
+            "LOWER(TRIM(TRAILING '.' FROM TRIM(tld))) IN (?, ?)",
+            [$normalizedTld, ltrim($normalizedTld, '.')],
+        );
         $count = \FOSSBilling\Tools::safeCount($service_domains);
         if ($count > 0) {
             throw new \FOSSBilling\InformationException('TLD is used by :count: domains', [':count:' => $count], 707);

--- a/src/modules/Servicedomain/Api/Guest.php
+++ b/src/modules/Servicedomain/Api/Guest.php
@@ -91,6 +91,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
 
         $tld = $this->getService()->tldFindOneByTld($data['tld']);
         if (!$tld instanceof \Model_Tld) {
+            throw new \FOSSBilling\InformationException('Domain availability could not be determined. TLD is not configured.');
+        }
+        if (!$tld->active) {
             throw new \FOSSBilling\InformationException('Domain availability could not be determined. TLD is not active.');
         }
 
@@ -117,6 +120,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
 
         $tld = $this->getService()->tldFindOneByTld($data['tld']);
         if (!$tld instanceof \Model_Tld) {
+            throw new \FOSSBilling\InformationException('TLD is not configured.');
+        }
+        if (!$tld->active) {
             throw new \FOSSBilling\InformationException('TLD is not active.');
         }
         if (!$this->getService()->canBeTransferred($tld, $data['sld'])) {

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -109,6 +109,8 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             if (!$validator->isTldValid($data['owndomain_tld'])) {
                 throw new \FOSSBilling\InformationException('TLD is invalid');
             }
+
+            $data['owndomain_tld'] = $this->normalizeTld($data['owndomain_tld']);
         }
 
         if ($action == 'transfer') {
@@ -128,6 +130,10 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             if (!$tld instanceof \Model_Tld) {
                 throw new \FOSSBilling\InformationException('TLD not found');
             }
+            if (!$tld->active) {
+                throw new \FOSSBilling\InformationException('TLD is not active');
+            }
+            $data['transfer_tld'] = $tld->tld;
 
             $domain = $data['transfer_sld'] . $tld->tld;
             if (!$this->canBeTransferred($tld, $data['transfer_sld'])) {
@@ -156,8 +162,15 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             if (!$tld instanceof \Model_Tld) {
                 throw new \FOSSBilling\InformationException('TLD not found');
             }
+            if (!$tld->active) {
+                throw new \FOSSBilling\InformationException('TLD is not active');
+            }
+            $data['register_tld'] = $tld->tld;
 
-            $years = (int) $data['register_years'];
+            $years = filter_var($data['register_years'], FILTER_VALIDATE_INT);
+            if ($years === false || $years < 1) {
+                throw new \FOSSBilling\InformationException('Domain registration period must be a positive integer');
+            }
             if ($years < $tld->min_years) {
                 throw new \FOSSBilling\Exception(':tld can be registered for at least :years years', [':tld' => $tld->tld, ':years' => $tld->min_years]);
             }
@@ -557,7 +570,8 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $domain->setTld($model->tld);
         $domain->setSld($sld);
 
-        $tldRegistrar = $this->di['db']->load('TldRegistrar', $model->tld_registrar_id);
+        $tldRegistrar = $this->di['db']->getExistingModelById('TldRegistrar', $model->tld_registrar_id, 'Registrar not found');
+        $this->registrarValidateConfiguration($tldRegistrar);
         $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
 
         return $adapter->isDomaincanBeTransferred($domain);
@@ -585,7 +599,8 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $domain->setTld($model->tld);
         $domain->setSld($sld);
 
-        $tldRegistrar = $this->di['db']->load('TldRegistrar', $model->tld_registrar_id);
+        $tldRegistrar = $this->di['db']->getExistingModelById('TldRegistrar', $model->tld_registrar_id, 'Registrar not found');
+        $this->registrarValidateConfiguration($tldRegistrar);
         $adapter = $this->registrarGetRegistrarAdapter($tldRegistrar);
 
         return $adapter->isDomainAvailable($domain);
@@ -780,8 +795,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function tldCreate($data)
     {
+        $data = $this->validateTldConfiguration($data);
+        $normalizedTld = $this->normalizeTld($data['tld']);
+        $registrar = $this->di['db']->getExistingModelById('TldRegistrar', $data['tld_registrar_id'], 'Registrar not found');
+        $this->registrarValidateConfiguration($registrar);
+
         $model = $this->di['db']->dispense('Tld');
-        $model->tld = $data['tld'];
+        $model->tld = $normalizedTld;
         $model->tld_registrar_id = $data['tld_registrar_id'];
         $model->price_registration = $data['price_registration'];
         $model->price_renew = $data['price_renew'];
@@ -789,7 +809,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->min_years = isset($data['min_years']) ? (int) $data['min_years'] : 1;
         $model->allow_register = isset($data['allow_register']) ? (bool) $data['allow_register'] : true;
         $model->allow_transfer = isset($data['allow_transfer']) ? (bool) $data['allow_transfer'] : true;
-        $model->active = isset($data['active']) && (bool) $data['active'];
+        $model->active = isset($data['active']) ? (bool) $data['active'] : true;
         $model->updated_at = date('Y-m-d H:i:s');
         $model->created_at = date('Y-m-d H:i:s');
 
@@ -802,6 +822,14 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function tldUpdate(\Model_Tld $model, $data): bool
     {
+        $data = $this->validateTldConfiguration($data);
+        $model->tld = $this->normalizeTld($model->tld);
+
+        if (array_key_exists('tld_registrar_id', $data)) {
+            $registrar = $this->di['db']->getExistingModelById('TldRegistrar', $data['tld_registrar_id'], 'Registrar not found');
+            $this->registrarValidateConfiguration($registrar);
+        }
+
         $model->tld_registrar_id = $data['tld_registrar_id'] ?? $model->tld_registrar_id;
         $model->price_registration = $data['price_registration'] ?? $model->price_registration;
         $model->price_renew = $data['price_renew'] ?? $model->price_renew;
@@ -817,6 +845,35 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $this->di['logger']->info('Updated top level domain %s', $model->tld);
 
         return true;
+    }
+
+    private function validateTldConfiguration(array $data): array
+    {
+        foreach (['price_registration', 'price_renew', 'price_transfer'] as $field) {
+            if (!array_key_exists($field, $data)) {
+                continue;
+            }
+
+            if (!is_numeric($data[$field])) {
+                throw new \FOSSBilling\InformationException('Domain price must be a non-negative number');
+            }
+
+            $price = (float) $data[$field];
+            if (!is_finite($price) || $price < 0) {
+                throw new \FOSSBilling\InformationException('Domain price must be a non-negative number');
+            }
+            $data[$field] = $price;
+        }
+
+        if (array_key_exists('min_years', $data)) {
+            $minimumYears = filter_var($data['min_years'], FILTER_VALIDATE_INT);
+            if ($minimumYears === false || $minimumYears < 1) {
+                throw new \FOSSBilling\InformationException('Minimum registration period must be a positive integer');
+            }
+            $data['min_years'] = $minimumYears;
+        }
+
+        return $data;
     }
 
     public function tldGetSearchQuery($data): array
@@ -868,9 +925,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
 
     public function tldAlreadyRegistered($tld): bool
     {
-        $tld = $this->di['db']->findOne('Tld', 'tld = :tld ORDER by id ASC', [':tld' => $tld]);
-
-        return $tld instanceof \Model_Tld;
+        return $this->tldFindOneByTld($tld) instanceof \Model_Tld;
     }
 
     public function tldRm(\Model_Tld $model): bool
@@ -913,12 +968,69 @@ class Service implements \FOSSBilling\InjectionAwareInterface
      */
     public function tldFindOneByTld($tld)
     {
-        return $this->di['db']->findOne('Tld', 'tld = :tld ORDER by id ASC', [':tld' => $tld]);
+        $normalizedTld = $this->normalizeTld($tld);
+        $model = $this->di['db']->findOne('Tld', 'tld = ? ORDER by id ASC', [$normalizedTld]);
+        if (!$model instanceof \Model_Tld) {
+            $model = $this->di['db']->findOne('Tld', 'tld = ? ORDER by id ASC', [ltrim($normalizedTld, '.')]);
+        }
+
+        if (!$model instanceof \Model_Tld) {
+            // Compatibility fallback for older rows containing whitespace,
+            // mixed case, or a trailing dot.
+            $model = $this->di['db']->findOne(
+                'Tld',
+                "LOWER(TRIM(TRAILING '.' FROM TRIM(tld))) IN (?, ?) ORDER by id ASC",
+                [$normalizedTld, ltrim($normalizedTld, '.')],
+            );
+        }
+
+        if ($model instanceof \Model_Tld) {
+            // Keep legacy rows usable without performing an unexpected
+            // database write during a read.
+            $model->tld = $normalizedTld;
+        }
+
+        return $model;
+    }
+
+    /**
+     * Convert a TLD or public suffix to the representation used throughout
+     * FOSSBilling and registrar adapters.
+     */
+    public function normalizeTld(string $tld): string
+    {
+        $tld = trim($tld);
+        $tld = trim($tld, '.');
+        if ($tld === '') {
+            throw new \FOSSBilling\InformationException('TLD is invalid.');
+        }
+
+        $asciiTld = idn_to_ascii($tld, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+        if ($asciiTld === false || strlen($asciiTld) > 253) {
+            throw new \FOSSBilling\InformationException('TLD is invalid.');
+        }
+
+        foreach (explode('.', strtolower($asciiTld)) as $label) {
+            if (!preg_match('/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/', $label)) {
+                throw new \FOSSBilling\InformationException('TLD is invalid.');
+            }
+        }
+
+        return '.' . strtolower($asciiTld);
     }
 
     public function tldFindOneById($id)
     {
-        return $this->di['db']->findOne('Tld', 'id = :id ORDER by id ASC', [':id' => $id]);
+        $model = $this->di['db']->findOne('Tld', 'id = :id ORDER by id ASC', [':id' => $id]);
+        if ($model instanceof \Model_Tld) {
+            try {
+                $model->tld = $this->normalizeTld($model->tld);
+            } catch (\FOSSBilling\InformationException) {
+                // Keep malformed legacy rows accessible to administrators.
+            }
+        }
+
+        return $model;
     }
 
     public function registrarGetSearchQuery($data): array
@@ -1017,6 +1129,33 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         return $registrar;
     }
 
+    public function registrarValidateConfiguration(\Model_TldRegistrar $model): void
+    {
+        $configuration = $this->registrarGetConfiguration($model);
+        $adapterConfiguration = $this->registrarGetRegistrarAdapterConfig($model);
+
+        foreach ($adapterConfiguration['form'] ?? [] as $field => $element) {
+            $options = $element[1] ?? [];
+            $required = isset($options['required']) && $options['required'] !== false && $options['required'] !== 'false';
+
+            if (isset($options['required_when']) && is_array($options['required_when'])) {
+                $required = true;
+                foreach ($options['required_when'] as $modelField => $expectedValue) {
+                    if ($model->{$modelField} != $expectedValue) {
+                        $required = false;
+
+                        break;
+                    }
+                }
+            }
+
+            $value = $configuration[$field] ?? null;
+            if ($required && ($value === null || $value === '' || $value === [])) {
+                throw new \FOSSBilling\InformationException('Registrar :registrar is missing required configuration: :field', [':registrar' => $model->name ?: $model->registrar, ':field' => $options['label'] ?? $field]);
+            }
+        }
+    }
+
     public function registrarCreate($code): bool
     {
         $model = $this->di['db']->dispense('TldRegistrar');
@@ -1050,7 +1189,18 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->name = $data['title'] ?? $model->name;
         $model->test_mode = $data['test_mode'] ?? $model->test_mode;
         if (isset($data['config']) && is_array($data['config'])) {
-            $model->config = json_encode($data['config']);
+            $configuration = array_replace($this->registrarGetConfiguration($model), $data['config']);
+            $adapterConfiguration = $this->registrarGetRegistrarAdapterConfig($model);
+
+            foreach ($adapterConfiguration['form'] ?? [] as $field => $element) {
+                $options = $element[1] ?? [];
+                if (!array_key_exists($field, $configuration) && array_key_exists('default', $options)) {
+                    $configuration[$field] = $options['default'];
+                }
+            }
+
+            $model->config = json_encode($configuration, JSON_THROW_ON_ERROR);
+            $this->registrarValidateConfiguration($model);
         }
 
         $this->di['db']->store($model);

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
@@ -231,7 +231,8 @@
                             <div class="row g-3">
                                 <div class="col-md-6">
                                     <label class="form-label" for="new-tld-name">{{ 'TLD'|trans }}</label>
-                                    <input class="form-control" id="new-tld-name" type="text" name="tld" value="." required title="{{ 'Must start with a dot'|trans }}">
+                                    <input class="form-control" id="new-tld-name" type="text" name="tld" placeholder=".example" required>
+                                    <div class="form-hint">{{ 'The leading dot is optional. The value will be normalized automatically.'|trans }}</div>
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label" for="new-tld-registrar">{{ 'Registrar'|trans }}</label>
@@ -243,19 +244,19 @@
                                 </div>
                                 <div class="col-md-4">
                                     <label class="form-label" for="new-tld-registration-price">{{ 'Registration Price'|trans }}</label>
-                                    <input class="form-control" id="new-tld-registration-price" type="text" name="price_registration" required>
+                                    <input class="form-control" id="new-tld-registration-price" type="number" min="0" step="any" name="price_registration" required>
                                 </div>
                                 <div class="col-md-4">
                                     <label class="form-label" for="new-tld-renewal-price">{{ 'Renewal Price'|trans }}</label>
-                                    <input class="form-control" id="new-tld-renewal-price" type="text" name="price_renew" required>
+                                    <input class="form-control" id="new-tld-renewal-price" type="number" min="0" step="any" name="price_renew" required>
                                 </div>
                                 <div class="col-md-4">
                                     <label class="form-label" for="new-tld-transfer-price">{{ 'Transfer Price'|trans }}</label>
-                                    <input class="form-control" id="new-tld-transfer-price" type="text" name="price_transfer" required>
+                                    <input class="form-control" id="new-tld-transfer-price" type="number" min="0" step="any" name="price_transfer" required>
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label" for="new-tld-min-years">{{ 'Minimum Years of Registration'|trans }}</label>
-                                    <input class="form-control" id="new-tld-min-years" type="text" name="min_years" value="1" required>
+                                    <input class="form-control" id="new-tld-min-years" type="number" min="1" step="1" name="min_years" value="1" required>
                                 </div>
                             </div>
                         </section>

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
@@ -43,19 +43,19 @@
                     </div>
                     <div class="col-lg-3">
                         <label class="form-label">{{ 'Registration Price'|trans }}</label>
-                        <input class="form-control" type="text" name="price_registration" value="{{ tld.price_registration }}" required>
+                        <input class="form-control" type="number" min="0" step="any" name="price_registration" value="{{ tld.price_registration }}" required>
                     </div>
                     <div class="col-lg-3">
                         <label class="form-label">{{ 'Renewal Price'|trans }}</label>
-                        <input class="form-control" type="text" name="price_renew" value="{{ tld.price_renew }}" required>
+                        <input class="form-control" type="number" min="0" step="any" name="price_renew" value="{{ tld.price_renew }}" required>
                     </div>
                     <div class="col-lg-3">
                         <label class="form-label">{{ 'Transfer Price'|trans }}</label>
-                        <input class="form-control" type="text" name="price_transfer" value="{{ tld.price_transfer }}" required>
+                        <input class="form-control" type="number" min="0" step="any" name="price_transfer" value="{{ tld.price_transfer }}" required>
                     </div>
                     <div class="col-lg-3">
                         <label class="form-label">{{ 'Minimum Years of Registration'|trans }}</label>
-                        <input class="form-control" type="text" name="min_years" value="{{ tld.min_years }}" required>
+                        <input class="form-control" type="number" min="1" step="1" name="min_years" value="{{ tld.min_years }}" required>
                     </div>
                     <div class="col-lg-2">
                         <label class="form-label d-block">{{ 'Allow Registration'|trans }}</label>

--- a/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
@@ -287,6 +287,10 @@ test('deletes tld', function (): void {
     $tldMock->tld = '.com';
 
     $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('normalizeTld')
+        ->once()
+        ->with('.com')
+        ->andReturn('.com');
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
         ->andReturn($tldMock);
@@ -297,7 +301,7 @@ test('deletes tld', function (): void {
     $dbMock = Mockery::mock('\Box_Database');
     $dbMock->shouldReceive('find')
         ->once()
-        ->with('ServiceDomain', 'tld = :tld', [':tld' => $tldMock->tld])
+        ->with('ServiceDomain', "LOWER(TRIM(TRAILING '.' FROM TRIM(tld))) IN (?, ?)", ['.com', 'com'])
         ->andReturn([]);
 
     $di = container();
@@ -314,10 +318,40 @@ test('deletes tld', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('prevents deleting a tld used by a legacy uppercase domain row', function (): void {
+    $adminApi = apiEndpoint(new Admin());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->tld = '.com';
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('normalizeTld')->once()->with('.COM.')->andReturn('.com');
+    $serviceMock->shouldReceive('tldFindOneByTld')->once()->with('.com')->andReturn($tld);
+    $serviceMock->shouldReceive('tldRm')->never();
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('find')
+        ->once()
+        ->with('ServiceDomain', "LOWER(TRIM(TRAILING '.' FROM TRIM(tld))) IN (?, ?)", ['.com', 'com'])
+        ->andReturn([new Model_ServiceDomain()]);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $adminApi->setDi($di);
+    $adminApi->setService($serviceMock);
+
+    expect(fn () => $adminApi->tld_delete(['tld' => '.COM.']))
+        ->toThrow(FOSSBilling\InformationException::class, 'TLD is used by 1 domains');
+});
+
 test('throws exception when deleting tld not found', function (): void {
     $adminApi = apiEndpoint(new Admin());
     $api = apiEndpoint(new Admin());
     $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('normalizeTld')
+        ->once()
+        ->with('.com')
+        ->andReturn('.com');
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
         ->andReturn(null);

--- a/src/modules/Servicedomain/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/GuestTest.php
@@ -91,10 +91,13 @@ test('throws exception when getting pricing for tld not found', function (): voi
 test('checks domain availability', function (): void {
     $guestApi = apiEndpoint(new Guest());
     $api = apiEndpoint(new Guest());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->active = true;
     $serviceMock = Mockery::mock(Service::class);
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
-        ->andReturn(new Model_Tld());
+        ->andReturn($tld);
     $serviceMock->shouldReceive('isDomainAvailable')
         ->atLeast()->once()
         ->andReturn(true);
@@ -173,10 +176,13 @@ test('throws exception when checking tld not found', function (): void {
 test('throws exception when checking domain not available', function (): void {
     $guestApi = apiEndpoint(new Guest());
     $api = apiEndpoint(new Guest());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->active = true;
     $serviceMock = Mockery::mock(Service::class);
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
-        ->andReturn(new Model_Tld());
+        ->andReturn($tld);
     $serviceMock->shouldReceive('isDomainAvailable')
         ->atLeast()->once()
         ->andReturn(false);
@@ -201,13 +207,43 @@ test('throws exception when checking domain not available', function (): void {
         ->toThrow(FOSSBilling\Exception::class);
 });
 
+test('throws exception when checking an inactive tld', function (): void {
+    $guestApi = apiEndpoint(new Guest());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->active = false;
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('tldFindOneByTld')
+        ->once()
+        ->andReturn($tld);
+    $serviceMock->shouldReceive('isDomainAvailable')
+        ->never();
+
+    $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
+    $validatorMock->shouldReceive('isSldValid')
+        ->once()
+        ->andReturn(true);
+
+    $di = container();
+    $di['validator'] = $validatorMock;
+    $guestApi->setDi($di);
+    $guestApi->setService($serviceMock);
+
+    expect(fn (): bool => $guestApi->check(['tld' => '.com', 'sld' => 'example']))
+        ->toThrow(FOSSBilling\InformationException::class, 'TLD is not active');
+});
+
 test('checks if domain can be transferred', function (): void {
     $guestApi = apiEndpoint(new Guest());
     $api = apiEndpoint(new Guest());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->active = true;
     $serviceMock = Mockery::mock(Service::class);
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
-        ->andReturn(new Model_Tld());
+        ->andReturn($tld);
     $serviceMock->shouldReceive('canBeTransferred')
         ->atLeast()->once()
         ->andReturn(true);
@@ -258,10 +294,13 @@ test('throws exception when checking transfer for tld not found', function (): v
 test('throws exception when checking domain cannot be transferred', function (): void {
     $guestApi = apiEndpoint(new Guest());
     $api = apiEndpoint(new Guest());
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->active = true;
     $serviceMock = Mockery::mock(Service::class);
     $serviceMock->shouldReceive('tldFindOneByTld')
         ->atLeast()->once()
-        ->andReturn(new Model_Tld());
+        ->andReturn($tld);
     $serviceMock->shouldReceive('canBeTransferred')
         ->atLeast()->once()
         ->andReturn(false);

--- a/src/modules/Servicedomain/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicedomain/tests/Unit/ServiceTest.php
@@ -111,6 +111,7 @@ test('throws exception for transfer order data with invalid tld', function (arra
     $tldModel = new Model_Tld();
     $tldModel->loadBean(new Tests\Helpers\DummyBean());
     $tldModel->tld = '.com';
+    $tldModel->active = true;
 
     return [
         [
@@ -164,6 +165,7 @@ test('throws exception for register order data with invalid tld', function (arra
     $tldModel->loadBean(new Tests\Helpers\DummyBean());
     $tldModel->tld = '.com';
     $tldModel->min_years = 2;
+    $tldModel->active = true;
 
     return [
         [
@@ -201,6 +203,34 @@ test('throws exception for register order data with invalid tld', function (arra
         ],
     ];
 });
+
+test('rejects a crafted order for an inactive tld before contacting the registrar', function (string $action): void {
+    $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
+    $validatorMock->shouldReceive('checkRequiredParamsForArray')->atLeast()->once();
+    $validatorMock->shouldReceive('isSldValid')->once()->andReturnTrue();
+
+    $tld = new Model_Tld();
+    $tld->loadBean(new Tests\Helpers\DummyBean());
+    $tld->tld = '.com';
+    $tld->active = false;
+    $tld->min_years = 1;
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('tldFindOneByTld')->once()->andReturn($tld);
+    $service->shouldReceive('isDomainAvailable')->never();
+    $service->shouldReceive('canBeTransferred')->never();
+
+    $di = container();
+    $di['validator'] = $validatorMock;
+    $service->setDi($di);
+
+    $data = $action === 'register'
+        ? ['action' => 'register', 'register_sld' => 'example', 'register_tld' => '.com', 'register_years' => 1]
+        : ['action' => 'transfer', 'transfer_sld' => 'example', 'transfer_tld' => '.com'];
+
+    expect(fn () => $service->validateOrderData($data))
+        ->toThrow(FOSSBilling\InformationException::class, 'TLD is not active');
+})->with(['register', 'transfer']);
 
 test('creates action', function (): void {
     $service = new Service();
@@ -824,8 +854,9 @@ test('checks if domain can be transferred', function (): void {
         ->andReturn(true);
 
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('registrarValidateConfiguration')->once();
     $serviceMock->shouldReceive('registrarGetRegistrarAdapter')
-        ->atLeast()->once()
+        ->once()
         ->andReturn($registrarAdapterMock);
 
     $tldRegistrar = new Model_TldRegistrar();
@@ -833,8 +864,9 @@ test('checks if domain can be transferred', function (): void {
     $tldRegistrar->tld_registrar_id = 1;
 
     $dbMock = Mockery::mock('\Box_Database');
-    $dbMock->shouldReceive('load')
+    $dbMock->shouldReceive('getExistingModelById')
         ->atLeast()->once()
+        ->with('TldRegistrar', 1, 'Registrar not found')
         ->andReturn($tldRegistrar);
 
     $di = container();
@@ -876,8 +908,9 @@ test('checks if domain is available', function (): void {
         ->andReturn(true);
 
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('registrarValidateConfiguration')->once();
     $serviceMock->shouldReceive('registrarGetRegistrarAdapter')
-        ->atLeast()->once()
+        ->once()
         ->andReturn($registrarAdapterMock);
 
     $tldRegistrar = new Model_TldRegistrar();
@@ -885,8 +918,9 @@ test('checks if domain is available', function (): void {
     $tldRegistrar->tld_registrar_id = 1;
 
     $dbMock = Mockery::mock('\Box_Database');
-    $dbMock->shouldReceive('load')
+    $dbMock->shouldReceive('getExistingModelById')
         ->atLeast()->once()
+        ->with('TldRegistrar', 1, 'Registrar not found')
         ->andReturn($tldRegistrar);
 
     $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
@@ -1418,9 +1452,42 @@ test('finds one tld by tld', function (): void {
     $service = new Service();
     $tldModel = new Model_Tld();
     $tldModel->loadBean(new Tests\Helpers\DummyBean());
+    $tldModel->tld = 'com';
     $dbMock = Mockery::mock('\Box_Database');
     $dbMock->shouldReceive('findOne')
-        ->atLeast()->once()
+        ->once()
+        ->with('Tld', 'tld = ? ORDER by id ASC', ['.com'])
+        ->andReturn(null);
+    $dbMock->shouldReceive('findOne')
+        ->once()
+        ->with('Tld', 'tld = ? ORDER by id ASC', ['com'])
+        ->andReturn($tldModel);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $service->setDi($di);
+
+    $result = $service->tldFindOneByTld(' COM. ');
+
+    expect($result)->toBeInstanceOf(Model_Tld::class);
+    expect($result->tld)->toBe('.com');
+});
+
+test('finds a non-canonical legacy tld as a compatibility fallback', function (): void {
+    $service = new Service();
+    $tldModel = new Model_Tld();
+    $tldModel->loadBean(new Tests\Helpers\DummyBean());
+    $tldModel->tld = ' .COM. ';
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('findOne')->twice()->andReturnNull();
+    $dbMock->shouldReceive('findOne')
+        ->once()
+        ->with(
+            'Tld',
+            "LOWER(TRIM(TRAILING '.' FROM TRIM(tld))) IN (?, ?) ORDER by id ASC",
+            ['.com', 'com'],
+        )
         ->andReturn($tldModel);
 
     $di = container();
@@ -1429,8 +1496,51 @@ test('finds one tld by tld', function (): void {
 
     $result = $service->tldFindOneByTld('.com');
 
-    expect($result)->toBeInstanceOf(Model_Tld::class);
+    expect($result)->toBe($tldModel);
+    expect($result->tld)->toBe('.com');
 });
+
+test('normalizes tlds', function (string $input, string $expected): void {
+    $service = new Service();
+
+    expect($service->normalizeTld($input))->toBe($expected);
+})->with([
+    'leading dot' => ['.com', '.com'],
+    'missing leading dot' => ['com', '.com'],
+    'case and whitespace' => [' .COM.UA. ', '.com.ua'],
+    'internationalized tld' => ['.рф', '.xn--p1ai'],
+]);
+
+test('keeps a malformed legacy tld accessible when finding it by id', function (): void {
+    $service = new Service();
+    $model = new Model_Tld();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+    $model->tld = 'not a valid tld';
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('findOne')->once()->andReturn($model);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $service->setDi($di);
+
+    expect($service->tldFindOneById(1))->toBe($model);
+    expect($model->tld)->toBe('not a valid tld');
+});
+
+test('rejects invalid tlds', function (string $input): void {
+    $service = new Service();
+
+    expect(fn (): string => $service->normalizeTld($input))
+        ->toThrow(FOSSBilling\InformationException::class, 'TLD is invalid');
+})->with([
+    'empty' => '',
+    'only dots' => '..',
+    'empty label' => '.com..ua',
+    'whitespace within label' => '.com ua',
+    'leading hyphen' => '.-com',
+    'trailing hyphen' => '.com-',
+]);
 
 test('gets registrar search query', function (): void {
     $service = new Service();
@@ -1555,6 +1665,24 @@ test('gets registrar adapter', function (): void {
     expect($result)->toBeInstanceOf('Registrar_Adapter_' . $model->registrar);
 });
 
+test('validates required registrar fields even when the adapter constructor does not', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarGetConfiguration')->once()->andReturn([]);
+    $service->shouldReceive('registrarGetRegistrarAdapterConfig')->once()->andReturn([
+        'form' => [
+            'host' => ['text', ['label' => 'EPP host', 'required' => true]],
+        ],
+    ]);
+    $model = new Model_TldRegistrar();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+    $model->name = 'Namingo EPP';
+    $model->registrar = 'Namingo';
+    $model->test_mode = false;
+
+    expect(fn () => $service->registrarValidateConfiguration($model))
+        ->toThrow(FOSSBilling\InformationException::class, 'missing required configuration');
+});
+
 test('throws exception when getting registrar adapter for non-existing registrar', function (): void {
     $service = new Service();
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
@@ -1644,9 +1772,10 @@ test('converts registrar to api array', function (): void {
 });
 
 test('creates tld', function (): void {
-    $service = new Service();
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarValidateConfiguration')->once();
     $data = [
-        'tld' => '.com',
+        'tld' => ' COM.UA. ',
         'tld_registrar_id' => 1,
         'price_registration' => 1,
         'price_renew' => 1,
@@ -1664,6 +1793,10 @@ test('creates tld', function (): void {
     $tldModel->loadBean(new Tests\Helpers\DummyBean());
 
     $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('getExistingModelById')
+        ->once()
+        ->with('TldRegistrar', 1, 'Registrar not found')
+        ->andReturn(new Model_TldRegistrar());
     $dbMock->shouldReceive('store')
         ->atLeast()->once()
         ->andReturn($randId);
@@ -1680,10 +1813,13 @@ test('creates tld', function (): void {
 
     expect($result)->toBeInt();
     expect($result)->toBe($randId);
+    expect($tldModel->tld)->toBe('.com.ua');
+    expect($tldModel->active)->toBeTruthy();
 });
 
 test('updates tld', function (): void {
-    $service = new Service();
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarValidateConfiguration')->once();
     $data = [
         'tld' => '.com',
         'tld_registrar_id' => 1,
@@ -1701,6 +1837,10 @@ test('updates tld', function (): void {
     $randId = 1;
 
     $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('getExistingModelById')
+        ->once()
+        ->with('TldRegistrar', 1, 'Registrar not found')
+        ->andReturn(new Model_TldRegistrar());
     $dbMock->shouldReceive('store')
         ->atLeast()->once()
         ->andReturn($randId);
@@ -1719,6 +1859,31 @@ test('updates tld', function (): void {
 
     expect($result)->toBeTrue();
 });
+
+test('rejects invalid tld pricing and minimum periods', function (array $data): void {
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarValidateConfiguration')->never();
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldNotReceive('getExistingModelById');
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $service->setDi($di);
+
+    expect(fn () => $service->tldCreate(array_replace([
+        'tld' => '.com',
+        'tld_registrar_id' => 1,
+        'price_registration' => 1,
+        'price_renew' => 1,
+        'price_transfer' => 1,
+        'min_years' => 1,
+    ], $data)))->toThrow(FOSSBilling\InformationException::class);
+})->with([
+    'negative registration price' => [['price_registration' => -1]],
+    'non-numeric renewal price' => [['price_renew' => 'free']],
+    'non-positive minimum period' => [['min_years' => 0]],
+]);
 
 test('creates registrar', function (): void {
     $service = new Service();
@@ -1802,6 +1967,55 @@ test('updates registrar', function (): void {
     $result = $service->registrarUpdate($model, $data);
 
     expect($result)->toBeTrue();
+});
+
+test('preserves registrar configuration fields omitted from an update', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarGetRegistrarAdapterConfig')
+        ->once()
+        ->andReturn(['form' => []]);
+    $service->shouldReceive('registrarValidateConfiguration')->once();
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('store')->once()->andReturn(1);
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $service->setDi($di);
+
+    $model = new Model_TldRegistrar();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+    $model->registrar = 'Custom';
+    $model->config = json_encode(['existing' => 'value']);
+
+    $service->registrarUpdate($model, ['config' => ['new' => 'value']]);
+
+    expect(json_decode($model->config, true))->toBe([
+        'existing' => 'value',
+        'new' => 'value',
+    ]);
+});
+
+test('allows registrar metadata updates with an incomplete existing configuration', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarValidateConfiguration')->never();
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('store')->once()->andReturn(1);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $service->setDi($di);
+
+    $model = new Model_TldRegistrar();
+    $model->loadBean(new Tests\Helpers\DummyBean());
+    $model->name = 'Old name';
+    $model->registrar = 'Custom';
+    $model->config = null;
+
+    expect($service->registrarUpdate($model, ['title' => 'New name']))->toBeTrue();
+    expect($model->name)->toBe('New name');
 });
 
 test('updates domain', function (): void {


### PR DESCRIPTION
## What changed

- Normalise configured TLDs consistently, including optional leading dots, case, whitespace, IDNs, and compatible legacy rows.
- Distinguish missing TLD configuration from an inactive TLD in public availability and transfer checks.
- Enforce the active state during order validation so direct or crafted requests cannot bypass it.
- Validate registrar references and required adapter configuration before a TLD is assigned or used.
- Preserve omitted registrar configuration fields and apply adapter defaults during updates.
- Validate TLD prices and minimum registration periods in the service layer, with matching admin form constraints.
- Make TLD deletion checks tolerant of legacy formatting.
- Add regression coverage for API errors, canonicalisation, legacy data, inactive-order bypasses, registrar configuration, and numeric validation.