### PR TITLE
Add manual currency rate overrides

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','93',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','94',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -429,6 +429,7 @@ CREATE TABLE `currency` (
   `code` varchar(3) DEFAULT NULL,
   `is_default` tinyint(1) DEFAULT '0',
   `conversion_rate` decimal(13,6) DEFAULT '1.000000',
+  `is_rate_manual` tinyint(1) DEFAULT '0',
   `format_pattern` varchar(100) DEFAULT NULL,
   `fraction_digits` smallint DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -503,6 +503,7 @@ class UpdatePatcher implements InjectionAwareInterface
             91 => 'patch91',
             92 => 'patch92',
             93 => 'patch93',
+            94 => 'patch94',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2569,6 +2570,13 @@ class UpdatePatcher implements InjectionAwareInterface
 
         if (!$this->tableHasColumn('currency', 'fraction_digits')) {
             $this->executeSql('ALTER TABLE `currency` ADD COLUMN `fraction_digits` smallint DEFAULT NULL AFTER `format_pattern`');
+        }
+    }
+
+    private function patch94(): void
+    {
+        if (!$this->tableHasColumn('currency', 'is_rate_manual')) {
+            $this->executeSql("ALTER TABLE `currency` ADD COLUMN `is_rate_manual` tinyint(1) DEFAULT '0' AFTER `conversion_rate`");
         }
     }
 

--- a/src/modules/Currency/Api/Admin.php
+++ b/src/modules/Currency/Api/Admin.php
@@ -13,6 +13,7 @@ namespace Box\Mod\Currency\Api;
 
 use Box\Mod\Currency\Entity\Currency;
 use FOSSBilling\PaginationOptions;
+use FOSSBilling\Tools;
 use FOSSBilling\Validation\Api\RequiredParams;
 use Symfony\Component\Intl\Currencies;
 
@@ -126,14 +127,16 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         }
 
         $conversionRate = $data['conversion_rate'] ?? null;
+        $isRateManual = Tools::normalizeBoolean($data['is_rate_manual'] ?? false);
 
-        return $service->createCurrency($data['code'] ?? null, $conversionRate);
+        return $service->createCurrency($data['code'] ?? null, $conversionRate, $isRateManual);
     }
 
     /**
      * Updates system currency settings.
      *
      * @optional float $conversion_rate - new currency conversion rate
+     * @optional bool $is_rate_manual - preserve the conversion rate during automatic and manual bulk synchronization
      * @optional string $format_pattern - plain-text display pattern containing one {amount} placeholder
      * @optional int $fraction_digits - fraction digit override from 0 to 6, blank to use the ISO default
      *
@@ -145,6 +148,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $this->checkPermissions('currency', 'edit');
 
         $conversionRate = $data['conversion_rate'] ?? null;
+        $isRateManual = array_key_exists('is_rate_manual', $data)
+            ? Tools::normalizeBoolean($data['is_rate_manual'])
+            : null;
         $formatting = array_intersect_key($data, [
             'format_pattern' => true,
             'fraction_digits' => true,
@@ -154,6 +160,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
             $data['code'],
             $conversionRate,
             $formatting,
+            $isRateManual,
         );
     }
 

--- a/src/modules/Currency/Entity/Currency.php
+++ b/src/modules/Currency/Entity/Currency.php
@@ -38,6 +38,9 @@ class Currency implements ApiArrayInterface, TimestampInterface
 
     private ?float $conversionRateFloat = null;
 
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::BOOLEAN, options: ['default' => false])]
+    private bool $isRateManual = false;
+
     #[ORM\Column(type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: true)]
     private ?string $formatPattern = null;
 
@@ -57,6 +60,7 @@ class Currency implements ApiArrayInterface, TimestampInterface
             'name' => Currencies::getName($this->getCode()),
             'symbol' => Currencies::getSymbol($this->getCode()),
             'conversion_rate' => $this->getConversionRate(),
+            'is_rate_manual' => $this->isRateManual(),
             'format_pattern' => $this->getFormatPattern(),
             'fraction_digits' => $this->getFractionDigits(),
             'default' => $this->isDefault(),
@@ -90,6 +94,11 @@ class Currency implements ApiArrayInterface, TimestampInterface
     public function getConversionRateRaw(): string
     {
         return $this->conversionRate;
+    }
+
+    public function isRateManual(): bool
+    {
+        return $this->isRateManual;
     }
 
     public function getFormatPattern(): ?string
@@ -138,6 +147,13 @@ class Currency implements ApiArrayInterface, TimestampInterface
         }
         // Invalidate cached float value so it will be recalculated on next access
         $this->conversionRateFloat = null;
+
+        return $this;
+    }
+
+    public function setIsRateManual(bool $isRateManual): self
+    {
+        $this->isRateManual = $isRateManual;
 
         return $this;
     }

--- a/src/modules/Currency/Service.php
+++ b/src/modules/Currency/Service.php
@@ -213,7 +213,9 @@ class Service implements InjectionAwareInterface
             throw new \FOSSBilling\Exception("Currency with code {$currencyCode} not found after clearing identity map.");
         }
 
-        $currency->setIsDefault(true);
+        $currency
+            ->setIsDefault(true)
+            ->setIsRateManual(false);
         $em->persist($currency);
         $em->flush();
 
@@ -238,13 +240,21 @@ class Service implements InjectionAwareInterface
      *
      * @param string            $currencyCode   The ISO currency code (e.g., 'USD')
      * @param string|float|null $conversionRate The conversion rate to the default currency (optional)
+     * @param bool              $isRateManual   Whether bulk rate synchronization should preserve this rate
      *
      * @return string The code of the newly created currency
      *
      * @throws \FOSSBilling\Exception If currency code is invalid or if fetching the conversion rate fails
      */
