### PR TITLE
Fix client emails for automatic order renew/unsuspend/cancel/uncancel

### DIFF
--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -320,7 +320,7 @@ class Service implements InjectionAwareInterface
             if (!$order instanceof Order) {
                 throw new \FOSSBilling\Exception('Order not found');
             }
-            $identity = $di['loggedin_admin'];
+            $identity = $di['loggedin_admin'] ?? null;
             $service = $orderService->getOrderServiceData($order, $identity);
             $orderArr = $orderService->toApiArray($order, true, $identity);
 
@@ -378,7 +378,7 @@ class Service implements InjectionAwareInterface
             if (!$order instanceof Order) {
                 throw new \FOSSBilling\Exception('Order not found');
             }
-            $identity = $di['loggedin_admin'];
+            $identity = $di['loggedin_admin'] ?? null;
             $s = $service->getOrderServiceData($order, $identity);
             $orderArr = $service->toApiArray($order, true, $identity);
 
@@ -407,7 +407,7 @@ class Service implements InjectionAwareInterface
             if (!$order instanceof Order) {
                 throw new \FOSSBilling\Exception('Order not found');
             }
-            $identity = $di['loggedin_admin'];
+            $identity = $di['loggedin_admin'] ?? null;
             $orderArr = $service->toApiArray($order, true, $identity);
 
             $email = [];
@@ -434,7 +434,7 @@ class Service implements InjectionAwareInterface
             if (!$order instanceof Order) {
                 throw new \FOSSBilling\Exception('Order not found');
             }
-            $identity = $di['loggedin_admin'];
+            $identity = $di['loggedin_admin'] ?? null;
             $s = $service->getOrderServiceData($order, $identity);
             $orderArr = $service->toApiArray($order, true, $identity);
 

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -198,6 +198,49 @@ test('onAfterAdminOrderRenew fires template', function (): void {
     $serviceMock->onAfterAdminOrderRenew($eventMock);
 });
 
