### PR TITLE
Fix TypeError when creating order invoice with recurring promo

### DIFF
--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -198,7 +198,7 @@ class ServiceInvoiceItem implements InjectionAwareInterface
         $pi = new InvoiceItem();
         $pi->setInvoiceId((int) $proforma->getId());
         $pi->setType($data['type'] ?? InvoiceItem::TYPE_CUSTOM);
-        $pi->setRelId($data['rel_id'] ?? null);
+        $pi->setRelId(isset($data['rel_id']) ? (string) $data['rel_id'] : null);
         $pi->setTask($data['task'] ?? InvoiceItem::TASK_VOID);
         $pi->setStatus($data['status'] ?? InvoiceItem::STATUS_PENDING_PAYMENT);
         $pi->setTitle($data['title']);
@@ -444,7 +444,7 @@ class ServiceInvoiceItem implements InjectionAwareInterface
                 'price' => $promoAdjustment['discount_amount'] * -1,
                 'quantity' => 1,
                 'unit' => 'discount',
-                'rel_id' => $order->getId(),
+                'rel_id' => (string) $order->getId(),
                 'taxed' => $taxed,
             ];
 

--- a/src/modules/Invoice/tests/Unit/ServiceInvoiceItemTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceInvoiceItemTest.php
@@ -214,10 +214,12 @@ test('adds new item', function (): void {
     $newId = 1;
 
     $em = Mockery::mock(EntityManagerInterface::class);
+    $persistedItem = null;
     $em->shouldReceive('persist')
         ->once()
-        ->withArgs(function (InvoiceItem $pi) use ($newId): bool {
+        ->withArgs(function (InvoiceItem $pi) use ($newId, &$persistedItem): bool {
             $pi->setId($newId);
+            $persistedItem = $pi;
 
             return true;
         });
@@ -234,6 +236,106 @@ test('adds new item', function (): void {
 
     $result = $service->addNew($invoiceModel, $data);
     expect($result)->toBeInt()->toBe($newId);
+    expect($persistedItem->getRelId())->toBeNull();
+});
+
+test('adds new item casts a numeric rel_id to string', function (): void {
+    $data = [
+        'title' => 'Discount',
+        'price' => -10,
+        'rel_id' => 82,
+    ];
+
+    $em = Mockery::mock(EntityManagerInterface::class);
+    $persistedItem = null;
+    $em->shouldReceive('persist')
+        ->once()
+        ->withArgs(function (InvoiceItem $pi) use (&$persistedItem): bool {
+            $persistedItem = $pi;
+
+            return true;
+        });
+    $em->shouldReceive('flush')->once();
+    $repo = Mockery::mock(InvoiceItemRepository::class);
+    $em->shouldReceive('getRepository')->with(InvoiceItem::class)->andReturn($repo);
+
+    $service = new ServiceInvoiceItem();
+    $di = container();
+    $di['em'] = $em;
+    $service->setDi($di);
+
+    $invoiceModel = createEntity(Invoice::class);
+
+    $service->addNew($invoiceModel, $data);
+    expect($persistedItem->getRelId())->toBe('82');
+});
+
+test('generates invoice items from order with a recurring promo and casts rel_id to string', function (): void {
+    $orderId = 55;
+    $order = createEntity(Order::class, [
+        'id' => $orderId,
+        'clientId' => 3,
+        'title' => 'Hosting plan',
+        'quantity' => 1,
+        'unit' => null,
+        'period' => null,
+        'promoRecurring' => true,
+        'promoId' => 9,
+    ]);
+
+    $invoiceModel = createEntity(Invoice::class, ['id' => 42]);
+    $clientModel = createEntity(Box\Mod\Client\Entity\Client::class, ['id' => 3]);
+    $promo = createEntity(Box\Mod\Product\Entity\Promo::class, ['id' => 9]);
+
+    $em = Mockery::mock(EntityManagerInterface::class);
+    $persistedItems = [];
+    $em->shouldReceive('persist')
+        ->twice()
+        ->withArgs(function (InvoiceItem $pi) use (&$persistedItems): bool {
+            $persistedItems[] = $pi;
+
+            return true;
+        });
+    $em->shouldReceive('flush')->twice();
+    $repo = Mockery::mock(InvoiceItemRepository::class);
+    $em->shouldReceive('getRepository')->with(InvoiceItem::class)->andReturn($repo);
+    $clientRepo = Mockery::mock(Box\Mod\Client\Repository\ClientRepository::class);
+    $clientRepo->shouldReceive('find')->with(3)->andReturn($clientModel);
+    $em->shouldReceive('getRepository')->with(Box\Mod\Client\Entity\Client::class)->andReturn($clientRepo);
+
+    $orderServiceMock = Mockery::mock(OrderService::class);
+    $orderServiceMock->shouldReceive('setUnpaidInvoice')->with($order, $invoiceModel)->once();
+
+    $clientServiceMock = Mockery::mock(Box\Mod\Client\Service::class);
+    $clientServiceMock->shouldReceive('isClientTaxable')->with($clientModel)->andReturn(false);
+
+    $productServiceMock = Mockery::mock(Box\Mod\Product\Service::class);
+    $productServiceMock->shouldReceive('getRenewalPromoAdjustment')
+        ->andReturn([
+            'promo' => $promo,
+            'discount_amount' => 5.0,
+            'title' => 'Recurring discount',
+            'currency' => 'USD',
+        ]);
+    $productServiceMock->shouldReceive('createPromoRedemption')->once()->andReturn(1);
+
+    $di = container();
+    $di['em'] = $em;
+    $di['mod_service'] = $di->protect(fn (string $module): Mockery\MockInterface => match ($module) {
+        'Order' => $orderServiceMock,
+        'client' => $clientServiceMock,
+        'Product' => $productServiceMock,
+    });
+
+    $service = new ServiceInvoiceItem();
+    $service->setDi($di);
+
+    $service->generateFromOrder($invoiceModel, $order, InvoiceItem::TASK_RENEW, 10.0);
+
+    expect($persistedItems)->toHaveCount(2);
+    foreach ($persistedItems as $item) {
+        expect($item->getRelId())->toBe((string) $orderId);
+    }
 });
 
 test('gets total', function (): void {


### PR DESCRIPTION
- `addNew()` now casts `rel_id` to string defensively: `isset($data['rel_id']) ? (string) $data['rel_id'] : null`, making the shared entry point robust regardless of caller.
- The promo-adjustment call site now explicitly casts `'rel_id' => (string) $order->getId()`, consistent with the rest of the file.

Fixes #4142.