### PR TITLE
Fix undefined addons variable in order detail view

### DIFF
--- a/src/modules/Order/templates/admin/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_manage.html.twig
@@ -23,9 +23,7 @@
 {% set active_menu = 'order' %}
 
 {% set service_partial = 'mod_service' ~ order.service_type ~ '_manage.html.twig' %}
-{% if order.group_master == 1 %}
-    {% set addons = admin.order_addons({ 'id': order.id }) %}
-{% endif %}
+{% set addons = order.group_master == 1 ? admin.order_addons({ 'id': order.id }) : [] %}
 {% if order.status == 'active' or order.status == 'failed_renew' %}
     {% set can_cancel_at_period_end = admin.order_can_cancel_at_period_end({ 'id': order.id }) %}
 {% endif %}


### PR DESCRIPTION
## Summary
- Fixes #4059: the admin order detail view (`mod_order_manage.html.twig`) only set the `addons` template variable when `order.group_master == 1`, but read it unconditionally further down (nav-tab visibility check and the `tab-addons` loop).
- Any order where `group_master != 1` — e.g. an addon order such as a standalone domain-registration order linked to a hosting order via `group_id`, which is exactly how FOSSBilling's own cart checkout creates them — hit a Twig `RuntimeError: Variable "addons" does not exist` and failed to render.
- `addons` is now always set, defaulting to an empty array for non-group-master orders, matching the fix the issue reporter said they've been running in production without issues.

Credit to @raudraido for bug report and suggested fix.