### PR TITLE
Fix stray dark border on selected payment gateway (follow-up to #4096)

### DIFF
--- a/src/themes/huraga/assets/scss/huraga.scss
+++ b/src/themes/huraga/assets/scss/huraga.scss
@@ -131,15 +131,19 @@ body {
 
 .invoice-gateway {
     border: 1px solid var(--bs-border-color);
-    transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 
-    &:hover {
+    &:hover,
+    &:has(.btn-check:checked) {
         border: 1px solid var(--bs-primary);
     }
 
-    &:has(.btn-check:checked) {
-        border-color: var(--bs-primary);
-        background-color: rgba(var(--bs-primary-rgb), 0.08);
+    // Bootstrap's .btn-check:checked + .btn draws its own border using
+    // --bs-btn-active-border-color, which is never set on a bare .btn (no
+    // color variant). That leaves the browser to fall back to the inherited
+    // text color, drawing a stray dark border tight around the logo. The
+    // highlight above on the container is enough, so suppress it here.
+    .btn-check:checked + .btn {
+        border-color: transparent;
     }
 }
 


### PR DESCRIPTION
Follow-up to #4096. Fixes a visual regression noticed after that PR merged: on the real theme build (with gateway logo images, not plain text buttons), selecting a gateway drew an unwanted tight dark/black border around the logo itself, in addition to the intended blue container highlight.