### PR TITLE
Allow restricting TLD registration to an explicit period list

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','98',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','99',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -1421,6 +1421,7 @@ CREATE TABLE `tld` (
   `allow_transfer` tinyint(1) DEFAULT NULL,
   `active` tinyint(1) DEFAULT '1',
   `min_years` tinyint(4) DEFAULT NULL,
+  `periods` varchar(255) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -508,6 +508,7 @@ class UpdatePatcher implements InjectionAwareInterface
             96 => 'patch96',
             97 => 'patch97',
             98 => 'patch98',
+            99 => 'patch99',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2881,6 +2882,16 @@ class UpdatePatcher implements InjectionAwareInterface
             $this->executeFileActions([
                 $oldGatewayAssetsPath => 'unlink',
             ]);
+        }
+    }
+
+    private function patch99(): void
+    {
+        // Lets admins restrict a TLD's registration period to an explicit set of years
+        // (e.g. "1,2,5,10") instead of any integer at or above min_years.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/2075
+        if (!$this->tableHasColumn('tld', 'periods')) {
+            $this->executeSql('ALTER TABLE `tld` ADD COLUMN `periods` VARCHAR(255) DEFAULT NULL AFTER `min_years`');
         }
     }
 }

--- a/src/modules/Product/Repository/DomainPricingRepository.php
+++ b/src/modules/Product/Repository/DomainPricingRepository.php
@@ -20,7 +20,7 @@ class DomainPricingRepository
     }
 
     /**
-     * @return array<mixed, array<'active'|'allow_register'|'allow_transfer'|'min_years'|'price_registration'|'price_renew'|'price_transfer'|'registrar'|'tld', mixed>>
+     * @return array<mixed, array<'active'|'allow_register'|'allow_transfer'|'min_years'|'periods'|'price_registration'|'price_renew'|'price_transfer'|'registrar'|'tld', mixed>>
      */
     public function getActivePricingByTld(): array
     {
@@ -45,6 +45,7 @@ class DomainPricingRepository
                 'allow_register' => $tld['allow_register'],
                 'allow_transfer' => $tld['allow_transfer'],
                 'min_years' => $tld['min_years'],
+                'periods' => $tld['periods'] !== null && $tld['periods'] !== '' ? array_map('intval', explode(',', (string) $tld['periods'])) : null,
                 'registrar' => [
                     'id' => $tld['tld_registrar_id'],
                     'title' => $tld['name'],

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -376,7 +376,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * @return array<mixed, array<'active'|'allow_register'|'allow_transfer'|'min_years'|'price_registration'|'price_renew'|'price_transfer'|'registrar'|'tld', mixed>>
+     * @return array<mixed, array<'active'|'allow_register'|'allow_transfer'|'min_years'|'periods'|'price_registration'|'price_renew'|'price_transfer'|'registrar'|'tld', mixed>>
      */
     public function getDomainPricingArray(): array
     {

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -192,11 +192,12 @@ function productTestCreateDomainPricingDbalConnection(): Connection
         allow_register INTEGER,
         allow_transfer INTEGER,
         active INTEGER,
-        min_years INTEGER
+        min_years INTEGER,
+        periods TEXT
     )');
     $connection->executeStatement("INSERT INTO tld_registrar (id, name) VALUES (1, 'Registrar A')");
-    $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years) VALUES (1, 1, '.com', 10.00, 12.00, 14.00, 1, 1, 1, 1)");
-    $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years) VALUES (2, 1, '.net', 11.00, 13.00, 15.00, 1, 1, 0, 1)");
+    $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years, periods) VALUES (1, 1, '.com', 10.00, 12.00, 14.00, 1, 1, 1, 1, '1,2,5')");
+    $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years, periods) VALUES (2, 1, '.net', 11.00, 13.00, 15.00, 1, 1, 0, 1, NULL)");
 
     return $connection;
 }
@@ -574,6 +575,7 @@ test('get domain pricing array returns active tlds', function (): void {
     expect($result)->not->toHaveKey('.net');
     expect($result['.com']['price_registration'])->toEqual(10.0);
     expect($result['.com']['registrar']['title'])->toBe('Registrar A');
+    expect($result['.com']['periods'])->toBe([1, 2, 5]);
 });
 
 test('get product pricing array uses domain pricing implementation', function (): void {

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -198,6 +198,7 @@ function productTestCreateDomainPricingDbalConnection(): Connection
     $connection->executeStatement("INSERT INTO tld_registrar (id, name) VALUES (1, 'Registrar A')");
     $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years, periods) VALUES (1, 1, '.com', 10.00, 12.00, 14.00, 1, 1, 1, 1, '1,2,5')");
     $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years, periods) VALUES (2, 1, '.net', 11.00, 13.00, 15.00, 1, 1, 0, 1, NULL)");
