### PR TITLE
Add admin setting to Bcc a copy of every outgoing email

### DIFF
--- a/src/library/FOSSBilling/Mail.php
+++ b/src/library/FOSSBilling/Mail.php
@@ -67,7 +67,7 @@ class Mail
      */
     public function addTo(string|array $toAddresses): void
     {
-        $this->email->addTo($toAddresses);
+        $this->email->addTo(...(array) $toAddresses);
     }
 
     /**
@@ -77,7 +77,7 @@ class Mail
      */
     public function addCc(string|array $ccAddresses): void
     {
-        $this->email->addCc($ccAddresses);
+        $this->email->addCc(...(array) $ccAddresses);
     }
 
     /**
@@ -87,7 +87,7 @@ class Mail
      */
     public function addBcc(string|array $bccAddresses): void
     {
-        $this->email->addBcc($bccAddresses);
+        $this->email->addBcc(...(array) $bccAddresses);
     }
 
     /**
@@ -97,7 +97,7 @@ class Mail
      */
     public function addReplyTo(string|array $replyToAddresses): void
     {
-        $this->email->addReplyTo($replyToAddresses);
+        $this->email->addReplyTo(...(array) $replyToAddresses);
     }
 
     /**

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -1202,6 +1202,28 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         ];
     }
 
+    /**
+     * @return string[]
+     */
+    private function parseBccAddresses(string $value): array
+    {
+        $addresses = [];
+        foreach (explode(',', $value) as $address) {
+            $address = trim($address);
+            if ($address === '') {
+                continue;
+            }
+
+            if (filter_var($address, FILTER_VALIDATE_EMAIL)) {
+                $addresses[] = $address;
+            } else {
+                $this->di['logger']->setChannel('email')->warning('Skipping invalid Bcc address: ' . $address);
+            }
+        }
+
+        return $addresses;
+    }
+
     private function _sendFromQueue(QueuedEmail $queue, bool $throw_exceptions = false): bool
     {
         $extensionService = $this->di['mod_service']('extension');
@@ -1241,6 +1263,13 @@ class Service implements \FOSSBilling\InjectionAwareInterface
                     $mail->addReplyTo($settings['reply_to']);
                 } else {
                     $this->di['logger']->setChannel('email')->warning('Skipping invalid Reply-To address: ' . $settings['reply_to']);
+                }
+            }
+
+            if (!empty($settings['bcc_email'])) {
+                $bccAddresses = $this->parseBccAddresses((string) $settings['bcc_email']);
+                if ($bccAddresses !== []) {
+                    $mail->addBcc($bccAddresses);
                 }
             }
 

--- a/src/modules/Email/Service.php
+++ b/src/modules/Email/Service.php
@@ -36,6 +36,14 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     protected QueuedEmailRepository $queuedEmailRepository;
     private Filesystem $filesystem;
 
