### PR TITLE
Add currency display format overrides

### DIFF
--- a/frontend/core/currency-format.mts
+++ b/frontend/core/currency-format.mts
@@ -1,0 +1,52 @@
+export interface CurrencyFormatOptions {
+  code: string;
+  format_pattern?: string | null;
+  fraction_digits?: number | null;
+}
+
+function getFractionDigits(options: CurrencyFormatOptions): number | undefined {
+  const value = options.fraction_digits;
+
+  return Number.isInteger(value) && value >= 0 && value <= 6 ? value : undefined;
+}
+
+export function formatCurrencyAmount(
+  amount: number,
+  options: CurrencyFormatOptions,
+  locale?: string | string[],
+): string {
+  const fractionDigits = getFractionDigits(options);
+  const fractionOptions = fractionDigits === undefined ? {} : {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  };
+  const pattern = options.format_pattern?.trim();
+
+  if (!pattern || pattern.split('{amount}').length !== 2) {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: options.code,
+      currencyDisplay: 'narrowSymbol',
+      ...fractionOptions,
+    }).format(amount);
+  }
+
+  let decimalFractionOptions = fractionOptions;
+  if (fractionDigits === undefined) {
+    const currencyOptions = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: options.code,
+    }).resolvedOptions();
+    decimalFractionOptions = {
+      minimumFractionDigits: currencyOptions.minimumFractionDigits,
+      maximumFractionDigits: currencyOptions.maximumFractionDigits,
+    };
+  }
+
+  const formattedAmount = new Intl.NumberFormat(locale, {
+    style: 'decimal',
+    ...decimalFractionOptions,
+  }).format(amount);
+
+  return pattern.replace('{amount}', formattedAmount);
+}

--- a/frontend/core/fossbilling.ts
+++ b/frontend/core/fossbilling.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck -- Runtime DOM/widget integration; converted to TS without changing behavior.
+import { formatCurrencyAmount } from './currency-format.mts';
+
 /**
  * FOSSBilling browser runtime.
  *
@@ -106,6 +108,10 @@
   }
 
   FOSSBilling.cookieNames = cookieNames;
+
+  FOSSBilling.currency = Object.assign({
+    format: formatCurrencyAmount,
+  }, FOSSBilling.currency || {});
 
   // Returns the IANA timezone identifier the browser is running in, or null.
   // Used by signup and the public layout so guests see dates in their own zone.

--- a/frontend/core/tests/currency-format.test.mts
+++ b/frontend/core/tests/currency-format.test.mts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { formatCurrencyAmount } from '../currency-format.mts';
+
+describe('currency formatting', () => {
+  test('uses Intl currency formatting by default', () => {
+    assert.equal(
+      formatCurrencyAmount(1234, { code: 'USD' }, 'en-US'),
+      '$1,234.00',
+    );
+  });
+
+  test('applies a fraction digit override without replacing the currency display', () => {
+    assert.equal(
+      formatCurrencyAmount(1234.5, { code: 'THB', fraction_digits: 0 }, 'th-TH'),
+      '฿1,235',
+    );
+  });
+
+  test('applies a plain-text amount pattern using locale-aware decimal formatting', () => {
+    assert.equal(
+      formatCurrencyAmount(1234, {
+        code: 'THB',
+        format_pattern: '{amount} บาท',
+        fraction_digits: 0,
+      }, 'th-TH'),
+      '1,234 บาท',
+    );
+  });
+
+  test('uses currency minor units for a pattern without a fraction override', () => {
+    assert.equal(
+      formatCurrencyAmount(1234, {
+        code: 'JPY',
+        format_pattern: '{amount} 円',
+      }, 'ja-JP'),
+      '1,234 円',
+    );
+  });
+
+  test('keeps the locale-aware minus sign inside the amount', () => {
+    assert.equal(
+      formatCurrencyAmount(-1234, {
+        code: 'THB',
+        format_pattern: '{amount} บาท',
+        fraction_digits: 0,
+      }, 'en-US'),
+      '-1,234 บาท',
+    );
+  });
+});

--- a/frontend/types/globals.d.ts
+++ b/frontend/types/globals.d.ts
@@ -61,6 +61,17 @@ interface FOSSBillingRuntime {
   };
   cookieCreate?: (name: string, value: string, days?: number) => void;
   cookieRead?: (name: string) => string | null;
+  currency?: {
+    format: (
+      amount: number,
+      options: {
+        code: string;
+        format_pattern?: string | null;
+        fraction_digits?: number | null;
+      },
+      locale?: string | string[],
+    ) => string;
+  };
   detectTimezone?: () => string;
   editor?: FOSSBillingEditorRegistry;
   initTimezone?: () => void;

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','92',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','93',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -429,6 +429,8 @@ CREATE TABLE `currency` (
   `code` varchar(3) DEFAULT NULL,
   `is_default` tinyint(1) DEFAULT '0',
   `conversion_rate` decimal(13,6) DEFAULT '1.000000',
+  `format_pattern` varchar(100) DEFAULT NULL,
+  `fraction_digits` smallint DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/src/library/FOSSBilling/Twig/Extension/FOSSBillingExtension.php
+++ b/src/library/FOSSBilling/Twig/Extension/FOSSBillingExtension.php
@@ -215,6 +215,16 @@ class FOSSBillingExtension
         return \FOSSBilling\Tools::humanReadableBytes($size);
     }
 
+    /**
+     * Preserve Twig IntlExtra's format_currency signature while applying the
+     * optional FOSSBilling per-currency display override.
+     */
+    #[AsTwigFilter('format_currency')]
+    public function formatCurrency(mixed $amount, string $currency, array $attrs = [], ?string $locale = null): string
+    {
+        return $this->di['mod_service']('currency')->formatCurrency($amount, $currency, $attrs, $locale);
+    }
+
     #[AsTwigFilter('hash')]
     public function hash(mixed $value, string $algo = 'xxh128'): string
     {

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -502,6 +502,7 @@ class UpdatePatcher implements InjectionAwareInterface
             90 => 'patch90',
             91 => 'patch91',
             92 => 'patch92',
+            93 => 'patch93',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2557,6 +2558,17 @@ class UpdatePatcher implements InjectionAwareInterface
             if ($this->tableHasColumn('service_downloadable', $column)) {
                 $this->executeSql(sprintf('ALTER TABLE `service_downloadable` DROP COLUMN `%s`', $column));
             }
+        }
+    }
+
+    private function patch93(): void
+    {
+        if (!$this->tableHasColumn('currency', 'format_pattern')) {
+            $this->executeSql('ALTER TABLE `currency` ADD COLUMN `format_pattern` varchar(100) DEFAULT NULL AFTER `conversion_rate`');
+        }
+
+        if (!$this->tableHasColumn('currency', 'fraction_digits')) {
+            $this->executeSql('ALTER TABLE `currency` ADD COLUMN `fraction_digits` smallint DEFAULT NULL AFTER `format_pattern`');
         }
     }
 

