### PR TITLE
Fix signup country rendering timeout

### DIFF
--- a/src/modules/Page/templates/client/mod_page_signup.html.twig
+++ b/src/modules/Page/templates/client/mod_page_signup.html.twig
@@ -102,12 +102,13 @@
                             {% endif %}
 
                             {% if 'country' in r %}
+                                {% set selected_country = request.country|default(guest.system_default_country) %}
                                 <div class="mb-3">
                                     <label class="form-label" for="country">{{ 'Country'|trans }}</label>
                                     <select class="form-select" id="country" name="country" required="required">
                                         <option value="">{{ '-- Select Country --'|trans }}</option>
                                         {% for val,label in guest.system_countries %}
-                                            <option value="{{ val }}" label="{{ label|e }}" {% if request.country|default(guest.system_default_country) == val %}selected{% endif %}>{{ label|e }}</option>
+                                            <option value="{{ val }}" label="{{ label|e }}" {% if selected_country == val %}selected{% endif %}>{{ label|e }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 
 use Tests\Support\PermissiveStub;
 use Tests\Support\StrictTemplateRenderer;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 test('cron settings renders when module config has not been saved', function (): void {
     $renderer = new StrictTemplateRenderer();
@@ -188,6 +192,58 @@ test('orderbutton client form renders incomplete custom field configuration unde
     expect($html)
         ->not->toContain('id="custom_1"')
         ->toContain('id="custom_2"');
+});
+
+test('signup renders country options with one default-country lookup', function (): void {
+    $guest = new class {
+        public int $defaultCountryLookups = 0;
+
+        public function __isset(string $name): bool
+        {
+            return true;
+        }
+
+        public function __get(string $name): mixed
+        {
+            return match ($name) {
+                'client_required' => ['country'],
+                'system_countries' => ['GB' => 'United Kingdom', 'US' => 'United States'],
+                'system_default_country' => $this->defaultCountry(),
+                'system_timezones', 'client_custom_fields' => [],
+                default => null,
+            };
+        }
+
+        private function defaultCountry(): string
+        {
+            ++$this->defaultCountryLookups;
+
+            return 'GB';
+        }
+    };
+    $templateSource = file_get_contents(PATH_MODS . '/Page/templates/client/mod_page_signup.html.twig');
+    expect($templateSource)->not->toBeFalse();
+
+    $twig = new Environment(new ArrayLoader([
+        'signup' => $templateSource,
+        'layout_public.html.twig' => '{% block body %}{% endblock %}',
+        'macro_functions.html.twig' => '{% macro recaptcha() %}{% endmacro %}',
+    ]));
+    $twig->addFilter(new TwigFilter('trans', static fn (string $value): string => $value));
+    $twig->addFilter(new TwigFilter('url', static fn (string $value): string => $value));
+    $twig->addFilter(new TwigFilter('api_url', static fn (string $action, ?array $query = null, ?string $role = null): string => '/'));
+    $twig->addFunction(new TwigFunction('antispam_honeypot', static fn (): array => ['enabled' => false]));
+    $twig->addFunction(new TwigFunction('fb_api_form', static fn (array $config = []): string => ''));
+
+    $html = $twig->render('signup', [
+        'guest' => $guest,
+        'request' => [],
+        'settings' => ['signup_tos' => 'disabled'],
+    ]);
+
+    expect($html)
+        ->toContain('<option value="GB" label="United Kingdom" selected>United Kingdom</option>')
+        ->and($guest->defaultCountryLookups)->toBe(1);
 });
 
 /*

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -14,6 +14,8 @@ use Tests\Support\PermissiveStub;
 use Tests\Support\StrictTemplateRenderer;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -221,13 +223,14 @@ test('signup renders country options with one default-country lookup', function 
             return 'GB';
         }
     };
-    $templateSource = file_get_contents(PATH_MODS . '/Page/templates/client/mod_page_signup.html.twig');
-    expect($templateSource)->not->toBeFalse();
-
-    $twig = new Environment(new ArrayLoader([
-        'signup' => $templateSource,
-        'layout_public.html.twig' => '{% block body %}{% endblock %}',
-        'macro_functions.html.twig' => '{% macro recaptcha() %}{% endmacro %}',
+    $templateLoader = new FilesystemLoader();
+    $templateLoader->addPath(PATH_MODS . '/Page/templates/client', 'Page_client');
+    $twig = new Environment(new ChainLoader([
+        $templateLoader,
+        new ArrayLoader([
+            'layout_public.html.twig' => '{% block body %}{% endblock %}',
+            'macro_functions.html.twig' => '{% macro recaptcha() %}{% endmacro %}',
+        ]),
     ]));
     $twig->addFilter(new TwigFilter('trans', static fn (string $value): string => $value));
     $twig->addFilter(new TwigFilter('url', static fn (string $value): string => $value));
@@ -235,7 +238,7 @@ test('signup renders country options with one default-country lookup', function 
     $twig->addFunction(new TwigFunction('antispam_honeypot', static fn (): array => ['enabled' => false]));
     $twig->addFunction(new TwigFunction('fb_api_form', static fn (array $config = []): string => ''));
 
-    $html = $twig->render('signup', [
+    $html = $twig->render('@Page_client/mod_page_signup.html.twig', [
         'guest' => $guest,
         'request' => [],
         'settings' => ['signup_tos' => 'disabled'],

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -223,6 +223,17 @@ test('signup renders country options with one default-country lookup', function 
             return 'GB';
         }
     };
+    $request = new class {
+        public function __isset(string $name): bool
+        {
+            return true;
+        }
+
+        public function __get(string $name): mixed
+        {
+            return null;
+        }
+    };
     $templateLoader = new FilesystemLoader();
     $templateLoader->addPath(PATH_MODS . '/Page/templates/client', 'Page_client');
     $twig = new Environment(new ChainLoader([
@@ -231,7 +242,7 @@ test('signup renders country options with one default-country lookup', function 
             'layout_public.html.twig' => '{% block body %}{% endblock %}',
             'macro_functions.html.twig' => '{% macro recaptcha() %}{% endmacro %}',
         ]),
-    ]));
+    ]), ['strict_variables' => true]);
     $twig->addFilter(new TwigFilter('trans', static fn (string $value): string => $value));
     $twig->addFilter(new TwigFilter('url', static fn (string $value): string => $value));
     $twig->addFilter(new TwigFilter('api_url', static fn (string $action, ?array $query = null, ?string $role = null): string => '/'));
@@ -240,8 +251,10 @@ test('signup renders country options with one default-country lookup', function 
 
     $html = $twig->render('@Page_client/mod_page_signup.html.twig', [
         'guest' => $guest,
-        'request' => [],
-        'settings' => ['signup_tos' => 'disabled'],
+        'request' => $request,
+        'settings' => new PermissiveStub(['signup_tos' => 'disabled']),
+        'public_logo_url' => false,
+        'public_dark_logo_url' => false,
     ]);
 
     expect($html)


### PR DESCRIPTION
## Summary

- Cache the selected/default country once before rendering signup country options.
- Add a regression test that verifies the default country is looked up once and remains selected.

Fixes #4051.