### PR TITLE
Add locking to concurrent billing operations

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -286,7 +286,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     {
         $charge = $this->stripe->paymentIntents->retrieve($data['get']['payment_intent'], []);
 
-        $this->withPaymentIntentLock(
+        $this->withStripeObjectLock(
             $charge->id,
             (int) $tx->getGatewayId(),
             fn () => $this->processPaymentIntentUnderLock($tx, $invoice, $charge)
@@ -758,6 +758,16 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
             return false;
         }
 
+        // Those events can arrive concurrently, so the dedup below has to be held under a lock.
+        return $this->withStripeObjectLock(
+            $stripeInvoice->id,
+            $gateway_id,
+            fn (): bool => $this->handleInvoicePaymentSucceededUnderLock($api_admin, $tx, $stripeInvoice, $subscriptionId)
+        );
+    }
+
+    private function handleInvoicePaymentSucceededUnderLock($api_admin, Transaction $tx, object $stripeInvoice, string $subscriptionId): bool
+    {
         // Dedup: Stripe sends both invoice.payment_succeeded and invoice.paid for
         // the same payment. Use the Stripe invoice ID as the shared natural key so
         // whichever event arrives second sees the first is already processing/done.
@@ -893,7 +903,7 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
     {
         $paymentIntent = $event->data->object;
 
-        return $this->withPaymentIntentLock(
+        return $this->withStripeObjectLock(
             $paymentIntent->id,
             $gateway_id,
             fn (): bool => $this->handlePaymentIntentSucceededWebhookUnderLock($tx, $paymentIntent, $gateway_id)
@@ -954,9 +964,9 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
         return true;
     }
 
-    private function withPaymentIntentLock(string $paymentIntentId, int $gatewayId, callable $callback): mixed
+    private function withStripeObjectLock(string $objectId, int $gatewayId, callable $callback): mixed
     {
-        $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
+        $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $objectId), 0, 54);
         $waitStartedAt = hrtime(true);
         $acquired = (int) $this->di['dbal']->fetchOne(
             'SELECT GET_LOCK(:lock_name, 10)',
@@ -965,11 +975,11 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
 
         if ($acquired !== 1) {
             $waitDurationMs = (hrtime(true) - $waitStartedAt) / 1_000_000;
-            $this->di['logger']->warning(
-                'Timed out after %.1f ms waiting for Stripe PaymentIntent lock %s',
+            $this->di['logger']->warning(sprintf(
+                'Timed out after %.1f ms waiting for Stripe object lock %s',
                 $waitDurationMs,
                 $lockName
-            );
+            ));
 
             throw new FOSSBilling\Exception('Timed out waiting to process this Stripe payment');
         }

--- a/src/modules/Client/Repository/ClientBalanceRepository.php
+++ b/src/modules/Client/Repository/ClientBalanceRepository.php
@@ -32,6 +32,10 @@ class ClientBalanceRepository extends EntityRepository
     {
         $connection = $this->getEntityManager()->getConnection();
 
+        if (!$connection->isTransactionActive()) {
+            throw new \FOSSBilling\Exception('Client balance cannot be locked outside of a transaction.');
+        }
+
         // The balance sums insert-only rows, so a concurrent deduction inserts rather than updates
         // and there is nothing for the sum to serialize against. Lock the client row as the mutex.
         $connection->fetchOne(

--- a/src/modules/Client/Repository/ClientBalanceRepository.php
+++ b/src/modules/Client/Repository/ClientBalanceRepository.php
@@ -24,4 +24,28 @@ class ClientBalanceRepository extends EntityRepository
 
         return (float) ($result ?? 0);
     }
+
+    /**
+     * Must be called within a transaction, held until the deduction has been written.
+     */
+    public function getClientBalanceSumForUpdate(int $clientId): float
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        // The balance sums insert-only rows, so a concurrent deduction inserts rather than updates
+        // and there is nothing for the sum to serialize against. Lock the client row as the mutex.
+        $connection->fetchOne(
+            'SELECT id FROM client WHERE id = :client_id FOR UPDATE',
+            ['client_id' => $clientId],
+        );
+
+        // A locking read, because a plain one is served from the transaction snapshot, which under
+        // REPEATABLE READ can predate the deduction we just waited on above.
+        $result = $connection->fetchOne(
+            'SELECT SUM(amount) FROM client_balance WHERE client_id = :client_id FOR UPDATE',
+            ['client_id' => $clientId],
+        );
+
+        return (float) ($result ?? 0);
+    }
 }

--- a/src/modules/Client/ServiceBalance.php
+++ b/src/modules/Client/ServiceBalance.php
@@ -34,6 +34,13 @@ class ServiceBalance implements InjectionAwareInterface
         return $this->clientTotal($c);
     }
 
+    public function getClientBalanceForUpdate(Client|\Model_Client $c): float
+    {
+        $clientId = $c instanceof Client ? $c->getId() : $c->id;
+
+        return $this->clientBalanceRepository->getClientBalanceSumForUpdate((int) $clientId);
+    }
+
     public function clientTotal(Client|\Model_Client $c): float
     {
         $clientId = $c instanceof Client ? $c->getId() : $c->id;

--- a/src/modules/Client/ServiceBalance.php
+++ b/src/modules/Client/ServiceBalance.php
@@ -34,9 +34,17 @@ class ServiceBalance implements InjectionAwareInterface
         return $this->clientTotal($c);
     }
 
-    public function getClientBalanceForUpdate(Client|\Model_Client $c): float
+    /**
+     * Must be called within a transaction, held until the deduction has been written. The lock is
+     * released when the transaction ends, and the balance is unprotected from that point on.
+     */
+    public function getClientBalanceForUpdate(Client|\Model_Client|int $c): float
     {
-        $clientId = $c instanceof Client ? $c->getId() : $c->id;
+        $clientId = match (true) {
+            $c instanceof Client => $c->getId(),
+            $c instanceof \Model_Client => $c->id,
+            default => $c,
+        };
 
         return $this->clientBalanceRepository->getClientBalanceSumForUpdate((int) $clientId);
     }

--- a/src/modules/Invoice/Repository/InvoiceRepository.php
+++ b/src/modules/Invoice/Repository/InvoiceRepository.php
@@ -28,9 +28,18 @@ class InvoiceRepository extends EntityRepository
         return $invoice instanceof Invoice ? $invoice : null;
     }
 
+    /**
+     * Must be called within a transaction, held for as long as the status is acted on.
+     */
     public function lockAndGetStatus(int $invoiceId): ?string
     {
-        $status = $this->getEntityManager()->getConnection()->fetchOne(
+        $connection = $this->getEntityManager()->getConnection();
+
+        if (!$connection->isTransactionActive()) {
+            throw new \FOSSBilling\Exception('Invoice status cannot be locked outside of a transaction.');
+        }
+
+        $status = $connection->fetchOne(
             'SELECT status FROM invoice WHERE id = :id FOR UPDATE',
             ['id' => $invoiceId],
         );

--- a/src/modules/Invoice/Repository/InvoiceRepository.php
+++ b/src/modules/Invoice/Repository/InvoiceRepository.php
@@ -28,6 +28,16 @@ class InvoiceRepository extends EntityRepository
         return $invoice instanceof Invoice ? $invoice : null;
     }
 
+    public function lockAndGetStatus(int $invoiceId): ?string
+    {
+        $status = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT status FROM invoice WHERE id = :id FOR UPDATE',
+            ['id' => $invoiceId],
+        );
+
+        return $status === false ? null : (string) $status;
+    }
+
     /**
      * @return Invoice[]
      */

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -790,7 +790,7 @@ class Service implements InjectionAwareInterface
         return $email;
     }
 
