### PR TITLE
Add setting to disable the add funds feature

### DIFF
--- a/src/modules/Client/templates/client/mod_client_balance.html.twig
+++ b/src/modules/Client/templates/client/mod_client_balance.html.twig
@@ -17,10 +17,12 @@
                             <h1 class="mb-1">{{ 'Wallet'|trans }}</h1>
                             <span class="small text-muted">{{ 'Here you can manage and track your account balance.'|trans }}</span>
                         </div>
-                        <form method="post" class="form-inline d-flex gap-2 justify-content-end" action="{{ 'invoice/funds_invoice'|api_url }}" {{ fb_api_form({callback: 'onAfterInvoiceCreated'}) }}>
-                            <input id="appendedPrependedInput" class="form-control w-50" type="text" name="amount" placeholder="0" required="required">
-                            <button class="btn btn-primary" type="submit">{{ 'Add Funds'|trans }}</button>
-                        </form>
+                        {% if guest.invoice_funds_enabled %}
+                            <form method="post" class="form-inline d-flex gap-2 justify-content-end" action="{{ 'invoice/funds_invoice'|api_url }}" {{ fb_api_form({callback: 'onAfterInvoiceCreated'}) }}>
+                                <input id="appendedPrependedInput" class="form-control w-50" type="text" name="amount" placeholder="0" required="required">
+                                <button class="btn btn-primary" type="submit">{{ 'Add Funds'|trans }}</button>
+                            </form>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="card-body table-responsive">