+    $connection->executeStatement("INSERT INTO tld (id, tld_registrar_id, tld, price_registration, price_renew, price_transfer, allow_register, allow_transfer, active, min_years, periods) VALUES (3, 1, '.org', 9.00, 11.00, 13.00, 1, 1, 1, 1, NULL)");
 
     return $connection;
 }
@@ -576,6 +577,9 @@ test('get domain pricing array returns active tlds', function (): void {
     expect($result['.com']['price_registration'])->toEqual(10.0);
     expect($result['.com']['registrar']['title'])->toBe('Registrar A');
     expect($result['.com']['periods'])->toBe([1, 2, 5]);
+
+    expect($result)->toHaveKey('.org');
+    expect($result['.org']['periods'])->toBeNull();
 });
 
 test('get product pricing array uses domain pricing implementation', function (): void {

--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -239,6 +239,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     /**
      * Add new top level domain.
      *
+     * @optional int $min_years - minimum registration period, in years
+     * @optional string $periods - comma-separated list of the exact registration periods
+     *                             (in years) allowed for this TLD, e.g. "1,2,3,5,10". When
+     *                             omitted, any period from min_years upwards is allowed.
+     *
      * @return bool
      *
      * @throws \FOSSBilling\Exception
@@ -268,6 +273,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      * @optional float $price_registration - registration price
      * @optional float $price_renew - renewal price
      * @optional float $price_transfer - transfer price
+     * @optional int $min_years - minimum registration period, in years
+     * @optional string $periods - comma-separated list of the exact registration periods
+     *                             (in years) allowed for this TLD, e.g. "1,2,3,5,10". Pass
+     *                             an empty string to clear it and allow any period from
+     *                             min_years upwards again.
      *
      * @return bool
      *

--- a/src/modules/Servicedomain/Entity/Tld.php
+++ b/src/modules/Servicedomain/Entity/Tld.php
@@ -57,6 +57,14 @@ class Tld implements TimestampInterface
     #[ORM\Column(name: 'min_years', type: Types::SMALLINT, nullable: true)]
     private ?int $minYears = null;
 
+    /**
+     * Comma-separated list of the exact registration periods (in years) this TLD may be
+     * ordered for, e.g. "1,2,3,5,10". Null means any period from min_years upwards is
+     * allowed, matching the legacy behavior.
+     */
+    #[ORM\Column(name: 'periods', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $periods = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -175,5 +183,36 @@ class Tld implements TimestampInterface
         $this->minYears = $minYears;
 
         return $this;
+    }
+
+    public function getPeriods(): ?string
+    {
+        return $this->periods;
+    }
+
+    public function setPeriods(?string $periods): self
+    {
+        $this->periods = $periods;
+
+        return $this;
+    }
+
+    /**
+     * The allowed registration periods (in years), sorted ascending, or null when
+     * this TLD has no explicit period list and any period from min_years upwards
+     * is allowed.
+     *
+     * @return int[]|null
+     */
+    public function getPeriodsArray(): ?array
+    {
+        if ($this->periods === null || trim($this->periods) === '') {
+            return null;
+        }
+
+        $years = array_unique(array_map('intval', explode(',', $this->periods)));
+        sort($years);
+
+        return $years;
     }
 }

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -178,7 +178,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             if ($years === false || $years < 1) {
                 throw new \FOSSBilling\InformationException('Domain registration period must be a positive integer');
             }