-    public function markAsPaid(Invoice $invoice, $charge = true, $execute = false): bool
+    public function markAsPaid(Invoice $invoice, $charge = true, $execute = false, bool $deferEvents = false): bool
     {
         if ($invoice->getStatus() == Invoice::STATUS_PAID) {
             return true;
@@ -828,7 +828,11 @@ class Service implements InjectionAwareInterface
             $productService->commitReservedPromoRedemptionsForInvoice($invoice);
         });
 
-        $this->di['events_manager']->fire(['event' => 'onAfterAdminInvoicePaymentReceived', 'params' => ['id' => $invoice->getId()]]);
+        // Listeners render PDFs and send email, so a caller holding row locks defers this until
+        // after it has committed rather than holding them for the duration of an SMTP send.
+        if (!$deferEvents) {
+            $this->firePaymentReceivedEvent($invoice);
+        }
 
         if ($execute) {
             foreach ($invoiceItems as $item) {
@@ -1135,12 +1139,12 @@ class Service implements InjectionAwareInterface
         }
 
         $paid = $this->di['em']->wrapInTransaction(function () use ($invoice): bool {
-            $client = $this->di['db']->load('Client', $invoice->getClientId());
+            $clientId = (int) $invoice->getClientId();
             $cbrepo = $this->di['mod_service']('Client', 'Balance');
 
             // Locks the balance for the rest of this transaction, so a concurrent request cannot
             // spend the same credit.
-            $balance = $cbrepo->getClientBalanceForUpdate($client);
+            $balance = $cbrepo->getClientBalanceForUpdate($clientId);
 
             // Another request could have paid this invoice while we waited for the lock. A locking
             // read, as a plain one can be served from a snapshot predating that request's commit.
@@ -1170,7 +1174,7 @@ class Service implements InjectionAwareInterface
                 // Nothing at or below the epsilon is actually charged against the client's balance,
                 // so don't record a $0 credit transaction.
                 $balanceTransaction = new ClientBalance();
-                $balanceTransaction->setClientId((int) $client->id);
+                $balanceTransaction->setClientId($clientId);
                 $balanceTransaction->setType('invoice');
                 $balanceTransaction->setRelId((string) $invoice->getId());
 
@@ -1182,17 +1186,24 @@ class Service implements InjectionAwareInterface
                 $this->di['em']->flush();
             }
 
-            // Tasks run after the commit below, so provisioning is not held under the balance lock.
-            $this->markAsPaid($invoice, false, false);
+            // Events and tasks run after the commit below, so neither notifications nor
+            // provisioning are held under the balance lock.
+            $this->markAsPaid($invoice, false, false, true);
 
             return true;
         });
 
         if ($paid) {
+            $this->firePaymentReceivedEvent($invoice);
             $this->executeInvoiceItemTasks($invoice);
         }
 
         return $paid;
