### PR TITLE
Fix admin new-order form crash for products not priced for all periods

### DIFF
--- a/src/modules/Order/templates/admin/mod_order_new.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_new.html.twig
@@ -59,8 +59,8 @@
                         <div class="col-xl-6">
                             <label class="form-label" for="period">{{ 'Period'|trans }}</label>
                             <select class="form-select" name="period" id="period" required>
-                                {% for val,label in guest.system_periods %}
-                                <option value="{{ val }}" label="{{ label|e }}" data-price="{{ product.pricing.recurrent[val].price }}" data-status="{{ product.pricing.recurrent[val].enabled }}" {% if request.period == val %}selected="selected"{% endif %}>{{ label|e }}</option>
+                                {% for val,pricing in product.pricing.recurrent %}
+                                <option value="{{ val }}" label="{{ guest.system_periods[val]|e }}" data-price="{{ pricing.price }}" data-status="{{ pricing.enabled }}" {% if request.period == val %}selected="selected"{% endif %}>{{ guest.system_periods[val]|e }}</option>
                                 {% endfor %}
                             </select>
                             <div id="period-info" class="form-hint mt-2"></div>

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -53,6 +53,38 @@ test('cron settings renders when module config has not been saved', function ():
         ->and($html)->not->toContain('Guest Cron URL');
 });
 
+test('order new only lists periods the product is actually priced for', function (): void {
+    $renderer = new StrictTemplateRenderer();
+
+    // Box_Period::getPredefined() includes 4Y/5Y, but product_payment has no
+    // columns for those periods, so a product's pricing.recurrent never
+    // contains them. Regression test for #4063: indexing pricing.recurrent
+    // by every system period used to throw under strict_variables.
+    $html = $renderer->renderTemplate(PATH_MODS . '/Order/templates/admin/mod_order_new.html.twig', [
+        'admin' => new PermissiveStub(['system_template_exists' => false]),
+        'client' => ['id' => 1, 'first_name' => 'Jane', 'last_name' => 'Doe'],
+        'product' => [
+            'id' => 1,
+            'title' => 'Annual Hosting',
+            'type' => 'hosting',
+            'pricing' => [
+                'type' => 'recurrent',
+                'recurrent' => [
+                    '1Y' => ['price' => 10, 'setup' => 0, 'enabled' => true],
+                ],
+            ],
+        ],
+        'guest' => [
+            'system_periods' => \Box_Period::getPredefined(),
+        ],
+    ]);
+
+    expect($html)
+        ->toContain('value="1Y"')
+        ->not->toContain('value="4Y"')
+        ->not->toContain('value="5Y"');
+});
+
 /*
  * Verify that every FOSSBilling template compiles and renders successfully under
  * `strict_variables => true`. This catches undefined variable/attribute/key access,


### PR DESCRIPTION
## Summary
- `Box_Period::getPredefined()` (`src/library/Box/Period.php`) lists all 9 billing periods (`1W`…`5Y`), but `ProductPayment` has no database columns for `4Y`/`5Y`, so a product's `pricing.recurrent` array never contains those keys.
- `mod_order_new.html.twig` looped over the full period list and indexed into `pricing.recurrent[val]` for each one, which throws under Twig's `strict_variables` (enabled by default) whenever a product isn't priced for every period, e.g. an annual-only hosting product.
- Fixed by iterating `product.pricing.recurrent` (whose keys are always valid) and looking up each period's label from `guest.system_periods[val]`, matching the pattern already used in the client-facing order templates (`mod_orderbutton_product_configuration.html.twig`).