-            if ($years < $tld->getMinYears()) {
+
+            $allowedPeriods = $tld->getPeriodsArray();
+            if ($allowedPeriods !== null) {
+                if (!in_array($years, $allowedPeriods, true)) {
+                    throw new \FOSSBilling\Exception(':tld can only be registered for :periods years', [':tld' => $tld->getTld(), ':periods' => implode(', ', $allowedPeriods)]);
+                }
+            } elseif ($years < ($tld->getMinYears() ?? 1)) {
                 throw new \FOSSBilling\Exception(':tld can be registered for at least :years years', [':tld' => $tld->getTld(), ':years' => $tld->getMinYears()]);
             }
 
@@ -784,6 +790,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->setPriceRenew((string) $data['price_renew']);
         $model->setPriceTransfer((string) $data['price_transfer']);
         $model->setMinYears(isset($data['min_years']) ? (int) $data['min_years'] : 1);
+        $model->setPeriods(array_key_exists('periods', $data) ? $data['periods'] : null);
         $model->setAllowRegister(isset($data['allow_register']) ? (bool) $data['allow_register'] : true);
         $model->setAllowTransfer(isset($data['allow_transfer']) ? (bool) $data['allow_transfer'] : true);
         $model->setActive(isset($data['active']) ? (bool) $data['active'] : true);
@@ -811,6 +818,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->setPriceRenew(isset($data['price_renew']) ? (string) $data['price_renew'] : $model->getPriceRenew());
         $model->setPriceTransfer(isset($data['price_transfer']) ? (string) $data['price_transfer'] : $model->getPriceTransfer());
         $model->setMinYears(isset($data['min_years']) ? (int) $data['min_years'] : $model->getMinYears());
+        $model->setPeriods(array_key_exists('periods', $data) ? $data['periods'] : $model->getPeriods());
         $model->setAllowRegister(array_key_exists('allow_register', $data) ? (bool) $data['allow_register'] : $model->isAllowRegister());
         $model->setAllowTransfer(array_key_exists('allow_transfer', $data) ? (bool) $data['allow_transfer'] : $model->isAllowTransfer());
         $model->setActive(array_key_exists('active', $data) ? (bool) $data['active'] : $model->isActive());
@@ -848,7 +856,42 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             $data['min_years'] = $minimumYears;
         }
 
+        if (array_key_exists('periods', $data)) {
+            $data['periods'] = $this->normalizePeriods($data['periods']);
+        }
+
         return $data;
+    }
+
+    /**
+     * Normalize a raw comma-separated "periods" string into a sorted, deduplicated
+     * comma-separated string of positive integers, or null when empty.
+     */
+    private function normalizePeriods(?string $periods): ?string
+    {
+        if ($periods === null || trim($periods) === '') {
+            return null;
+        }
+
+        $years = array_filter(array_map('trim', explode(',', $periods)), fn ($year): bool => $year !== '');
+
+        $normalized = [];
+        foreach ($years as $year) {
+            $value = filter_var($year, FILTER_VALIDATE_INT);
+            if ($value === false || $value < 1) {
+                throw new \FOSSBilling\InformationException('Registration periods must be a comma-separated list of positive integers');
+            }
+            $normalized[] = $value;
+        }
+
+        if ($normalized === []) {
+            return null;
+        }
+
+        $normalized = array_unique($normalized);
+        sort($normalized);
+
+        return implode(',', $normalized);
     }
 
     public function tldGetSearchQuery($data): QueryBuilder
@@ -925,6 +968,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             'allow_register' => $model->isAllowRegister(),
             'allow_transfer' => $model->isAllowTransfer(),
             'min_years' => $model->getMinYears(),