+    }
+
+    private function firePaymentReceivedEvent(Invoice $invoice): void
+    {
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminInvoicePaymentReceived', 'params' => ['id' => $invoice->getId()]]);
     }
 
     /**

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -950,13 +950,16 @@ class Service implements InjectionAwareInterface
         if ($next_nr === null) {
             // In theory this code should never need to be called, but is provided as a fallback
             $r = $this->getInvoiceRepository()->findLatestWithNr();
-            if ($r instanceof Invoice && is_numeric($r->getNr())) {
-                $next_nr = intval($r->getNr()) + 1;
-            } else {
+            if (!$r instanceof Invoice || !is_numeric($r->getNr())) {
                 throw new \FOSSBilling\Exception('Unable to determine the next invoice number');
             }
 
-            $systemService->setParamValue('invoice_starting_number', $next_nr + 1);
+            // Seeding the counter and reserving from it has to be one locked step too, otherwise
+            // two callers deriving the same seed both write it and both reserve the same number.
+            $next_nr = $systemService->reserveNextNumericParamValue('invoice_starting_number', intval($r->getNr()) + 1);
+            if ($next_nr === null) {
+                throw new \FOSSBilling\Exception('Unable to determine the next invoice number');
+            }
         }
 
         return $next_nr;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -938,9 +938,12 @@ class Service implements InjectionAwareInterface
     public function getNextInvoiceNumber()
     {
         $systemService = $this->di['mod_service']('system');
-        $next_nr = $systemService->getParamValue('invoice_starting_number');
 
-        if (empty($next_nr)) {
+        // Claimed and advanced in one locked step, otherwise two concurrent approvals take the
+        // same number and issue two invoices sharing an invoice number.
+        $next_nr = $systemService->reserveNextNumericParamValue('invoice_starting_number');
+
+        if ($next_nr === null) {
             // In theory this code should never need to be called, but is provided as a fallback
             $r = $this->getInvoiceRepository()->findLatestWithNr();
             if ($r instanceof Invoice && is_numeric($r->getNr())) {
@@ -948,9 +951,9 @@ class Service implements InjectionAwareInterface
             } else {
                 throw new \FOSSBilling\Exception('Unable to determine the next invoice number');
             }
-        }
 
-        $systemService->setParamValue('invoice_starting_number', intval($next_nr) + 1);
+            $systemService->setParamValue('invoice_starting_number', $next_nr + 1);
+        }
 
         return $next_nr;
     }
@@ -1131,48 +1134,81 @@ class Service implements InjectionAwareInterface
             return false;
         }
 
-        $client = $this->di['db']->load('Client', $invoice->getClientId());
-        $cbrepo = $this->di['mod_service']('Client', 'Balance');
-        $balance = $cbrepo->getClientBalance($client);
-        $required = $this->getTotalWithTax($invoice);
-        $epsilon = 0.01;
-        $difference = $balance - $required;
+        $paid = $this->di['em']->wrapInTransaction(function () use ($invoice): bool {
+            $client = $this->di['db']->load('Client', $invoice->getClientId());
+            $cbrepo = $this->di['mod_service']('Client', 'Balance');
 
-        if ($difference >= -$epsilon) {
+            // Locks the balance for the rest of this transaction, so a concurrent request cannot
+            // spend the same credit.
+            $balance = $cbrepo->getClientBalanceForUpdate($client);
+
+            // Another request could have paid this invoice while we waited for the lock. A locking
+            // read, as a plain one can be served from a snapshot predating that request's commit.
+            if ($this->getInvoiceRepository()->lockAndGetStatus((int) $invoice->getId()) === Invoice::STATUS_PAID) {
+                return false;
+            }
+
+            $required = $this->getTotalWithTax($invoice);
+            $epsilon = 0.01;
+            $difference = $balance - $required;
+
+            if ($difference < -$epsilon) {
+                // @phpstan-ignore if.alwaysFalse (DEBUG is a runtime constant that may be true during debugging)
+                if (DEBUG) {
+                    $this->di['logger']->setChannel('billing')->info("Invoice {$invoice->getId()} could not be paid with credits. Money in balance {$balance} Required: {$required}.");
+                }
+
+                return false;
+            }
+
             // @phpstan-ignore if.alwaysFalse
             if (DEBUG) {
                 $this->di['logger']->setChannel('billing')->info("Setting invoice {$invoice->getId()} as paid with credits for the amount of {$required}.");
             }
 
-            if ($required <= $epsilon) {
-                // Nothing was actually charged against the client's balance, so don't record a $0 credit transaction.
-                $this->markAsPaid($invoice, false, true);
+            if ($required > $epsilon) {
+                // Nothing at or below the epsilon is actually charged against the client's balance,
+                // so don't record a $0 credit transaction.
+                $balanceTransaction = new ClientBalance();
+                $balanceTransaction->setClientId((int) $client->id);
+                $balanceTransaction->setType('invoice');
+                $balanceTransaction->setRelId((string) $invoice->getId());
 
-                return true;
+                $invoice_identifier = $invoice->getNr() ?: $invoice->getId();
+                $balanceTransaction->setDescription("Payment for invoice #{$invoice_identifier} using account credit.");
+
+                $balanceTransaction->setAmount((string) (-$required));
+                $this->di['em']->persist($balanceTransaction);
+                $this->di['em']->flush();
             }
 
-            $balanceTransaction = new ClientBalance();
-            $balanceTransaction->setClientId((int) $client->id);
-            $balanceTransaction->setType('invoice');
-            $balanceTransaction->setRelId((string) $invoice->getId());
-
-            $invoice_identifier = $invoice->getNr() ?: $invoice->getId();
-            $balanceTransaction->setDescription("Payment for invoice #{$invoice_identifier} using account credit.");
-
-            $balanceTransaction->setAmount((string) (-$required));
-            $this->di['em']->persist($balanceTransaction);
-            $this->di['em']->flush();
-
-            $this->markAsPaid($invoice, false, true);
+            // Tasks run after the commit below, so provisioning is not held under the balance lock.
+            $this->markAsPaid($invoice, false, false);
 
             return true;
-        }
-        // @phpstan-ignore if.alwaysFalse (DEBUG is a runtime constant that may be true during debugging)
-        if (DEBUG) {
-            $this->di['logger']->setChannel('billing')->info("Invoice {$invoice->getId()} could not be paid with credits. Money in balance {$balance} Required: {$required}.");
+        });
+
+        if ($paid) {
+            $this->executeInvoiceItemTasks($invoice);
         }
 
-        return false;
+        return $paid;
+    }
+
+    /**
+     * The task execution markAsPaid() performs with $execute, for callers that must run it after
+     * their transaction commits.
+     */
+    private function executeInvoiceItemTasks(Invoice $invoice): void
+    {
+        $invoiceItemService = $this->di['mod_service']('Invoice', 'InvoiceItem');
+        foreach ($this->getInvoiceItemRepository()->findByInvoiceId((int) $invoice->getId()) as $item) {
+            try {
+                $invoiceItemService->executeTask($item);
+            } catch (\Exception $e) {
+                $this->di['logger']->warning($e->getMessage());
+            }
+        }
     }
 
     public function getTotalWithTax(Invoice $invoice): float

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1486,21 +1486,16 @@ test('pays a zero-total invoice without recording a balance transaction', functi
     $invoice->approved = 1;
     $invoice->status = Invoice::STATUS_UNPAID;
 
-    $client = new Model_Client();
-    $client->loadBean(new Tests\Helpers\DummyBean());
-    $client->id = 20;
-
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
-    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(0.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with(20)->andReturn(0.0);
 
     $db = Mockery::mock(Box_Database::class);
-    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
     $db->shouldNotReceive('dispense');
     $db->shouldNotReceive('store');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(0.0);
-    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false, true)->andReturn(true);
 
     $di = container();
     $di['db'] = $db;
@@ -1519,21 +1514,16 @@ test('pays an invoice with credits and records a balance transaction', function 
     $invoice->approved = 1;
     $invoice->status = Invoice::STATUS_UNPAID;
 
-    $client = new Model_Client();
-    $client->loadBean(new Tests\Helpers\DummyBean());
-    $client->id = 20;
-
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
-    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(100.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with(20)->andReturn(100.0);
 
     $db = Mockery::mock(Box_Database::class);
-    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
     $db->shouldNotReceive('dispense');
     $db->shouldNotReceive('store');
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);
-    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false, true)->andReturn(true);
 
     $di = container();
     $di['db'] = $db;
@@ -1558,27 +1548,22 @@ test('reads the balance under lock and does so before re-checking the invoice', 
     $invoice->approved = 1;
     $invoice->status = Invoice::STATUS_UNPAID;
 
-    $client = new Model_Client();
-    $client->loadBean(new Tests\Helpers\DummyBean());
-    $client->id = 20;
-
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
     // The unlocked read must not be used on a path that deducts from the balance.
     $balanceService->shouldNotReceive('getClientBalance');
-    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->ordered()->andReturn(100.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with(20)->globally()->ordered()->andReturn(100.0);
 
     $db = Mockery::mock(Box_Database::class);
-    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);
-    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false, true)->andReturn(true);
 
     $di = container();
     $di['db'] = $db;
     // Ordered: the status re-check is only meaningful once the balance lock is held.
     $di['em']->getRepository(Invoice::class)->shouldReceive('lockAndGetStatus')->with(10)
-        ->ordered()->andReturn(Invoice::STATUS_UNPAID);
+        ->globally()->ordered()->andReturn(Invoice::STATUS_UNPAID);
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $balanceService);
     $service->setDi($di);
 