--- a/src/modules/Invoice/Api/Guest.php
+++ b/src/modules/Invoice/Api/Guest.php
@@ -96,6 +96,14 @@ class Guest extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
+     * Get whether the client add funds feature is enabled, or not.
+     */
+    public function funds_enabled(): bool
+    {
+        return $this->getService()->isFundsEnabled();
+    }
+
+    /**
      * Generates PDF for given invoice.
      *
      * @throws \FOSSBilling\Exception

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1695,10 +1695,21 @@ class Service implements InjectionAwareInterface
         ];
     }
 
+    public function isFundsEnabled(): bool
+    {
+        $systemService = $this->di['mod_service']('system');
+
+        return (bool) $systemService->getParamValue('funds_enabled', true);
+    }
+
     public function generateFundsInvoice(\Model_Client $client, $amount)
     {
         if (!$client->currency) {
             throw new InformationException('You must have at least one active order before you can add funds so you cannot proceed at the current time!');
+        }
+
+        if (!$this->isFundsEnabled()) {
+            throw new InformationException('Adding funds to the account balance is currently disabled', null, 980);
         }
 
         $systemService = $this->di['mod_service']('system');

--- a/src/modules/Invoice/templates/admin/mod_invoice_settings.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_settings.html.twig
@@ -167,7 +167,15 @@
             </div>
             <div class="card-body border-top">
                 <h4 class="card-title mb-2">{{ 'Add Funds Settings'|trans }}</h4>
-                <p class="text-secondary mb-3">{{ 'Set optional minimum and maximum invoice amounts for client add-funds requests.'|trans }}</p>
+                <p class="text-secondary mb-3">{{ 'Control whether clients can request to add funds to their account balance, and set optional minimum and maximum invoice amounts for those requests.'|trans }}</p>
+                <div class="mb-3">
+                    <input type="hidden" name="funds_enabled" value="0">
+                    <label class="form-check form-switch form-switch-2">
+                        <input class="form-check-input" type="checkbox" name="funds_enabled" value="1" {% if params.funds_enabled|default('1') != '0' %}checked{% endif %}>
+                        <span class="form-check-label">{{ 'Enable Add Funds Feature'|trans }}</span>
+                    </label>
+                    <small class="form-hint">{{ 'When disabled, clients cannot add funds and the Wallet link is hidden from client menus.'|trans }}</small>
+                </div>
                 <div class="row g-3">
                     <div class="col-lg-6">
                         <label class="form-label" for="funds_min_amount">{{ 'Minimum Amount for Add Funds Invoice'|trans }}</label>

--- a/src/modules/Invoice/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/GuestTest.php
@@ -126,6 +126,19 @@ test('throws exception when payment gateway id is missing', function (): void {
         ->toThrow(FOSSBilling\InformationException::class, 'Payment method not found. Missing param gateway_id');
 });
 
+test('gets whether add funds is enabled', function (): void {
+    $api = apiEndpoint(new Guest());
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('isFundsEnabled')
+        ->atLeast()->once()
+        ->andReturn(false);
+
+    $api->setService($serviceMock);
+
+    $result = $api->funds_enabled();
+    expect($result)->toBeFalse();
+});
+
 test('generates PDF', function (): void {
     $api = apiEndpoint(new Guest());
     $data = [

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -2591,6 +2591,27 @@ test('throws exception when generating funds invoice without active order', func
         ->toThrow(FOSSBilling\Exception::class, 'You must have at least one active order before you can add funds so you cannot proceed at the current time!');
 });
 
+test('throws exception when generating funds invoice while the feature is disabled', function (): void {
+    $service = new Service();
+    $clientModel = new Model_Client();
+    $clientModel->loadBean(new Tests\Helpers\DummyBean());
+    $clientModel->currency = 'EUR';
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->once()
+        ->with('funds_enabled', true)
+        ->andReturn('0');
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+
+    $service->setDi($di);
+
+    expect(fn () => $service->generateFundsInvoice($clientModel, 10))
+        ->toThrow(FOSSBilling\Exception::class, 'Adding funds to the account balance is currently disabled');
+});
+
 test('throws exception when generating funds invoice below minimum amount', function (): void {
     $service = new Service();
     $clientModel = new Model_Client();
@@ -2601,12 +2622,9 @@ test('throws exception when generating funds invoice below minimum amount', func
     $minAmount = 10;
     $maxAmount = 50;
     $systemService = Mockery::mock(SystemService::class);
-    $paramCallCount = 0;
-    $systemService->shouldReceive('getParamValue')
-        ->atLeast()->once()
-        ->andReturnUsing(function () use (&$paramCallCount, $minAmount, $maxAmount) {
-            return ++$paramCallCount === 1 ? $minAmount : $maxAmount;
-        });
+    $systemService->shouldReceive('getParamValue')->with('funds_enabled', true)->andReturn(true);
+    $systemService->shouldReceive('getParamValue')->with('funds_min_amount', null)->andReturn($minAmount);
+    $systemService->shouldReceive('getParamValue')->with('funds_max_amount', null)->andReturn($maxAmount);
 
     $di = container();
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
@@ -2627,12 +2645,9 @@ test('throws exception when generating funds invoice above maximum amount', func
     $minAmount = 10;
     $maxAmount = 50;
     $systemService = Mockery::mock(SystemService::class);
-    $paramCallCount = 0;
-    $systemService->shouldReceive('getParamValue')
-        ->atLeast()->once()
-        ->andReturnUsing(function () use (&$paramCallCount, $minAmount, $maxAmount) {
-            return ++$paramCallCount === 1 ? $minAmount : $maxAmount;
-        });
+    $systemService->shouldReceive('getParamValue')->with('funds_enabled', true)->andReturn(true);
+    $systemService->shouldReceive('getParamValue')->with('funds_min_amount', null)->andReturn($minAmount);
+    $systemService->shouldReceive('getParamValue')->with('funds_max_amount', null)->andReturn($maxAmount);
 
     $di = container();
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
@@ -2661,20 +2676,10 @@ test('generates funds invoice', function (): void {
     $maxAmount = 50;
 
     $systemService = Mockery::mock(SystemService::class);
-    $paramCallCount = 0;
-    $systemService->shouldReceive('getParamValue')
-        ->atLeast()->once()
-        ->andReturnUsing(function () use (&$paramCallCount, $minAmount, $maxAmount) {
-            ++$paramCallCount;
-            if ($paramCallCount === 1) {
-                return $minAmount;
-            }
-            if ($paramCallCount === 2) {
-                return $maxAmount;
-            }
-
-            return true;
-        });
+    $systemService->shouldReceive('getParamValue')->with('funds_enabled', true)->andReturn(true);
+    $systemService->shouldReceive('getParamValue')->with('funds_min_amount', null)->andReturn($minAmount);
+    $systemService->shouldReceive('getParamValue')->with('funds_max_amount', null)->andReturn($maxAmount);
+    $systemService->shouldReceive('getParamValue')->with('invoice_auto_approval', true)->andReturn(true);
 
     $itemInvoiceServiceMock = Mockery::mock(ServiceInvoiceItem::class);
     $itemInvoiceServiceMock->shouldReceive('generateForAddFunds')
@@ -2702,6 +2707,40 @@ test('generates funds invoice', function (): void {
 
     $result = $serviceMock->generateFundsInvoice($clientModel, $fundsAmount);
     expect($result)->toBeInstanceOf(Model_Invoice::class);
+});
+
+test('isFundsEnabled defaults to true when the setting was never saved', function (): void {
+    $service = new Service();
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->once()
+        ->with('funds_enabled', true)
+        ->andReturn(true);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+
+    $service->setDi($di);
+
+    expect($service->isFundsEnabled())->toBeTrue();
+});
+
+test('isFundsEnabled returns false when explicitly disabled', function (): void {
+    $service = new Service();
+
+    $systemService = Mockery::mock(SystemService::class);
+    $systemService->shouldReceive('getParamValue')
+        ->once()
+        ->with('funds_enabled', true)
+        ->andReturn('0');
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $systemService);
+
+    $service->setDi($di);
+
+    expect($service->isFundsEnabled())->toBeFalse();
 });
 
 test('throws exception when processing invoice not found', function (): void {

--- a/src/themes/huraga/html/mobile_menu.html.twig
+++ b/src/themes/huraga/html/mobile_menu.html.twig
@@ -54,7 +54,7 @@
     </li>
 {% endif %}
 
-{% if settings.side_menu_payments %}
+{% if settings.side_menu_payments and guest.invoice_funds_enabled %}
     <li class="nav-item">
         <a class="nav-link d-flex align-items-center gap-2{% if current_active_menu == 'payments' %} active{% endif %}" href="{{ 'client/balance'|url }}"{% if current_active_menu == 'payments' %} aria-current="page"{% endif %}>
             <svg class="icon"><use href="#wallet" /></svg>

--- a/src/themes/huraga/html/partial_menu.html.twig
+++ b/src/themes/huraga/html/partial_menu.html.twig
@@ -55,7 +55,7 @@
                 </li>
             {% endif %}
 
-            {% if settings.side_menu_payments %}
+            {% if settings.side_menu_payments and guest.invoice_funds_enabled %}
                 <li class="nav-item offcanvas-item{% if current_active_menu == 'payments' %} active{% endif %}">
                     <a class="nav-link d-flex align-items-center gap-2{% if current_active_menu == 'payments' %} active{% endif %}" href="{{ 'client/balance'|url }}"{% if current_active_menu == 'payments' %} aria-current="page"{% endif %}>
                         <svg class="icon"><use href="#wallet" /></svg>


### PR DESCRIPTION
Closes #3054. Adds a real "Enable Add Funds Feature" toggle to Invoice Settings that comprehensively disables the client self-service "add funds" / Wallet feature, not just a cosmetic menu hide.

Previously, the only related controls were theme-level cosmetic toggles (`side_menu_payments` to hide the Wallet link, `funds_min_amount`/`funds_max_amount` to clamp the amount). None of them actually blocked the feature; the Wallet page and its "Add Funds" form were always rendered, and the `invoice/funds_invoice` API endpoint had no way to be turned off, so a client could still submit requests directly even with the menu link hidden.

Admin-side manual balance credit (`Client\Api\Admin::balance_add_funds`) is intentionally untouched; admins can still credit a client's balance manually regardless of this setting.