--- a/src/modules/Currency/Api/Admin.php
+++ b/src/modules/Currency/Api/Admin.php
@@ -134,6 +134,8 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * Updates system currency settings.
      *
      * @optional float $conversion_rate - new currency conversion rate
+     * @optional string $format_pattern - plain-text display pattern containing one {amount} placeholder
+     * @optional int $fraction_digits - fraction digit override from 0 to 6, blank to use the ISO default
      *
      * @throws \FOSSBilling\Exception
      */
@@ -143,8 +145,16 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('currency', 'edit');
 
         $conversionRate = $data['conversion_rate'] ?? null;
+        $formatting = array_intersect_key($data, [
+            'format_pattern' => true,
+            'fraction_digits' => true,
+        ]);
 
-        return $this->getService()->updateCurrency($data['code'], $conversionRate);
+        return $this->getService()->updateCurrency(
+            $data['code'],
+            $conversionRate,
+            $formatting,
+        );
     }
 
     /**

--- a/src/modules/Currency/Api/Guest.php
+++ b/src/modules/Currency/Api/Guest.php
@@ -14,7 +14,6 @@ namespace Box\Mod\Currency\Api;
 use Box\Mod\Currency\Entity\Currency;
 use FOSSBilling\i18n;
 use FOSSBilling\Tools;
-use Symfony\Component\Intl\Currencies;
 
 class Guest extends \FOSSBilling\Api\AbstractApi
 {
@@ -77,15 +76,9 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         $locale = i18n::getActiveLocale($di['request'], true, $di['cookie_queue']);
 
         if ($withoutCurrency) {
-            $fractionDigits = Currencies::getFractionDigits($c['code']);
-            $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-            $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $fractionDigits);
-
-            return $formatter->format($p);
+            return $this->getService()->formatNumber($p, $c['code'], locale: $locale);
         }
 
-        $formatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
-
-        return $formatter->formatCurrency($p, $c['code']);
+        return $this->getService()->formatCurrency($p, $c['code'], locale: $locale);
     }
 }

--- a/src/modules/Currency/Entity/Currency.php
+++ b/src/modules/Currency/Entity/Currency.php
@@ -38,6 +38,12 @@ class Currency implements ApiArrayInterface, TimestampInterface
 
     private ?float $conversionRateFloat = null;
 
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: true)]
+    private ?string $formatPattern = null;
+
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::SMALLINT, nullable: true)]
+    private ?int $fractionDigits = null;
+
     public function __construct(
         #[ORM\Column(type: \Doctrine\DBAL\Types\Types::STRING, length: 3, unique: true)]
         private string $code,
@@ -51,6 +57,8 @@ class Currency implements ApiArrayInterface, TimestampInterface
             'name' => Currencies::getName($this->getCode()),
             'symbol' => Currencies::getSymbol($this->getCode()),
             'conversion_rate' => $this->getConversionRate(),
+            'format_pattern' => $this->getFormatPattern(),
+            'fraction_digits' => $this->getFractionDigits(),
             'default' => $this->isDefault(),
         ];
     }
@@ -82,6 +90,16 @@ class Currency implements ApiArrayInterface, TimestampInterface
     public function getConversionRateRaw(): string
     {
         return $this->conversionRate;
+    }
+
+    public function getFormatPattern(): ?string
+    {
+        return $this->formatPattern;
+    }
+
+    public function getFractionDigits(): ?int
+    {
+        return $this->fractionDigits;
     }
 
     public function getCreatedAt(): ?\DateTime
@@ -120,6 +138,20 @@ class Currency implements ApiArrayInterface, TimestampInterface
         }
         // Invalidate cached float value so it will be recalculated on next access
         $this->conversionRateFloat = null;
+
+        return $this;
+    }
+
+    public function setFormatPattern(?string $formatPattern): self
+    {
+        $this->formatPattern = $formatPattern;
+
+        return $this;
+    }
+
+    public function setFractionDigits(?int $fractionDigits): self
+    {
+        $this->fractionDigits = $fractionDigits;
 
         return $this;
     }

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -15,17 +15,26 @@ use Box\Mod\Currency\Entity\Currency;
 use Box\Mod\Currency\Repository\CurrencyRepository;
 use FOSSBilling\InformationException;
 use FOSSBilling\InjectionAwareInterface;
+use Symfony\Component\Intl\Currencies;
 use Symfony\Contracts\Cache\ItemInterface;
+use Twig\Extra\Intl\IntlExtension;
 
 class Service implements InjectionAwareInterface
 {
+    private const AMOUNT_PLACEHOLDER = '{amount}';
+    private const MAX_FRACTION_DIGITS = 6;
+
     protected ?\Pimple\Container $di = null;
     protected ?CurrencyRepository $currencyRepository = null;
+    private ?IntlExtension $intlExtension = null;
+    /** @var array<string, array{format_pattern: ?string, fraction_digits: ?int}> */
+    private array $formattingCache = [];
 
     public function setDi(\Pimple\Container $di): void
     {
         $this->di = $di;
         $this->currencyRepository = $this->di['em']->getRepository(Currency::class);
+        $this->formattingCache = [];
     }
 
     public function getDi(): ?\Pimple\Container
