### PR TITLE
Reserve stock at checkout instead of order activation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -59,7 +59,8 @@
         "initialises",
         "WORKTREE",
         "previewable",
-        "falsey"
+        "falsey",
+        "unindexed"
     ],
 
     "ignoreWords": [

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','100',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','101',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','99',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','100',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/install/sql/structure.sql
+++ b/src/install/sql/structure.sql
@@ -364,7 +364,8 @@ CREATE TABLE `client_order` (
   KEY `product_id_idx` (`product_id`),
   KEY `form_id_idx` (`form_id`),
   KEY `promo_id_idx` (`promo_id`),
-  KEY `client_order_status_expires_at_idx` (`status`, `expires_at`)
+  KEY `client_order_status_expires_at_idx` (`status`, `expires_at`),
+  KEY `client_order_unpaid_invoice_id_idx` (`unpaid_invoice_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -2914,7 +2914,7 @@ class UpdatePatcher implements InjectionAwareInterface
                    SELECT 1 FROM client_order_meta m
                    WHERE m.client_order_id = co.id AND m.name = 'stock_reserved_qty'
                )
-             ORDER BY co.product_id ASC, co.id ASC"
+             ORDER BY co.product_id ASC, co.created_at ASC, co.id ASC"
         );
         // The NOT EXISTS above excludes already-backfilled orders, so this is safe to rerun
         // after a partial failure.

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -2923,35 +2923,58 @@ class UpdatePatcher implements InjectionAwareInterface
             return;
         }
 
-        // Stock updates are batched per product after all its orders are processed, so without
-        // a transaction a partial failure could leave meta rows claiming a reservation whose
-        // stock was never actually deducted.
+        // manual_update() (the only caller of this) applies patches without enabling
+        // maintenance mode, so checkout can be reserving stock for other orders on the same
+        // products the whole time this runs. Each order below is therefore reserved with the
+        // same guarded, relative decrement real-time checkout uses (see
+        // ProductRepository::decrementStockIfAvailable()) instead of computing a batch of
+        // "remaining" values up front and overwriting quantity_in_stock with them - an
+        // absolute write like that would silently erase whatever a concurrent checkout had
+        // just decremented. The decrement's WHERE clause also re-checks the order's status and
+        // reservation state at the moment of the attempt rather than trusting the snapshot
+        // read above, so an order canceled or already reserved by then is skipped instead of
+        // double-reserved.
+        $now = date('Y-m-d H:i:s');
         $pdo = $this->getPdo();
-        $pdo->beginTransaction();
 
-        try {
-            $now = date('Y-m-d H:i:s');
-            $remainingByProduct = [];
-            $touchedProducts = [];
+        foreach ($orders as $order) {
+            // Matches Product\Service::reserveStockForOrder(): a non-positive quantity is never
+            // reserved, not rounded up to one.
+            $quantity = (int) ($order['quantity'] ?? 1);
+            if ($quantity <= 0) {
+                continue;
+            }
 
-            foreach ($orders as $order) {
-                $productId = (int) $order['product_id'];
-                if (!array_key_exists($productId, $remainingByProduct)) {
-                    $remainingByProduct[$productId] = (int) $this->fetchOne(
-                        'SELECT quantity_in_stock FROM product WHERE id = :id',
-                        ['id' => $productId]
-                    );
-                }
+            $pdo->beginTransaction();
 
-                // Matches Product\Service::reserveStockForOrder(): a non-positive quantity is
-                // never reserved, not rounded up to one.
-                $quantity = (int) ($order['quantity'] ?? 1);
-                if ($quantity <= 0 || $remainingByProduct[$productId] < $quantity) {
+            try {
+                $decrement = $pdo->prepare(
+                    "UPDATE product p
+                     INNER JOIN client_order co ON co.id = ?
+                     SET p.quantity_in_stock = p.quantity_in_stock - ?, p.updated_at = ?
+                     WHERE p.id = ?
+                       AND p.quantity_in_stock >= ?
+                       AND co.status IN ('pending_setup', 'failed_setup')
+                       AND NOT EXISTS (
+                           SELECT 1 FROM client_order_meta m
+                           WHERE m.client_order_id = co.id AND m.name = 'stock_reserved_qty'
+                       )"
+                );
+                $decrement->execute([
+                    $order['order_id'],
+                    $quantity,
+                    $now,
+                    $order['product_id'],
+                    $quantity,
+                ]);
+
+                if ($decrement->rowCount() === 0) {
+                    // Either out of stock, or the order stopped qualifying since the candidate
+                    // list above was read - leave it unreserved, same as pre-patch behavior.
+                    $pdo->rollBack();
+
                     continue;
                 }
-
-                $remainingByProduct[$productId] -= $quantity;
-                $touchedProducts[$productId] = true;
 
                 $this->executeSql(
                     'INSERT INTO client_order_meta (client_order_id, name, value, created_at, updated_at)
@@ -2964,23 +2987,13 @@ class UpdatePatcher implements InjectionAwareInterface
                         'updated_at' => $now,
                     ]
                 );
+
+                $pdo->commit();
+            } catch (\Throwable $e) {
+                $pdo->rollBack();
+
+                throw $e;
             }
-
-            // Only products with an actual reservation applied need writing back - a product
-            // whose stock was merely read to check availability must not have its updated_at
-            // touched for nothing.
-            foreach (array_keys($touchedProducts) as $productId) {
-                $this->executeSql(
-                    'UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id',
-                    ['remaining' => $remainingByProduct[$productId], 'updated_at' => $now, 'id' => $productId]
-                );
-            }
-
-            $pdo->commit();
-        } catch (\Throwable $e) {
-            $pdo->rollBack();
-
-            throw $e;
         }
     }
 

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -509,6 +509,7 @@ class UpdatePatcher implements InjectionAwareInterface
             97 => 'patch97',
             98 => 'patch98',
             99 => 'patch99',
+            100 => 'patch100',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2892,6 +2893,72 @@ class UpdatePatcher implements InjectionAwareInterface
         // @see https://github.com/FOSSBilling/FOSSBilling/issues/2075
         if (!$this->tableHasColumn('tld', 'periods')) {
             $this->executeSql('ALTER TABLE `tld` ADD COLUMN `periods` VARCHAR(255) DEFAULT NULL AFTER `min_years`');
+        }
+    }
+
+    private function patch100(): void
+    {
+        // Backfills stock reservations for orders that pre-date this version, since activation
+        // no longer decrements stock itself (see Product\Service::reserveStockForOrder()).
+        // Reservations are granted oldest-order-first per product and stop once stock runs out,
+        // so an already-oversold product keeps as many orders "covered" as it has stock for.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/4130
+        $orders = $this->fetchAll(
+            "SELECT co.id AS order_id, co.product_id, co.quantity
+             FROM client_order co
+             INNER JOIN product p ON p.id = co.product_id
+             WHERE co.status IN ('pending_setup', 'failed_setup')
+               AND p.stock_control = 1
+               AND NOT EXISTS (
+                   SELECT 1 FROM client_order_meta m
+                   WHERE m.client_order_id = co.id AND m.name = 'stock_reserved_qty'
+               )
+             ORDER BY co.product_id ASC, co.id ASC"
+        );
+        // The NOT EXISTS above excludes already-backfilled orders, so this is safe to rerun
+        // after a partial failure.
+
+        if ($orders === []) {
+            return;
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $remainingByProduct = [];
+
+        foreach ($orders as $order) {
+            $productId = (int) $order['product_id'];
+            if (!array_key_exists($productId, $remainingByProduct)) {
+                $remainingByProduct[$productId] = (int) $this->fetchOne(
+                    'SELECT quantity_in_stock FROM product WHERE id = :id',
+                    ['id' => $productId]
+                );
+            }
+
+            $quantity = max(1, (int) ($order['quantity'] ?? 1));
+            if ($remainingByProduct[$productId] < $quantity) {
+                continue;
+            }
+
+            $remainingByProduct[$productId] -= $quantity;
+
+            $this->executeSql(
+                'INSERT INTO client_order_meta (client_order_id, name, value, created_at, updated_at)
+                 VALUES (:order_id, :name, :value, :created_at, :updated_at)',
+                [
+                    'order_id' => $order['order_id'],
+                    'name' => 'stock_reserved_qty',
+                    'value' => (string) $quantity,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]
+            );
+        }
+
+        foreach ($remainingByProduct as $productId => $remaining) {
+            $this->executeSql(
+                'UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id',
+                ['remaining' => $remaining, 'updated_at' => $now, 'id' => $productId]
+            );
         }
     }
 }

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -510,6 +510,7 @@ class UpdatePatcher implements InjectionAwareInterface
             98 => 'patch98',
             99 => 'patch99',
             100 => 'patch100',
+            101 => 'patch101',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2922,43 +2923,73 @@ class UpdatePatcher implements InjectionAwareInterface
             return;
         }
 
-        $now = date('Y-m-d H:i:s');
-        $remainingByProduct = [];
+        // Stock updates are batched per product after all its orders are processed, so without
+        // a transaction a partial failure could leave meta rows claiming a reservation whose
+        // stock was never actually deducted.
+        $pdo = $this->getPdo();
+        $pdo->beginTransaction();
 
-        foreach ($orders as $order) {
-            $productId = (int) $order['product_id'];
-            if (!array_key_exists($productId, $remainingByProduct)) {
-                $remainingByProduct[$productId] = (int) $this->fetchOne(
-                    'SELECT quantity_in_stock FROM product WHERE id = :id',
-                    ['id' => $productId]
+        try {
+            $now = date('Y-m-d H:i:s');
+            $remainingByProduct = [];
+            $touchedProducts = [];
+
+            foreach ($orders as $order) {
+                $productId = (int) $order['product_id'];
+                if (!array_key_exists($productId, $remainingByProduct)) {
+                    $remainingByProduct[$productId] = (int) $this->fetchOne(
+                        'SELECT quantity_in_stock FROM product WHERE id = :id',
+                        ['id' => $productId]
+                    );
+                }
+
+                // Matches Product\Service::reserveStockForOrder(): a non-positive quantity is
+                // never reserved, not rounded up to one.
+                $quantity = (int) ($order['quantity'] ?? 1);
+                if ($quantity <= 0 || $remainingByProduct[$productId] < $quantity) {
+                    continue;
+                }
+
+                $remainingByProduct[$productId] -= $quantity;
+                $touchedProducts[$productId] = true;
+
+                $this->executeSql(
+                    'INSERT INTO client_order_meta (client_order_id, name, value, created_at, updated_at)
+                     VALUES (:order_id, :name, :value, :created_at, :updated_at)',
+                    [
+                        'order_id' => $order['order_id'],
+                        'name' => 'stock_reserved_qty',
+                        'value' => (string) $quantity,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]
                 );
             }
 
-            $quantity = max(1, (int) ($order['quantity'] ?? 1));
-            if ($remainingByProduct[$productId] < $quantity) {
-                continue;
+            // Only products with an actual reservation applied need writing back - a product
+            // whose stock was merely read to check availability must not have its updated_at
+            // touched for nothing.
+            foreach (array_keys($touchedProducts) as $productId) {
+                $this->executeSql(
+                    'UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id',
+                    ['remaining' => $remainingByProduct[$productId], 'updated_at' => $now, 'id' => $productId]
+                );
             }
 
-            $remainingByProduct[$productId] -= $quantity;
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            $pdo->rollBack();
 
-            $this->executeSql(
-                'INSERT INTO client_order_meta (client_order_id, name, value, created_at, updated_at)
-                 VALUES (:order_id, :name, :value, :created_at, :updated_at)',
-                [
-                    'order_id' => $order['order_id'],
-                    'name' => 'stock_reserved_qty',
-                    'value' => (string) $quantity,
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ]
-            );
+            throw $e;
         }
+    }
 
-        foreach ($remainingByProduct as $productId => $remaining) {
-            $this->executeSql(
-                'UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id',
-                ['remaining' => $remaining, 'updated_at' => $now, 'id' => $productId]
-            );
+    private function patch101(): void
+    {
+        // findByUnpaidInvoiceId() (invoice cancellation/deletion) filters client_order by this
+        // column, previously unindexed.
+        if (!$this->tableHasIndex('client_order', 'client_order_unpaid_invoice_id_idx')) {
+            $this->executeSql('ALTER TABLE `client_order` ADD INDEX `client_order_unpaid_invoice_id_idx` (`unpaid_invoice_id`)');
         }
     }
 }

--- a/src/modules/Cart/Service.php
+++ b/src/modules/Cart/Service.php
@@ -665,6 +665,7 @@ class Service implements InjectionAwareInterface
 
         $reservedOrderIds = [];
         $reservedCount = 0;
+        $stockReservedOrders = [];
 
         if (!$this->clientCurrency($client)) {
             $this->setClientCurrency($client, $currencyCode);
@@ -680,7 +681,7 @@ class Service implements InjectionAwareInterface
         }
 
         try {
-            return $this->di['em']->wrapInTransaction(function () use ($ca, $cart, $client, $legacyClient, $currency, $currencyCode, $gateway_id, $taxed, $promo, $promoProductService, $promoId, &$reservedOrderIds, &$reservedCount) {
+            return $this->di['em']->wrapInTransaction(function () use ($ca, $cart, $client, $legacyClient, $currency, $currencyCode, $gateway_id, $taxed, $promo, $promoProductService, $promoId, &$reservedOrderIds, &$reservedCount, &$stockReservedOrders) {
                 if ($this->clientCurrency($client) != $currencyCode) {
                     throw new \FOSSBilling\InformationException('Selected currency :selected does not match your profile currency :code. Please change cart currency to continue.', [':selected' => $currencyCode, ':code' => $this->clientCurrency($client)]);
                 }
@@ -749,6 +750,10 @@ class Service implements InjectionAwareInterface
                     $this->di['em']->flush();
 
                     $orders[] = $order;
+
+                    // Reserve stock at order creation time instead of leaving it unclaimed until activation.
+                    $this->getProductService()->reserveStockForOrder($order);
+                    $stockReservedOrders[] = $order;
 
                     // Reserve promo capacity at order creation time.
                     if ($promo instanceof Promo && $promoProductService !== null) {
@@ -881,6 +886,17 @@ class Service implements InjectionAwareInterface
                     $this->di['logger']->error('Failed to compensate promo checkout failure', [
                         'exception' => $compensationError->getMessage(),
                         'promo_id' => $promo->getId(),
+                    ]);
+                }
+            }
+
+            foreach ($stockReservedOrders as $stockReservedOrder) {
+                try {
+                    $this->getProductService()->releaseReservedStockForOrder($stockReservedOrder, 'checkout_failed');
+                } catch (\Throwable $compensationError) {
+                    $this->di['logger']->error('Failed to compensate stock checkout failure', [
+                        'exception' => $compensationError->getMessage(),
+                        'order_id' => $stockReservedOrder->getId(),
                     ]);
                 }
             }

--- a/src/modules/Cart/tests/Unit/ServiceTest.php
+++ b/src/modules/Cart/tests/Unit/ServiceTest.php
@@ -832,6 +832,7 @@ test('createFromCart with promo entity uses product promo service', function ():
 
     $productService = Mockery::mock(ProductService::class);
     $productService->shouldReceive('findPromoById')->once()->with(7)->andReturn($promo);
+    $productService->shouldReceive('reserveStockForOrder')->once()->with(Mockery::type(Order::class));
     $productService->shouldReceive('reservePromoForOrder')->once()->with($promo, Mockery::type(Order::class));
     $productService->shouldReceive('createCheckoutPromoRedemptions')->once()->with(
         $promo,
@@ -942,16 +943,21 @@ test('createFromCart compensates promo usage on transaction failure', function (
 
     $productService = Mockery::mock(ProductService::class);
     $productService->shouldReceive('findPromoById')->once()->with(7)->andReturn($promo);
+    $productService->shouldReceive('reserveStockForOrder')->once()->with(Mockery::type(Order::class));
     $productService->shouldReceive('reservePromoForOrder')->once()->with($promo, Mockery::type(Order::class));
 
     // Simulate Doctrine-side failure during redemption creation.
     $productService->shouldReceive('createCheckoutPromoRedemptions')
         ->andThrow(new RuntimeException('Doctrine flush failed'));
 
-    // The compensating method must be invoked.
+    // The compensating method must be invoked for both promo usage and the stock reservation
+    // taken earlier in the same loop iteration.
     $productService->shouldReceive('compensateCheckoutPromoFailure')
         ->once()
         ->with($promo, Mockery::any(), Mockery::any());
+    $productService->shouldReceive('releaseReservedStockForOrder')
+        ->once()
+        ->with(Mockery::type(Order::class), 'checkout_failed');
 
     $product = new Product();
     $productIdReflection = new ReflectionProperty($product, 'id');
@@ -1099,6 +1105,7 @@ test('createFromCart does not roll back order creation when synchronous activati
 
     $productService = Mockery::mock(ProductService::class);
     $productService->shouldReceive('findProductById')->twice()->with(5)->andReturn($product);
+    $productService->shouldReceive('reserveStockForOrder')->once()->with(Mockery::type(Order::class));
 
     $di = container();
     $di['db'] = $dbMock;

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1487,6 +1487,7 @@ class Service implements InjectionAwareInterface
         if ($previousStatus === Invoice::STATUS_UNPAID && $model->getStatus() === Invoice::STATUS_CANCELED) {
             $productService = $this->di['mod_service']('Product');
             $productService->releaseReservedPromoRedemptionsForInvoice($model, 'invoice_canceled');
+            $productService->releaseReservedStockForInvoice($model, 'invoice_canceled');
         }
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminInvoiceUpdate', 'params' => $this->toApiArray($model)]);
@@ -1500,6 +1501,7 @@ class Service implements InjectionAwareInterface
     {
         $productService = $this->di['mod_service']('Product');
         $productService->releaseReservedPromoRedemptionsForInvoice($model, 'invoice_deleted');
+        $productService->releaseReservedStockForInvoice($model, 'invoice_deleted');
 
         // remove related invoice from orders
         $sql = '

--- a/src/modules/Order/Repository/OrderMetaRepository.php
+++ b/src/modules/Order/Repository/OrderMetaRepository.php
@@ -37,4 +37,12 @@ class OrderMetaRepository extends EntityRepository
             ['order_id' => $orderId]
         );
     }
+
+    public function deleteByOrderIdAndName(int $orderId, string $name): int
+    {
+        return $this->getEntityManager()->getConnection()->executeStatement(
+            'DELETE FROM client_order_meta WHERE client_order_id = :order_id AND name = :name',
+            ['order_id' => $orderId, 'name' => $name]
+        );
+    }
 }

--- a/src/modules/Order/Repository/OrderRepository.php
+++ b/src/modules/Order/Repository/OrderRepository.php
@@ -17,6 +17,14 @@ class OrderRepository extends EntityRepository
         return $this->findBy(['clientId' => $clientId]);
     }
 
+    /**
+     * @return Order[]
+     */
+    public function findByUnpaidInvoiceId(int $invoiceId): array
+    {
+        return $this->findBy(['unpaidInvoiceId' => $invoiceId]);
+    }
+
     public function findForClientById(int $clientId, int $orderId): ?Order
     {
         $order = $this->findOneBy(['id' => $orderId, 'clientId' => $clientId]);

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -52,6 +52,8 @@ class Service implements InjectionAwareInterface
     public const META_CANCEL_AT_PERIOD_END = 'cancel_at_period_end';
     private const string META_SUSPENSION_WARNING_FOR = 'suspension_warning_for';
 
+    public const META_STOCK_RESERVED_QTY = 'stock_reserved_qty';
+
     private const array BUILT_IN_SERVICE_TYPES = [
         \Box\Mod\Product\Service::CUSTOM,
         \Box\Mod\Product\Service::LICENSE,
@@ -962,6 +964,9 @@ class Service implements InjectionAwareInterface
             $this->di['em']->flush();
             $orderId = $order->getId();
 
+            // Reserve stock now rather than at activation - this path bypasses the cart, but has the same race.
+            $this->di['mod_service']('Product')->reserveStockForOrder($order);
+
             if (isset($data['meta']) && is_array($data['meta'])) {
                 foreach ($data['meta'] as $k => $v) {
                     $mm = $this->getOrderMetaRepository()->findOneByOrderIdAndName($orderId, $k);
@@ -1166,13 +1171,12 @@ class Service implements InjectionAwareInterface
             throw $e;
         }
 
-        if ($order->getProductId()) {
-            $productService = $this->di['mod_service']('product');
-            $productService->reduceStock((int) $order->getProductId(), (int) ($order->getQuantity() ?? 1));
-        } else {
+        if (!$order->getProductId()) {
             $this->di['logger']->info("Order without product ID detected Order #{$orderId}.");
         }
 
+        // Stock was already reserved atomically at order-creation time (see
+        // Product\Service::reserveStockForOrder()), so it must not be decremented again here.
         $this->saveStatusChange($order, 'Order activated');
 
         return $result;
@@ -1484,6 +1488,7 @@ class Service implements InjectionAwareInterface
 
         $productService = $this->di['mod_service']('Product');
         $productService->releaseReservedPromoRedemptionsForOrder($order, 'order_canceled');
+        $productService->releaseReservedStockForOrder($order, 'order_canceled');
 
         $note = ($reason === null) ? 'Order canceled' : 'Canceled order for ' . $reason;
         $this->saveStatusChange($order, $note);
@@ -1658,6 +1663,7 @@ class Service implements InjectionAwareInterface
 
         $productService = $this->di['mod_service']('Product');
         $productService->releaseReservedPromoRedemptionsForOrder($order, 'order_deleted');
+        $productService->releaseReservedStockForOrder($order, 'order_deleted');
         $this->rmClientOrderStatusByOrder($order);
         $this->rmOrder($order);
 
@@ -2018,6 +2024,7 @@ class Service implements InjectionAwareInterface
         $orders = $this->getOrderRepository()->findByClientId((int) $clientId);
         foreach ($orders as $order) {
             $productService->releaseReservedPromoRedemptionsForOrder($order, 'client_deleted');
+            $productService->releaseReservedStockForOrder($order, 'client_deleted');
             $this->getOrderMetaRepository()->deleteByOrderId($this->orderId($order));
             $this->getOrderStatusRepository()->rmByOrderId($this->orderId($order));
         }

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -964,9 +964,6 @@ class Service implements InjectionAwareInterface
             $this->di['em']->flush();
             $orderId = $order->getId();
 
-            // Reserve stock now rather than at activation - this path bypasses the cart, but has the same race.
-            $this->di['mod_service']('Product')->reserveStockForOrder($order);
-
             if (isset($data['meta']) && is_array($data['meta'])) {
                 foreach ($data['meta'] as $k => $v) {
                     $mm = $this->getOrderMetaRepository()->findOneByOrderIdAndName($orderId, $k);
@@ -982,6 +979,11 @@ class Service implements InjectionAwareInterface
                 }
                 $this->di['em']->flush();
             }
+
+            // Reserve stock now rather than at activation - this path bypasses the cart, but has
+            // the same race. Done after the caller-supplied meta above so it can't be overwritten
+            // by a caller passing their own "stock_reserved_qty" meta entry.
+            $this->di['mod_service']('Product')->reserveStockForOrder($order);
 
             if ($invoiceOption == 'issue-invoice') {
                 $invoiceService = $this->di['mod_service']('invoice');

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -1626,6 +1626,7 @@ test('createOrder creates order', function (): void {
     $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
     $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
     $pricingServiceMock->shouldReceive('getProductOrderLineConfig')->never();
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $persistedEntities = [];
     $nextOrderId = 1;
@@ -1722,6 +1723,7 @@ test('createOrder sets form id from product', function (): void {
     $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
     $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
     $pricingServiceMock->shouldReceive('getProductOrderLineConfig')->never();
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $persistedEntities = [];
     $nextOrderId = 1;
@@ -1817,6 +1819,7 @@ test('createOrder returns success when invoice follow up fails', function (): vo
     $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
     $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
     $pricingServiceMock->shouldReceive('getProductOrderLineConfig')->never();
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $invoiceModel = orderServiceCreateInvoiceModel(10);
 
@@ -1960,6 +1963,7 @@ test('createOrder uses product pricing service for domain orders', function (): 
             'quantity' => 2,
             'setup_price' => 0.0,
         ]);
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $persistedEntities = [];
     $nextOrderId = 1;
@@ -2077,12 +2081,14 @@ test('createFromOrder activates the order after successful provisioning', functi
     $periodMock = Mockery::mock(Box_Period::class);
     $periodMock->shouldReceive('getExpirationTime')->once()->andReturn(strtotime('2027-01-01 00:00:00'));
 
-    $productServiceMock = Mockery::mock();
-    $productServiceMock->shouldReceive('reduceStock')->once()->with(7, 2);
-
+    // Stock is reserved atomically at order-creation time (see
+    // Product\Service::reserveStockForOrder()), not here at activation, so createFromOrder()
+    // must not touch the product service at all.
     $di = container();
     $di['period'] = $di->protect(fn (): Mockery\MockInterface => $periodMock);
-    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $productServiceMock);
+    $di['mod_service'] = $di->protect(function (): never {
+        throw new LogicException('createFromOrder() must not reach into any module service for stock handling');
+    });
 
     $serviceMock->setDi($di);
 
@@ -2641,6 +2647,9 @@ test('cancelFromOrder cancels linked subscriptions', function (): void {
     $productService->shouldReceive('releaseReservedPromoRedemptionsForOrder')
         ->once()
         ->with($clientOrderModel, 'order_canceled');
+    $productService->shouldReceive('releaseReservedStockForOrder')
+        ->once()
+        ->with($clientOrderModel, 'order_canceled');
 
     $connectionMock = Mockery::mock(Doctrine\DBAL\Connection::class);
     $connectionMock->shouldReceive('executeStatement')
@@ -2883,6 +2892,9 @@ test('rmByClient removes all client orders', function (): void {
 
     $productServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
     $productServiceMock->shouldReceive('releaseReservedPromoRedemptionsForOrder')
+        ->once()
+        ->with($orderModel, 'client_deleted');
+    $productServiceMock->shouldReceive('releaseReservedStockForOrder')
         ->once()
         ->with($orderModel, 'client_deleted');
 
@@ -3340,6 +3352,7 @@ test('createOrder generates an invoice for a zero-price order with issue-invoice
     $productServiceMock = Mockery::mock(Box\Mod\Servicecustom\Service::class);
     $pricingServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
     $pricingServiceMock->shouldReceive('getProductOrderLineConfig')->never();
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $invoiceModel = orderServiceCreateInvoiceModel(10);
 
@@ -3457,6 +3470,7 @@ test('createOrder does not roll back when invoice generation fails for a negativ
     $pricingServiceMock->shouldReceive('getProductOrderLineConfig')
         ->atLeast()->once()
         ->andReturn(['price' => -5.0, 'quantity' => 1]);
+    $pricingServiceMock->shouldReceive('reserveStockForOrder')->once();
 
     $invoiceServiceMock = Mockery::mock();
     $invoiceServiceMock->shouldReceive('generateForOrder')

--- a/src/modules/Product/Repository/ProductRepository.php
+++ b/src/modules/Product/Repository/ProductRepository.php
@@ -224,6 +224,14 @@ class ProductRepository extends EntityRepository
         );
     }
 
+    public function incrementStock(int $productId, int $quantity, \DateTimeInterface $updatedAt): int
+    {
+        return $this->getEntityManager()->getConnection()->executeStatement(
+            'UPDATE product SET quantity_in_stock = quantity_in_stock + ?, updated_at = ? WHERE id = ?',
+            [$quantity, $updatedAt->format('Y-m-d H:i:s'), $productId]
+        );
+    }
+
     public function findEnabledAddonById(int $id): ?Product
     {
         return $this->findOneBy([

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -1008,6 +1008,80 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
+    public function reserveStockForOrder(Order $order): void
+    {
+        $productId = (int) $order->getProductId();
+        if ($productId <= 0) {
+            return;
+        }
+
+        $resolvedProduct = $this->findProductById($productId);
+        $quantity = (int) ($order->getQuantity() ?? 1);
+        if (!$resolvedProduct->isStockControl() || $quantity <= 0) {
+            return;
+        }
+
+        $this->reduceStock($resolvedProduct, $quantity);
+
+        $orderService = $this->di['mod_service']('Order');
+        $orderService->updateOrderMeta($order, [
+            \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY => (string) $quantity,
+        ]);
+    }
+
+    // Activation leaves the reservation meta untouched, so cancelling an order that already
+    // went active does not restock it here - only never-activated reservations get released.
+    public function releaseReservedStockForOrder(Order $order, string $reason): void
+    {
+        $orderId = (int) $order->getId();
+        if ($orderId <= 0) {
+            return;
+        }
+
+        $orderService = $this->di['mod_service']('Order');
+        $metaRepository = $orderService->getOrderMetaRepository();
+        $meta = $metaRepository->findOneByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
+        if ($meta === null) {
+            return;
+        }
+
+        $quantity = (int) $meta->getValue();
+
+        $deleted = $metaRepository->deleteByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
+        if ($deleted === 0 || $quantity <= 0) {
+            // A concurrent release already claimed this reservation.
+            return;
+        }
+
+        $productId = (int) $order->getProductId();
+        if ($productId <= 0) {
+            return;
+        }
+
+        $this->getProductRepository()->incrementStock($productId, $quantity, new \DateTime());
+
+        $resolvedProduct = $this->getProductRepository()->find($productId);
+        if ($resolvedProduct instanceof Product) {
+            // The statement above bypassed the entity, so bring the in-memory copy back in line.
+            $this->di['em']->refresh($resolvedProduct);
+        }
+
+        $this->di['logger']->info('Released stock reservation for order #%s (%s)', $orderId, $reason);
+    }
+
+    public function releaseReservedStockForInvoice(Invoice $invoice, string $reason): void
+    {
+        $invoiceId = (int) $invoice->getId();
+        if ($invoiceId <= 0) {
+            return;
+        }
+
+        $orderService = $this->di['mod_service']('Order');
+        foreach ($orderService->getOrderRepository()->findByUnpaidInvoiceId($invoiceId) as $order) {
+            $this->releaseReservedStockForOrder($order, $reason);
+        }
+    }
+
     private function getPeriods(Promo $model): array
     {
         return $this->decodePromoSelection($this->getPromoSourceArray($model)['periods'] ?? null);

--- a/src/modules/Product/Service.php
+++ b/src/modules/Product/Service.php
@@ -1040,33 +1040,39 @@ class Service implements InjectionAwareInterface
 
         $orderService = $this->di['mod_service']('Order');
         $metaRepository = $orderService->getOrderMetaRepository();
-        $meta = $metaRepository->findOneByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
-        if ($meta === null) {
-            return;
-        }
 
-        $quantity = (int) $meta->getValue();
+        // Unlike reserveStockForOrder(), callers of this method (order/invoice cancellation and
+        // deletion) don't already run inside a transaction, so the meta delete and the stock
+        // increment it authorizes need their own to avoid losing stock to a crash between them.
+        $this->di['em']->wrapInTransaction(function () use ($order, $orderId, $reason, $metaRepository): void {
+            $meta = $metaRepository->findOneByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
+            if ($meta === null) {
+                return;
+            }
 
-        $deleted = $metaRepository->deleteByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
-        if ($deleted === 0 || $quantity <= 0) {
-            // A concurrent release already claimed this reservation.
-            return;
-        }
+            $quantity = (int) $meta->getValue();
 
-        $productId = (int) $order->getProductId();
-        if ($productId <= 0) {
-            return;
-        }
+            $deleted = $metaRepository->deleteByOrderIdAndName($orderId, \Box\Mod\Order\Service::META_STOCK_RESERVED_QTY);
+            if ($deleted === 0 || $quantity <= 0) {
+                // A concurrent release already claimed this reservation.
+                return;
+            }
 
-        $this->getProductRepository()->incrementStock($productId, $quantity, new \DateTime());
+            $productId = (int) $order->getProductId();
+            if ($productId <= 0) {
+                return;
+            }
 
-        $resolvedProduct = $this->getProductRepository()->find($productId);
-        if ($resolvedProduct instanceof Product) {
-            // The statement above bypassed the entity, so bring the in-memory copy back in line.
-            $this->di['em']->refresh($resolvedProduct);
-        }
+            $this->getProductRepository()->incrementStock($productId, $quantity, new \DateTime());
 
-        $this->di['logger']->info('Released stock reservation for order #%s (%s)', $orderId, $reason);
+            $resolvedProduct = $this->getProductRepository()->find($productId);
+            if ($resolvedProduct instanceof Product) {
+                // The statement above bypassed the entity, so bring the in-memory copy back in line.
+                $this->di['em']->refresh($resolvedProduct);
+            }
+
+            $this->di['logger']->info('Released stock reservation for order #%s (%s)', $orderId, $reason);
+        });
     }
 
     public function releaseReservedStockForInvoice(Invoice $invoice, string $reason): void

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -152,6 +152,11 @@ function productTestCreateEntityManagerWithRepositories(
         {
             // Stock is decremented with a direct UPDATE, so nothing to re-read in the stub.
         }
+
+        public function wrapInTransaction(callable $callback): mixed
+        {
+            return $callback();
+        }
     };
 }
 

--- a/src/modules/Product/tests/Unit/ServiceTest.php
+++ b/src/modules/Product/tests/Unit/ServiceTest.php
@@ -493,6 +493,216 @@ test('is stock available uses doctrine product state', function (): void {
     expect($service->isStockAvailable($product, 2))->toBeFalse();
 });
 
+test('reserveStockForOrder reserves stock atomically and records the reservation', function (): void {
+    $service = new Service();
+    $product = productTestCreateProductEntity(1)
+        ->setStockControl(true)
+        ->setQuantityInStock(5);
+
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, [
+        'id' => 99,
+        'product_id' => 1,
+        'quantity' => 2,
+    ]);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('find')->once()->with(1)->andReturn($product);
+    $productRepo->shouldReceive('decrementStockIfAvailable')
+        ->once()
+        ->with(1, 2, Mockery::type(DateTimeInterface::class))
+        ->andReturn(1);
+
+    $orderServiceMock = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderServiceMock->shouldReceive('updateOrderMeta')
+        ->once()
+        ->with($order, [Box\Mod\Order\Service::META_STOCK_RESERVED_QTY => '2']);
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        default => throw new RuntimeException("Unexpected module service {$module}"),
+    });
+    $service->setDi($di);
+
+    $service->reserveStockForOrder($order);
+});
+
+test('reserveStockForOrder does not touch stock or write reservation meta for a non stock-controlled product', function (): void {
+    $service = new Service();
+    $product = productTestCreateProductEntity(1)->setStockControl(false);
+
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, [
+        'id' => 99,
+        'product_id' => 1,
+        'quantity' => 2,
+    ]);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('find')->once()->with(1)->andReturn($product);
+    $productRepo->shouldNotReceive('decrementStockIfAvailable');
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $di['mod_service'] = $di->protect(fn (): never => throw new RuntimeException('mod_service should not be called'));
+    $service->setDi($di);
+
+    $service->reserveStockForOrder($order);
+});
+
+test('reserveStockForOrder is a no-op for an order without a product', function (): void {
+    $service = new Service();
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, ['id' => 99]);
+
+    // Neither 'em' nor 'mod_service' is registered: if the code tried to touch either one it
+    // would hit Pimple's "identifier is not defined" error rather than return quietly.
+    $service->setDi(container());
+
+    expect(fn () => $service->reserveStockForOrder($order))->not->toThrow(Throwable::class);
+});
+
+test('releaseReservedStockForOrder restores stock and clears the reservation', function (): void {
+    $service = new Service();
+    $product = productTestCreateProductEntity(1)->setStockControl(true)->setQuantityInStock(0);
+
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, [
+        'id' => 99,
+        'product_id' => 1,
+    ]);
+
+    $meta = createEntity(Box\Mod\Order\Entity\OrderMeta::class, [
+        'client_order_id' => 99,
+        'name' => Box\Mod\Order\Service::META_STOCK_RESERVED_QTY,
+        'value' => '3',
+    ]);
+
+    $metaRepo = Mockery::mock(Box\Mod\Order\Repository\OrderMetaRepository::class);
+    $metaRepo->shouldReceive('findOneByOrderIdAndName')
+        ->once()
+        ->with(99, Box\Mod\Order\Service::META_STOCK_RESERVED_QTY)
+        ->andReturn($meta);
+    $metaRepo->shouldReceive('deleteByOrderIdAndName')
+        ->once()
+        ->with(99, Box\Mod\Order\Service::META_STOCK_RESERVED_QTY)
+        ->andReturn(1);
+
+    $orderServiceMock = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderServiceMock->shouldReceive('getOrderMetaRepository')->once()->andReturn($metaRepo);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldReceive('incrementStock')
+        ->once()
+        ->with(1, 3, Mockery::type(DateTimeInterface::class))
+        ->andReturn(1);
+    $productRepo->shouldReceive('find')->once()->with(1)->andReturn($product);
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        default => throw new RuntimeException("Unexpected module service {$module}"),
+    });
+    $di['logger'] = new Box_Log();
+    $service->setDi($di);
+
+    $service->releaseReservedStockForOrder($order, 'order_canceled');
+});
+
+test('releaseReservedStockForOrder is idempotent once the reservation is already released', function (): void {
+    $service = new Service();
+
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, [
+        'id' => 99,
+        'product_id' => 1,
+    ]);
+
+    $metaRepo = Mockery::mock(Box\Mod\Order\Repository\OrderMetaRepository::class);
+    $metaRepo->shouldReceive('findOneByOrderIdAndName')
+        ->once()
+        ->with(99, Box\Mod\Order\Service::META_STOCK_RESERVED_QTY)
+        ->andReturn(null);
+    $metaRepo->shouldNotReceive('deleteByOrderIdAndName');
+
+    $orderServiceMock = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderServiceMock->shouldReceive('getOrderMetaRepository')->once()->andReturn($metaRepo);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldNotReceive('incrementStock');
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        default => throw new RuntimeException("Unexpected module service {$module}"),
+    });
+    $service->setDi($di);
+
+    $service->releaseReservedStockForOrder($order, 'order_canceled');
+});
+
+test('releaseReservedStockForOrder does not double-restock when a concurrent release already claimed it', function (): void {
+    // The delete's affected-row count is the atomicity gate: a concurrent release could have
+    // read the same meta row and deleted it first, in which case this call must not restock.
+    $service = new Service();
+
+    $order = createEntity(Box\Mod\Order\Entity\Order::class, [
+        'id' => 99,
+        'product_id' => 1,
+    ]);
+
+    $meta = createEntity(Box\Mod\Order\Entity\OrderMeta::class, [
+        'client_order_id' => 99,
+        'name' => Box\Mod\Order\Service::META_STOCK_RESERVED_QTY,
+        'value' => '3',
+    ]);
+
+    $metaRepo = Mockery::mock(Box\Mod\Order\Repository\OrderMetaRepository::class);
+    $metaRepo->shouldReceive('findOneByOrderIdAndName')->once()->andReturn($meta);
+    $metaRepo->shouldReceive('deleteByOrderIdAndName')->once()->andReturn(0);
+
+    $orderServiceMock = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderServiceMock->shouldReceive('getOrderMetaRepository')->once()->andReturn($metaRepo);
+
+    $productRepo = Mockery::mock(ProductRepository::class);
+    $productRepo->shouldNotReceive('incrementStock');
+
+    $di = container();
+    $di['em'] = productTestCreateEntityManagerWithRepositories($productRepo);
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        default => throw new RuntimeException("Unexpected module service {$module}"),
+    });
+    $service->setDi($di);
+
+    $service->releaseReservedStockForOrder($order, 'order_canceled');
+});
+
+test('releaseReservedStockForInvoice releases every order still linked to the invoice', function (): void {
+    $invoice = productTestCreateInvoiceModel(55);
+
+    $firstOrder = createEntity(Box\Mod\Order\Entity\Order::class, ['id' => 1]);
+    $secondOrder = createEntity(Box\Mod\Order\Entity\Order::class, ['id' => 2]);
+
+    $orderRepo = Mockery::mock(Box\Mod\Order\Repository\OrderRepository::class);
+    $orderRepo->shouldReceive('findByUnpaidInvoiceId')->once()->with(55)->andReturn([$firstOrder, $secondOrder]);
+
+    $orderServiceMock = Mockery::mock(Box\Mod\Order\Service::class);
+    $orderServiceMock->shouldReceive('getOrderRepository')->once()->andReturn($orderRepo);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        default => throw new RuntimeException("Unexpected module service {$module}"),
+    });
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('releaseReservedStockForOrder')->once()->with($firstOrder, 'invoice_canceled');
+    $serviceMock->shouldReceive('releaseReservedStockForOrder')->once()->with($secondOrder, 'invoice_canceled');
+    $serviceMock->setDi($di);
+
+    $serviceMock->releaseReservedStockForInvoice($invoice, 'invoice_canceled');
+});
+
 test('get product pricing array uses product payment implementation', function (): void {
     $service = new Service();
     $product = productTestCreateProductEntity(1)

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -19,6 +19,13 @@ test('downloadable file migration follows the client balance gateway repair', fu
         ->and($patches[93][1])->toBe('patch93');
 });
 
+test('stock reservation backfill patch follows the TLD periods patch', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 99);
+
+    expect($patches)->toHaveKey(100)
+        ->and($patches[100][1])->toBe('patch100');
+});
+
 test('manual currency rate patch follows the currency formatting patch', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 93);
 
@@ -239,4 +246,120 @@ test('legacy email patch restores untouched 0.7.2 defaults without replacing cus
     $patcher = new UpdatePatcher();
     $patcher->setDi($di);
     (new ReflectionMethod($patcher, 'patch90'))->invoke($patcher);
+});
+
+test('stock reservation backfill patch is a no-op when there is nothing to backfill', function (): void {
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([]);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->andReturn($selectOrders);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
+test('stock reservation backfill patch reserves stock for a pending order and decrements it', function (): void {
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
+        ['order_id' => 5, 'product_id' => 1, 'quantity' => 2],
+    ]);
+
+    $selectStock = Mockery::mock(PDOStatement::class);
+    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
+    $selectStock->expects('fetchColumn')->andReturn(10);
+
+    $insertMeta = Mockery::mock(PDOStatement::class);
+    $insertMeta->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params['order_id'])->toBe(5)
+            ->and($params['name'])->toBe('stock_reserved_qty')
+            ->and($params['value'])->toBe('2');
+
+        return true;
+    }))->andReturnTrue();
+
+    $updateStock = Mockery::mock(PDOStatement::class);
+    $updateStock->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params['id'])->toBe(1)
+            ->and($params['remaining'])->toBe(8);
+
+        return true;
+    }))->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->andReturn($selectOrders);
+    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')))
+        ->andReturn($insertMeta);
+    $pdo->expects('prepare')
+        ->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id')
+        ->andReturn($updateStock);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
+test('stock reservation backfill patch stops once a product is already oversold', function (): void {
+    // Two pending orders for the same product, but only one unit left: the older order (lower
+    // id) is granted the reservation, the newer one is left exactly as it was pre-patch.
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
+        ['order_id' => 5, 'product_id' => 1, 'quantity' => 1],
+        ['order_id' => 6, 'product_id' => 1, 'quantity' => 1],
+    ]);
+
+    $selectStock = Mockery::mock(PDOStatement::class);
+    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
+    $selectStock->expects('fetchColumn')->andReturn(1);
+
+    $insertMeta = Mockery::mock(PDOStatement::class);
+    $insertMeta->expects('execute')->with(Mockery::on(function (array $params): bool {
+        // Only order 5 may be reserved; order 6 must never reach this statement.
+        expect($params['order_id'])->toBe(5);
+
+        return true;
+    }))->andReturnTrue();
+
+    $updateStock = Mockery::mock(PDOStatement::class);
+    $updateStock->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params['id'])->toBe(1)
+            ->and($params['remaining'])->toBe(0);
+
+        return true;
+    }))->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->andReturn($selectOrders);
+    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')))
+        ->andReturn($insertMeta);
+    $pdo->expects('prepare')
+        ->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id')
+        ->andReturn($updateStock);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
 });

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -26,6 +26,13 @@ test('stock reservation backfill patch follows the TLD periods patch', function 
         ->and($patches[100][1])->toBe('patch100');
 });
 
+test('unpaid invoice id index patch follows the stock reservation backfill patch', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 100);
+
+    expect($patches)->toHaveKey(101)
+        ->and($patches[101][1])->toBe('patch101');
+});
+
 test('manual currency rate patch follows the currency formatting patch', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 93);
 
@@ -107,6 +114,13 @@ test('fresh installs index order suspension candidates', function (): void {
     $structure = $filesystem->readFile(Path::join(PATH_ROOT, 'install', 'sql', 'structure.sql'));
 
     expect($structure)->toContain('KEY `client_order_status_expires_at_idx` (`status`, `expires_at`)');
+});
+
+test('fresh installs index unpaid invoice lookups', function (): void {
+    $filesystem = new Filesystem();
+    $structure = $filesystem->readFile(Path::join(PATH_ROOT, 'install', 'sql', 'structure.sql'));
+
+    expect($structure)->toContain('KEY `client_order_unpaid_invoice_id_idx` (`unpaid_invoice_id`)');
 });
 
 test('fresh installs constrain client balance to one credit per invoice item', function (): void {
@@ -295,6 +309,8 @@ test('stock reservation backfill patch reserves stock for a pending order and de
     }))->andReturnTrue();
 
     $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('beginTransaction')->andReturnTrue();
+    $pdo->expects('commit')->andReturnTrue();
     $pdo->expects('prepare')
         ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
         ->andReturn($selectOrders);
@@ -312,6 +328,67 @@ test('stock reservation backfill patch reserves stock for a pending order and de
     $patcher = new UpdatePatcher();
     $patcher->setDi($di);
     (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
+test('stock reservation backfill patch skips orders with a non-positive quantity', function (): void {
+    // Matches Product\Service::reserveStockForOrder(): a zero/negative quantity is never
+    // reserved, not rounded up to one unit.
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
+        ['order_id' => 5, 'product_id' => 1, 'quantity' => 0],
+    ]);
+
+    $selectStock = Mockery::mock(PDOStatement::class);
+    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
+    $selectStock->expects('fetchColumn')->andReturn(10);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('beginTransaction')->andReturnTrue();
+    $pdo->expects('commit')->andReturnTrue();
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->andReturn($selectOrders);
+    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->shouldNotReceive('prepare')->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')));
+    // Nothing was reserved, so the product's stock is never rewritten either.
+    $pdo->shouldNotReceive('prepare')->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id');
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
+test('stock reservation backfill patch rolls back if a statement fails partway through', function (): void {
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
+        ['order_id' => 5, 'product_id' => 1, 'quantity' => 2],
+    ]);
+
+    $selectStock = Mockery::mock(PDOStatement::class);
+    $selectStock->expects('execute')->with(['id' => 1])->andThrow(new PDOException('gone away'));
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('beginTransaction')->andReturnTrue();
+    $pdo->expects('rollBack')->andReturnTrue();
+    $pdo->shouldNotReceive('commit');
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->andReturn($selectOrders);
+    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+
+    expect(fn () => (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher))
+        ->toThrow(PDOException::class, 'gone away');
 });
 
 test('stock reservation backfill patch stops once a product is already oversold', function (): void {
@@ -345,6 +422,8 @@ test('stock reservation backfill patch stops once a product is already oversold'
     }))->andReturnTrue();
 
     $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('beginTransaction')->andReturnTrue();
+    $pdo->expects('commit')->andReturnTrue();
     $pdo->expects('prepare')
         ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
         ->andReturn($selectOrders);
@@ -362,4 +441,45 @@ test('stock reservation backfill patch stops once a product is already oversold'
     $patcher = new UpdatePatcher();
     $patcher->setDi($di);
     (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
+test('unpaid invoice id index patch adds the index for existing installs', function (): void {
+    $indexes = Mockery::mock(PDOStatement::class);
+    $indexes->expects('execute')->with([])->andReturnTrue();
+    $indexes->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([]);
+
+    $addIndex = Mockery::mock(PDOStatement::class);
+    $addIndex->expects('execute')->with([])->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')->with('SHOW INDEX FROM `client_order`')->andReturn($indexes);
+    $pdo->expects('prepare')
+        ->with('ALTER TABLE `client_order` ADD INDEX `client_order_unpaid_invoice_id_idx` (`unpaid_invoice_id`)')
+        ->andReturn($addIndex);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch101'))->invoke($patcher);
+});
+
+test('unpaid invoice id index patch is a no-op when the index already exists', function (): void {
+    $indexes = Mockery::mock(PDOStatement::class);
+    $indexes->expects('execute')->with([])->andReturnTrue();
+    $indexes->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
+        ['Key_name' => 'client_order_unpaid_invoice_id_idx'],
+    ]);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')->with('SHOW INDEX FROM `client_order`')->andReturn($indexes);
+    $pdo->shouldNotReceive('prepare')->with('ALTER TABLE `client_order` ADD INDEX `client_order_unpaid_invoice_id_idx` (`unpaid_invoice_id`)');
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch101'))->invoke($patcher);
 });

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -280,6 +280,27 @@ test('stock reservation backfill patch is a no-op when there is nothing to backf
     (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
 });
 
+test('stock reservation backfill patch orders candidates by creation time, not id', function (): void {
+    // An order's id doesn't necessarily reflect when it was created (e.g. an imported or
+    // manually restored order), so "oldest first" has to mean created_at, with id only as a
+    // deterministic tie-breaker for orders created at the same instant.
+    $selectOrders = Mockery::mock(PDOStatement::class);
+    $selectOrders->expects('execute')->with([])->andReturnTrue();
+    $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([]);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'ORDER BY co.product_id ASC, co.created_at ASC, co.id ASC')))
+        ->andReturn($selectOrders);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch100'))->invoke($patcher);
+});
+
 test('stock reservation backfill patch reserves stock for a pending order and decrements it', function (): void {
     $selectOrders = Mockery::mock(PDOStatement::class);
     $selectOrders->expects('execute')->with([])->andReturnTrue();
@@ -386,19 +407,21 @@ test('stock reservation backfill patch rolls back if a statement fails partway t
 });
 
 test('stock reservation backfill patch stops once a product is already oversold', function (): void {
-    // Two pending orders for the same product, but only one unit left: the older order (lower
-    // id) is granted the reservation via a guarded decrement; the newer one's decrement affects
-    // zero rows once stock is gone, so it's rolled back and left exactly as it was pre-patch.
+    // Two pending orders for the same product, but only one unit left. Order 6 has the higher
+    // id but was actually created first (e.g. an imported order) - the ORDER BY created_at
+    // clause means it's the one processed first and granted the reservation via a guarded
+    // decrement; order 5's decrement affects zero rows once stock is gone, so it's rolled back
+    // and left exactly as it was pre-patch.
     $selectOrders = Mockery::mock(PDOStatement::class);
     $selectOrders->expects('execute')->with([])->andReturnTrue();
     $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
-        ['order_id' => 5, 'product_id' => 1, 'quantity' => 1],
         ['order_id' => 6, 'product_id' => 1, 'quantity' => 1],
+        ['order_id' => 5, 'product_id' => 1, 'quantity' => 1],
     ]);
 
     $firstDecrement = Mockery::mock(PDOStatement::class);
     $firstDecrement->expects('execute')->with(Mockery::on(function (array $params): bool {
-        expect($params[0])->toBe(5)->and($params[3])->toBe(1);
+        expect($params[0])->toBe(6)->and($params[3])->toBe(1);
 
         return true;
     }))->andReturnTrue();
@@ -406,7 +429,7 @@ test('stock reservation backfill patch stops once a product is already oversold'
 
     $secondDecrement = Mockery::mock(PDOStatement::class);
     $secondDecrement->expects('execute')->with(Mockery::on(function (array $params): bool {
-        expect($params[0])->toBe(6)->and($params[3])->toBe(1);
+        expect($params[0])->toBe(5)->and($params[3])->toBe(1);
 
         return true;
     }))->andReturnTrue();
@@ -414,8 +437,8 @@ test('stock reservation backfill patch stops once a product is already oversold'
 
     $insertMeta = Mockery::mock(PDOStatement::class);
     $insertMeta->expects('execute')->with(Mockery::on(function (array $params): bool {
-        // Only order 5 may be reserved; order 6's decrement never succeeded.
-        expect($params['order_id'])->toBe(5);
+        // Only order 6 may be reserved; order 5's decrement never succeeded.
+        expect($params['order_id'])->toBe(6);
 
         return true;
     }))->andReturnTrue();

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -287,9 +287,17 @@ test('stock reservation backfill patch reserves stock for a pending order and de
         ['order_id' => 5, 'product_id' => 1, 'quantity' => 2],
     ]);
 
-    $selectStock = Mockery::mock(PDOStatement::class);
-    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
-    $selectStock->expects('fetchColumn')->andReturn(10);
+    $decrementStock = Mockery::mock(PDOStatement::class);
+    $decrementStock->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params[0])->toBe(5)
+            ->and($params[1])->toBe(2)
+            ->and($params[2])->toBeString()
+            ->and($params[3])->toBe(1)
+            ->and($params[4])->toBe(2);
+
+        return true;
+    }))->andReturnTrue();
+    $decrementStock->expects('rowCount')->andReturn(1);
 
     $insertMeta = Mockery::mock(PDOStatement::class);
     $insertMeta->expects('execute')->with(Mockery::on(function (array $params): bool {
@@ -300,27 +308,18 @@ test('stock reservation backfill patch reserves stock for a pending order and de
         return true;
     }))->andReturnTrue();
 
-    $updateStock = Mockery::mock(PDOStatement::class);
-    $updateStock->expects('execute')->with(Mockery::on(function (array $params): bool {
-        expect($params['id'])->toBe(1)
-            ->and($params['remaining'])->toBe(8);
-
-        return true;
-    }))->andReturnTrue();
-
     $pdo = Mockery::mock(PDO::class);
-    $pdo->expects('beginTransaction')->andReturnTrue();
-    $pdo->expects('commit')->andReturnTrue();
+    $pdo->expects('beginTransaction')->once()->andReturnTrue();
+    $pdo->expects('commit')->once()->andReturnTrue();
     $pdo->expects('prepare')
-        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS') && !str_contains($sql, 'UPDATE')))
         ->andReturn($selectOrders);
-    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'UPDATE product p')))
+        ->andReturn($decrementStock);
     $pdo->expects('prepare')
         ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')))
         ->andReturn($insertMeta);
-    $pdo->expects('prepare')
-        ->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id')
-        ->andReturn($updateStock);
 
     $di = new Pimple\Container();
     $di['pdo'] = $pdo;
@@ -332,27 +331,20 @@ test('stock reservation backfill patch reserves stock for a pending order and de
 
 test('stock reservation backfill patch skips orders with a non-positive quantity', function (): void {
     // Matches Product\Service::reserveStockForOrder(): a zero/negative quantity is never
-    // reserved, not rounded up to one unit.
+    // reserved, not rounded up to one unit. Skipped before a transaction is even opened.
     $selectOrders = Mockery::mock(PDOStatement::class);
     $selectOrders->expects('execute')->with([])->andReturnTrue();
     $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
         ['order_id' => 5, 'product_id' => 1, 'quantity' => 0],
     ]);
 
-    $selectStock = Mockery::mock(PDOStatement::class);
-    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
-    $selectStock->expects('fetchColumn')->andReturn(10);
-
     $pdo = Mockery::mock(PDO::class);
-    $pdo->expects('beginTransaction')->andReturnTrue();
-    $pdo->expects('commit')->andReturnTrue();
+    $pdo->shouldNotReceive('beginTransaction');
     $pdo->expects('prepare')
-        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS') && !str_contains($sql, 'UPDATE')))
         ->andReturn($selectOrders);
-    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->shouldNotReceive('prepare')->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'UPDATE product p')));
     $pdo->shouldNotReceive('prepare')->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')));
-    // Nothing was reserved, so the product's stock is never rewritten either.
-    $pdo->shouldNotReceive('prepare')->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id');
 
     $di = new Pimple\Container();
     $di['pdo'] = $pdo;
@@ -369,17 +361,19 @@ test('stock reservation backfill patch rolls back if a statement fails partway t
         ['order_id' => 5, 'product_id' => 1, 'quantity' => 2],
     ]);
 
-    $selectStock = Mockery::mock(PDOStatement::class);
-    $selectStock->expects('execute')->with(['id' => 1])->andThrow(new PDOException('gone away'));
+    $decrementStock = Mockery::mock(PDOStatement::class);
+    $decrementStock->expects('execute')->andThrow(new PDOException('gone away'));
 
     $pdo = Mockery::mock(PDO::class);
-    $pdo->expects('beginTransaction')->andReturnTrue();
-    $pdo->expects('rollBack')->andReturnTrue();
+    $pdo->expects('beginTransaction')->once()->andReturnTrue();
+    $pdo->expects('rollBack')->once()->andReturnTrue();
     $pdo->shouldNotReceive('commit');
     $pdo->expects('prepare')
-        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS') && !str_contains($sql, 'UPDATE')))
         ->andReturn($selectOrders);
-    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'UPDATE product p')))
+        ->andReturn($decrementStock);
 
     $di = new Pimple\Container();
     $di['pdo'] = $pdo;
@@ -393,7 +387,8 @@ test('stock reservation backfill patch rolls back if a statement fails partway t
 
 test('stock reservation backfill patch stops once a product is already oversold', function (): void {
     // Two pending orders for the same product, but only one unit left: the older order (lower
-    // id) is granted the reservation, the newer one is left exactly as it was pre-patch.
+    // id) is granted the reservation via a guarded decrement; the newer one's decrement affects
+    // zero rows once stock is gone, so it's rolled back and left exactly as it was pre-patch.
     $selectOrders = Mockery::mock(PDOStatement::class);
     $selectOrders->expects('execute')->with([])->andReturnTrue();
     $selectOrders->expects('fetchAll')->with(PDO::FETCH_ASSOC)->andReturn([
@@ -401,39 +396,44 @@ test('stock reservation backfill patch stops once a product is already oversold'
         ['order_id' => 6, 'product_id' => 1, 'quantity' => 1],
     ]);
 
-    $selectStock = Mockery::mock(PDOStatement::class);
-    $selectStock->expects('execute')->with(['id' => 1])->andReturnTrue();
-    $selectStock->expects('fetchColumn')->andReturn(1);
+    $firstDecrement = Mockery::mock(PDOStatement::class);
+    $firstDecrement->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params[0])->toBe(5)->and($params[3])->toBe(1);
+
+        return true;
+    }))->andReturnTrue();
+    $firstDecrement->expects('rowCount')->andReturn(1);
+
+    $secondDecrement = Mockery::mock(PDOStatement::class);
+    $secondDecrement->expects('execute')->with(Mockery::on(function (array $params): bool {
+        expect($params[0])->toBe(6)->and($params[3])->toBe(1);
+
+        return true;
+    }))->andReturnTrue();
+    $secondDecrement->expects('rowCount')->andReturn(0);
 
     $insertMeta = Mockery::mock(PDOStatement::class);
     $insertMeta->expects('execute')->with(Mockery::on(function (array $params): bool {
-        // Only order 5 may be reserved; order 6 must never reach this statement.
+        // Only order 5 may be reserved; order 6's decrement never succeeded.
         expect($params['order_id'])->toBe(5);
 
         return true;
     }))->andReturnTrue();
 
-    $updateStock = Mockery::mock(PDOStatement::class);
-    $updateStock->expects('execute')->with(Mockery::on(function (array $params): bool {
-        expect($params['id'])->toBe(1)
-            ->and($params['remaining'])->toBe(0);
-
-        return true;
-    }))->andReturnTrue();
-
     $pdo = Mockery::mock(PDO::class);
-    $pdo->expects('beginTransaction')->andReturnTrue();
-    $pdo->expects('commit')->andReturnTrue();
+    $pdo->expects('beginTransaction')->twice()->andReturnTrue();
+    $pdo->expects('commit')->once()->andReturnTrue();
+    $pdo->expects('rollBack')->once()->andReturnTrue();
     $pdo->expects('prepare')
-        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS')))
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'NOT EXISTS') && !str_contains($sql, 'UPDATE')))
         ->andReturn($selectOrders);
-    $pdo->expects('prepare')->with('SELECT quantity_in_stock FROM product WHERE id = :id')->andReturn($selectStock);
+    $pdo->expects('prepare')
+        ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'UPDATE product p')))
+        ->twice()
+        ->andReturn($firstDecrement, $secondDecrement);
     $pdo->expects('prepare')
         ->with(Mockery::on(fn (string $sql): bool => str_contains($sql, 'INSERT INTO client_order_meta')))
         ->andReturn($insertMeta);
-    $pdo->expects('prepare')
-        ->with('UPDATE product SET quantity_in_stock = :remaining, updated_at = :updated_at WHERE id = :id')
-        ->andReturn($updateStock);
 
     $di = new Pimple\Container();
     $di['pdo'] = $pdo;


### PR DESCRIPTION
## Summary

Closes #4130.

Stock-controlled products could be oversold because availability was only *checked* at add-to-cart and checkout, while the actual decrement happened later at order activation. Two clients could both pass the checkout check for the last unit — the second one only found out after paying.

## What changed

Moved the atomic stock decrement to order-creation time (checkout, and admin order creation) instead of activation, mirroring the promo-code reservation pattern already in the codebase (reserve immediately, release on cancel/delete, no expiry — same as promo reservations today).

**Also fixes a related bug** found while tracing the activation path: `reduceStock()` used to run *after* the order was already persisted as `STATUS_ACTIVE` and the remote service already provisioned. If that decrement failed (the atomic guard firing), the exception was caught by a handler that only logged a `failed_setup` history note — it never touched `order.status` — so the order was silently left `ACTIVE` with the service provisioned despite the stock guard rejecting it.

**Migration**: added `UpdatePatcher::patch100()` to backfill reservations for orders that pre-date this change (they never took one at checkout under the old code). It grants reservations oldest-order-first per product and stops once stock runs out, so a product that was already oversold before this fix keeps exactly as many pending orders "covered" as it has physical stock for.