+    /**
+     * Cache of the parsed "Bcc" setting for the lifetime of this instance, so an invalid
+     * configured address is logged once per batch run rather than once per queued email.
+     *
+     * @var string[]|null
+     */
+    private ?array $validatedBccAddresses = null;
+
     public function __construct()
     {
         $this->filesystem = new Filesystem();
@@ -1267,7 +1275,8 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             }
 
             if (!empty($settings['bcc_email'])) {
-                $bccAddresses = $this->parseBccAddresses((string) $settings['bcc_email']);
+                $this->validatedBccAddresses ??= $this->parseBccAddresses((string) $settings['bcc_email']);
+                $bccAddresses = $this->validatedBccAddresses;
                 if ($bccAddresses !== []) {
                     $mail->addBcc($bccAddresses);
                 }

--- a/src/modules/Email/templates/admin/mod_email_settings.html.twig
+++ b/src/modules/Email/templates/admin/mod_email_settings.html.twig
@@ -439,6 +439,11 @@
                                     <input class="form-control" id="email-reply-to" type="email" name="reply_to" value="{{ params.reply_to|default('') }}" placeholder="{{ company.email }}">
                                     <small class="form-hint">{{ 'Leave blank to omit the Reply-To header.'|trans }}</small>
                                 </div>
+                                <div class="col-lg-6">
+                                    <label class="form-label" for="email-bcc">{{ 'Bcc Email'|trans }}</label>
+                                    <input class="form-control" id="email-bcc" type="text" name="bcc_email" value="{{ params.bcc_email|default('') }}" placeholder="billing@example.com">
+                                    <small class="form-hint">{{ 'Send a hidden copy of every outgoing email to this address, e.g. an accounts or billing mailbox. Comma-separate multiple addresses. Leave blank to disable.'|trans }}</small>
+                                </div>
                                 <div class="col-12">
                                     <label class="form-label" for="email-signature">{{ 'Email Signature'|trans }}</label>
                                     <textarea class="form-control" id="email-signature" name="signature" rows="4" placeholder="{{ company.signature }}">{{ params.signature|default('') }}</textarea>

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -1610,3 +1610,32 @@ test('loggedAttachmentToArray converts a logged attachment into a mail-ready arr
         'mime' => 'application/pdf',
     ]);
 });
+
+test('parseBccAddresses returns validated addresses and logs invalid ones', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $di = container();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $service->setDi($di);
+
+    $ref = new ReflectionMethod($service, 'parseBccAddresses');
+    $result = $ref->invoke($service, ' billing@example.com ,not-an-email, accounts@example.com,');
+
+    expect($result)->toBe(['billing@example.com', 'accounts@example.com']);
+
+    $logMessages = array_map(static fn (array $call): string => $call['params'][0], $di['logger']->calls);
+    expect($logMessages)->toContain('Skipping invalid Bcc address: not-an-email');
+});
+
+test('parseBccAddresses returns an empty array for a blank setting', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $di = container();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $service->setDi($di);
+
+    $ref = new ReflectionMethod($service, 'parseBccAddresses');
+    $result = $ref->invoke($service, '  ,  ');
+
+    expect($result)->toBe([]);
+});

--- a/src/modules/Email/tests/Unit/ServiceTest.php
+++ b/src/modules/Email/tests/Unit/ServiceTest.php
@@ -1639,3 +1639,55 @@ test('parseBccAddresses returns an empty array for a blank setting', function ()
 
     expect($result)->toBe([]);
 });
+
+test('_sendFromQueue only logs an invalid Bcc address once per service instance', function (): void {
+    $service = new Box\Mod\Email\Service();
+
+    $buildQueue = static function (int $id): Box\Mod\Email\Entity\QueuedEmail {
+        $queue = new Box\Mod\Email\Entity\QueuedEmail();
+        \Tests\Helpers\setEntityId($queue, $id);
+        $queue->setSubject('subject');
+        $queue->setSender('sender@example.com');
+        $queue->setRecipient('receiver@example.com');
+        $queue->setContent('content');
+
+        return $queue;
+    };
+
+    $em = emailBuildEm();
+    $em->shouldReceive('flush')->atLeast()->once();
+
+    $modMock = Mockery::mock(FOSSBilling\Module::class);
+    $modMock->shouldReceive('getConfig')
+        ->atLeast()->once()
+        ->andReturn([
+            'mailer' => 'sendmail',
+            'bcc_email' => 'billing@example.com,not-an-email',
+        ]);
+
+    $extension = Mockery::mock(Box\Mod\Extension\Service::class);
+    $extension->shouldReceive('isExtensionActive')->atLeast()->once()->andReturn(false);
+
+    $di = container();
+    $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod_service'] = $di->protect(function ($name) use ($extension) {
+        if ($name == 'extension') {
+            return $extension;
+        }
+    });
+    $di['mod'] = $di->protect(fn () => $modMock);
+
+    $service->setDi($di);
+
+    $ref = new ReflectionMethod($service, '_sendFromQueue');
+    $ref->invoke($service, $buildQueue(1));
+    $ref->invoke($service, $buildQueue(2));
+
+    $bccWarnings = array_filter(
+        $di['logger']->calls,
+        static fn (array $call): bool => $call['method'] === 'warning' && str_contains((string) $call['params'][0], 'Skipping invalid Bcc address')
+    );
+
+    expect($bccWarnings)->toHaveCount(1);
+});