-    public function createCurrency(string $currencyCode, string|float|null $conversionRate = 1.0): string
-    {
+    public function createCurrency(
+        string $currencyCode,
+        string|float|null $conversionRate = 1.0,
+        bool $isRateManual = false,
+    ): string {
+        if ($isRateManual && ($conversionRate === null || $conversionRate === '')) {
+            throw new InformationException('A conversion rate is required when manual override is enabled.');
+        }
+
         if ($conversionRate === null || $conversionRate === '') {
             try {
                 $conversionRate = $this->getRate(null, $currencyCode);
@@ -266,7 +276,9 @@ class Service implements InjectionAwareInterface
         }
 
         $currency = new Currency($currencyCode);
-        $currency->setConversionRate($conversionRate);
+        $currency
+            ->setConversionRate($conversionRate)
+            ->setIsRateManual($isRateManual);
 
         $em = $this->di['em'];
         $em->persist($currency);
@@ -319,6 +331,7 @@ class Service implements InjectionAwareInterface
      *     format_pattern?: mixed,
      *     fraction_digits?: mixed
      * } $formatting Formatting values to update; omitted keys are left unchanged
+     * @param bool|null $isRateManual Whether bulk rate synchronization should preserve this rate; null leaves it unchanged
      *
      * @throws \FOSSBilling\Exception If currency not found
      * @throws InformationException   If a provided value is invalid
@@ -327,6 +340,7 @@ class Service implements InjectionAwareInterface
         string $currencyCode,
         string|float|null $conversionRate = null,
         array $formatting = [],
+        ?bool $isRateManual = null,
     ): bool {
         $model = $this->currencyRepository->findOneByCode($currencyCode);
         if (!$model instanceof Currency) {
@@ -337,6 +351,10 @@ class Service implements InjectionAwareInterface
         $updateFractionDigits = array_key_exists('fraction_digits', $formatting);
         $formatPattern = $updateFormatPattern ? $this->normalizeFormatPattern($formatting['format_pattern']) : null;
         $fractionDigits = $updateFractionDigits ? $this->normalizeFractionDigits($formatting['fraction_digits']) : null;
+
+        if ($isRateManual === true && $model->isDefault()) {
+            throw new InformationException('The default currency cannot use a manual rate override.');
+        }
 
         if ($conversionRate !== null) {
             if (!is_numeric($conversionRate) || $conversionRate <= 0) {
@@ -351,6 +369,10 @@ class Service implements InjectionAwareInterface
 
         if ($updateFractionDigits) {
             $model->setFractionDigits($fractionDigits);
+        }
+
+        if ($isRateManual !== null) {
+            $model->setIsRateManual($isRateManual);
         }
 
         $em = $this->di['em'];
@@ -507,6 +529,8 @@ class Service implements InjectionAwareInterface
         foreach ($all as $currency) {
             if ($currency->isDefault()) {
                 $rate = 1.0;
+            } elseif ($currency->isRateManual()) {
+                continue;
             } else {
                 $rate = $this->getRate($defaultCurrency->getCode(), $currency->getCode());
             }

--- a/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
+++ b/src/modules/Currency/templates/admin/mod_currency_manage.html.twig
@@ -38,7 +38,18 @@
                 <div class="col-lg-6">
                     <label class="form-label">{{ 'Conversion Rate'|trans }}</label>
                     <input class="form-control" type="text" name="conversion_rate" value="{{ currency.conversion_rate }}" required>
+                    <div class="form-hint">{{ 'The value of one unit of the default currency in this currency.'|trans }}</div>
                 </div>
+                {% if not currency.default %}
+                <div class="col-lg-6 d-flex align-items-end">
+                    <div class="form-check mb-2">
+                        <input type="hidden" name="is_rate_manual" value="0">
+                        <input class="form-check-input" id="is-rate-manual" type="checkbox" name="is_rate_manual" value="1"{% if currency.is_rate_manual|default(false) %} checked{% endif %}>
+                        <label class="form-check-label" for="is-rate-manual">{{ 'Manual rate override'|trans }}</label>
+                        <div class="form-hint">{{ 'Preserve this rate when scheduled or on-demand rate synchronization runs.'|trans }}</div>
+                    </div>
+                </div>
+                {% endif %}
                 <div class="col-12">
                     {% set has_formatting_overrides = currency.format_pattern|default('') is not empty or currency.fraction_digits|default(null) is not null %}
                     <div class="accordion" id="currency-formatting-accordion">

--- a/src/modules/Currency/templates/admin/mod_currency_settings.html.twig
+++ b/src/modules/Currency/templates/admin/mod_currency_settings.html.twig
@@ -95,6 +95,7 @@
                                     <th>{{ 'Currency Code'|trans }}</th>
                                     <th>{{ 'Currency'|trans }}</th>
                                     <th>{{ 'Conversion Rate'|trans }}</th>
+                                    <th>{{ 'Rate Updates'|trans }}</th>
                                     <th>{{ 'Example Price'|trans }}</th>
                                     <th class="w-1">{{ 'Actions'|trans }}</th>
                                 </tr>
@@ -108,6 +109,15 @@
                                         <a href='{{ "currency/manage/#{currency.code}"|url }}'>{{ currency.code|currency_name }}</a>
                                     </td>
                                     <td>{{ currency.conversion_rate }}</td>
+                                    <td>
+                                        {% if currency.default %}
+                                            <span class="badge bg-secondary-lt">{{ 'Fixed'|trans }}</span>
+                                        {% elseif currency.is_rate_manual|default(false) %}
+                                            <span class="badge bg-blue-lt">{{ 'Manual'|trans }}</span>
+                                        {% else %}
+                                            <span class="badge bg-green-lt">{{ 'Automatic'|trans }}</span>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ 1|format_currency(default_currency.code) }} = {{ (1 * currency.conversion_rate)|format_currency(currency.code) }}</td>
                                     <td>
                                         {% if can_edit_currency %}
@@ -140,7 +150,7 @@
                                 </tr>
                             {% else %}
                                 <tr>
-                                    <td colspan="5" class="text-center text-muted py-3">{{ 'The list is empty'|trans }}</td>
+                                    <td colspan="6" class="text-center text-muted py-3">{{ 'The list is empty'|trans }}</td>
                                 </tr>
                             {% endfor %}
                             </tbody>
@@ -288,6 +298,13 @@
                         <div>
                             <label class="form-label" for="new-currency-rate">{{ 'Conversion Rate'|trans }}</label>
                             <input class="form-control" id="new-currency-rate" type="text" name="conversion_rate" value="" placeholder="{{ 'Leave blank to automatically set'|trans }}">
+                            <div class="form-hint">{{ 'Enter the value of one unit of the default currency in this currency.'|trans }}</div>
+                        </div>
+                        <div class="form-check mt-3">
+                            <input type="hidden" name="is_rate_manual" value="0">
+                            <input class="form-check-input" id="new-currency-manual-rate" type="checkbox" name="is_rate_manual" value="1">
+                            <label class="form-check-label" for="new-currency-manual-rate">{{ 'Keep this as a manual override'|trans }}</label>
+                            <div class="form-hint">{{ 'Manual rates are preserved when scheduled or on-demand rate synchronization runs.'|trans }}</div>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/src/modules/Currency/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Currency/tests/Unit/Api/AdminTest.php
@@ -356,6 +356,8 @@ test('create', function (): void {
 
     $data = [
         'code' => 'EUR',
+        'conversion_rate' => '0.92',
+        'is_rate_manual' => '1',
         'format' => '€{{price}}',
     ];
 
@@ -372,7 +374,8 @@ test('create', function (): void {
     ->andReturn($repositoryMock);
     $service
     ->shouldReceive('createCurrency')
-    ->atLeast()->once()
+    ->once()
+    ->with('EUR', '0.92', true)
     ->andReturn($data['code']);
 
     $di = container();
@@ -392,6 +395,7 @@ test('update', function (): void {
     $data = [
         'code' => 'EUR',
         'conversion_rate' => 0.6,
+        'is_rate_manual' => '1',
         'format_pattern' => '{amount} EUR',
         'fraction_digits' => '0',
     ];
@@ -403,7 +407,7 @@ test('update', function (): void {
     ->with('EUR', 0.6, [
         'format_pattern' => '{amount} EUR',
         'fraction_digits' => '0',
-    ])
+    ], true)
     ->andReturn(true);
 
     $di = container();
@@ -420,7 +424,7 @@ test('update forwards individual formatting fields without clearing the other se
     $adminApi = apiEndpoint(new Box\Mod\Currency\Api\Admin());
     $service = Mockery::mock(Box\Mod\Currency\Service::class);
     $service->expects('updateCurrency')
-        ->with('EUR', null, ['format_pattern' => '{amount} EUR'])
+        ->with('EUR', null, ['format_pattern' => '{amount} EUR'], null)
         ->andReturnTrue();
 
     $adminApi->setDi(container());

--- a/src/modules/Currency/tests/Unit/ServiceTest.php
+++ b/src/modules/Currency/tests/Unit/ServiceTest.php
@@ -241,8 +241,13 @@ test('setAsDefault sets currency as default', function (string $modelType, strin
     // setIsDefault is only called when currency is not already default
     if ($modelType === 'default_currency') {
         $refetchedModel->shouldReceive('setIsDefault')
-            ->atLeast()->once()
-            ->with(true);
+            ->once()
+            ->with(true)
+            ->andReturnSelf();
+        $refetchedModel->shouldReceive('setIsRateManual')
+            ->once()
+            ->with(false)
+            ->andReturnSelf();
     }
 
     $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class)->shouldIgnoreMissing();
@@ -452,6 +457,19 @@ test('toApiArray returns API array for currency', function (): void {
     expect($result)->toBe($expected);
 });
 
+test('currency API data exposes whether its rate is a manual override', function (): void {
+    $currency = (new Box\Mod\Currency\Entity\Currency('LAK'))
+        ->setConversionRate(21_650.0)
+        ->setIsRateManual(true);
+
+    expect($currency->toApiArray())
+        ->toMatchArray([
+            'code' => 'LAK',
+            'conversion_rate' => 21_650.0,
+            'is_rate_manual' => true,
+        ]);
+});
+
 test('createCurrency creates new currency', function (): void {
     $code = 'EUR';
     $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class)->shouldIgnoreMissing();
@@ -479,6 +497,21 @@ test('createCurrency creates new currency', function (): void {
     expect($result)->toBe($code);
 });
 
+test('createCurrency requires an explicit rate for a manual override', function (): void {
+    $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class)->shouldIgnoreMissing();
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $emMock->shouldReceive('getRepository')->andReturn($repositoryMock);
+
+    $di = container();
+    $di['em'] = $emMock;
+
+    $service = new Box\Mod\Currency\Service();
+    $service->setDi($di);
+
+    expect(fn (): string => $service->createCurrency('LAK', null, true))
+        ->toThrow(FOSSBilling\InformationException::class, 'A conversion rate is required when manual override is enabled.');
+});
+
 test('updateCurrency updates currency', function (): void {
     $code = 'EUR';
     $conversion_rate = 0.6;
@@ -490,6 +523,12 @@ test('updateCurrency updates currency', function (): void {
     $model->shouldReceive('setConversionRate')
         ->atLeast()->once()
         ->with(0.6);
+    $model->shouldReceive('setIsRateManual')
+        ->once()
+        ->with(true);
+    $model->shouldReceive('isDefault')
+        ->once()
+        ->andReturn(false);
 
     $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class)->shouldIgnoreMissing();
     $repositoryMock->shouldReceive('findOneByCode')
@@ -512,10 +551,34 @@ test('updateCurrency updates currency', function (): void {
     $service = new Box\Mod\Currency\Service();
     $service->setDi($di);
 
-    $result = $service->updateCurrency($code, $conversion_rate);
+    $result = $service->updateCurrency($code, $conversion_rate, [], true);
 
     expect($result)->toBeBool();
     expect($result)->toBeTrue();
+});
+
+test('updateCurrency rejects manual overrides for the default currency', function (): void {
+    $model = Mockery::mock(Box\Mod\Currency\Entity\Currency::class);
+    $model->shouldReceive('isDefault')->once()->andReturn(true);
+    $model->shouldNotReceive('setConversionRate');
+    $model->shouldNotReceive('setIsRateManual');
+
+    $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $repositoryMock->shouldReceive('findOneByCode')->once()->with('USD')->andReturn($model);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $emMock->shouldReceive('getRepository')->andReturn($repositoryMock);
+    $emMock->shouldNotReceive('persist');
+    $emMock->shouldNotReceive('flush');
+
+    $di = container();
+    $di['em'] = $emMock;
+
+    $service = new Box\Mod\Currency\Service();
+    $service->setDi($di);
+
+    expect(fn (): bool => $service->updateCurrency('USD', 2.0, [], true))
+        ->toThrow(FOSSBilling\InformationException::class, 'The default currency cannot use a manual rate override.');
 });
 
 test('updateCurrency throws exception when currency not found', function (): void {
@@ -578,6 +641,9 @@ test('updateCurrencyRates updates rates for all currencies', function (): void {
     $defaultModel->shouldReceive('isDefault')
         ->byDefault()
         ->andReturn(true);
+    $defaultModel->shouldReceive('isRateManual')
+        ->byDefault()
+        ->andReturn(false);
     $defaultModel->shouldReceive('setConversionRate')
         ->byDefault();
 
@@ -586,6 +652,9 @@ test('updateCurrencyRates updates rates for all currencies', function (): void {
         ->byDefault()
         ->andReturn('USD');
     $otherModel->shouldReceive('isDefault')
+        ->byDefault()
+        ->andReturn(false);
+    $otherModel->shouldReceive('isRateManual')
         ->byDefault()
         ->andReturn(false);
     $otherModel->shouldReceive('setConversionRate')
@@ -632,6 +701,9 @@ test('updateCurrencyRates handles non-numeric rates', function (): void {
     $model->shouldReceive('isDefault')
         ->byDefault()
         ->andReturn(false);
+    $model->shouldReceive('isRateManual')
+        ->byDefault()
+        ->andReturn(false);
     $model->shouldReceive('setConversionRate')
         ->byDefault();
 
@@ -666,6 +738,38 @@ test('updateCurrencyRates handles non-numeric rates', function (): void {
 
     expect($result)->toBeBool();
     expect($result)->toBeTrue();
+});
+
+test('updateCurrencyRates preserves manual overrides', function (): void {
+    $defaultModel = Mockery::mock(Box\Mod\Currency\Entity\Currency::class);
+    $defaultModel->shouldReceive('getCode')->andReturn('USD');
+    $defaultModel->shouldReceive('isDefault')->andReturn(true);
+    $defaultModel->shouldReceive('setConversionRate')->once()->with(1.0);
+
+    $manualModel = Mockery::mock(Box\Mod\Currency\Entity\Currency::class);
+    $manualModel->shouldReceive('isDefault')->andReturn(false);
+    $manualModel->shouldReceive('isRateManual')->once()->andReturn(true);
+    $manualModel->shouldNotReceive('setConversionRate');
+
+    $repositoryMock = Mockery::mock(Box\Mod\Currency\Repository\CurrencyRepository::class);
+    $repositoryMock->shouldReceive('findDefault')->once()->andReturn($defaultModel);
+    $repositoryMock->shouldReceive('findAll')->once()->andReturn([$defaultModel, $manualModel]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManager::class);
+    $emMock->shouldReceive('getRepository')->andReturn($repositoryMock);
+    $emMock->shouldReceive('flush')->once();
+
+    $service = Mockery::mock(Box\Mod\Currency\Service::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $service->shouldNotReceive('getRate');
+
+    $di = container();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['em'] = $emMock;
+    $service->setDi($di);
+
+    expect($service->updateCurrencyRates())->toBeTrue();
 });
 
 test('removeCurrency deletes currency by code', function (): void {

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -19,6 +19,14 @@ test('downloadable file migration follows the client balance gateway repair', fu
         ->and($patches[93][1])->toBe('patch93');
 });
 
+test('manual currency rate patch follows the currency formatting patch', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 93);
+
+    expect($patches)->toHaveCount(1)
+        ->toHaveKey(94)
+        ->and($patches[94][1])->toBe('patch94');
+});
+
 test('fresh installs start at the latest patch level', function (): void {
     $content = file_get_contents(Path::join(PATH_ROOT, 'install', 'sql', 'content.sql'));
     expect($content)->toBeString();


### PR DESCRIPTION
## Summary

- add a persistent per-currency manual rate override
- preserve manual rates during scheduled and on-demand synchronization
- expose the setting in the admin UI and API, with clear Fixed/Manual/Automatic status
- prevent the default currency from retaining or enabling a manual override
- add fresh-install schema support and upgrade patch 94

Addresses the manual-override use case described in #3517.