+test('onAfterAdminOrderRenew fires template without an admin session', function (): void {
+    $params = ['id' => 1];
+
+    $eventMock = Mockery::mock(Box_Event::class);
+    $eventMock->shouldReceive('getParameters')->once()->andReturn($params);
+
+    $order = createEntity(Order::class, ['id' => 1]);
+    $orderArr = [
+        'id' => 1,
+        'client' => ['id' => 1],
+        'service_type' => 'domain',
+    ];
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->once()->with([
+        'to_client' => 1,
+        'code' => 'mod_servicedomain_renewed',
+        'service' => [],
+        'order' => $orderArr,
+    ])->andReturn(true);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderServiceData')->once()->with($order, null)->andReturn([]);
+    $serviceMock->shouldReceive('toApiArray')->once()->with($order, true, null)->andReturn($orderArr);
+
+    $di = container();
+    $di['em']->getRepository(Order::class)->shouldReceive('find')->once()->with(1)->andReturn($order);
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        if ($serviceName == 'email') {
+            return $emailServiceMock;
+        }
+        if ($serviceName == 'order') {
+            return $serviceMock;
+        }
+    });
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')->once()->andReturn($di);
+
+    $serviceMock->onAfterAdminOrderRenew($eventMock);
+});
+
 test('onAfterAdminOrderRenew logs exceptions', function (): void {
     $params = ['id' => 1];
 
@@ -405,6 +448,49 @@ test('onAfterAdminOrderUnsuspend fires template', function (): void {
     $serviceMock->onAfterAdminOrderUnsuspend($eventMock);
 });
 
+test('onAfterAdminOrderUnsuspend fires template without an admin session', function (): void {
+    $params = ['id' => 1];
+
+    $eventMock = Mockery::mock(Box_Event::class);
+    $eventMock->shouldReceive('getParameters')->once()->andReturn($params);
+
+    $order = createEntity(Order::class, ['id' => 1]);
+    $orderArr = [
+        'id' => 1,
+        'client' => ['id' => 1],
+        'service_type' => 'domain',
+    ];
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->once()->with([
+        'to_client' => 1,
+        'code' => 'mod_servicedomain_unsuspended',
+        'service' => [],
+        'order' => $orderArr,
+    ])->andReturn(true);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderServiceData')->once()->with($order, null)->andReturn([]);
+    $serviceMock->shouldReceive('toApiArray')->once()->with($order, true, null)->andReturn($orderArr);
+
+    $di = container();
+    $di['em']->getRepository(Order::class)->shouldReceive('find')->once()->with(1)->andReturn($order);
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        if ($serviceName == 'email') {
+            return $emailServiceMock;
+        }
+        if ($serviceName == 'order') {
+            return $serviceMock;
+        }
+    });
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')->once()->andReturn($di);
+
+    $serviceMock->onAfterAdminOrderUnsuspend($eventMock);
+});
+
 test('onAfterAdminOrderUnsuspend logs exceptions', function (): void {
     $params = ['id' => 1];
 
@@ -486,6 +572,47 @@ test('onAfterAdminOrderCancel fires template', function (): void {
     $serviceMock->onAfterAdminOrderCancel($eventMock);
 });
 
+test('onAfterAdminOrderCancel fires template without an admin session', function (): void {
+    $params = ['id' => 1];
+
+    $eventMock = Mockery::mock(Box_Event::class);
+    $eventMock->shouldReceive('getParameters')->once()->andReturn($params);
+
+    $order = createEntity(Order::class, ['id' => 1]);
+    $orderArr = [
+        'id' => 1,
+        'client' => ['id' => 1],
+        'service_type' => 'domain',
+    ];
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->once()->with([
+        'to_client' => 1,
+        'code' => 'mod_servicedomain_canceled',
+        'order' => $orderArr,
+    ])->andReturn(true);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('toApiArray')->once()->with($order, true, null)->andReturn($orderArr);
+
+    $di = container();
+    $di['em']->getRepository(Order::class)->shouldReceive('find')->once()->with(1)->andReturn($order);
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        if ($serviceName == 'email') {
+            return $emailServiceMock;
+        }
+        if ($serviceName == 'order') {
+            return $serviceMock;
+        }
+    });
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')->once()->andReturn($di);
+
+    $serviceMock->onAfterAdminOrderCancel($eventMock);
+});
+
 test('onAfterAdminOrderCancel logs exceptions', function (): void {
     $params = ['id' => 1];
 
@@ -563,6 +690,49 @@ test('onAfterAdminOrderUncancel fires template', function (): void {
 
     $serviceMock->setDi($di);
     $eventMock->shouldReceive('getDi')->atLeast()->once()->andReturn($di);
+
+    $serviceMock->onAfterAdminOrderUncancel($eventMock);
+});
+
+test('onAfterAdminOrderUncancel fires template without an admin session', function (): void {
+    $params = ['id' => 1];
+
+    $eventMock = Mockery::mock(Box_Event::class);
+    $eventMock->shouldReceive('getParameters')->once()->andReturn($params);
+
+    $order = createEntity(Order::class, ['id' => 1]);
+    $orderArr = [
+        'id' => 1,
+        'client' => ['id' => 1],
+        'service_type' => 'domain',
+    ];
+
+    $emailServiceMock = Mockery::mock(Box\Mod\Email\Service::class);
+    $emailServiceMock->shouldReceive('sendTemplate')->once()->with([
+        'to_client' => 1,
+        'code' => 'mod_servicedomain_renewed',
+        'order' => $orderArr,
+        'service' => [],
+    ])->andReturn(true);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('getOrderServiceData')->once()->with($order, null)->andReturn([]);
+    $serviceMock->shouldReceive('toApiArray')->once()->with($order, true, null)->andReturn($orderArr);
+
+    $di = container();
+    $di['em']->getRepository(Order::class)->shouldReceive('find')->once()->with(1)->andReturn($order);
+    $di['mod_service'] = $di->protect(function ($serviceName) use ($emailServiceMock, $serviceMock) {
+        if ($serviceName == 'email') {
+            return $emailServiceMock;
+        }
+        if ($serviceName == 'order') {
+            return $serviceMock;
+        }
+    });
+
+    $serviceMock->setDi($di);
+    $eventMock->shouldReceive('getDi')->once()->andReturn($di);
 
     $serviceMock->onAfterAdminOrderUncancel($eventMock);
 });


### PR DESCRIPTION
Follow-up to #4110. That PR fixed `onAfterAdminOrderSuspend()` so it no longer requires a logged-in admin session, since automatic (cron/webcron) order suspensions run without one. The same unguarded `$di['loggedin_admin']` lookup exists in three sibling order-lifecycle email handlers, so the identical failure mode (silently skipped client email) applies to them too.