### PR TITLE
Prevent duplicate credits per invoice item

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','95',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','96',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -293,11 +293,13 @@ CREATE TABLE `client_balance` (
   `client_id` bigint(20) DEFAULT NULL,
   `type` varchar(100) DEFAULT NULL,
   `rel_id` varchar(20) DEFAULT NULL,
+  `invoice_item_id` bigint(20) DEFAULT NULL,
   `amount` decimal(18,2) DEFAULT '0.00',
   `description` text,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_invoice_item_credit` (`invoice_item_id`),
   KEY `client_id_idx` (`client_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -505,6 +505,7 @@ class UpdatePatcher implements InjectionAwareInterface
             93 => 'patch93',
             94 => 'patch94',
             95 => 'patch95',
+            96 => 'patch96',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2593,6 +2594,20 @@ class UpdatePatcher implements InjectionAwareInterface
 
         if (!$this->tableHasIndex('client_order', 'client_order_status_expires_at_idx')) {
             $this->executeSql('ALTER TABLE `client_order` ADD INDEX `client_order_status_expires_at_idx` (`status`, `expires_at`)');
+        }
+    }
+
+    private function patch96(): void
+    {
+        // Unique constraint on client_balance.invoice_item_id prevents duplicate credits
+        // for the same invoice item. MySQL treats multiple NULLs as distinct, so other
+        // rows (transaction debits, default deductions) are unaffected.
+        if (!$this->tableHasColumn('client_balance', 'invoice_item_id')) {
+            $this->executeSql('ALTER TABLE `client_balance` ADD COLUMN `invoice_item_id` BIGINT DEFAULT NULL AFTER `rel_id`');
+        }
+
+        if (!$this->tableHasIndex('client_balance', 'uniq_invoice_item_credit')) {
+            $this->executeSql('ALTER TABLE `client_balance` ADD UNIQUE INDEX `uniq_invoice_item_credit` (`invoice_item_id`)');
         }
     }
 

--- a/src/modules/Client/Entity/ClientBalance.php
+++ b/src/modules/Client/Entity/ClientBalance.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: \Box\Mod\Client\Repository\ClientBalanceRepository::class)]
 #[ORM\Table(name: 'client_balance')]
 #[ORM\Index(name: 'client_id_idx', columns: ['client_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_invoice_item_credit', columns: ['invoice_item_id'])]
 #[ORM\HasLifecycleCallbacks]
 class ClientBalance
 {
@@ -34,6 +35,9 @@ class ClientBalance
 
     #[ORM\Column(name: 'rel_id', type: Types::STRING, length: 20, nullable: true)]
     private ?string $relId = null;
+
+    #[ORM\Column(name: 'invoice_item_id', type: Types::BIGINT, nullable: true)]
+    private ?int $invoiceItemId = null;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 18, scale: 2, nullable: true, options: ['default' => '0.00'])]
     private ?string $amount = '0.00';
@@ -84,6 +88,18 @@ class ClientBalance
     public function setRelId(?string $relId): self
     {
         $this->relId = $relId;
+
+        return $this;
+    }
+
+    public function getInvoiceItemId(): ?int
+    {
+        return $this->invoiceItemId;
+    }
+
+    public function setInvoiceItemId(?int $invoiceItemId): self
+    {
+        $this->invoiceItemId = $invoiceItemId;
 
         return $this;
     }