@@ -62,7 +71,7 @@ class Service implements InjectionAwareInterface
             'edit' => [
                 'type' => 'bool',
                 'display_name' => __trans('Edit Currencies'),
-                'description' => __trans('Allows the staff member to update currency conversion rates.'),
+                'description' => __trans('Allows the staff member to update currency conversion rates and display formatting.'),
             ],
             'delete' => [
                 'type' => 'bool',
@@ -306,16 +315,28 @@ class Service implements InjectionAwareInterface
      *
      * @param string            $currencyCode   Currency code to update
      * @param string|float|null $conversionRate Conversion rate (optional)
+     * @param array{
+     *     format_pattern?: mixed,
+     *     fraction_digits?: mixed
+     * } $formatting Formatting values to update; omitted keys are left unchanged
      *
      * @throws \FOSSBilling\Exception If currency not found
-     * @throws InformationException   If conversion rate is invalid
+     * @throws InformationException   If a provided value is invalid
      */
-    public function updateCurrency(string $currencyCode, string|float|null $conversionRate = null): bool
-    {
+    public function updateCurrency(
+        string $currencyCode,
+        string|float|null $conversionRate = null,
+        array $formatting = [],
+    ): bool {
         $model = $this->currencyRepository->findOneByCode($currencyCode);
         if (!$model instanceof Currency) {
             throw new \FOSSBilling\Exception('Currency not found.');
         }
+
+        $updateFormatPattern = array_key_exists('format_pattern', $formatting);
+        $updateFractionDigits = array_key_exists('fraction_digits', $formatting);
+        $formatPattern = $updateFormatPattern ? $this->normalizeFormatPattern($formatting['format_pattern']) : null;
+        $fractionDigits = $updateFractionDigits ? $this->normalizeFractionDigits($formatting['fraction_digits']) : null;
 
         if ($conversionRate !== null) {
             if (!is_numeric($conversionRate) || $conversionRate <= 0) {
@@ -324,13 +345,144 @@ class Service implements InjectionAwareInterface
             $model->setConversionRate($conversionRate);
         }
 
+        if ($updateFormatPattern) {
+            $model->setFormatPattern($formatPattern);
+        }
+
+        if ($updateFractionDigits) {
+            $model->setFractionDigits($fractionDigits);
+        }
+
         $em = $this->di['em'];
         $em->persist($model);
         $em->flush();
 
+        unset($this->formattingCache[$currencyCode]);
         $this->di['logger']->info('Updated currency %s.', $model->getCode());
 
         return true;
+    }
+
+    /**
+     * Format a currency amount using Twig IntlExtra semantics and optional per-currency overrides.
+     *
+     * Call-site attributes take precedence over the stored fraction digit override.
+     */
+    public function formatCurrency(mixed $amount, string $currencyCode, array $attributes = [], ?string $locale = null): string
+    {
+        $formatting = $this->getFormattingOverrides($currencyCode);
+        $intl = $this->intlExtension ??= new IntlExtension();
+
+        if ($formatting['format_pattern'] === null) {
+            $attributes = $this->applyFractionDigits($attributes, $formatting['fraction_digits']);
+
+            return $intl->formatCurrency($amount, $currencyCode, $attributes, $locale);
+        }
+
+        $attributes = $this->applyFractionDigits($attributes, $this->resolveFractionDigits($currencyCode, $formatting['fraction_digits']));
+        $formattedAmount = $intl->formatNumber($amount, $attributes, 'decimal', 'default', $locale);
+
+        return str_replace(self::AMOUNT_PLACEHOLDER, $formattedAmount, $formatting['format_pattern']);
+    }
+
+    public function formatNumber(mixed $amount, string $currencyCode, array $attributes = [], ?string $locale = null): string
+    {
+        $formatting = $this->getFormattingOverrides($currencyCode);
+        $attributes = $this->applyFractionDigits($attributes, $this->resolveFractionDigits($currencyCode, $formatting['fraction_digits']));
+        $intl = $this->intlExtension ??= new IntlExtension();
+
+        return $intl->formatNumber($amount, $attributes, 'decimal', 'default', $locale);
+    }
+
+    private function normalizeFormatPattern(mixed $formatPattern): ?string
+    {
+        if ($formatPattern !== null && !is_string($formatPattern)) {
+            throw new InformationException('Currency format pattern must be plain text.');
+        }
+
+        $formatPattern = trim($formatPattern ?? '');
+        if ($formatPattern === '') {
+            return null;
+        }
+
+        if (mb_strlen($formatPattern) > 100) {
+            throw new InformationException('Currency format pattern cannot exceed 100 characters.');
+        }
+
+        if (substr_count($formatPattern, self::AMOUNT_PLACEHOLDER) !== 1) {
+            throw new InformationException('Currency format pattern must contain exactly one {amount} placeholder.');
+        }
+
+        if (preg_match('/[\x00-\x1F\x7F]/u', $formatPattern) === 1) {
+            throw new InformationException('Currency format pattern must be a single line of plain text.');
+        }
+
+        return $formatPattern;
+    }
+
+    private function normalizeFractionDigits(mixed $fractionDigits): ?int
+    {
+        if ($fractionDigits === null || $fractionDigits === '') {
+            return null;
+        }
+
+        if (!is_int($fractionDigits) && !is_string($fractionDigits)) {
+            throw new InformationException('Currency fraction digits must be a whole number between 0 and 6.');
+        }
+
+        $normalized = filter_var($fractionDigits, FILTER_VALIDATE_INT, [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => self::MAX_FRACTION_DIGITS,
+            ],
+        ]);
+
+        if ($normalized === false) {
+            throw new InformationException('Currency fraction digits must be a whole number between 0 and 6.');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{format_pattern: ?string, fraction_digits: ?int}
+     */
+    private function getFormattingOverrides(string $currencyCode): array
+    {
+        if (isset($this->formattingCache[$currencyCode])) {
+            return $this->formattingCache[$currencyCode];
+        }
+
+        $currency = $this->currencyRepository->findOneByCode($currencyCode);
+        if (!$currency instanceof Currency) {
+            return $this->formattingCache[$currencyCode] = [
+                'format_pattern' => null,
+                'fraction_digits' => null,
+            ];
+        }
+
+        return $this->formattingCache[$currencyCode] = [
+            'format_pattern' => $currency->getFormatPattern(),
+            'fraction_digits' => $currency->getFractionDigits(),
+        ];
+    }
+
+    private function applyFractionDigits(array $attributes, ?int $fractionDigits): array
+    {
+        if ($fractionDigits !== null && !array_key_exists('fraction_digit', $attributes)) {
+            $attributes['fraction_digit'] = $fractionDigits;
+        }
+
+        return $attributes;
+    }
+
+    private function resolveFractionDigits(string $currencyCode, ?int $fractionDigits): ?int
+    {
+        if ($fractionDigits !== null) {
+            return $fractionDigits;
+        }
+
+        return Currencies::exists($currencyCode) ? Currencies::getFractionDigits($currencyCode) : null;
     }
 
     /**

--- a/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
@@ -39,6 +39,43 @@
                     <label class="form-label">{{ 'Conversion Rate'|trans }}</label>
                     <input class="form-control" type="text" name="conversion_rate" value="{{ currency.conversion_rate }}" required>
                 </div>
+                <div class="col-12">
+                    <hr class="my-2">
+                    <h4 class="mb-1">{{ 'Display Formatting'|trans }}</h4>
+                    <p class="text-secondary mb-0">
+                        {{ 'Leave these fields blank to use the standard format for the active language and currency. These settings affect display only; calculations and payment gateway values are unchanged.'|trans }}
+                    </p>
+                </div>
+                <div class="col-lg-6">
+                    <label class="form-label" for="fraction-digits">{{ 'Decimal Places'|trans }}</label>
+                    <select class="form-select" id="fraction-digits" name="fraction_digits">
+                        <option value="">{{ 'Automatic (currency default)'|trans }}</option>
+                        {% for digit in 0..6 %}
+                            <option value="{{ digit }}"{% if currency.fraction_digits is same as(digit) %} selected{% endif %}>{{ digit }}</option>
+                        {% endfor %}
+                    </select>
+                    <div class="form-hint">{{ 'Overrides only the number of displayed decimal places.'|trans }}</div>
+                </div>
+                <div class="col-lg-6">
+                    <label class="form-label" for="format-pattern">{{ 'Format Pattern'|trans }}</label>
+                    <input
+                        class="form-control"
+                        id="format-pattern"
+                        type="text"
+                        name="format_pattern"
+                        value="{{ currency.format_pattern|default('') }}"
+                        maxlength="100"
+                        placeholder="{amount} บาท"
+                    >
+                    <div class="form-hint">{{ 'Plain text containing {amount} exactly once. Example: {amount} บาท'|trans }}</div>
+                </div>
+                <div class="col-12">
+                    <div class="rounded border p-3">
+                        <div><span class="text-secondary">{{ 'Standard format:'|trans }}</span> <span id="currency-default-preview"></span></div>
+                        <div><span class="text-secondary">{{ 'Effective display:'|trans }}</span> <strong id="currency-effective-preview"></strong></div>
+                        <button class="btn btn-sm btn-ghost-secondary mt-2" id="reset-formatting" type="button">{{ 'Reset to standard format'|trans }}</button>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="card-footer d-flex justify-content-end">
@@ -51,4 +88,41 @@
     </div>
     {% endif %}
 </div>
+{% endblock %}
+
+{% block js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const currency = JSON.parse('{{ currency|json_encode|e('js') }}');
+        const fractionDigits = document.getElementById('fraction-digits');
+        const formatPattern = document.getElementById('format-pattern');
+        const defaultPreview = document.getElementById('currency-default-preview');
+        const effectivePreview = document.getElementById('currency-effective-preview');
+        const resetButton = document.getElementById('reset-formatting');
+
+        const renderPreview = function () {
+            const selectedDigits = fractionDigits.value === '' ? null : Number(fractionDigits.value);
+            defaultPreview.textContent = FOSSBilling.currency.format(1234, {
+                code: currency.code,
+                format_pattern: null,
+                fraction_digits: null,
+            });
+            effectivePreview.textContent = FOSSBilling.currency.format(1234, {
+                code: currency.code,
+                format_pattern: formatPattern.value || null,
+                fraction_digits: selectedDigits,
+            });
+        };
+
+        fractionDigits.addEventListener('change', renderPreview);
+        formatPattern.addEventListener('input', renderPreview);
+        resetButton.addEventListener('click', function () {
+            fractionDigits.value = '';
+            formatPattern.value = '';
+            renderPreview();
+        });
+
+        renderPreview();
+    });
+</script>
 {% endblock %}

--- a/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
@@ -99,6 +99,9 @@
         const defaultPreview = document.getElementById('currency-default-preview');
         const effectivePreview = document.getElementById('currency-effective-preview');
         const resetButton = document.getElementById('reset-formatting');
+        if (!fractionDigits || !formatPattern || !defaultPreview || !effectivePreview || !resetButton) {
+            return;
+        }
 
         const renderPreview = function () {
             const selectedDigits = fractionDigits.value === '' ? null : Number(fractionDigits.value);

--- a/src/modules/Currency/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Currency/tests/Unit/Api/AdminTest.php
@@ -225,10 +225,11 @@ test('get', function (): void {
     ->atLeast()->once()
     ->andReturn([
         'code' => 'EUR',
-        'title' => 'Euro',
+        'name' => 'Euro',
+        'symbol' => '€',
         'conversion_rate' => 1.0,
-        'format' => '€{{price}}',
-        'price_format' => '€{{price}}',
+        'format_pattern' => null,
+        'fraction_digits' => null,
     ]);
 
     $repositoryMock = Mockery::mock('\\' . Box\Mod\Currency\Repository\CurrencyRepository::class);
@@ -260,10 +261,11 @@ test('get default', function (): void {
 
     $returnArr = [
         'code' => 'EUR',
-        'title' => 'Euro',
+        'name' => 'Euro',
+        'symbol' => '€',
         'conversion_rate' => 3.4528,
-        'format' => '',
-        'price_format' => '',
+        'format_pattern' => null,
+        'fraction_digits' => null,
         'default' => true,
     ];
 
@@ -291,11 +293,11 @@ test('get default', function (): void {
     expect($result)->toBeArray();
     expect($returnArr)->toEqual($result);
     expect($returnArr['code'])->toEqual('EUR');
-    expect($returnArr['title'])->toEqual('Euro');
+    expect($returnArr['name'])->toEqual('Euro');
     expect($returnArr['conversion_rate'])->toBeFloat();
     expect($returnArr['conversion_rate'])->toEqual(3.4528);
-    expect($returnArr['format'])->toEqual('');
-    expect($returnArr['price_format'])->toEqual('');
+    expect($returnArr['format_pattern'])->toBeNull();
+    expect($returnArr['fraction_digits'])->toBeNull();
     expect($returnArr['default'])->toBeTrue();
 });
 
@@ -389,16 +391,19 @@ test('update', function (): void {
 
     $data = [
         'code' => 'EUR',
-        'format' => '€{{price}}',
-        'title' => 'Euros',
-        'price_format' => '€{{Price}}',
         'conversion_rate' => 0.6,
+        'format_pattern' => '{amount} EUR',
+        'fraction_digits' => '0',
     ];
 
     $service = Mockery::mock(Box\Mod\Currency\Service::class);
     $service
     ->shouldReceive('updateCurrency')
-    ->atLeast()->once()
+    ->once()
+    ->with('EUR', 0.6, [
+        'format_pattern' => '{amount} EUR',
+        'fraction_digits' => '0',
+    ])
     ->andReturn(true);
 
     $di = container();
@@ -409,6 +414,22 @@ test('update', function (): void {
 
     expect($result)->toBeBool();
     expect($result)->toBeTrue();
+});
+
+test('update forwards individual formatting fields without clearing the other setting', function (): void {
+    $adminApi = apiEndpoint(new Box\Mod\Currency\Api\Admin());
+    $service = Mockery::mock(Box\Mod\Currency\Service::class);
+    $service->expects('updateCurrency')
+        ->with('EUR', null, ['format_pattern' => '{amount} EUR'])
+        ->andReturnTrue();
+
+    $adminApi->setDi(container());
+    $adminApi->setService($service);
+
+    expect($adminApi->update([
+        'code' => 'EUR',
+        'format_pattern' => '{amount} EUR',
+    ]))->toBeTrue();
 });
 
 test('delete exception', function (): void {

--- a/src/modules/Currency/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Currency/tests/Unit/Api/GuestTest.php
@@ -61,10 +61,11 @@ test('get', function ($data, $modelFlag, $expectsGetByCode, $expectsGetDefault):
 
     $willReturn = [
         'code' => 'EUR',
-        'title' => 'Euro',
+        'name' => 'Euro',
+        'symbol' => '€',
         'conversion_rate' => 1,
-        'format' => '{{price}}',
-        'price_format' => 1,
+        'format_pattern' => null,
+        'fraction_digits' => null,
         'default' => 1,
     ];
 
@@ -129,51 +130,13 @@ test('get exception', function (): void {
     $result = $guestApi->get([]);
 });
 
-dataset('formatPriceFormatProvider', [
-    [1, '€60,000.00'],
-    [2, '€60,000.00'],
-    [3, '€60,000.00'],
-    [4, '€60,000.00'],
-    [5, '€60,000.00'],
-]);
-
-test('format price format', function ($price_format, $expectedResult): void {
-    $willReturn = [
-        'code' => 'EUR',
-        'title' => 'Euro',
-        'conversion_rate' => 0.6,
-        'format' => '€ {{price}}',
-        'price_format' => $price_format,
-        'default' => 1,
-    ];
-
-    $data = [
-        'code' => 'EUR',
-        'price' => 100000,
-        'without_currency' => false,
-    ];
-    $guestApi = Mockery::mock(Box\Mod\Currency\Api\Guest::class)->makePartial();
-    $guestApi
-    ->shouldReceive('get')
-    ->atLeast()->once()
-    ->andReturn($willReturn);
-
-    $service = $this->createStub(Box\Mod\Currency\Service::class);
-
-    $di = container();
-
-    $guestApi->setDi($di);
-    $guestApi->setService($service);
-
-    $result = $guestApi->format($data);
-    expect($expectedResult)->toEqual($result);
-})->with('formatPriceFormatProvider');
-
 dataset('formatProvider', [
     [
         [
             'code' => 'EUR',
         ],
+        'formatCurrency',
+        0.0,
         '€0.00',
     ],
     [
@@ -182,6 +145,8 @@ dataset('formatProvider', [
             'price' => 100000,
             'convert' => false,
         ],
+        'formatCurrency',
+        100000.0,
         '€100,000.00',
     ],
     [
@@ -190,17 +155,20 @@ dataset('formatProvider', [
             'price' => 100000,
             'without_currency' => true,
         ],
+        'formatNumber',
+        60000.0,
         '60,000.00',
     ],
 ]);
 
-test('format', function ($data, $expectedResult): void {
+test('format', function ($data, $formatMethod, $expectedAmount, $expectedResult): void {
     $willReturn = [
         'code' => 'EUR',
-        'title' => 'Euro',
+        'name' => 'Euro',
+        'symbol' => '€',
         'conversion_rate' => 0.6,
-        'format' => '€ {{price}}',
-        'price_format' => 1,
+        'format_pattern' => null,
+        'fraction_digits' => null,
         'default' => 1,
     ];
 
@@ -210,7 +178,11 @@ test('format', function ($data, $expectedResult): void {
     ->atLeast()->once()
     ->andReturn($willReturn);
 
-    $service = $this->createStub(Box\Mod\Currency\Service::class);
+    $service = Mockery::mock(Box\Mod\Currency\Service::class);
+    $service->shouldReceive($formatMethod)
+        ->once()
+        ->withArgs(fn ($amount, $code): bool => $amount === $expectedAmount && $code === 'EUR')
+        ->andReturn($expectedResult);
 
     $di = container();
 

--- a/src/modules/Currency/tests/Unit/FormattingTest.php
+++ b/src/modules/Currency/tests/Unit/FormattingTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+use Box\Mod\Currency\Entity\Currency;
+use Box\Mod\Currency\Repository\CurrencyRepository;
+use Box\Mod\Currency\Service;
+use FOSSBilling\InformationException;
+use FOSSBilling\Twig\Extension\FOSSBillingExtension;
+use Twig\Environment;
+use Twig\Extension\AttributeExtension;
+use Twig\Extra\Intl\IntlExtension;
+use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
+
+test('currency formatting delegates to IntlExtra when no override is configured', function (): void {
+    $currency = new Currency('USD');
+    $repository = Mockery::mock(CurrencyRepository::class);
+    $repository->expects('findOneByCode')->with('USD')->once()->andReturn($currency);
+
+    $em = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $em->expects('getRepository')->with(Currency::class)->andReturn($repository);
+
+    $di = new Pimple\Container();
+    $di['em'] = $em;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    $expected = (new IntlExtension())->formatCurrency(1234, 'USD', locale: 'en_US');
+    expect($service->formatCurrency(1234, 'USD', locale: 'en_US'))->toBe($expected);
+});
+
+test('currency formatting applies a locale-aware plain-text pattern and fraction digits', function (): void {
+    $currency = (new Currency('THB'))
+        ->setFormatPattern('{amount} บาท')
+        ->setFractionDigits(0);
+    $repository = Mockery::mock(CurrencyRepository::class);
+    $repository->expects('findOneByCode')->with('THB')->once()->andReturn($currency);
+
+    $em = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $em->expects('getRepository')->with(Currency::class)->andReturn($repository);
+
+    $di = new Pimple\Container();
+    $di['em'] = $em;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect($service->formatCurrency(1234, 'THB', locale: 'th_TH'))->toBe('1,234 บาท')
+        ->and($service->formatCurrency(-1234, 'THB', locale: 'en_US'))->toBe('-1,234 บาท');
+});
+
+test('explicit Twig fraction attributes take precedence over stored settings', function (): void {
+    $currency = (new Currency('THB'))->setFractionDigits(0);
+    $repository = Mockery::mock(CurrencyRepository::class);
+    $repository->expects('findOneByCode')->with('THB')->once()->andReturn($currency);
+
+    $em = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $em->expects('getRepository')->with(Currency::class)->andReturn($repository);
+
+    $di = new Pimple\Container();
+    $di['em'] = $em;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect($service->formatCurrency(1234, 'THB', ['fraction_digit' => 2], 'th_TH'))->toBe('฿1,234.00');
+});
+
+test('FOSSBilling currency formatting decorates the IntlExtra Twig filter', function (): void {
+    $currencyService = Mockery::mock(Service::class);
+    $currencyService->expects('formatCurrency')
+        ->with(1234, 'THB', [], null)
+        ->andReturn('1,234 บาท');
+
+    $di = new Pimple\Container();
+    $di['mod_service'] = $di->protect(
+        fn (string $module): Service => $currencyService,
+    );
+
+    $twig = new Environment(new ArrayLoader([
+        'currency' => '{{ 1234|format_currency("THB") }}',
+    ]));
+    $twig->addExtension(new IntlExtension());
+    $twig->addExtension(new AttributeExtension(FOSSBillingExtension::class));
+    $twig->addRuntimeLoader(new FactoryRuntimeLoader([
+        FOSSBillingExtension::class => fn (): FOSSBillingExtension => new FOSSBillingExtension($di),
+    ]));
+
+    expect($twig->render('currency'))->toBe('1,234 บาท');
+});
+
+test('currency formatting settings are normalized and can be reset', function (): void {
+    $currency = new Currency('THB');
+    $repository = Mockery::mock(CurrencyRepository::class);
+    $repository->expects('findOneByCode')->with('THB')->twice()->andReturn($currency);
+
+    $em = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $em->expects('getRepository')->with(Currency::class)->andReturn($repository);
+    $em->expects('persist')->with($currency)->twice();
+    $em->expects('flush')->twice();
+
+    $di = new Pimple\Container();
+    $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect($service->updateCurrency('THB', null, [
+        'format_pattern' => ' {amount} บาท ',
+        'fraction_digits' => '0',
+    ]))->toBeTrue()
+        ->and($currency->getFormatPattern())->toBe('{amount} บาท')
+        ->and($currency->getFractionDigits())->toBe(0);
+
+    expect($service->updateCurrency('THB', null, [
+        'format_pattern' => '',
+        'fraction_digits' => '',
+    ]))->toBeTrue()
+        ->and($currency->getFormatPattern())->toBeNull()
+        ->and($currency->getFractionDigits())->toBeNull();
+});
+
+dataset('invalid currency formatting settings', [
+    ['บาท', '0'],
+    ['{amount} {amount}', '0'],
+    ["{amount}\nบาท", '0'],
+    ['{amount}', '-1'],
+    ['{amount}', '7'],
+    ['{amount}', '1.5'],
+    ['{amount}', true],
+    [123, '0'],
+]);
+
+test('invalid currency formatting settings are rejected', function (mixed $pattern, mixed $fractionDigits): void {
+    $currency = new Currency('THB');
+    $repository = Mockery::mock(CurrencyRepository::class);
+    $repository->allows('findOneByCode')->with('THB')->andReturn($currency);
+
+    $em = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $em->expects('getRepository')->with(Currency::class)->andReturn($repository);
+    $em->shouldNotReceive('persist');
+    $em->shouldNotReceive('flush');
+
+    $di = new Pimple\Container();
+    $di['em'] = $em;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect(fn (): bool => $service->updateCurrency('THB', 2.0, [
+        'format_pattern' => $pattern,
+        'fraction_digits' => $fractionDigits,
+    ]))
+        ->toThrow(InformationException::class)
+        ->and($currency->getConversionRate())->toBe(1.0);
+})->with('invalid currency formatting settings');

--- a/src/modules/Currency/tests/Unit/FormattingTest.php
+++ b/src/modules/Currency/tests/Unit/FormattingTest.php
@@ -133,7 +133,7 @@ test('currency formatting settings are normalized and can be reset', function ()
 dataset('invalid currency formatting settings', [
     ['บาท', '0'],
     ['{amount} {amount}', '0'],
-    ["{amount}\nบาท", '0'],
+    ['{amount}' . PHP_EOL . 'บาท', '0'],
     ['{amount}', '-1'],
     ['{amount}', '7'],
     ['{amount}', '1.5'],

--- a/src/modules/Servicedomain/templates/client/mod_servicedomain_order_form.html.twig
+++ b/src/modules/Servicedomain/templates/client/mod_servicedomain_order_form.html.twig
@@ -115,6 +115,8 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
+        const currencyFormat = JSON.parse('{{ currency|json_encode|e('js') }}');
+
         document.querySelectorAll('ul.nav.nav-tabs > li.domain-tab a').forEach(a => {
             a.addEventListener('click', function () {
                 document.getElementById('domain-action').value = this.getAttribute('rel');
@@ -155,11 +157,10 @@
             if (typeof multiply !== 'undefined') {
                 total *= multiply;
             }
-            return new Intl.NumberFormat(undefined, {
-                style: 'currency',
-                currency: code,
-                currencyDisplay: 'narrowSymbol',
-            }).format(total);
+            return FOSSBilling.currency.format(total, {
+                ...currencyFormat,
+                code: code,
+            });
         };
 
         const transferCheck = document.getElementById('transfer-check');

--- a/src/modules/Servicehosting/templates/client/mod_servicehosting_order_form.html.twig
+++ b/src/modules/Servicehosting/templates/client/mod_servicehosting_order_form.html.twig
@@ -176,6 +176,8 @@
     }
 
     document.addEventListener('DOMContentLoaded', function() {
+        const currencyFormat = JSON.parse('{{ currency|json_encode|e('js') }}');
+
         // Update domain action when switching tabs
         document.querySelectorAll('.nav-pills .nav-link[data-action]').forEach(tab => {
             tab.addEventListener('click', function() {
@@ -192,11 +194,10 @@
             if (typeof multiply !== 'undefined') {
                 total *= multiply;
             }
-            return new Intl.NumberFormat(undefined, {
-                style: 'currency',
-                currency: code,
-                currencyDisplay: 'narrowSymbol',
-            }).format(total);
+            return FOSSBilling.currency.format(total, {
+                ...currencyFormat,
+                code: code,
+            });
         };
 
         // Domain registration check

--- a/src/themes/admin_default/assets/js/ui/charts.ts
+++ b/src/themes/admin_default/assets/js/ui/charts.ts
@@ -62,6 +62,14 @@ function formatTooltipValue(value, options) {
 
   if (options.valueFormat === 'currency' && options.currency) {
     try {
+      if (globalThis.FOSSBilling?.currency?.format) {
+        return globalThis.FOSSBilling.currency.format(numericValue, {
+          code: options.currency,
+          format_pattern: options.currencyFormat?.format_pattern,
+          fraction_digits: options.currencyFormat?.fraction_digits,
+        });
+      }
+
       return new Intl.NumberFormat(undefined, {
         style: 'currency',
         currency: options.currency,

--- a/src/themes/admin_default/html/mod_index_dashboard.html.twig
+++ b/src/themes/admin_default/html/mod_index_dashboard.html.twig
@@ -493,6 +493,7 @@
                         height: 112,
                         valueFormat: 'currency',
                         currency: "{{ currency.code|default('USD') }}",
+                        currencyFormat: JSON.parse('{{ currency|json_encode|e('js') }}'),
                     }],
                     ['chart-orders', {{ admin.stats_get_orders({ 'date_from': request.date_from, 'date_to': request.date_to })|json_encode }}, {
                         label: "{{ 'Orders'|trans }}",

--- a/tests/Support/PermissiveStub.php
+++ b/tests/Support/PermissiveStub.php
@@ -59,6 +59,16 @@ final class PermissiveStub implements \ArrayAccess, \Countable, \IteratorAggrega
         return $this->data[$name] ?? new self();
     }
 
+    public function __invoke(mixed ...$arguments): self
+    {
+        return $this;
+    }
+
+    public function formatCurrency(mixed $amount, string $currency, array $attributes = [], ?string $locale = null): string
+    {
+        return '';
+    }
+
     public function __toString(): string
     {
         return '';

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -14,7 +14,9 @@ test('downloadable file migration follows the client balance gateway repair', fu
         ->and($patches)->toHaveKey(91)
         ->and($patches[91][1])->toBe('patch91')
         ->and($patches)->toHaveKey(92)
-        ->and($patches[92][1])->toBe('patch92');
+        ->and($patches[92][1])->toBe('patch92')
+        ->and($patches)->toHaveKey(93)
+        ->and($patches[93][1])->toBe('patch93');
 });
 
 test('fresh installs start at the latest patch level', function (): void {


### PR DESCRIPTION
## Summary

- add optional per-currency decimal-place and plain-text `{amount}` pattern overrides
- keep Twig IntlExtra as the default formatter when no override is configured
- apply the same formatting to Twig, the guest formatting API, dynamic order prices, and dashboard charts
- add an admin preview/reset UI and database patch 93

## Why

Some currencies need a commercial display that differs from their locale default. For example, Thai Baht may need to appear as `1,234 บาท` with no decimals.

This addresses that need without restoring the former manual separator and price-format system. Grouping, decimal separators, signs, and locale behavior remain owned by Intl; administrators can only choose the displayed decimal places and position localized text around `{amount}`.

Blank override fields preserve the existing locale-aware behavior. These settings affect presentation only and do not change calculations or gateway values.

Closes #3724.