### PR TITLE
Fix crash on every page when currency table is missing PR #4053 columns

### DIFF
--- a/src/library/FOSSBilling/Twig/TwigFactory.php
+++ b/src/library/FOSSBilling/Twig/TwigFactory.php
@@ -446,8 +446,15 @@ class TwigFactory
             return null;
         }
 
-        $repository = $this->di['em']->getRepository(Currency::class);
-        $currency = $repository->findDefault();
+        try {
+            $repository = $this->di['em']->getRepository(Currency::class);
+            $currency = $repository->findDefault();
+        } catch (\Doctrine\DBAL\Exception) {
+            // The currency table may not have the latest columns yet if pending
+            // database patches have not been applied. Number formatting falls
+            // back to its default rather than breaking every page render.
+            return null;
+        }
 
         return $currency instanceof Currency ? $currency->getCode() : null;
     }

--- a/tests/Unit/FOSSBilling/Twig/TwigFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Twig/TwigFactoryTest.php
@@ -34,3 +34,22 @@ test('configureCsrf expires the legacy cookie with matching attributes', functio
         ->and($cookies[CookieNames::LEGACY_CSRF]->isHttpOnly())->toBeFalse()
         ->and($cookies[CookieNames::LEGACY_CSRF]->getSameSite())->toBe($cookies[CookieNames::CSRF]->getSameSite());
 });
+
+test('getDefaultCurrencyCode returns null instead of crashing when the currency table is missing patched columns', function (): void {
+    $di = Tests\Helpers\container();
+
+    $currencyRepository = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $currencyRepository->shouldReceive('findDefault')
+        ->once()
+        ->andThrow(new class('Column not found: 1054 Unknown column t0.format_pattern') extends RuntimeException implements Doctrine\DBAL\Exception {});
+
+    $di['em'] = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class)->shouldIgnoreMissing();
+    $di['em']->shouldReceive('getRepository')
+        ->with(Box\Mod\Currency\Entity\Currency::class)
+        ->andReturn($currencyRepository);
+
+    $factory = new TwigFactory($di);
+    $result = (new ReflectionMethod($factory, 'getDefaultCurrencyCode'))->invoke($factory);
+
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- PR #4053 added `format_pattern` and `fraction_digits` columns to the Doctrine `Currency` entity, applied by `UpdatePatcher::patch93()`.
- `TwigFactory::createBaseEnvironment()` (and the email/sandboxed-fragment environments) unconditionally query the default currency on **every** Twig environment build — admin, client, and email — to configure number formatting. This happens before routing/auth/permission checks even run.
- On installs where the DB patch hasn't run yet, that query now fails with `SQLSTATE[42S22]: Column not found: 1054 Unknown column 't0.format_pattern'`, crashing **every page**, including the admin login page — so the admin can never even reach System > Update to apply the pending patch.
- `TwigFactory::getDefaultCurrencyCode()` now catches `\Doctrine\DBAL\Exception` and falls back to `null` (default 2 fraction digits, no `default_currency` global) instead of throwing, mirroring the existing bootstrap-resilience pattern in `Session.php`.

Fixes the issue reported in https://github.com/FOSSBilling/FOSSBilling/issues/3724#issuecomment-5086962328.