### PR TITLE
Fix hosting orders stuck in pending_setup with duplicate createacct retries

### DIFF
--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1334,7 +1334,11 @@ class Service implements InjectionAwareInterface
             }
 
             $this->persistOrder($order);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // Caught broadly (not just \Exception): an \Error or \TypeError
+            // here means the service was already provisioned remotely, so
+            // the order must still be recorded as failed_setup rather than
+            // left in pending_setup for a retry to re-provision it.
             if ($order instanceof Order) {
                 $order->setStatus(Order::STATUS_FAILED_SETUP);
             } else {

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1295,51 +1295,57 @@ class Service implements InjectionAwareInterface
             }
         }
 
+        // The provisioning call and the order status update that records its
+        // outcome are treated as one unit: if anything here fails after the
+        // service has already been provisioned (e.g. while computing the new
+        // expiry date), the order must still end up in failed_setup instead
+        // of being left in pending_setup. Otherwise a retry would call
+        // _callOnService() again against a service that already exists on
+        // the remote server.
         try {
             $result = $this->_callOnService($order, Order::ACTION_ACTIVATE);
+
+            $period = $this->orderPeriod($order);
+            $expiresAt = $order instanceof Order ? $order->getExpiresAt() : $order->expires_at;
+            if (!empty($period)) {
+                $from_time = ($expiresAt === null) ? time() : ($order instanceof Order ? ($expiresAt->getTimestamp() ?? time()) : strtotime((string) $expiresAt));
+
+                $periodObj = $this->di['period']($period);
+                $newExpires = date('Y-m-d H:i:s', $periodObj->getExpirationTime($from_time));
+                if ($order instanceof Order) {
+                    $order->setExpiresAt(new \DateTime($newExpires));
+                } else {
+                    $order->expires_at = $newExpires;
+                }
+            }
+
+            if ($order instanceof Order) {
+                $order->setStatus(Order::STATUS_ACTIVE);
+                $order->setActivatedAt(new \DateTime());
+                $order->setSuspendedAt(null);
+                $order->setCanceledAt(null);
+                $order->setUpdatedAt(new \DateTime());
+            } else {
+                $order->status = Order::STATUS_ACTIVE;
+                $order->activated_at = date('Y-m-d H:i:s');
+                $order->suspended_at = null;
+                $order->canceled_at = null;
+                $order->updated_at = date('Y-m-d H:i:s');
+            }
+
+            $this->persistOrder($order);
         } catch (\Exception $e) {
             if ($order instanceof Order) {
                 $order->setStatus(Order::STATUS_FAILED_SETUP);
-                $this->persistOrder($order);
             } else {
                 $order->status = Order::STATUS_FAILED_SETUP;
-                $this->persistOrder($order);
             }
+            $this->persistOrder($order);
 
             $this->saveStatusChange($order, $e->getMessage());
 
             throw $e;
         }