--- a/src/modules/Client/tests/Unit/Entity/ClientBalanceTest.php
+++ b/src/modules/Client/tests/Unit/Entity/ClientBalanceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Box\Mod\Client\Entity\ClientBalance;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Component\Filesystem\Path;
+
+beforeEach(function (): void {
+    $config = ORMSetup::createAttributeMetadataConfig([Path::join(__DIR__, '..', '..', '..', 'Entity')], true);
+    $config->setProxyDir(sys_get_temp_dir());
+    $config->setProxyNamespace('FOSSBilling\\Tests\\DoctrineProxies');
+    $this->entityManager = new EntityManager(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]), $config);
+    $metadata = $this->entityManager->getClassMetadata(ClientBalance::class);
+    (new SchemaTool($this->entityManager))->createSchema([$metadata]);
+});
+
+test('rejects duplicate invoice_item_id credits', function (): void {
+    $first = (new ClientBalance())->setClientId(1)->setType('invoice')->setInvoiceItemId(42)->setAmount('-10.00');
+    $this->entityManager->persist($first);
+    $this->entityManager->flush();
+
+    $duplicate = (new ClientBalance())->setClientId(1)->setType('invoice')->setInvoiceItemId(42)->setAmount('-10.00');
+    $this->entityManager->persist($duplicate);
+    $this->entityManager->flush();
+})->throws(UniqueConstraintViolationException::class);
+
+test('allows multiple rows with NULL invoice_item_id', function (): void {
+    $first = (new ClientBalance())->setClientId(1)->setType('default')->setAmount('-5.00');
+    $second = (new ClientBalance())->setClientId(1)->setType('transaction')->setAmount('15.00');
+    $this->entityManager->persist($first);
+    $this->entityManager->persist($second);
+    $this->entityManager->flush();
+
+    expect($this->entityManager->getRepository(ClientBalance::class)->count([]))->toBe(2);
+});
+
+test('allows distinct invoice_item_id values', function (): void {
+    $first = (new ClientBalance())->setClientId(1)->setType('invoice')->setInvoiceItemId(10)->setAmount('-10.00');
+    $second = (new ClientBalance())->setClientId(1)->setType('invoice')->setInvoiceItemId(20)->setAmount('-20.00');
+    $this->entityManager->persist($first);
+    $this->entityManager->persist($second);
+    $this->entityManager->flush();
+
+    expect($this->entityManager->getRepository(ClientBalance::class)->count([]))->toBe(2);
+});

