### PR TITLE
Fix Namecheap adapter never returning domain expiration/registration dates

### DIFF
--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -310,8 +310,12 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
 
         $result = $this->_makeRequest($params);
 
-        $domain->setRegistrationTime((string) $result->CommandResponse->DomainGetInfoResult->DomainDetails->CreatedDate);
-        $domain->setExpirationTime((string) $result->CommandResponse->DomainGetInfoResult->DomainDetails->ExpiredDate);
+        // Namecheap returns these as "MM/DD/YYYY" strings, not Unix timestamps.
+        $registrationTime = strtotime((string) $result->CommandResponse->DomainGetInfoResult->DomainDetails->CreatedDate);
+        $expirationTime = strtotime((string) $result->CommandResponse->DomainGetInfoResult->DomainDetails->ExpiredDate);
+
+        $domain->setRegistrationTime($registrationTime === false ? null : $registrationTime);
+        $domain->setExpirationTime($expirationTime === false ? null : $expirationTime);
         $domain->setPrivacyEnabled((string) $result->CommandResponse->DomainGetInfoResult->Whoisguard['Enabled']);
 
         $params = [
@@ -334,6 +338,8 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
         // set SLD and TLD
         $newDomain->setSld($domain->getSld());
         $newDomain->setTld($domain->getTld());
+        $newDomain->setRegistrationTime($domain->getRegistrationTime());
+        $newDomain->setExpirationTime($domain->getExpirationTime());
 
         $registrarContact = new Registrar_Domain_Contact();
         $adminContact = new Registrar_Domain_Contact();


### PR DESCRIPTION
## Summary

`Registrar_Adapter_Namecheap::getDomainDetails()` has two compounding bugs that mean it always returns a domain with a `null` expiration/registration date, regardless of what the registrar actually reports.

## Fix

- Convert the two date strings via `strtotime()` before storing them, matching the pattern already used by `Registrar_Adapter_Internetbs::getDomainDetails()`.
- Copy the resulting registration/expiration timestamps onto `$newDomain` before it's returned, alongside the existing SLD/TLD copy.
