### PR TITLE
Fix crash on Cookie Consent settings page when never configured

### DIFF
--- a/src/modules/Cookieconsent/templates/admin/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/templates/admin/mod_cookieconsent_index.html.twig
@@ -21,7 +21,7 @@
                         </div>
                         {% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
                         <textarea class="form-control" cols="5" rows="10" name="message" id="cookie-message"
-                                  placeholder="{{ 'Add Note or Todo Task'|trans }}">{% if params.message %}{{ params.message }}{% else %}This website uses cookies. By continuing to use this website, you consent to our use of these cookies.{% endif %}</textarea>
+                                  placeholder="{{ 'Add Note or Todo Task'|trans }}">{% if params.message|default(false) %}{{ params.message }}{% else %}This website uses cookies. By continuing to use this website, you consent to our use of these cookies.{% endif %}</textarea>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Opening **Settings > Extensions > Cookie Consent** in the admin panel throws a
hard error the very first time it's visited on any install that has never
saved a config for this extension (e.g. a fresh install), instead of showing
the settings form with the default placeholder message:

```
Key "message" for sequence/mapping with keys "ext" does not exist
```

## Root cause

`Extension\Service::getConfig()` returns just `["ext" => $ext]` (no `message`
key at all) until a config row actually exists for that extension. The
Cookie Consent admin template reads that value directly:

```twig
{% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
...{% if params.message %}{{ params.message }}{% else %}...{% endif %}...
```

With Twig's `strict_variables` enabled, accessing `params.message` when the
key genuinely doesn't exist (as opposed to existing with a falsy value)
throws instead of evaluating to falsy — so the `else` branch (the intended
default message) is never reached, and the whole page fails to render. This
also means an admin can't fix it from the UI either, since the page that
would let them save a config is the one that's crashing.

## Fix

Guard the read with `|default(false)`, the same pattern already used
elsewhere in the codebase for this exact situation (extension config read
before it's ever been saved).

## Test plan

- [x] Reproduced on a real install: visited the Cookie Consent settings page
      before ever saving its config, got the exact error above.
- [x] Applied the one-line fix, cleared the compiled Twig cache, confirmed
      the page now renders normally with the default placeholder text.
- [x] Saved the form once config exists, confirmed the saved message still
      displays correctly (unaffected code path).