--- a/src/modules/Client/tests/Unit/Entity/ClientTest.php
+++ b/src/modules/Client/tests/Unit/Entity/ClientTest.php
@@ -39,7 +39,7 @@ test('maps client tables without changing their columns', function (): void {
         ->and($client->getFieldMapping('gender')['columnDefinition'])->toContain('ENUM')
         ->and($balance->getTableName())->toBe('client_balance')
         ->and($balance->getColumnNames())->toBe([
-            'id', 'client_id', 'type', 'rel_id', 'amount', 'description', 'created_at', 'updated_at',
+            'id', 'client_id', 'type', 'rel_id', 'invoice_item_id', 'amount', 'description', 'created_at', 'updated_at',
         ])
         ->and($balance->getFieldMapping('amount')['nullable'])->toBeTrue()
         ->and($group->getTableName())->toBe('client_group')

--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -14,6 +14,8 @@ namespace Box\Mod\Invoice;
 use Box\Mod\Client\Entity\ClientBalance;
 use Box\Mod\Invoice\Entity\InvoiceItem;
 use Box\Mod\Invoice\Repository\InvoiceItemRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use FOSSBilling\Doctrine\EntityManagerFactory;
 use FOSSBilling\InjectionAwareInterface;
 use FOSSBilling\Validation\PriceValidator;
 
@@ -254,8 +256,25 @@ class ServiceInvoiceItem implements InjectionAwareInterface
         $invoice = $this->di['db']->getExistingModelById('Invoice', $item->getInvoiceId(), 'Invoice not found');
         $total = $this->getTotalWithTax($item);
         $this->persistCredit($item, $invoice, $total);
-        $this->di['em']->flush();
+
+        // Idempotency: the unique constraint on invoice_item_id guarantees at most one
+        // credit per item. A violation means a retry already credited it — treat as no-op.
+        try {
+            $this->di['em']->flush();
+        } catch (UniqueConstraintViolationException $e) {
+            $this->di['logger']->setChannel('billing')->info(sprintf('Invoice item #%d was already credited; skipping duplicate credit.', (int) $item->getId()));
+            $this->resetEntityManager();
+
+            return;
+        }
+
         $this->addChargeNote($item, $invoice, $total);
+    }
+
+    protected function resetEntityManager(): void
+    {
+        unset($this->di['em']);
+        $this->di['em'] = EntityManagerFactory::create();
     }
 
     private function persistCredit(InvoiceItem $item, \Model_Invoice $invoice, float $total): ClientBalance
@@ -266,6 +285,7 @@ class ServiceInvoiceItem implements InjectionAwareInterface
         $credit->setClientId((int) $client->id);
         $credit->setType('invoice');
         $credit->setRelId((string) $invoice->id);
+        $credit->setInvoiceItemId($item->getId());
         $credit->setDescription($item->getTitle());
         $credit->setAmount((string) (-$total));
         $this->di['em']->persist($credit);

--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -47,12 +47,25 @@ class ServiceInvoiceItem implements InjectionAwareInterface
             $invoice = $this->di['db']->getExistingModelById('Invoice', $item->getInvoiceId(), 'Invoice not found');
             $total = $this->getTotalWithTax($item);
             $em = $this->di['em'];
-            $em->wrapInTransaction(function () use ($item, $invoice, $total, $em): void {
-                $this->persistCredit($item, $invoice, $total);
+
+            try {
+                $em->wrapInTransaction(function () use ($item, $invoice, $total, $em): void {
+                    $this->persistCredit($item, $invoice, $total);
+                    $item->setCharged(true);
+                    $item->setStatus(InvoiceItem::STATUS_PENDING_SETUP);
+                    $em->persist($item);
+                });
+            } catch (UniqueConstraintViolationException $e) {
+                // Idempotency: the unique constraint on invoice_item_id means a prior
+                // attempt already credited this item. Mark it as charged without re-crediting.
+                $this->di['logger']->setChannel('billing')->info(sprintf('Invoice item #%d was already credited; skipping duplicate credit.', (int) $item->getId()));
+                $this->resetEntityManager();
+                $item = $this->di['em']->find(InvoiceItem::class, $item->getId());
                 $item->setCharged(true);
                 $item->setStatus(InvoiceItem::STATUS_PENDING_SETUP);
-                $em->persist($item);
-            });
+                $this->di['em']->persist($item);
+                $this->di['em']->flush();
+            }
 
             $this->addChargeNote($item, $invoice, $total);
         } else {

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -33,6 +33,13 @@ test('suspension grace patch follows the manual currency rate patch', function (
         ->and($patches[95][1])->toBe('patch95');
 });
 
+test('client balance unique credit patch follows the suspension grace patch', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 95);
+
+    expect($patches)->toHaveKey(96)
+        ->and($patches[96][1])->toBe('patch96');
+});
+
 test('fresh installs start at the latest patch level', function (): void {
     $content = file_get_contents(Path::join(PATH_ROOT, 'install', 'sql', 'content.sql'));
     expect($content)->toBeString();
@@ -47,6 +54,47 @@ test('fresh installs index order suspension candidates', function (): void {
     $structure = $filesystem->readFile(Path::join(PATH_ROOT, 'install', 'sql', 'structure.sql'));
 
     expect($structure)->toContain('KEY `client_order_status_expires_at_idx` (`status`, `expires_at`)');
+});
+
+test('fresh installs constrain client balance to one credit per invoice item', function (): void {
+    $filesystem = new Filesystem();
+    $structure = $filesystem->readFile(Path::join(PATH_ROOT, 'install', 'sql', 'structure.sql'));
+
+    expect($structure)->toContain('`invoice_item_id` bigint(20) DEFAULT NULL')
+        ->and($structure)->toContain('UNIQUE KEY `uniq_invoice_item_credit` (`invoice_item_id`)');
+});
+
+test('client balance unique credit patch adds column and index for existing installs', function (): void {
+    $balanceColumns = Mockery::mock(PDOStatement::class);
+    $balanceColumns->expects('execute')->with([])->andReturnTrue();
+    $balanceColumns->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([]);
+
+    $balanceIndexes = Mockery::mock(PDOStatement::class);
+    $balanceIndexes->expects('execute')->with([])->andReturnTrue();
+    $balanceIndexes->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([]);
+
+    $addColumn = Mockery::mock(PDOStatement::class);
+    $addColumn->expects('execute')->with([])->andReturnTrue();
+
+    $addIndex = Mockery::mock(PDOStatement::class);
+    $addIndex->expects('execute')->with([])->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')->with('SHOW COLUMNS FROM `client_balance`')->andReturn($balanceColumns);
+    $pdo->expects('prepare')->with('SHOW INDEX FROM `client_balance`')->andReturn($balanceIndexes);
+    $pdo->expects('prepare')
+        ->with('ALTER TABLE `client_balance` ADD COLUMN `invoice_item_id` BIGINT DEFAULT NULL AFTER `rel_id`')
+        ->andReturn($addColumn);
+    $pdo->expects('prepare')
+        ->with('ALTER TABLE `client_balance` ADD UNIQUE INDEX `uniq_invoice_item_credit` (`invoice_item_id`)')
+        ->andReturn($addIndex);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch96'))->invoke($patcher);
 });
 
 test('suspension grace patch indexes existing order tables', function (): void {


### PR DESCRIPTION
Introduces a new mechanism to ensure that each invoice item can only be credited once in the `client_balance` table, improving data integrity and preventing duplicate credits.