### PR TITLE
Fix PayPal IPN validation corrupting field values with backslashes

### DIFF
--- a/src/library/Payment/Adapter/PayPalEmail.php
+++ b/src/library/Payment/Adapter/PayPalEmail.php
@@ -294,7 +294,10 @@ class Payment_Adapter_PayPalEmail extends Payment_AdapterAbstract implements FOS
         parse_str((string) $data['http_raw_post_data'], $post);
         $req = 'cmd=_notify-validate';
         foreach ($post as $key => $value) {
-            $value = urlencode(stripslashes($value));
+            // No stripslashes() here: that undid PHP's long-removed magic_quotes_gpc
+            // escaping. Applied unconditionally it corrupts any value containing a
+            // backslash, so the re-posted request no longer matches what PayPal sent.
+            $value = urlencode((string) $value);
             $req .= "&$key=$value";
         }
 

--- a/tests/Unit/Payment/Adapter/PayPalEmailTest.php
+++ b/tests/Unit/Payment/Adapter/PayPalEmailTest.php
@@ -14,7 +14,7 @@ use Payment_Adapter_PayPalEmail;
 
 use function Tests\Helpers\container;
 
-function buildPayPalEmailAdapter(string $configuredEmail, string $postbackResponse, ?array &$capturedRequestBody = null): Payment_Adapter_PayPalEmail
+function buildPayPalEmailAdapter(string $configuredEmail, string $postbackResponse, ?array &$capturedRequestBody = null, ?string &$capturedRawRequestBody = null): Payment_Adapter_PayPalEmail
 {
     $response = Mockery::mock();
     $response->shouldReceive('getContent')->andReturn($postbackResponse);
@@ -22,8 +22,9 @@ function buildPayPalEmailAdapter(string $configuredEmail, string $postbackRespon
     $httpClient = Mockery::mock();
     $httpClient->shouldReceive('withOptions')->andReturnSelf();
     $httpClient->shouldReceive('request')
-        ->with('POST', Mockery::any(), Mockery::on(function (array $options) use (&$capturedRequestBody): bool {
-            parse_str((string) ($options['body'] ?? ''), $capturedRequestBody);
+        ->with('POST', Mockery::any(), Mockery::on(function (array $options) use (&$capturedRequestBody, &$capturedRawRequestBody): bool {
+            $capturedRawRequestBody = (string) ($options['body'] ?? '');
+            parse_str($capturedRawRequestBody, $capturedRequestBody);
 
             return true;
         }))
@@ -135,15 +136,21 @@ describe('_isIpnValid receiver verification', function (): void {
 
     test('sends field values back to PayPal unmodified, backslashes included', function (): void {
         $captured = [];
-        $adapter = buildPayPalEmailAdapter('merchant@example.com', 'VERIFIED', $captured);
+        $capturedRaw = null;
+        $adapter = buildPayPalEmailAdapter('merchant@example.com', 'VERIFIED', $captured, $capturedRaw);
 
+        $addressStreet = 'C:\\Users\\Test 1\\2 Foo St';
         $result = callIsIpnValid($adapter, http_build_query([
             'receiver_email' => 'merchant@example.com',
             'mc_gross' => '10.00',
-            'address_street' => 'C:\\Users\\Test 1\\2 Foo St',
+            'address_street' => $addressStreet,
         ]));
 
         expect($result)->toBeTrue();
-        expect($captured['address_street'])->toBe('C:\\Users\\Test 1\\2 Foo St');
+        expect($captured['address_street'])->toBe($addressStreet);
+        // Assert on the raw wire body too, not just its parse_str()-decoded form,
+        // so a bug in the percent-encoding itself (not just the decoded value)
+        // would still be caught.
+        expect($capturedRaw)->toContain('address_street=' . urlencode($addressStreet));
     });
 });

--- a/tests/Unit/Payment/Adapter/PayPalEmailTest.php
+++ b/tests/Unit/Payment/Adapter/PayPalEmailTest.php
@@ -14,14 +14,20 @@ use Payment_Adapter_PayPalEmail;
 
 use function Tests\Helpers\container;
 
-function buildPayPalEmailAdapter(string $configuredEmail, string $postbackResponse): Payment_Adapter_PayPalEmail
+function buildPayPalEmailAdapter(string $configuredEmail, string $postbackResponse, ?array &$capturedRequestBody = null): Payment_Adapter_PayPalEmail
 {
     $response = Mockery::mock();
     $response->shouldReceive('getContent')->andReturn($postbackResponse);
 
     $httpClient = Mockery::mock();
     $httpClient->shouldReceive('withOptions')->andReturnSelf();
-    $httpClient->shouldReceive('request')->with('POST', Mockery::any(), Mockery::any())->andReturn($response);
+    $httpClient->shouldReceive('request')
+        ->with('POST', Mockery::any(), Mockery::on(function (array $options) use (&$capturedRequestBody): bool {
+            parse_str((string) ($options['body'] ?? ''), $capturedRequestBody);
+
+            return true;
+        }))
+        ->andReturn($response);
 
     $adapter = new Payment_Adapter_PayPalEmail(['email' => $configuredEmail, 'test_mode' => false]);
     $di = container();
@@ -125,5 +131,19 @@ describe('_isIpnValid receiver verification', function (): void {
         ]));
 
         expect($result)->toBeFalse();
+    });
+
+    test('sends field values back to PayPal unmodified, backslashes included', function (): void {
+        $captured = [];
+        $adapter = buildPayPalEmailAdapter('merchant@example.com', 'VERIFIED', $captured);
+
+        $result = callIsIpnValid($adapter, http_build_query([
+            'receiver_email' => 'merchant@example.com',
+            'mc_gross' => '10.00',
+            'address_street' => 'C:\\Users\\Test 1\\2 Foo St',
+        ]));
+
+        expect($result)->toBeTrue();
+        expect($captured['address_street'])->toBe('C:\\Users\\Test 1\\2 Foo St');
     });
 });


### PR DESCRIPTION
Drop the `stripslashes()` call so the re-posted verification request is byte-identical to what PayPal sent.

Fixes #4092.