+            'periods' => $model->getPeriodsArray(),
         ];
 
         if ($identity instanceof \Model_Admin) {

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_index.html.twig
@@ -258,6 +258,11 @@
                                     <label class="form-label" for="new-tld-min-years">{{ 'Minimum Years of Registration'|trans }}</label>
                                     <input class="form-control" id="new-tld-min-years" type="number" min="1" step="1" name="min_years" value="1" required>
                                 </div>
+                                <div class="col-md-6">
+                                    <label class="form-label" for="new-tld-periods">{{ 'Allowed Registration Periods (years)'|trans }}</label>
+                                    <input class="form-control" id="new-tld-periods" type="text" name="periods" placeholder="{{ '1,2,3,5,10'|trans }}">
+                                    <div class="form-hint">{{ 'Comma-separated list of exact registration periods, in years. Leave blank to allow any period from the minimum above upwards.'|trans }}</div>
+                                </div>
                             </div>
                         </section>
 

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_tld.html.twig
@@ -57,6 +57,11 @@
                         <label class="form-label">{{ 'Minimum Years of Registration'|trans }}</label>
                         <input class="form-control" type="number" min="1" step="1" name="min_years" value="{{ tld.min_years }}" required>
                     </div>
+                    <div class="col-lg-6">
+                        <label class="form-label">{{ 'Allowed Registration Periods (years)'|trans }}</label>
+                        <input class="form-control" type="text" name="periods" value="{{ tld.periods ? tld.periods|join(',') : '' }}" placeholder="{{ '1,2,3,5,10'|trans }}">
+                        <div class="form-hint">{{ 'Comma-separated list of exact registration periods, in years. Leave blank to allow any period from the minimum above upwards.'|trans }}</div>
+                    </div>
                     <div class="col-lg-2">
                         <label class="form-label d-block">{{ 'Allow Registration'|trans }}</label>
                         <div class="d-flex flex-wrap gap-3">

--- a/src/modules/Servicedomain/templates/client/mod_servicedomain_order_form.html.twig
+++ b/src/modules/Servicedomain/templates/client/mod_servicedomain_order_form.html.twig
@@ -237,7 +237,18 @@
                     const yearLabel = "{{ ' Year @ '|trans }}";
                     const yearsLabel = "{{ ' Years @ '|trans }}";
 
-                    for (let i = 1; i <= 5; i++) {
+                    // Use the TLD's explicit period list when configured; otherwise fall
+                    // back to a range starting at its minimum registration period.
+                    let allowedYears = Array.isArray(result.periods) && result.periods.length ? result.periods : null;
+                    if (!allowedYears) {
+                        const minYears = Number(result.min_years) > 0 ? Number(result.min_years) : 1;
+                        allowedYears = [];
+                        for (let i = minYears; i < minYears + 5; i++) {
+                            allowedYears.push(i);
+                        }
+                    }
+
+                    allowedYears.forEach(function (i) {
                         const totalPrice = (i === 1) ? regPrice : regPrice + (i - 1) * renewPrice;
                         const priceFormatted = formatCurrency(
                             totalPrice,
@@ -249,7 +260,7 @@
                         yearsSelect.append(
                             new Option(i + (i === 1 ? yearLabel : yearsLabel) + priceFormatted, i)
                         );
-                    }
+                    });
 
                     configNext.style.display = '';
                     configNext.disabled = false;

--- a/src/modules/Servicedomain/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicedomain/tests/Unit/ServiceTest.php
@@ -210,6 +210,66 @@ test('throws exception for register order data with invalid tld', function (arra
     ];
 });
 
+test('rejects a registration period outside the tld allowed periods list', function (): void {
+    $tldModel = new Tld();
+    $tldModel->setTld('.com');
+    $tldModel->setMinYears(1);
+    $tldModel->setPeriods('1,2,5');
+    $tldModel->setActive(true);
+
+    $data = [
+        'action' => 'register',
+        'register_sld' => 'example',
+        'register_years' => 3,
+        'register_tld' => '.com',
+    ];
+
+    $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
+    $validatorMock->shouldReceive('isSldValid')->atLeast()->once()->andReturn(true);
+    $validatorMock->shouldReceive('checkRequiredParamsForArray')->zeroOrMoreTimes();
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('tldFindOneByTld')->atLeast()->once()->andReturn($tldModel);
+
+    $di = container();
+    $di['validator'] = $validatorMock;
+    $serviceMock->setDi($di);
+
+    expect(fn () => $serviceMock->validateOrderData($data))
+        ->toThrow(FOSSBilling\Exception::class);
+});
+
+test('accepts a registration period within the tld allowed periods list', function (): void {
+    $tldModel = new Tld();
+    $tldModel->setTld('.com');
+    $tldModel->setMinYears(1);
+    $tldModel->setPeriods('1,2,5');
+    $tldModel->setActive(true);
+
+    $data = [
+        'action' => 'register',
+        'register_sld' => 'example',
+        'register_years' => 5,
+        'register_tld' => '.com',
+    ];
+
+    $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
+    $validatorMock->shouldReceive('isSldValid')->atLeast()->once()->andReturn(true);
+    $validatorMock->shouldReceive('checkRequiredParamsForArray')->zeroOrMoreTimes();
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $serviceMock->shouldReceive('tldFindOneByTld')->atLeast()->once()->andReturn($tldModel);
+    $serviceMock->shouldReceive('isDomainAvailable')->atLeast()->once()->andReturn(true);
+
+    $di = container();
+    $di['validator'] = $validatorMock;
+    $serviceMock->setDi($di);
+
+    $serviceMock->validateOrderData($data);
+
+    expect($data['period'])->toBe('5Y');
+});
+
 test('rejects a crafted order for an inactive tld before contacting the registrar', function (string $action): void {
     $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
     $validatorMock->shouldReceive('checkRequiredParamsForArray')->atLeast()->once();
@@ -1371,6 +1431,7 @@ test('converts tld to api array', function (): void {
     $model->setAllowRegister(true);
     $model->setAllowTransfer(true);
     $model->setMinYears(2);
+    $model->setPeriods('5,2,2,10');
     $model->setTldRegistrarId(1);
 
     $result = $service->tldToApiArray($model, new Model_Admin());
@@ -1384,6 +1445,7 @@ test('converts tld to api array', function (): void {
     expect($result)->toHaveKey('allow_register');
     expect($result)->toHaveKey('allow_transfer');
     expect($result)->toHaveKey('min_years');
+    expect($result)->toHaveKey('periods');
     expect($result)->toHaveKey('registrar');
 
     $registrar = $result['registrar'];
@@ -1399,6 +1461,7 @@ test('converts tld to api array', function (): void {
     expect($result['allow_register'])->toBe($model->isAllowRegister());
     expect($result['allow_transfer'])->toBe($model->isAllowTransfer());
     expect($result['min_years'])->toBe($model->getMinYears());
+    expect($result['periods'])->toBe([2, 5, 10]);
 
     expect($registrar['id'])->toBe($model->getTldRegistrarId());
     expect($registrar['title'])->toBe($tldRegistrar->getName());
@@ -1757,6 +1820,7 @@ test('creates tld', function (): void {
         'price_renew' => 1,
         'price_transfer' => 1,
         'min_years' => random_int(1, 5),
+        'periods' => '5,1,1,3',
         'allow_register' => 1,
         'allow_transfer' => 1,
     ];
@@ -1767,10 +1831,13 @@ test('creates tld', function (): void {
     $trRepo->shouldReceive('find')->with(1)->andReturn($tldRegistrar);
     $trRepo->shouldIgnoreMissing();
 
+    $createdModel = null;
+
     $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
     $emMock->shouldReceive('getRepository')->with(TldRegistrar::class)->andReturn($trRepo);
-    $emMock->shouldReceive('persist')->once()->andReturnUsing(function ($model): void {
+    $emMock->shouldReceive('persist')->once()->andReturnUsing(function ($model) use (&$createdModel): void {
         $model->setId(1);
+        $createdModel = $model;
     });
     $emMock->shouldReceive('flush')->atLeast()->once();
 
@@ -1783,6 +1850,7 @@ test('creates tld', function (): void {
 
     expect($result)->toBeInt();
     expect($result)->toBe(1);
+    expect($createdModel->getPeriods())->toBe('1,3,5');
 });
 
 test('updates tld', function (): void {
@@ -1795,6 +1863,7 @@ test('updates tld', function (): void {
         'price_renew' => 1,
         'price_transfer' => 1,
         'min_years' => random_int(1, 5),
+        'periods' => '10,2',
         'allow_register' => true,
         'allow_transfer' => true,
         'active' => true,
@@ -1822,6 +1891,29 @@ test('updates tld', function (): void {
     $result = $service->tldUpdate($model, $data);
 
     expect($result)->toBeTrue();
+    expect($model->getPeriods())->toBe('2,10');
+});
+
+test('clears tld periods when an empty value is provided', function (): void {
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('registrarValidateConfiguration')->never();
+
+    $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $emMock->shouldReceive('flush')->atLeast()->once();
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $service->setDi($di);
+
+    $model = new Tld();
+    $model->setTld('.com');
+    $model->setPeriods('1,2,5');
+
+    $result = $service->tldUpdate($model, ['tld' => '.com', 'periods' => '']);
+
+    expect($result)->toBeTrue();
+    expect($model->getPeriods())->toBeNull();
 });
 
 test('rejects invalid tld pricing and minimum periods', function (array $data): void {
@@ -1843,6 +1935,8 @@ test('rejects invalid tld pricing and minimum periods', function (array $data): 
     'negative registration price' => [['price_registration' => -1]],
     'non-numeric renewal price' => [['price_renew' => 'free']],
     'non-positive minimum period' => [['min_years' => 0]],
+    'non-numeric period in periods list' => [['periods' => '1,2,five']],
+    'non-positive period in periods list' => [['periods' => '1,0,3']],
 ]);
 
 test('creates registrar', function (): void {


### PR DESCRIPTION
Closes #2075. That issue asked for three things:

- API to add/delete TLDs - already implemented (`tld_create`/`tld_delete`)
- API to edit live TLD prices - already implemented (`tld_update`)
- The ability to match registrar-specific registration/renewal periods (e.g. only `1, 2, 5, or 10 years`, not any integer) - **missing**, only a `min_years` floor existed

This PR adds the third piece: an optional, explicit list of allowed registration years per TLD.