### PR TITLE
Highlight the selected payment gateway on checkout/invoice payment

### DIFF
--- a/src/themes/huraga/assets/scss/huraga.scss
+++ b/src/themes/huraga/assets/scss/huraga.scss
@@ -131,9 +131,15 @@ body {
 
 .invoice-gateway {
     border: 1px solid var(--bs-border-color);
+    transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 
     &:hover {
         border: 1px solid var(--bs-primary);
+    }
+
+    &:has(.btn-check:checked) {
+        border-color: var(--bs-primary);
+        background-color: rgba(var(--bs-primary-rgb), 0.08);
     }
 }
 


### PR DESCRIPTION
Adds a visible highlight (primary-coloured border + tinted background) to the payment gateway option a user has selected on the order checkout form and the invoice payment page.

Closes #4094.