--- a/tests/Unit/FOSSBilling/MailTest.php
+++ b/tests/Unit/FOSSBilling/MailTest.php
@@ -53,3 +53,35 @@ test('attach can be called multiple times to add several attachments', function 
 
     expect(mailGetUnderlyingEmail($mail)->getAttachments())->toHaveCount(2);
 });
+
+test('addBcc accepts a single address string', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addBcc('billing@example.com');
+
+    $bcc = mailGetUnderlyingEmail($mail)->getBcc();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $bcc))
+        ->toBe(['billing@example.com']);
+});
+
+test('addBcc accepts an array of address strings', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addBcc(['billing@example.com', 'accounts@example.com']);
+
+    $bcc = mailGetUnderlyingEmail($mail)->getBcc();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $bcc))
+        ->toBe(['billing@example.com', 'accounts@example.com']);
+});

--- a/tests/Unit/FOSSBilling/MailTest.php
+++ b/tests/Unit/FOSSBilling/MailTest.php
@@ -85,3 +85,99 @@ test('addBcc accepts an array of address strings', function (): void {
     expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $bcc))
         ->toBe(['billing@example.com', 'accounts@example.com']);
 });
+
+test('addTo accepts a single address string', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addTo('second@example.com');
+
+    $to = mailGetUnderlyingEmail($mail)->getTo();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $to))
+        ->toBe(['receiver@example.com', 'second@example.com']);
+});
+
+test('addTo accepts an array of address strings', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addTo(['second@example.com', 'third@example.com']);
+
+    $to = mailGetUnderlyingEmail($mail)->getTo();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $to))
+        ->toBe(['receiver@example.com', 'second@example.com', 'third@example.com']);
+});
+
+test('addCc accepts a single address string', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addCc('manager@example.com');
+
+    $cc = mailGetUnderlyingEmail($mail)->getCc();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $cc))
+        ->toBe(['manager@example.com']);
+});
+
+test('addCc accepts an array of address strings', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addCc(['manager@example.com', 'accounts@example.com']);
+
+    $cc = mailGetUnderlyingEmail($mail)->getCc();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $cc))
+        ->toBe(['manager@example.com', 'accounts@example.com']);
+});
+
+test('addReplyTo accepts a single address string', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addReplyTo('support@example.com');
+
+    $replyTo = mailGetUnderlyingEmail($mail)->getReplyTo();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $replyTo))
+        ->toBe(['support@example.com']);
+});
+
+test('addReplyTo accepts an array of address strings', function (): void {
+    $mail = new Mail(
+        ['email' => 'sender@example.com'],
+        ['email' => 'receiver@example.com'],
+        'Subject',
+        '<p>Body</p>',
+        'sendmail'
+    );
+
+    $mail->addReplyTo(['support@example.com', 'billing@example.com']);
+
+    $replyTo = mailGetUnderlyingEmail($mail)->getReplyTo();
+    expect(array_map(static fn (Symfony\Component\Mime\Address $address): string => $address->getAddress(), $replyTo))
+        ->toBe(['support@example.com', 'billing@example.com']);
+});


### PR DESCRIPTION
Closes #2642, which requested two things:

1. **Multiple overdue-invoice reminder notices** - already implemented: `invoice_reminder_before_due_days` / `invoice_reminder_after_due_days` in Invoice settings already accept comma-separated day intervals, so admins can already configure any number of reminders before/after the due date.
2. **Copy all outgoing emails to another admin-defined address** - was not implemented. `FOSSBilling\Mail::addBcc()` existed but nothing in the app ever called it, and there was no admin-facing setting.

This PR adds the missing piece (2).