### PR TITLE
Allow client/admin login() to strip admin identity in the same request

### DIFF
--- a/src/modules/Client/Api/Admin.php
+++ b/src/modules/Client/Api/Admin.php
@@ -96,6 +96,17 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     /**
      * Login to clients area with client id.
      *
+     * @optional bool $strip_admin_identity - Also remove the admin identity from the current
+     *                                        session, in the same request that sets the client
+     *                                        identity. Without this, impersonating a client and
+     *                                        then dropping admin access requires a second,
+     *                                        separate API call — which is unsafe with session ID
+     *                                        rotation enabled, since the session ID returned by
+     *                                        this call may already be stale by the time the
+     *                                        second call uses it, leaving the session in an
+     *                                        inconsistent state (see PR description for a
+     *                                        real-world example).
+     *
      * @return array - client details
      */
     #[RequiredParams(['id' => 'ID required'])]
@@ -111,6 +122,10 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         $session = $this->getDi()['session'];
         $session->set('client_id', $client->getId());
         $this->getDi()['logger']->info('Logged in as client #%s', $client->getId());
+
+        if (!empty($data['strip_admin_identity'])) {
+            $session->destroy('admin');
+        }
 
         return $result;
     }


### PR DESCRIPTION
## Summary

`admin/client/login()` sets `client_id` on the current session but leaves the
admin identity in place alongside it. If a caller wants a clean, client-only
session afterward (e.g. to hand off to fully client-scoped code, or simply to
avoid an admin-tainted session lingering after impersonation), the only way
today is a **second, separate** API call to drop the admin identity.

That second call is unsafe as things stand: `Session::destroy('admin')` calls
`regenerateId()` as part of removing the admin identity. So the session ID
returned by the `login()` response can already be stale by the time a second
request uses it — the exact ordering/timing between the two calls determines
whether the resulting session is consistent.

This PR adds an optional `strip_admin_identity` flag to `login()` so both
session mutations (set client identity, drop admin identity) happen within
the same request and the same session-ID lifecycle — no gap for that race to
happen in.

## Real-world motivation

We run a Next.js storefront in front of FOSSBilling (BFF pattern — the
customer never sees FOSSBilling's own UI/session directly). Several
customer-facing flows need our backend to act *as* a specific client without
the client ever logging in themselves, e.g.:

- Estonian Smart-ID authentication/signup, where a successful ID-card/mobile
  signature needs to resolve directly to an authenticated client session.
- Automated domain + hosting registration immediately after a successful
  payment (Stripe/bank-link), where our server creates and activates the
  order "as" the client in the same request that confirms payment.
- A scheduled job that auto-renews domains/hosting for clients who opted in,
  which needs to act as each client to create/pay the renewal.

All of these call `admin/client/login` from server-side code (never exposed
to the browser) specifically to get a clean client session for the rest of
that request — they must never end up with a session that's still
admin-identified afterward, since that session state can end up observable
to (or reused by) client-facing code paths later in the same flow. Doing the
strip in a guaranteed-atomic second step, right where the client identity is
set, removed a real (if narrow) class of session bugs for us and seems
generally useful for anyone else building similar server-side
impersonation/automation on top of FOSSBilling.

## Test plan

- [ ] Confirm existing behavior is unchanged when `strip_admin_identity` is
      omitted (default `admin/client/login` callers unaffected).
- [ ] Call `admin/client/login` with `strip_admin_identity: true` and confirm
      the resulting session responds to `client/*` API calls but no longer to
      `admin/*` API calls, using only the session ID returned by that single
      call.