### PR TITLE
Fix Plesk subscription updates sending an invalid webspace 'set' request

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -538,7 +538,9 @@
         "whsec",
         "IDNA",
         "Namingo",
-        "htype"
+        "htype",
+        "webspace",
+        "webspaces"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/cspell.json
+++ b/cspell.json
@@ -537,7 +537,8 @@
         "Brien",
         "whsec",
         "IDNA",
-        "Namingo"
+        "Namingo",
+        "htype"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -571,11 +571,9 @@ class Server_Manager_Plesk extends Server_Manager
         ];
 
         if ($action === 'set') {
-            // The 'set' operation requires <filter> (which subscription to update) and <values>
-            // (the settings to apply) as the only direct children of <set> -- unlike 'add', the
-            // settings can't be placed directly under the action node. Filtering by 'owner-login'
-            // would match every webspace this customer owns and apply $values to all of them; 'name'
-            // (like deleteSubscription() already uses) scopes the update to this one subscription.
+            // Filtering by 'owner-login' would match every webspace this customer owns, applying
+            // $values to all of them; 'name' (like deleteSubscription() already uses) scopes the
+            // update to this one subscription.
             return [
                 'set' => [
                     'filter' => [

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -401,8 +401,16 @@ class Server_Manager_Plesk extends Server_Manager
      * Creates an array of properties for a subscription.
      * The properties include the domain name, owner login, hosting type, IP address, FTP login, FTP password, PHP, SSL, CGI, limits, and permissions.
      *
+     * For the 'add' action, the properties are sent as the direct children of the <add> node, per the
+     * webspace add operation's schema. For the 'set' action, Plesk requires the <set> node to contain only
+     * a <filter> (identifying which subscription to update) and a <values> node wrapping the actual
+     * settings; its gen_setup element also does not accept 'htype', which only applies at creation time.
+     *
+     * @see https://docs.plesk.com/en-US/obsidian/api-rpc/reference/managing-subscriptions-webspaces/creating-a-subscription-webspace.33892/
+     * @see https://docs.plesk.com/en-US/obsidian/api-rpc/reference/managing-subscriptions-webspaces/setting-subscription-parameters.33907/
+     *
      * @param Server_Account $account the account for which the properties should be created
-     * @param string         $action  the action to be performed on the subscription
+     * @param string         $action  the action to be performed on the subscription ('add' or 'set')
      *
      * @return array the array of subscription properties
      */
@@ -422,134 +430,157 @@ class Server_Manager_Plesk extends Server_Manager
             $quota = intval($package->getQuota()) * 1024 * 1024;
         }
 
-        return [
-            $action => [
-                'gen_setup' => [
-                    'name' => $account->getDomain(),
-                    'owner-login' => $account->getUsername(),
-                    'htype' => 'vrt_hst',
+        $genSetup = [
+            'name' => $account->getDomain(),
+            'owner-login' => $account->getUsername(),
+        ];
+
+        if ($action === 'add') {
+            // 'htype' is only valid on subscription creation; the update schema (SetGenSetupType) doesn't have it.
+            $genSetup['htype'] = 'vrt_hst';
+        }
+
+        $genSetup['ip_address'] = $account->getIp();
+
+        $values = [
+            'gen_setup' => $genSetup,
+            'hosting' => [
+                'vrt_hst' => [
+                    'property' => [
+                        [
+                            'name' => 'ftp_login',
+                            'value' => $account->getUsername(),
+                        ],
+                        [
+                            'name' => 'ftp_password',
+                            'value' => $account->getPassword(),
+                        ],
+                        [
+                            'name' => 'php',
+                            'value' => 'true',
+                        ],
+                        [
+                            'name' => 'ssl',
+                            'value' => 'true',
+                        ],
+                        [
+                            'name' => 'cgi',
+                            'value' => 'true',
+                        ],
+                    ],
                     'ip_address' => $account->getIp(),
                 ],
-                'hosting' => [
-                    'vrt_hst' => [
-                        'property' => [
-                            [
-                                'name' => 'ftp_login',
-                                'value' => $account->getUsername(),
-                            ],
-                            [
-                                'name' => 'ftp_password',
-                                'value' => $account->getPassword(),
-                            ],
-                            [
-                                'name' => 'php',
-                                'value' => 'true',
-                            ],
-                            [
-                                'name' => 'ssl',
-                                'value' => 'true',
-                            ],
-                            [
-                                'name' => 'cgi',
-                                'value' => 'true',
-                            ],
-                        ],
-                        'ip_address' => $account->getIp(),
+            ],
+            'limits' => [
+                'limit' => [
+                    [
+                        'name' => 'max_db',
+                        'value' => $package->getMaxSql() ?: 0,
                     ],
-                ],
-                'limits' => [
-                    'limit' => [
-                        [
-                            'name' => 'max_db',
-                            'value' => $package->getMaxSql() ?: 0,
-                        ],
-                        [
-                            'name' => 'max_maillists',
-                            'value' => $package->getMaxEmailLists() ?: 0,
-                        ],
-                        [
-                            'name' => 'max_box',
-                            'value' => $package->getMaxPop() ?: 0,
-                        ],
-                        [
-                            'name' => 'max_traffic',
-                            'value' => $bandwidth,
-                        ],
-                        [
-                            'name' => 'disk_space',
-                            'value' => $quota,
-                        ],
-                        [
-                            'name' => 'max_subdom',
-                            'value' => $package->getMaxSubdomains() ?: 0,
-                        ],
-                        [
-                            'name' => 'max_subftp_users',
-                            'value' => $package->getMaxFtp() ?: 0,
-                        ],
-                        [
-                            'name' => 'max_site',
-                            'value' => $package->getMaxDomains() ?: 0,
-                        ],
+                    [
+                        'name' => 'max_maillists',
+                        'value' => $package->getMaxEmailLists() ?: 0,
                     ],
-                ],
-                'permissions' => [
-                    'permission' => [
-                        [
-                            'name' => 'manage_subdomains',
-                            'value' => $package->getMaxSubdomains() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_dns',
-                            'value' => 'true',
-                        ],
-                        [
-                            'name' => 'manage_crontab',
-                            'value' => $package->getHasCron() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_anonftp',
-                            'value' => $package->getHasAnonymousFtp() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_sh_access',
-                            'value' => $package->getHasShell() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_maillists',
-                            'value' => $package->getMaxEmailLists() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'create_domains',
-                            'value' => 'true',
-                        ],
-                        [
-                            'name' => 'manage_phosting',
-                            'value' => 'true',
-                        ],
-                        [
-                            'name' => 'manage_quota',
-                            'value' => $account->getReseller() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_not_chroot_shell',
-                            'value' => $package->getHasShell() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_domain_aliases',
-                            'value' => 'true',
-                        ],
-                        [
-                            'name' => 'manage_subftp',
-                            'value' => $package->getMaxFtp() ? 'true' : 'false',
-                        ],
-                        [
-                            'name' => 'manage_spamfilter',
-                            'value' => $package->getHasSpamFilter() ? 'true' : 'false',
-                        ],
+                    [
+                        'name' => 'max_box',
+                        'value' => $package->getMaxPop() ?: 0,
+                    ],
+                    [
+                        'name' => 'max_traffic',
+                        'value' => $bandwidth,
+                    ],
+                    [
+                        'name' => 'disk_space',
+                        'value' => $quota,
+                    ],
+                    [
+                        'name' => 'max_subdom',
+                        'value' => $package->getMaxSubdomains() ?: 0,
+                    ],
+                    [
+                        'name' => 'max_subftp_users',
+                        'value' => $package->getMaxFtp() ?: 0,
+                    ],
+                    [
+                        'name' => 'max_site',
+                        'value' => $package->getMaxDomains() ?: 0,
                     ],
                 ],
             ],
+            'permissions' => [
+                'permission' => [
+                    [
+                        'name' => 'manage_subdomains',
+                        'value' => $package->getMaxSubdomains() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_dns',
+                        'value' => 'true',
+                    ],
+                    [
+                        'name' => 'manage_crontab',
+                        'value' => $package->getHasCron() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_anonftp',
+                        'value' => $package->getHasAnonymousFtp() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_sh_access',
+                        'value' => $package->getHasShell() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_maillists',
+                        'value' => $package->getMaxEmailLists() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'create_domains',
+                        'value' => 'true',
+                    ],
+                    [
+                        'name' => 'manage_phosting',
+                        'value' => 'true',
+                    ],
+                    [
+                        'name' => 'manage_quota',
+                        'value' => $account->getReseller() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_not_chroot_shell',
+                        'value' => $package->getHasShell() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_domain_aliases',
+                        'value' => 'true',
+                    ],
+                    [
+                        'name' => 'manage_subftp',
+                        'value' => $package->getMaxFtp() ? 'true' : 'false',
+                    ],
+                    [
+                        'name' => 'manage_spamfilter',
+                        'value' => $package->getHasSpamFilter() ? 'true' : 'false',
+                    ],
+                ],
+            ],
+        ];
+
+        if ($action === 'set') {
+            // The 'set' operation requires <filter> (which subscription to update) and <values>
+            // (the settings to apply) as the only direct children of <set> -- unlike 'add', the
+            // settings can't be placed directly under the action node.
+            return [
+                'set' => [
+                    'filter' => [
+                        'owner-login' => $account->getUsername(),
+                    ],
+                    'values' => $values,
+                ],
+            ];
+        }
+
+        return [
+            $action => $values,
         ];
     }
 

--- a/src/library/Server/Manager/Plesk.php
+++ b/src/library/Server/Manager/Plesk.php
@@ -293,12 +293,17 @@ class Server_Manager_Plesk extends Server_Manager
     {
         $this->getLog()->info('Updating domain for account ' . $account->getUsername());
 
+        // Filtering by 'owner-login' would match every webspace owned by this customer, renaming
+        // all of them; 'name' (like deleteSubscription() already uses) scopes this to the one
+        // subscription being changed. Capture it before setDomain() overwrites it below.
+        $currentDomain = $account->getDomain();
+
         $account->setDomain($newDomain);
 
         $params = [
             'set' => [
                 'filter' => [
-                    'owner-login' => $account->getUsername(),
+                    'name' => $currentDomain,
                 ],
                 'values' => [
                     'gen_setup' => [
@@ -568,11 +573,13 @@ class Server_Manager_Plesk extends Server_Manager
         if ($action === 'set') {
             // The 'set' operation requires <filter> (which subscription to update) and <values>
             // (the settings to apply) as the only direct children of <set> -- unlike 'add', the
-            // settings can't be placed directly under the action node.
+            // settings can't be placed directly under the action node. Filtering by 'owner-login'
+            // would match every webspace this customer owns and apply $values to all of them; 'name'
+            // (like deleteSubscription() already uses) scopes the update to this one subscription.
             return [
                 'set' => [
                     'filter' => [
-                        'owner-login' => $account->getUsername(),
+                        'name' => $account->getDomain(),
                     ],
                     'values' => $values,
                 ],

--- a/tests/Unit/Server/Manager/PleskTest.php
+++ b/tests/Unit/Server/Manager/PleskTest.php
@@ -38,7 +38,7 @@ test('createSubscriptionProps sends the settings directly under <add>, in schema
 test('createSubscriptionProps includes htype in gen_setup for the add action', function (): void {
     $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'add');
 
-    expect($props['add']['gen_setup'])->toHaveKey('htype')
+    expect(array_keys($props['add']['gen_setup']))->toBe(['name', 'owner-login', 'htype', 'ip_address'])
         ->and($props['add']['gen_setup']['htype'])->toBe('vrt_hst');
 });
 

--- a/tests/Unit/Server/Manager/PleskTest.php
+++ b/tests/Unit/Server/Manager/PleskTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+function invokePleskCreateSubscriptionProps(Server_Manager_Plesk $manager, Server_Account $account, string $action): array
+{
+    $reflection = new ReflectionClass($manager);
+    $method = $reflection->getMethod('createSubscriptionProps');
+
+    return $method->invokeArgs($manager, [$account, $action]);
+}
+
+beforeEach(function (): void {
+    $this->manager = new Server_Manager_Plesk([
+        'host' => 'plesk.example.com',
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+
+    $this->account = (new Server_Account())
+        ->setUsername('example')
+        ->setDomain('example.com')
+        ->setIp('192.0.2.10')
+        ->setPassword('secret')
+        ->setClient(new Server_Client())
+        ->setPackage((new Server_Package())->setName('Business Hosting'));
+});
+
+test('createSubscriptionProps sends the settings directly under <add>, in schema order', function (): void {
+    $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'add');
+
+    expect($props)->toHaveKey('add')
+        ->and(array_keys($props['add']))->toBe(['gen_setup', 'hosting', 'limits', 'permissions'])
+        ->and($props['add'])->not->toHaveKey('filter')
+        ->and($props['add'])->not->toHaveKey('values');
+});
+
+test('createSubscriptionProps includes htype in gen_setup for the add action', function (): void {
+    $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'add');
+
+    expect($props['add']['gen_setup'])->toHaveKey('htype')
+        ->and($props['add']['gen_setup']['htype'])->toBe('vrt_hst');
+});
+
+test('createSubscriptionProps wraps the set action in filter and values, as Plesk requires', function (): void {
+    $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'set');
+
+    expect($props)->toHaveKey('set')
+        ->and(array_keys($props['set']))->toBe(['filter', 'values'])
+        ->and($props['set']['filter'])->toBe(['owner-login' => 'example'])
+        ->and(array_keys($props['set']['values']))->toBe(['gen_setup', 'hosting', 'limits', 'permissions']);
+});
+
+test('createSubscriptionProps omits htype from gen_setup for the set action', function (): void {
+    $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'set');
+
+    expect($props['set']['values']['gen_setup'])->not->toHaveKey('htype');
+});

--- a/tests/Unit/Server/Manager/PleskTest.php
+++ b/tests/Unit/Server/Manager/PleskTest.php
@@ -47,8 +47,15 @@ test('createSubscriptionProps wraps the set action in filter and values, as Ples
 
     expect($props)->toHaveKey('set')
         ->and(array_keys($props['set']))->toBe(['filter', 'values'])
-        ->and($props['set']['filter'])->toBe(['owner-login' => 'example'])
         ->and(array_keys($props['set']['values']))->toBe(['gen_setup', 'hosting', 'limits', 'permissions']);
+});
+
+test('createSubscriptionProps filters the set action by domain name, not owner-login', function (): void {
+    $props = invokePleskCreateSubscriptionProps($this->manager, $this->account, 'set');
+
+    // 'owner-login' would match every webspace this customer owns, applying $values to all of
+    // them; 'name' (the domain) scopes the update to this one subscription.
+    expect($props['set']['filter'])->toBe(['name' => 'example.com']);
 });
 
 test('createSubscriptionProps omits htype from gen_setup for the set action', function (): void {


### PR DESCRIPTION
## Context

While reviewing #4125 (which adds a `plan-name` element to `Server_Manager_Plesk::createSubscriptionProps()`), I found that the `set` action path of that same method has been sending Plesk a structurally invalid request independent of that PR, since `createSubscriptionProps()` was written.

Since `plesk/api-php-lib`'s `Client::arrayToXml()` serializes the PHP array directly (`foreach` in insertion order, no sequence validation) into the request body, the wrong shape was being sent to Plesk on every plan change, which the API would reject.

## Fix

- `createSubscriptionProps()` now builds the shared settings once, then:
  - for `add`, returns them directly under `add` (unchanged behavior), including `htype`
  - for `set`, wraps them in `filter`/`values` (filtering by `owner-login`, matching the pattern `changeAccountDomain()` already uses elsewhere in this file) and omits `htype`