-
-        $period = $this->orderPeriod($order);
-        $expiresAt = $order instanceof Order ? $order->getExpiresAt() : $order->expires_at;
-        if (!empty($period)) {
-            $from_time = ($expiresAt === null) ? time() : ($order instanceof Order ? ($expiresAt->getTimestamp() ?? time()) : strtotime((string) $expiresAt));
-
-            $periodObj = $this->di['period']($period);
-            $newExpires = date('Y-m-d H:i:s', $periodObj->getExpirationTime($from_time));
-            if ($order instanceof Order) {
-                $order->setExpiresAt(new \DateTime($newExpires));
-            } else {
-                $order->expires_at = $newExpires;
-            }
-        }
-
-        if ($order instanceof Order) {
-            $order->setStatus(Order::STATUS_ACTIVE);
-            $order->setActivatedAt(new \DateTime());
-            $order->setSuspendedAt(null);
-            $order->setCanceledAt(null);
-            $order->setUpdatedAt(new \DateTime());
-        } else {
-            $order->status = Order::STATUS_ACTIVE;
-            $order->activated_at = date('Y-m-d H:i:s');
-            $order->suspended_at = null;
-            $order->canceled_at = null;
-            $order->updated_at = date('Y-m-d H:i:s');
-        }
-
-        $this->persistOrder($order);
 
         if ($this->orderProductId($order)) {
             $productService = $this->di['mod_service']('product');

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1825,6 +1825,41 @@ test('createFromOrder marks the order failed_setup when provisioning succeeds bu
     expect($order->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
 });
 
+test('createFromOrder marks the order failed_setup when activation bookkeeping raises a TypeError', function (): void {
+    // Same regression as above, but for the wider \Throwable hierarchy: an
+    // \Error/\TypeError after a successful provisioning call must also be
+    // caught, otherwise the order is left in pending_setup with the remote
+    // account already created and a retry would call the provisioning
+    // action again against a service that already exists.
+    $order = createEntity(Order::class, [
+        'id' => 1,
+        'period' => '1Y',
+        'serviceType' => 'hosting',
+    ]);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderService')->atLeast()->once()->andReturn(new stdClass());
+    $serviceMock->shouldReceive('_callOnService')
+        ->once()
+        ->with($order, Order::ACTION_ACTIVATE)
+        ->andReturn(['username' => 'created-before-the-failure']);
+    $serviceMock->shouldReceive('saveStatusChange')
+        ->once()
+        ->with($order, 'Simulated TypeError after provisioning');
+
+    $di = container();
+    $di['period'] = $di->protect(function (): never {
+        throw new TypeError('Simulated TypeError after provisioning');
+    });
+    $serviceMock->setDi($di);
+
+    expect(fn (): mixed => $serviceMock->createFromOrder($order))
+        ->toThrow(TypeError::class, 'Simulated TypeError after provisioning');
+
+    expect($order->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
+});
+
 test('activateOrder throws for non-pending order', function (): void {
     $clientOrderModel = createEntity(Order::class);
     $clientOrderModel->status = Order::STATUS_CANCELED;

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1754,6 +1754,77 @@ test('getMasterOrderForClient returns master order', function (): void {
     expect($result)->toBeInstanceOf(Order::class);
 });
 
+test('createFromOrder activates the order after successful provisioning', function (): void {
+    $order = createEntity(Order::class, [
+        'id' => 1,
+        'period' => '1Y',
+        'productId' => 7,
+        'quantity' => 2,
+        'serviceType' => 'hosting',
+    ]);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderService')->atLeast()->once()->andReturn(new stdClass());
+    $serviceMock->shouldReceive('_callOnService')
+        ->once()
+        ->with($order, Order::ACTION_ACTIVATE)
+        ->andReturn(['username' => 'created']);
+    $serviceMock->shouldReceive('saveStatusChange')->once()->with($order, 'Order activated');
+
+    $periodMock = Mockery::mock(Box_Period::class);
+    $periodMock->shouldReceive('getExpirationTime')->once()->andReturn(strtotime('2027-01-01 00:00:00'));
+
+    $productServiceMock = Mockery::mock();
+    $productServiceMock->shouldReceive('reduceStock')->once()->with(7, 2);
+
+    $di = container();
+    $di['period'] = $di->protect(fn (): Mockery\MockInterface => $periodMock);
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $productServiceMock);
+
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->createFromOrder($order);
+
+    expect($result)->toBe(['username' => 'created'])
+        ->and($order->getStatus())->toBe(Order::STATUS_ACTIVE);
+});
+
+test('createFromOrder marks the order failed_setup when provisioning succeeds but activation bookkeeping fails', function (): void {
+    // Regression test: the remote account is created successfully by
+    // _callOnService(), but computing the new expiry date afterwards throws.
+    // The order must be recorded as failed_setup instead of being left in
+    // pending_setup - otherwise a retry would call _callOnService() again
+    // against a service that already exists on the remote server.
+    $order = createEntity(Order::class, [
+        'id' => 1,
+        'period' => '1Y',
+        'serviceType' => 'hosting',
+    ]);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderService')->atLeast()->once()->andReturn(new stdClass());
+    $serviceMock->shouldReceive('_callOnService')
+        ->once()
+        ->with($order, Order::ACTION_ACTIVATE)
+        ->andReturn(['username' => 'created-before-the-failure']);
+    $serviceMock->shouldReceive('saveStatusChange')
+        ->once()
+        ->with($order, 'Simulated post-provisioning failure');
+
+    $di = container();
+    $di['period'] = $di->protect(function (): never {
+        throw new FOSSBilling\Exception('Simulated post-provisioning failure');
+    });
+    $serviceMock->setDi($di);
+
+    expect(fn (): mixed => $serviceMock->createFromOrder($order))
+        ->toThrow(FOSSBilling\Exception::class, 'Simulated post-provisioning failure');
+
+    expect($order->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
+});
+
 test('activateOrder throws for non-pending order', function (): void {
     $clientOrderModel = createEntity(Order::class);
     $clientOrderModel->status = Order::STATUS_CANCELED;

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1813,7 +1813,16 @@ test('createFromOrder marks the order failed_setup when provisioning succeeds bu
         ->once()
         ->with($order, 'Simulated post-provisioning failure');
 
+    $orderRepoMock = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepoMock->shouldReceive('find')->with(1)->andReturn($order);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class)->shouldIgnoreMissing();
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepoMock);
+    $emMock->shouldReceive('persist')->once()->with($order);
+    $emMock->shouldReceive('flush')->once();
+
     $di = container();
+    $di['em'] = $emMock;
     $di['period'] = $di->protect(function (): never {
         throw new FOSSBilling\Exception('Simulated post-provisioning failure');
     });
@@ -1822,7 +1831,11 @@ test('createFromOrder marks the order failed_setup when provisioning succeeds bu
     expect(fn (): mixed => $serviceMock->createFromOrder($order))
         ->toThrow(FOSSBilling\Exception::class, 'Simulated post-provisioning failure');
 
-    expect($order->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
+    // Confirm persistOrder() actually stored the failure - not just that the
+    // in-memory $order object was mutated - by reloading it through the
+    // repository.
+    $reloadedOrder = $di['em']->getRepository(Order::class)->find(1);
+    expect($reloadedOrder->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
 });
 
 test('createFromOrder marks the order failed_setup when activation bookkeeping raises a TypeError', function (): void {
@@ -1848,7 +1861,16 @@ test('createFromOrder marks the order failed_setup when activation bookkeeping r
         ->once()
         ->with($order, 'Simulated TypeError after provisioning');
 
+    $orderRepoMock = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepoMock->shouldReceive('find')->with(1)->andReturn($order);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class)->shouldIgnoreMissing();
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepoMock);
+    $emMock->shouldReceive('persist')->once()->with($order);
+    $emMock->shouldReceive('flush')->once();
+
     $di = container();
+    $di['em'] = $emMock;
     $di['period'] = $di->protect(function (): never {
         throw new TypeError('Simulated TypeError after provisioning');
     });
@@ -1857,7 +1879,11 @@ test('createFromOrder marks the order failed_setup when activation bookkeeping r
     expect(fn (): mixed => $serviceMock->createFromOrder($order))
         ->toThrow(TypeError::class, 'Simulated TypeError after provisioning');
 
-    expect($order->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
+    // Confirm persistOrder() actually stored the failure - not just that the
+    // in-memory $order object was mutated - by reloading it through the
+    // repository.
+    $reloadedOrder = $di['em']->getRepository(Order::class)->find(1);
+    expect($reloadedOrder->getStatus())->toBe(Order::STATUS_FAILED_SETUP);
 });
 
 test('activateOrder throws for non-pending order', function (): void {

--- a/src/modules/Servicehosting/Service.php
+++ b/src/modules/Servicehosting/Service.php
@@ -186,6 +186,15 @@ class Service implements InjectionAwareInterface
         // Retrieve the server manager for the order
         $serverManager = $this->_getServerManagerForOrder($model);
 
+        // A username is only ever persisted below once the account has
+        // actually been created on the server. If one is already present,
+        // a previous activation attempt already provisioned this account -
+        // most likely the order's status update afterwards failed to save,
+        // and this call is a retry. Re-running createAccount() in that case
+        // would only fail with a "domain/account already exists" server
+        // error, so treat the account as already provisioned instead.
+        $alreadyProvisioned = !empty($model->getUsername());
+
         // Generate a password for the service
         $pass = $this->di['tools']->generatePassword($serverManager->getPasswordLength(), true);
 
@@ -195,7 +204,9 @@ class Service implements InjectionAwareInterface
         }
 
         // Generate a username for the service
-        if (isset($config['username']) && !empty($config['username'])) {
+        if ($alreadyProvisioned) {
+            $username = $model->getUsername();
+        } elseif (isset($config['username']) && !empty($config['username'])) {
             $username = $config['username'];
         } else {
             $username = $serverManager->generateUsername($model->getSld() . $model->getTld());
@@ -206,7 +217,7 @@ class Service implements InjectionAwareInterface
         $model->setPass($pass);
 
         // If the order's configuration does not specify that the service should be imported, create an account for the service on the server
-        if (!isset($config['import']) || !$config['import']) {
+        if (!$alreadyProvisioned && (!isset($config['import']) || !$config['import'])) {
             [$adapter, $account] = $this->_getAM($model);
             $adapter->createAccount($account);
         }

--- a/src/modules/Servicehosting/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicehosting/tests/Unit/ServiceTest.php
@@ -179,6 +179,91 @@ test('action create', function (): void {
     expect($result->getTld())->toBe($confArr['tld']);
 });
 
+test('action activate creates the account when it has not been provisioned yet', function (): void {
+    $orderModel = new Model_ClientOrder();
+    $orderModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $model = new ServiceHosting();
+    $model->setServiceHostingServerId(1);
+    $model->setSld('example');
+    $model->setTld('.com');
+
+    $orderServiceMock = Mockery::mock(OrderService::class);
+    $orderServiceMock->shouldReceive('getOrderService')->atLeast()->once()->andReturn($model);
+    $orderServiceMock->shouldReceive('getConfig')->atLeast()->once()->andReturn([]);
+
+    $serverRepo = Mockery::mock(ServiceHostingServerRepository::class)->shouldIgnoreMissing();
+    $serverRepo->shouldReceive('find')->atLeast()->once()->andReturn(new ServiceHostingServer());
+
+    $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $emMock->shouldReceive('getRepository')->with(ServiceHostingServer::class)->andReturn($serverRepo);
+    $emMock->shouldReceive('flush')->atLeast()->once();
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $orderServiceMock);
+
+    $serverManagerMock = Mockery::mock('\Server_Manager_Custom');
+    $serverManagerMock->shouldReceive('getPasswordLength')->atLeast()->once()->andReturn(12);
+    $serverManagerMock->shouldReceive('generateUsername')->atLeast()->once()->with('example.com')->andReturn('example');
+
+    $adapterMock = Mockery::mock('\Server_Manager_Custom');
+    $adapterMock->shouldReceive('createAccount')->once();
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('getServerManager')->atLeast()->once()->andReturn($serverManagerMock);
+    $serviceMock->shouldReceive('_getAM')->once()->andReturn([$adapterMock, new Server_Account()]);
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->action_activate($orderModel);
+
+    expect($result)->toBe(['username' => 'example'])
+        ->and($model->getUsername())->toBe('example');
+});
+
+test('action activate does not recreate an account that was already provisioned', function (): void {
+    // Regression test: if a previous activation attempt already created the
+    // account on the server (its username was persisted), retrying must not
+    // call createAccount() again - the account already exists remotely and
+    // doing so only fails with a duplicate-account server error.
+    $orderModel = new Model_ClientOrder();
+    $orderModel->loadBean(new Tests\Helpers\DummyBean());
+
+    $model = new ServiceHosting();
+    $model->setServiceHostingServerId(1);
+    $model->setSld('example');
+    $model->setTld('.com');
+    $model->setUsername('example');
+
+    $orderServiceMock = Mockery::mock(OrderService::class);
+    $orderServiceMock->shouldReceive('getOrderService')->atLeast()->once()->andReturn($model);
+    $orderServiceMock->shouldReceive('getConfig')->atLeast()->once()->andReturn([]);
+
+    $serverRepo = Mockery::mock(ServiceHostingServerRepository::class)->shouldIgnoreMissing();
+    $serverRepo->shouldReceive('find')->atLeast()->once()->andReturn(new ServiceHostingServer());
+
+    $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $emMock->shouldReceive('getRepository')->with(ServiceHostingServer::class)->andReturn($serverRepo);
+    $emMock->shouldReceive('flush')->atLeast()->once();
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $orderServiceMock);
+
+    $serverManagerMock = Mockery::mock('\Server_Manager_Custom');
+    $serverManagerMock->shouldReceive('getPasswordLength')->atLeast()->once()->andReturn(12);
+    $serverManagerMock->shouldNotReceive('generateUsername');
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('getServerManager')->atLeast()->once()->andReturn($serverManagerMock);
+    $serviceMock->shouldNotReceive('_getAM');
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->action_activate($orderModel);
+
+    expect($result)->toBe(['username' => 'example']);
+});
+
 test('action renew', function (): void {
     $service = new Service();
     $orderModel = new Model_ClientOrder();


### PR DESCRIPTION
- **`src/modules/Order/Service.php`** — Widened the existing try/catch in `createFromOrder()` to cover the whole activation sequence (provisioning call → expiry calculation → status persist) instead of just the provisioning call. Any failure in that unit now reliably lands the order in `failed_setup` with the real error recorded via `saveStatusChange()`, instead of leaving it stuck in `pending_setup`. This is a pure code-motion — no behavior change on the success path.
- **`src/modules/Servicehosting/Service.php`** — Added a one-line idempotency check to `action_activate()`: a `ServiceHosting` row's `username` is only ever persisted *after* `createAccount()` succeeds, so its presence reliably means the account already exists remotely. When present, activation now reuses it instead of calling `createAccount()` again — closing the exact "domain already exists" failure mode from the report.