### PR TITLE
Deduplicate order status/action constants between legacy model and Doctrine entity

### DIFF
--- a/src/library/Model/ClientOrder.php
+++ b/src/library/Model/ClientOrder.php
@@ -10,31 +10,24 @@ declare(strict_types=1);
  */
 class Model_ClientOrder extends RedBeanPHP\SimpleModel
 {
-    final public const string STATUS_PENDING_SETUP = 'pending_setup';
-    final public const string STATUS_FAILED_SETUP = 'failed_setup';
-    final public const string STATUS_FAILED_RENEW = 'failed_renew';
-    final public const string STATUS_ACTIVE = 'active';
-    final public const string STATUS_CANCELED = 'canceled';
-    final public const string STATUS_SUSPENDED = 'suspended';
+    final public const string STATUS_PENDING_SETUP = \Box\Mod\Order\Entity\Order::STATUS_PENDING_SETUP;
+    final public const string STATUS_FAILED_SETUP = \Box\Mod\Order\Entity\Order::STATUS_FAILED_SETUP;
+    final public const string STATUS_FAILED_RENEW = \Box\Mod\Order\Entity\Order::STATUS_FAILED_RENEW;
+    final public const string STATUS_ACTIVE = \Box\Mod\Order\Entity\Order::STATUS_ACTIVE;
+    final public const string STATUS_CANCELED = \Box\Mod\Order\Entity\Order::STATUS_CANCELED;
+    final public const string STATUS_SUSPENDED = \Box\Mod\Order\Entity\Order::STATUS_SUSPENDED;
 
-    final public const string ACTION_CREATE = 'create';
-    final public const string ACTION_ACTIVATE = 'activate';
-    final public const string ACTION_RENEW = 'renew';
-    final public const string ACTION_SUSPEND = 'suspend';
-    final public const string ACTION_UNSUSPEND = 'unsuspend';
-    final public const string ACTION_CANCEL = 'cancel';
-    final public const string ACTION_UNCANCEL = 'uncancel';
-    final public const string ACTION_DELETE = 'delete';
+    final public const string ACTION_CREATE = \Box\Mod\Order\Entity\Order::ACTION_CREATE;
+    final public const string ACTION_ACTIVATE = \Box\Mod\Order\Entity\Order::ACTION_ACTIVATE;
+    final public const string ACTION_RENEW = \Box\Mod\Order\Entity\Order::ACTION_RENEW;
+    final public const string ACTION_SUSPEND = \Box\Mod\Order\Entity\Order::ACTION_SUSPEND;
+    final public const string ACTION_UNSUSPEND = \Box\Mod\Order\Entity\Order::ACTION_UNSUSPEND;
+    final public const string ACTION_CANCEL = \Box\Mod\Order\Entity\Order::ACTION_CANCEL;
+    final public const string ACTION_UNCANCEL = \Box\Mod\Order\Entity\Order::ACTION_UNCANCEL;
+    final public const string ACTION_DELETE = \Box\Mod\Order\Entity\Order::ACTION_DELETE;
 
     public static function getValidStatuses(): array
     {
-        return [
-            self::STATUS_PENDING_SETUP,
-            self::STATUS_FAILED_SETUP,
-            self::STATUS_FAILED_RENEW,
-            self::STATUS_ACTIVE,
-            self::STATUS_CANCELED,
-            self::STATUS_SUSPENDED,
-        ];
+        return \Box\Mod\Order\Entity\Order::getValidStatuses();
     }
 }


### PR DESCRIPTION
## Summary
- `Model_ClientOrder` (legacy RedBean model) duplicated the `STATUS_*`/`ACTION_*` constants and `getValidStatuses()` logic already defined on `Box\Mod\Order\Entity\Order` (the already-migrated Doctrine entity).
- `Model_ClientOrder` now delegates to `Order`'s constants/method instead of redefining them, giving a single source of truth while remaining a drop-in replacement for the many still-unmigrated modules that reference `Model_ClientOrder::STATUS_*`/`ACTION_*` (Servicehosting, Servicedomain, Invoice, Servicecustom, etc.).