@@ -1592,15 +1577,10 @@ test('does not deduct credits when the invoice was paid concurrently before the 
     $invoice->approved = 1;
     $invoice->status = Invoice::STATUS_UNPAID;
 
-    $client = new Model_Client();
-    $client->loadBean(new Tests\Helpers\DummyBean());
-    $client->id = 20;
-
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
-    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(100.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with(20)->andReturn(100.0);
 
     $db = Mockery::mock(Box_Database::class);
-    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldNotReceive('markAsPaid');
@@ -1624,16 +1604,11 @@ test('does not deduct credits when the locked balance is insufficient', function
     $invoice->approved = 1;
     $invoice->status = Invoice::STATUS_UNPAID;
 
-    $client = new Model_Client();
-    $client->loadBean(new Tests\Helpers\DummyBean());
-    $client->id = 20;
-
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
     // Another request spent the credit first, so the locked read sees the reduced balance.
-    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(10.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with(20)->andReturn(10.0);
 
     $db = Mockery::mock(Box_Database::class);
-    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -1389,8 +1389,13 @@ test('sets invoice defaults', function (): void {
     $systemService->shouldReceive('getParamValue')
         ->atLeast()->once()
         ->andReturn(1);
+    $systemService->shouldReceive('reserveNextNumericParamValue')
+        ->once()
+        ->with('invoice_starting_number')
+        ->andReturn(1);
+    // Only reached by the fallback path now that the counter is claimed atomically.
     $systemService->shouldReceive('setParamValue')
-        ->atLeast()->once();
+        ->zeroOrMoreTimes();
 
     $serviceTaxMock = Mockery::mock(ServiceTax::class);
     $serviceTaxMock->shouldReceive('getTaxRateForClient');
@@ -1486,7 +1491,7 @@ test('pays a zero-total invoice without recording a balance transaction', functi
     $client->id = 20;
 
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
-    $balanceService->shouldReceive('getClientBalance')->once()->with($client)->andReturn(0.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(0.0);
 
     $db = Mockery::mock(Box_Database::class);
     $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
@@ -1495,7 +1500,7 @@ test('pays a zero-total invoice without recording a balance transaction', functi
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(0.0);
-    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, true)->andReturn(true);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
 
     $di = container();
     $di['db'] = $db;
@@ -1519,7 +1524,7 @@ test('pays an invoice with credits and records a balance transaction', function 
     $client->id = 20;
 
     $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
-    $balanceService->shouldReceive('getClientBalance')->once()->with($client)->andReturn(100.0);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(100.0);
 
     $db = Mockery::mock(Box_Database::class);
     $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
@@ -1528,7 +1533,7 @@ test('pays an invoice with credits and records a balance transaction', function 
 
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);
-    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, true)->andReturn(true);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
 
     $di = container();
     $di['db'] = $db;
@@ -1544,6 +1549,105 @@ test('pays an invoice with credits and records a balance transaction', function 
     $service->setDi($di);
 
     expect($service->tryPayWithCredits($invoice))->toBeTrue();
+});
+
+test('reads the balance under lock and does so before re-checking the invoice', function (): void {
+    $invoice = createEntity(Invoice::class);
+    $invoice->id = 10;
+    $invoice->client_id = 20;
+    $invoice->approved = 1;
+    $invoice->status = Invoice::STATUS_UNPAID;
+
+    $client = new Model_Client();
+    $client->loadBean(new Tests\Helpers\DummyBean());
+    $client->id = 20;
+
+    $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
+    // The unlocked read must not be used on a path that deducts from the balance.
+    $balanceService->shouldNotReceive('getClientBalance');
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->ordered()->andReturn(100.0);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);
+    $service->shouldReceive('markAsPaid')->once()->with($invoice, false, false)->andReturn(true);
+
+    $di = container();
+    $di['db'] = $db;
+    // Ordered: the status re-check is only meaningful once the balance lock is held.
+    $di['em']->getRepository(Invoice::class)->shouldReceive('lockAndGetStatus')->with(10)
+        ->ordered()->andReturn(Invoice::STATUS_UNPAID);
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $balanceService);
+    $service->setDi($di);
+
+    expect($service->tryPayWithCredits($invoice))->toBeTrue();
+});
+
+test('does not deduct credits when the invoice was paid concurrently before the lock was acquired', function (): void {
+    $invoice = createEntity(Invoice::class);
+    $invoice->id = 10;
+    $invoice->client_id = 20;
+    $invoice->approved = 1;
+    $invoice->status = Invoice::STATUS_UNPAID;
+
+    $client = new Model_Client();
+    $client->loadBean(new Tests\Helpers\DummyBean());
+    $client->id = 20;
+
+    $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(100.0);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldNotReceive('markAsPaid');
+
+    $di = container();
+    $di['db'] = $db;
+    // Stand in for another request having paid this invoice while we waited on the lock.
+    $di['em']->getRepository(Invoice::class)->shouldReceive('lockAndGetStatus')->with(10)
+        ->andReturn(Invoice::STATUS_PAID);
+    $di['em']->shouldNotReceive('persist');
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $balanceService);
+    $service->setDi($di);
+
+    expect($service->tryPayWithCredits($invoice))->toBeFalse();
+});
+
+test('does not deduct credits when the locked balance is insufficient', function (): void {
+    $invoice = createEntity(Invoice::class);
+    $invoice->id = 10;
+    $invoice->client_id = 20;
+    $invoice->approved = 1;
+    $invoice->status = Invoice::STATUS_UNPAID;
+
+    $client = new Model_Client();
+    $client->loadBean(new Tests\Helpers\DummyBean());
+    $client->id = 20;
+
+    $balanceService = Mockery::mock(Box\Mod\Client\ServiceBalance::class);
+    // Another request spent the credit first, so the locked read sees the reduced balance.
+    $balanceService->shouldReceive('getClientBalanceForUpdate')->once()->with($client)->andReturn(10.0);
+
+    $db = Mockery::mock(Box_Database::class);
+    $db->shouldReceive('load')->once()->with('Client', 20)->andReturn($client);
+
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('getTotalWithTax')->once()->with($invoice)->andReturn(50.0);
+    $service->shouldNotReceive('markAsPaid');
+
+    $di = container();
+    $di['db'] = $db;
+    $di['em']->getRepository(Invoice::class)->shouldReceive('lockAndGetStatus')->with(10)
+        ->andReturn(Invoice::STATUS_UNPAID);
+    $di['em']->shouldNotReceive('persist');
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $balanceService);
+    $service->setDi($di);
+
+    expect($service->tryPayWithCredits($invoice))->toBeFalse();
 });
 
 test('gets total', function (): void {

--- a/src/modules/Product/Repository/ProductRepository.php
+++ b/src/modules/Product/Repository/ProductRepository.php
@@ -216,6 +216,14 @@ class ProductRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    public function decrementStockIfAvailable(int $productId, int $quantity, \DateTimeInterface $updatedAt): int
+    {
+        return $this->getEntityManager()->getConnection()->executeStatement(
+            'UPDATE product SET quantity_in_stock = quantity_in_stock - ?, updated_at = ? WHERE id = ? AND quantity_in_stock >= ?',
+            [$quantity, $updatedAt->format('Y-m-d H:i:s'), $productId, $quantity]
+        );
+    }
+
     public function findEnabledAddonById(int $id): ?Product
     {
         return $this->findOneBy([

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -985,15 +985,21 @@ class Service implements InjectionAwareInterface
         }
 
         $quantity = (int) $qty;
-        $available = $resolvedProduct->getQuantityInStock();
-        if ($available < $quantity) {
+
+        // A single statement, otherwise concurrent orders both read the same quantity and each
+        // subtract from it, overselling the product. Zero rows means stock ran out meanwhile.
+        $updated = $this->getProductRepository()->decrementStockIfAvailable(
+            (int) $resolvedProduct->getId(),
+            $quantity,
+            new \DateTime()
+        );
+
+        if ($updated === 0) {
             throw new \FOSSBilling\InformationException('Product :id is out of stock.', [':id' => $resolvedProduct->getId()], 831);
         }
 
-        $resolvedProduct->setQuantityInStock($available - $quantity);
-        $resolvedProduct->setUpdatedAt(new \DateTime());
-
-        $this->di['em']->flush();
+        // The statement above bypassed the entity, so bring the in-memory copy back in line.
+        $this->di['em']->refresh($resolvedProduct);
 
         return true;
     }

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -985,6 +985,10 @@ class Service implements InjectionAwareInterface
         }
 
         $quantity = (int) $qty;
+        if ($quantity <= 0) {
+            // Subtracting a non-positive quantity would leave stock unchanged or inflate it.
+            return true;
+        }
 
         // A single statement, otherwise concurrent orders both read the same quantity and each
         // subtract from it, overselling the product. Zero rows means stock ran out meanwhile.

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -440,6 +440,25 @@ test('reduce stock decrements atomically rather than writing back a read value',
     expect($product->getQuantityInStock())->toBe(3);
 });
 
+test('reduce stock ignores non-positive quantities rather than inflating stock', function (): void {
+    $service = new Service();
+    $product = productTestCreateProductEntity(1)
+        ->setStockControl(true)
+        ->setQuantityInStock(5);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    // Subtracting a negative would increase stock, so the decrement must not be reached.
+    $productRepo->shouldNotReceive('decrementStockIfAvailable');
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $service->setDi($di);
+
+    expect($service->reduceStock($product, -5))->toBeTrue();
+    expect($service->reduceStock($product, 0))->toBeTrue();
+    expect($product->getQuantityInStock())->toBe(5);
+});
+
 test('reduce stock throws when the atomic decrement finds insufficient stock', function (): void {
     $service = new Service();
     $product = productTestCreateProductEntity(1)

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -147,6 +147,11 @@ function productTestCreateEntityManagerWithRepositories(
         {
             ++$this->flushCalls;
         }
+
+        public function refresh(object $entity): void
+        {
+            // Stock is decremented with a direct UPDATE, so nothing to re-read in the stub.
+        }
     };
 }
 
@@ -408,20 +413,52 @@ test('get selected addons for cart returns prepared addon items', function (): v
     expect($result[0]['config']['parent_id'])->toBe(10);
 });
 
-test('reduce stock updates doctrine product state', function (): void {
+test('reduce stock decrements atomically rather than writing back a read value', function (): void {
     $service = new Service();
     $product = productTestCreateProductEntity(1)
         ->setStockControl(true)
         ->setQuantityInStock(5);
 
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('decrementStockIfAvailable')
+        ->once()
+        ->with(1, 2, Mockery::type(DateTimeInterface::class))
+        ->andReturnUsing(function () use ($product): int {
+            // Stand in for the UPDATE ... WHERE quantity_in_stock >= ? applying to the row.
+            $product->setQuantityInStock(3);
+
+            return 1;
+        });
+
     $di = container();
-    $di['em'] = productTestCreateEntityManagerWithRepositories();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
     $service->setDi($di);
 
     $result = $service->reduceStock($product, 2);
 
     expect($result)->toBeTrue();
     expect($product->getQuantityInStock())->toBe(3);
+});
+
+test('reduce stock throws when the atomic decrement finds insufficient stock', function (): void {
+    $service = new Service();
+    $product = productTestCreateProductEntity(1)
+        ->setStockControl(true)
+        ->setQuantityInStock(1);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    // Zero rows updated: another order took the remaining stock first.
+    $productRepo->shouldReceive('decrementStockIfAvailable')
+        ->once()
+        ->with(1, 2, Mockery::type(DateTimeInterface::class))
+        ->andReturn(0);
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $service->setDi($di);
+
+    expect(fn (): bool => $service->reduceStock($product, 2))
+        ->toThrow(FOSSBilling\InformationException::class);
 });
 
 test('is stock available uses doctrine product state', function (): void {

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Box\Mod\System;
 
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use FOSSBilling\Config;
 use FOSSBilling\Environment;
 use FOSSBilling\GeoIP\Reader;
@@ -726,6 +727,43 @@ class Service
         } catch (\Exception $e) {
             error_log($e->getMessage());
         }
+    }
+
+    /**
+     * Claims a numeric counter setting's current value and advances it, under a row lock so two
+     * concurrent callers are never handed the same number. Returns null if it is missing or not
+     * numeric.
+     *
+     * Not subject to canUpdateParam(): this reserves an internal counter rather than applying a
+     * user-driven settings change, and must work in client and cron contexts.
+     */
+    public function reserveNextNumericParamValue(string $param): ?int
+    {
+        if (empty($param)) {
+            throw new \FOSSBilling\Exception('Parameter key is missing.');
+        }
+
+        return $this->di['dbal']->transactional(function (Connection $connection) use ($param): ?int {
+            $current = $connection->fetchOne(
+                'SELECT value FROM setting WHERE param = :param FOR UPDATE',
+                ['param' => $param]
+            );
+
+            if ($current === false || !is_numeric($current)) {
+                return null;
+            }
+
+            $connection->executeStatement(
+                'UPDATE setting SET value = :value, updated_at = :updated_at WHERE param = :param',
+                [
+                    'value' => (string) (intval($current) + 1),
+                    'updated_at' => date('Y-m-d H:i:s'),
+                    'param' => $param,
+                ]
+            );
+
+            return intval($current);
+        });
     }
 
     private function canUpdateParam(string $param): bool

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -13,6 +13,8 @@ namespace Box\Mod\System;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use FOSSBilling\Config;
 use FOSSBilling\Environment;
 use FOSSBilling\GeoIP\Reader;
@@ -735,7 +737,8 @@ class Service
      * numeric and no $seed was given to repair it with.
      *
      * A $seed is only used if the setting is still missing or invalid once the lock is held, so
-     * concurrent callers seeding the same value cannot both reserve it.
+     * concurrent callers seeding the same value cannot both reserve it. If they collide on
+     * creating the row, the loser reserves from the winner's row instead.
      *
      * Not subject to canUpdateParam(): this reserves an internal counter rather than applying a
      * user-driven settings change, and must work in client and cron contexts.
@@ -746,6 +749,19 @@ class Service
             throw new \FOSSBilling\Exception('Parameter key is missing.');
         }
 
+        try {
+            return $this->reserveNumericParamValue($param, $seed);
+        } catch (UniqueConstraintViolationException|DeadlockException) {
+            // Two callers seeding a counter that does not exist yet both pass the locking read:
+            // InnoDB gap locks are shared, so neither blocks the other, and they collide on the
+            // insert instead. The loser's transaction is rolled back, so reserve from the row the
+            // winner committed rather than failing the caller.
+            return $this->reserveNumericParamValue($param, $seed);
+        }
+    }
+
+    private function reserveNumericParamValue(string $param, ?int $seed): ?int
+    {
         return $this->di['dbal']->transactional(function (Connection $connection) use ($param, $seed): ?int {
             $now = date('Y-m-d H:i:s');
             $current = $connection->fetchOne(

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -732,34 +732,51 @@ class Service
     /**
      * Claims a numeric counter setting's current value and advances it, under a row lock so two
      * concurrent callers are never handed the same number. Returns null if it is missing or not
-     * numeric.
+     * numeric and no $seed was given to repair it with.
+     *
+     * A $seed is only used if the setting is still missing or invalid once the lock is held, so
+     * concurrent callers seeding the same value cannot both reserve it.
      *
      * Not subject to canUpdateParam(): this reserves an internal counter rather than applying a
      * user-driven settings change, and must work in client and cron contexts.
      */
-    public function reserveNextNumericParamValue(string $param): ?int
+    public function reserveNextNumericParamValue(string $param, ?int $seed = null): ?int
     {
         if (empty($param)) {
             throw new \FOSSBilling\Exception('Parameter key is missing.');
         }
 
-        return $this->di['dbal']->transactional(function (Connection $connection) use ($param): ?int {
+        return $this->di['dbal']->transactional(function (Connection $connection) use ($param, $seed): ?int {
+            $now = date('Y-m-d H:i:s');
             $current = $connection->fetchOne(
                 'SELECT value FROM setting WHERE param = :param FOR UPDATE',
                 ['param' => $param]
             );
 
-            if ($current === false || filter_var($current, FILTER_VALIDATE_INT) === false) {
-                return null;
+            $exists = $current !== false;
+            if (!$exists || filter_var($current, FILTER_VALIDATE_INT) === false) {
+                if ($seed === null) {
+                    return null;
+                }
+
+                if ($exists) {
+                    $connection->executeStatement(
+                        'UPDATE setting SET value = :value, updated_at = :updated_at WHERE param = :param',
+                        ['value' => (string) ($seed + 1), 'updated_at' => $now, 'param' => $param]
+                    );
+                } else {
+                    $connection->executeStatement(
+                        'INSERT INTO setting (param, value, created_at, updated_at) VALUES (:param, :value, :created_at, :updated_at)',
+                        ['param' => $param, 'value' => (string) ($seed + 1), 'created_at' => $now, 'updated_at' => $now]
+                    );
+                }
+
+                return $seed;
             }
 
             $connection->executeStatement(
                 'UPDATE setting SET value = :value, updated_at = :updated_at WHERE param = :param',
-                [
-                    'value' => (string) (intval($current) + 1),
-                    'updated_at' => date('Y-m-d H:i:s'),
-                    'param' => $param,
-                ]
+                ['value' => (string) (intval($current) + 1), 'updated_at' => $now, 'param' => $param]
             );
 
             return intval($current);

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -749,7 +749,7 @@ class Service
                 ['param' => $param]
             );
 
-            if ($current === false || !is_numeric($current)) {
+            if ($current === false || filter_var($current, FILTER_VALIDATE_INT) === false) {
                 return null;
             }
 

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -322,3 +322,47 @@ test('clearPendingMessages clears pending messages', function (): void {
     $result = $service->clearPendingMessages();
     expect($result)->toBeTrue();
 });
+
+test('reserveNextNumericParamValue claims the current value and advances the counter under lock', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+    // The read must take the row lock, otherwise two callers can be handed the same number.
+    $dbalMock->shouldReceive('fetchOne')
+        ->once()
+        ->with('SELECT value FROM setting WHERE param = :param FOR UPDATE', ['param' => 'invoice_starting_number'])
+        ->andReturn('7');
+    $dbalMock->shouldReceive('executeStatement')
+        ->once()
+        ->with(
+            'UPDATE setting SET value = :value, updated_at = :updated_at WHERE param = :param',
+            Mockery::on(fn (array $params): bool => $params['value'] === '8' && $params['param'] === 'invoice_starting_number')
+        )
+        ->andReturn(1);
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    expect($service->reserveNextNumericParamValue('invoice_starting_number'))->toBe(7);
+});
+
+test('reserveNextNumericParamValue returns null when the counter is missing or not numeric', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+    $dbalMock->shouldReceive('fetchOne')->once()->andReturn(false);
+    $dbalMock->shouldNotReceive('executeStatement');
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    expect($service->reserveNextNumericParamValue('invoice_starting_number'))->toBeNull();
+});

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -366,3 +366,21 @@ test('reserveNextNumericParamValue returns null when the counter is missing or n
 
     expect($service->reserveNextNumericParamValue('invoice_starting_number'))->toBeNull();
 });
+
+test('reserveNextNumericParamValue rejects non-integer counter values', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+    // Truncating this to 5 and writing 6 would silently skip a number.
+    $dbalMock->shouldReceive('fetchOne')->once()->andReturn('5.5');
+    $dbalMock->shouldNotReceive('executeStatement');
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    expect($service->reserveNextNumericParamValue('invoice_starting_number'))->toBeNull();
+});

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -431,3 +431,38 @@ test('reserveNextNumericParamValue ignores the seed when the counter became vali
 
     expect($service->reserveNextNumericParamValue('invoice_starting_number', 101))->toBe(102);
 });
+
+test('reserveNextNumericParamValue reserves from the winning row when seeding collides', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->twice()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+
+    // First attempt: the row is missing, so we seed it, but another caller inserts it first.
+    // Second attempt: that caller's row is now visible, so reserve from it rather than failing.
+    $dbalMock->shouldReceive('fetchOne')->once()->ordered()->andReturn(false);
+    $dbalMock->shouldReceive('executeStatement')
+        ->once()
+        ->ordered()
+        ->with(Mockery::pattern('/^INSERT INTO setting/'), Mockery::any())
+        ->andThrow(Mockery::mock(Doctrine\DBAL\Exception\UniqueConstraintViolationException::class));
+    // The winner seeded the row with 102, having itself reserved 101.
+    $dbalMock->shouldReceive('fetchOne')->once()->ordered()->andReturn('102');
+    $dbalMock->shouldReceive('executeStatement')
+        ->once()
+        ->ordered()
+        ->with(
+            Mockery::pattern('/^UPDATE setting/'),
+            Mockery::on(fn (array $params): bool => $params['value'] === '103')
+        )
+        ->andReturn(1);
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    // Must not be 101: that is the number the winner reserved.
+    expect($service->reserveNextNumericParamValue('invoice_starting_number', 101))->toBe(102);
+});

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -384,3 +384,50 @@ test('reserveNextNumericParamValue rejects non-integer counter values', function
 
     expect($service->reserveNextNumericParamValue('invoice_starting_number'))->toBeNull();
 });
+
+test('reserveNextNumericParamValue seeds a missing counter and reserves from it', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+    $dbalMock->shouldReceive('fetchOne')->once()->andReturn(false);
+    $dbalMock->shouldReceive('executeStatement')
+        ->once()
+        ->with(
+            Mockery::pattern('/^INSERT INTO setting/'),
+            Mockery::on(fn (array $params): bool => $params['value'] === '102' && $params['param'] === 'invoice_starting_number')
+        )
+        ->andReturn(1);
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    expect($service->reserveNextNumericParamValue('invoice_starting_number', 101))->toBe(101);
+});
+
+test('reserveNextNumericParamValue ignores the seed when the counter became valid under the lock', function (): void {
+    $service = new Service();
+
+    $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $dbalMock->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $callback): mixed => $callback($dbalMock));
+    // A concurrent caller seeded the counter while we waited for the lock.
+    $dbalMock->shouldReceive('fetchOne')->once()->andReturn('102');
+    $dbalMock->shouldReceive('executeStatement')
+        ->once()
+        ->with(
+            Mockery::pattern('/^UPDATE setting/'),
+            Mockery::on(fn (array $params): bool => $params['value'] === '103')
+        )
+        ->andReturn(1);
+
+    $di = container();
+    $di['dbal'] = $dbalMock;
+    $service->setDi($di);
+
+    expect($service->reserveNextNumericParamValue('invoice_starting_number', 101))->toBe(102);
+});

--- a/tests/Helpers/Container.php
+++ b/tests/Helpers/Container.php
@@ -260,6 +260,10 @@ function container(): Container
         $invoiceRepository->shouldReceive('findUnpaidApprovedNotRemindedBefore')->byDefault()->andReturn([]);
         $invoiceRepository->shouldReceive('findPaidByRelId')->byDefault()->andReturn([]);
 
+        $invoiceItemRepository = \Mockery::mock(\Box\Mod\Invoice\Repository\InvoiceItemRepository::class)->shouldIgnoreMissing();
+        $invoiceItemRepository->shouldReceive('find')->byDefault()->andReturn(null);
+        $invoiceItemRepository->shouldReceive('findByInvoiceId')->byDefault()->andReturn([]);
+
         $em = \Mockery::mock(\Doctrine\ORM\EntityManagerInterface::class)->shouldIgnoreMissing();
         $em->shouldReceive('wrapInTransaction')->byDefault()->andReturnUsing(static fn (callable $callback): mixed => $callback());
         $em->shouldReceive('getRepository')->byDefault()->andReturnUsing(static fn (string $class): object => match ($class) {
@@ -286,6 +290,7 @@ function container(): Container
             \Box\Mod\Invoice\Entity\Transaction::class => $transactionRepository,
             \Box\Mod\Invoice\Entity\Subscription::class => $subscriptionRepository,
             \Box\Mod\Invoice\Entity\Invoice::class => $invoiceRepository,
+            \Box\Mod\Invoice\Entity\InvoiceItem::class => $invoiceItemRepository,
             \Box\Mod\Extension\Entity\Extension::class => \Mockery::mock(\Box\Mod\Extension\Repository\ExtensionRepository::class)->shouldIgnoreMissing(),
             default => $extensionMetaRepository,
         });

--- a/tests/Unit/Payment/Adapter/StripeTest.php
+++ b/tests/Unit/Payment/Adapter/StripeTest.php
@@ -96,9 +96,9 @@ function setPrivateProperty(object $obj, string $property, mixed $value): void
     $prop->setValue($obj, $value);
 }
 
-function expectPaymentIntentLock(Mockery\MockInterface $dbalMock, string $paymentIntentId, int $gatewayId): void
+function expectStripeObjectLock(Mockery\MockInterface $dbalMock, string $objectId, int $gatewayId): void
 {
-    $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $paymentIntentId), 0, 54);
+    $lockName = 'fb:stripe:' . substr(hash('sha256', $gatewayId . ':' . $objectId), 0, 54);
     $dbalMock->shouldReceive('fetchOne')
         ->once()
         ->with('SELECT GET_LOCK(:lock_name, 10)', ['lock_name' => $lockName])
@@ -620,7 +620,10 @@ describe('handleInvoicePaymentSucceeded invoice linking', function (): void {
         // flush() happens when the invoice link is persisted.
         $em->shouldReceive('flush')->atLeast()->once();
 
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectStripeObjectLock($dbalMock, 'in_123', 1);
         $di = container();
+        $di['dbal'] = $dbalMock;
         $di['db'] = $dbMock;
         $di['em'] = $em;
         $di['mod_service'] = $di->protect(function ($module, $service = null) use ($transactionService) {
@@ -724,7 +727,10 @@ describe('handleInvoicePaymentSucceeded invoice linking', function (): void {
             ->with('in_456', null, 50)
             ->andReturn(null);
 
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectStripeObjectLock($dbalMock, 'in_456', 1);
         $di = container();
+        $di['dbal'] = $dbalMock;
         $di['db'] = $dbMock;
         $di['em'] = $em;
         $di['mod_service'] = $di->protect(fn ($module, $service = null) => match ($service) {
@@ -945,7 +951,10 @@ describe('handleInvoicePaymentSucceeded with invoice_payment event (API 2026-06-
             ->with('in_1TnBdC', null, 101)
             ->andReturn(null);
 
+        $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
+        expectStripeObjectLock($dbalMock, 'in_1TnBdC', 4);
         $di = container();
+        $di['dbal'] = $dbalMock;
         $di['db'] = $dbMock;
         $di['em'] = $em;
         $di['mod_service'] = $di->protect(fn ($module, $service = null) => match ($service) {
@@ -989,7 +998,7 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
         $existingTx->invoice_id = 10;
 
         $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
-        expectPaymentIntentLock($dbalMock, 'pi_existing', 1);
+        expectStripeObjectLock($dbalMock, 'pi_existing', 1);
 
         ['em' => $em, 'txRepo' => $txRepo] = buildEntityManagerMocks();
         $txRepo->shouldReceive('findProcessingOrProcessedByTxnId')
@@ -1036,7 +1045,7 @@ describe('handlePaymentIntentSucceededWebhook', function (): void {
 
         $dbMock = Mockery::mock('\Box_Database');
         $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
-        expectPaymentIntentLock($dbalMock, 'pi_new', 1);
+        expectStripeObjectLock($dbalMock, 'pi_new', 1);
         $clientModel = new Model_Client();
         $clientModel->loadBean(new DummyBean());
         $clientModel->id = 7;
@@ -1116,7 +1125,7 @@ describe('processPaymentIntent', function (): void {
         setPrivateProperty($this->adapter, 'stripe', $stripeMock);
 
         $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
-        expectPaymentIntentLock($dbalMock, 'pi_webhook_first', 4);
+        expectStripeObjectLock($dbalMock, 'pi_webhook_first', 4);
 
         ['em' => $em, 'txRepo' => $txRepo] = buildEntityManagerMocks();
         $txRepo->shouldReceive('findActiveByTxnIdAndGatewayId')
@@ -1141,22 +1150,22 @@ describe('processPaymentIntent', function (): void {
     });
 });
 
-test('releases the PaymentIntent lock when processing fails', function (): void {
+test('releases the Stripe object lock when processing fails', function (): void {
     $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
-    expectPaymentIntentLock($dbalMock, 'pi_failure', 2);
+    expectStripeObjectLock($dbalMock, 'pi_failure', 2);
 
     $di = container();
     $di['dbal'] = $dbalMock;
     $this->adapter->setDi($di);
 
-    expect(fn (): mixed => invokePrivateMethod($this->adapter, 'withPaymentIntentLock', [
+    expect(fn (): mixed => invokePrivateMethod($this->adapter, 'withStripeObjectLock', [
         'pi_failure',
         2,
         fn () => throw new RuntimeException('Processing failed'),
     ]))->toThrow(RuntimeException::class, 'Processing failed');
 });
 
-test('logs PaymentIntent lock timeouts with lock context', function (): void {
+test('logs Stripe object lock timeouts with lock context', function (): void {
     $lockName = 'fb:stripe:' . substr(hash('sha256', '2:pi_timeout'), 0, 54);
     $dbalMock = Mockery::mock(Doctrine\DBAL\Connection::class);
     $dbalMock->shouldReceive('fetchOne')
@@ -1170,7 +1179,7 @@ test('logs PaymentIntent lock timeouts with lock context', function (): void {
     $di['logger'] = $logger;
     $this->adapter->setDi($di);
 
-    expect(fn (): mixed => invokePrivateMethod($this->adapter, 'withPaymentIntentLock', [
+    expect(fn (): mixed => invokePrivateMethod($this->adapter, 'withStripeObjectLock', [
         'pi_timeout',
         2,
         fn (): null => null,
@@ -1178,7 +1187,7 @@ test('logs PaymentIntent lock timeouts with lock context', function (): void {
         ->and($logger->calls)->toHaveCount(1)
         ->and($logger->calls[0]['method'])->toBe('warning')
         ->and($logger->calls[0]['params'][0])->toContain('Timed out after')
-        ->and($logger->calls[0]['params'][2])->toBe($lockName);
+        ->and($logger->calls[0]['params'][0])->toContain($lockName);
 });
 
 describe('handleSetupIntentSucceededWebhook', function (): void {


### PR DESCRIPTION
Several billing paths follow a check-then-act pattern without holding a lock, so concurrent requests can each read the same state, each pass the check, and each act on it. This adds locking to those paths.