### PR TITLE
Add duplicate action for promo codes

### DIFF
--- a/src/modules/Product/Api/Admin.php
+++ b/src/modules/Product/Api/Admin.php
@@ -485,6 +485,24 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
+     * Duplicate an existing promo code.
+     *
+     * @return int - ID of the new promo code
+     *
+     * @throws \FOSSBilling\Exception
+     */
+    #[RequiredParams(['id' => 'Promo ID was not passed'])]
+    public function promo_duplicate($data)
+    {
+        $this->checkPermissions('product', 'manage_promos');
+
+        $service = $this->getService();
+        $model = $service->findPromoById((int) $data['id']);
+
+        return $service->duplicatePromo($model);
+    }
+
+    /**
      * Get promo redemption history.
      *
      * @return array

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -1193,6 +1193,35 @@ class Service implements InjectionAwareInterface
         return $promoId;
     }
 
+    public function duplicatePromo(Promo $model): int
+    {
+        $promo = new Promo();
+        $promo
+            ->setCode($this->generateUniquePromoCode($model->getCode()))
+            ->setDescription($model->getDescription())
+            ->setType($model->getType())
+            ->setValue($model->getValue())
+            ->setActive(false)
+            ->setFreeSetup($model->isFreeSetup())
+            ->setOncePerClient($model->isOncePerClient())
+            ->setRecurring($model->isRecurring())
+            ->setUsed(0)
+            ->setMaxUses($model->getMaxUses())
+            ->setProducts($model->getProducts())
+            ->setPeriods($model->getPeriods())
+            ->setClientGroups($model->getClientGroups())
+            ->setStartAt($model->getStartAt() !== null ? clone $model->getStartAt() : null)
+            ->setEndAt($model->getEndAt() !== null ? clone $model->getEndAt() : null);
+
+        $this->di['em']->persist($promo);
+        $this->di['em']->flush();
+        $promoId = (int) $promo->getId();
+
+        $this->di['logger']->info('Duplicated promotion code %s into new promotion code %s', $model->getCode(), $promo->getCode());
+
+        return $promoId;
+    }
+
     public function findActivePromoByCode($code): ?Promo
     {
         return $this->getPromoRepository()->findActiveByCode((string) $code);
@@ -2431,6 +2460,20 @@ class Service implements InjectionAwareInterface
     private function decodePromoSelection(?string $selection): array
     {
         return json_decode($selection ?? '', true) ?? [];
+    }
+
+    private function generateUniquePromoCode(?string $code): string
+    {
+        $baseCode = trim((string) $code) !== '' ? (string) $code : 'PROMO';
+
+        $attempt = 1;
+        do {
+            $suffix = $attempt === 1 ? '-COPY' : sprintf('-COPY-%d', $attempt);
+            $candidate = substr($baseCode, 0, 100 - strlen($suffix)) . $suffix;
+            ++$attempt;
+        } while ($this->getPromoRepository()->findOneBy(['code' => $candidate]) instanceof Promo);
+
+        return $candidate;
     }
 
     private function normalizePromoDateTime(mixed $value): ?string

--- a/src/modules/Product/templates/admin/mod_product_promos.html.twig
+++ b/src/modules/Product/templates/admin/mod_product_promos.html.twig
@@ -96,6 +96,12 @@
                                     <use href="#eye" />
                                 </svg>
                             </a>
+                            <a class="btn btn-icon" href="{{ 'product/promo_duplicate'|api_url(query: { 'id': promo.id }) }}" title="{{ 'Duplicate'|trans }}"
+                                {{ fb_api_link({redirect: 'product/promos'|url}) }}>
+                                <svg class="icon">
+                                    <use href="#copy" />
+                                </svg>
+                            </a>
                             {% if promo.can_be_deleted %}
                                 <a class="btn btn-icon" href="{{ 'product/promo_delete'|api_url(query: { 'id': promo.id }) }}"
                                     {{ fb_api_link({modal: {type: 'confirm', title: 'Are you sure?'|trans}, redirect: 'product/promos'|url}) }}>

--- a/src/modules/Product/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Product/tests/Unit/Api/AdminTest.php
@@ -379,6 +379,21 @@ test('gets a promo', function (): void {
     expect($api->promo_get($data))->toBeArray();
 });
 
+test('duplicates a promo', function (): void {
+    $api = apiEndpoint(new Admin());
+    $data = ['id' => 1];
+    $model = new Promo();
+    $newPromoId = 2;
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('findPromoById')->atLeast()->once()->with(1)->andReturn($model);
+    $serviceMock->shouldReceive('duplicatePromo')->atLeast()->once()->with($model)->andReturn($newPromoId);
+
+    $api->setDi(container());
+    $api->setService($serviceMock);
+    expect($api->promo_duplicate($data))->toBe($newPromoId);
+});
+
 test('gets promo redemption list', function (): void {
     $api = apiEndpoint(new Admin());
     $qbMock = Mockery::mock(Doctrine\ORM\QueryBuilder::class);

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -1039,6 +1039,121 @@ test('create promo', function (): void {
     expect($result)->toEqual(1);
 });
 
+test('duplicate promo', function (): void {
+    $service = new Service();
+
+    $promoEntity = productTestCreatePromoEntity(1)
+        ->setCode('PROMO')
+        ->setDescription('desc')
+        ->setType('percentage')
+        ->setValue(50)
+        ->setActive(true)
+        ->setFreeSetup(true)
+        ->setOncePerClient(true)
+        ->setRecurring(true)
+        ->setUsed(5)
+        ->setMaxUses(10)
+        ->setProducts('[1]')
+        ->setPeriods('["1M"]')
+        ->setClientGroups('[2]')
+        ->setStartAt(new DateTime('2012-01-01'))
+        ->setEndAt(new DateTime('2012-01-02'));
+
+    $promoRepo = Mockery::mock(PromoRepository::class);
+    $promoRepo->shouldReceive('findOneBy')->once()->with(['code' => 'PROMO-COPY'])->andReturn(null);
+
+    $emMock = new class($promoRepo) {
+        public ?Promo $captured = null;
+
+        public function __construct(private object $promoRepo)
+        {
+        }
+
+        public function getRepository(string $class): object
+        {
+            return $this->promoRepo;
+        }
+
+        public function persist(object $entity): void
+        {
+            $reflection = new ReflectionProperty($entity, 'id');
+            $reflection->setValue($entity, 2);
+            $this->captured = $entity;
+        }
+
+        public function flush(): void
+        {
+        }
+    };
+
+    $di = container();
+    $di['logger'] = new Box_Log();
+    $di['em'] = $emMock;
+
+    $service->setDi($di);
+    $result = $service->duplicatePromo($promoEntity);
+
+    expect($result)->toBeInt();
+    expect($result)->toEqual(2);
+    expect($emMock->captured)->not->toBeNull();
+    expect($emMock->captured->getCode())->toBe('PROMO-COPY');
+    expect($emMock->captured->getDescription())->toBe('desc');
+    expect($emMock->captured->isActive())->toBeFalse();
+    expect($emMock->captured->getUsed())->toBe(0);
+    expect($emMock->captured->getMaxUses())->toBe(10);
+    expect($emMock->captured->isFreeSetup())->toBeTrue();
+    expect($emMock->captured->isOncePerClient())->toBeTrue();
+    expect($emMock->captured->isRecurring())->toBeTrue();
+    expect($emMock->captured->getProducts())->toBe('[1]');
+    expect($emMock->captured->getPeriods())->toBe('["1M"]');
+    expect($emMock->captured->getClientGroups())->toBe('[2]');
+});
+
+test('duplicate promo generates alternate code when copy code already exists', function (): void {
+    $service = new Service();
+
+    $promoEntity = productTestCreatePromoEntity(1)->setCode('PROMO');
+    $existingCopy = productTestCreatePromoEntity(2)->setCode('PROMO-COPY');
+
+    $promoRepo = Mockery::mock(PromoRepository::class);
+    $promoRepo->shouldReceive('findOneBy')->once()->with(['code' => 'PROMO-COPY'])->andReturn($existingCopy);
+    $promoRepo->shouldReceive('findOneBy')->once()->with(['code' => 'PROMO-COPY-2'])->andReturn(null);
+
+    $emMock = new class($promoRepo) {
+        public ?Promo $captured = null;
+
+        public function __construct(private object $promoRepo)
+        {
+        }
+
+        public function getRepository(string $class): object
+        {
+            return $this->promoRepo;
+        }
+
+        public function persist(object $entity): void
+        {
+            $reflection = new ReflectionProperty($entity, 'id');
+            $reflection->setValue($entity, 3);
+            $this->captured = $entity;
+        }
+
+        public function flush(): void
+        {
+        }
+    };
+
+    $di = container();
+    $di['logger'] = new Box_Log();
+    $di['em'] = $emMock;
+
+    $service->setDi($di);
+    $result = $service->duplicatePromo($promoEntity);
+
+    expect($result)->toEqual(3);
+    expect($emMock->captured->getCode())->toBe('PROMO-COPY-2');
+});
+
 test('to promo api array', function (): void {
     $service = new Service();
     $model = productTestCreatePromoEntity(1)


### PR DESCRIPTION
Closes #978.

Admins previously had to re-enter every field by hand to create a similar promo code (e.g. for a giveaway with many one-off codes). This adds a **Duplicate** action to the Product Promotions list, mirroring the existing "Copy" action on the Payment Gateways page.

Note: the "reusable code limited to N uses" part of the original request (`maxuses` / `once_per_client`) was already implemented in a prior migration, so this PR only adds the missing duplicate action.