### PR TITLE
Fix Session::destroy() hardcoding a zero-second regeneration grace period

### DIFF
--- a/src/library/FOSSBilling/Session.php
+++ b/src/library/FOSSBilling/Session.php
@@ -115,13 +115,13 @@ class Session implements InjectionAwareInterface
         switch ($type) {
             case 'admin':
                 $this->delete('admin');
-                $this->regenerateId(0);
+                $this->regenerateId();
 
                 return true;
             case 'client':
                 $this->delete('client');
                 $this->delete('client_id');
-                $this->regenerateId(0);
+                $this->regenerateId();
 
                 return true;
         }

--- a/tests/Unit/FOSSBilling/SessionTest.php
+++ b/tests/Unit/FOSSBilling/SessionTest.php
@@ -351,3 +351,38 @@ test('destroying an admin login preserves the client login', function (): void {
         ->and($_SESSION)->not->toHaveKey('admin')
         ->and($_SESSION)->toHaveKeys(['client', 'client_id']);
 });
+
+test('destroying a client login regenerates the session with the configured grace period, not zero', function (): void {
+    $handler = new class extends PdoSessionHandler {
+        public function __construct()
+        {
+        }
+    };
+
+    $session = Mockery::mock(FOSSBilling\Session::class, [$handler])->makePartial();
+    $session->shouldReceive('regenerateId')->withNoArgs()->once();
+
+    $_SESSION = [
+        'client' => ['id' => 2],
+        'client_id' => 2,
+    ];
+
+    $session->destroy('client');
+});
+
+test('destroying an admin login regenerates the session with the configured grace period, not zero', function (): void {
+    $handler = new class extends PdoSessionHandler {
+        public function __construct()
+        {
+        }
+    };
+
+    $session = Mockery::mock(FOSSBilling\Session::class, [$handler])->makePartial();
+    $session->shouldReceive('regenerateId')->withNoArgs()->once();
+
+    $_SESSION = [
+        'admin' => ['id' => 1],
+    ];
+
+    $session->destroy('admin');
+});


### PR DESCRIPTION
## Summary
- `Session::destroy()` called `regenerateId(0)` in both the `admin` and `client` branches, overriding the configured `security.session_regeneration_grace_period` (default 300s) and marking the just-replaced session ID as obsolete-expired the instant the new one is issued.
- This is observable in admin-impersonation flows: a follow-up request that races in on the outgoing session ID gets treated as obsolete by `handleObsoleteSession()`, which then wipes `admin`/`client`/`client_id` from the session that should still be valid.
- `regenerateId()` already falls back to the configured grace period when called with no argument, so the fix is simply to stop passing `0`.

Fixes #4060.