### PR TITLE
Use DBAL inserts to avoid closing EntityManager on conflict

### DIFF
--- a/src/modules/Custompages/Service.php
+++ b/src/modules/Custompages/Service.php
@@ -107,30 +107,28 @@ class Service
     public function createPage($title, $description, $keywords, $content): int
     {
         // generateUniqueSlug() picks a free candidate, but a concurrent request can
-        // claim the same slug between the check and the flush. The unique index on
-        // custom_pages.slug turns that race into a catchable constraint violation,
-        // which we resolve by clearing the EM and retrying with a fresh candidate.
-        $page = null;
+        // claim the same slug before the insert. Insert via the DBAL connection (not
+        // an ORM flush) so a constraint violation doesn't close the EntityManager and
+        // break the retry loop on the next iteration.
+        $connection = $this->di['em']->getConnection();
         for ($attempt = 0; $attempt < 5; ++$attempt) {
             $slug = $this->generateUniqueSlug($title);
 
-            $page = new CustomPage();
-            $page->setTitle($title)
-                ->setDescription($description ?? '')
-                ->setKeywords($keywords ?? '')
-                ->setContent($content)
-                ->setSlug($slug);
-
             try {
-                $this->di['em']->persist($page);
-                $this->di['em']->flush();
+                $connection->insert('custom_pages', [
+                    'title' => $title,
+                    'description' => $description ?? '',
+                    'keywords' => $keywords ?? '',
+                    'content' => $content,
+                    'slug' => $slug,
+                ]);
 
-                $id = $page->getId() ?? 0;
+                $id = (int) $connection->lastInsertId();
                 $this->di['logger']->info('Created new custom page #%s', $id);
 
                 return $id;
             } catch (UniqueConstraintViolationException) {
-                $this->di['em']->clear();
+                // Slug lost the race; loop and try the next candidate.
             }
         }
 

--- a/src/modules/Custompages/tests/Unit/ServiceTest.php
+++ b/src/modules/Custompages/tests/Unit/ServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Box\Mod\Custompages\Entity\CustomPage;
 use Box\Mod\Custompages\Service;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
@@ -113,22 +114,26 @@ test('get page rejects unknown column type', function (): void {
     expect(fn () => $service->getPage(1, 'title'))->toThrow(FOSSBilling\Exception::class);
 });
 
-test('create page generates unique slug and persists entity', function (): void {
+test('create page generates unique slug and inserts via dbal', function (): void {
     $repo = Mockery::mock(Box\Mod\Custompages\Repository\CustomPageRepository::class);
     $repo->expects('findOneBySlug')->with('about-us')->andReturn(null);
 
     $captured = null;
-    $em = Mockery::mock(EntityManagerInterface::class);
-    $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->expects('persist')->once()->andReturnUsing(function (CustomPage $page) use (&$captured): void {
-        $captured = $page;
+    $connection = Mockery::mock(Connection::class);
+    $connection->expects('insert')->once()->andReturnUsing(function (string $table, array $data) use (&$captured): int {
+        expect($table)->toBe('custom_pages');
+        $captured = $data;
+
+        return 1;
     });
-    $em->expects('flush')->once()->andReturnUsing(function () use (&$captured): void {
-        Tests\Helpers\accessPrivate($captured, 'id', 42);
-    });
+    $connection->expects('lastInsertId')->once()->andReturn(42);
 
     $logger = Mockery::mock();
     $logger->expects('info')->with('Created new custom page #%s', 42)->once();
+
+    $em = Mockery::mock(EntityManagerInterface::class);
+    $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
+    $em->allows('getConnection')->andReturn($connection);
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -142,12 +147,11 @@ test('create page generates unique slug and persists entity', function (): void 
     $id = $service->createPage('About Us', null, null, 'page body');
 
     expect($id)->toBe(42);
-    expect($captured)->toBeInstanceOf(CustomPage::class);
-    expect($captured->getTitle())->toBe('About Us');
-    expect($captured->getDescription())->toBe('');
-    expect($captured->getKeywords())->toBe('');
-    expect($captured->getContent())->toBe('page body');
-    expect($captured->getSlug())->toBe('about-us');
+    expect($captured['title'])->toBe('About Us');
+    expect($captured['description'])->toBe('');
+    expect($captured['keywords'])->toBe('');
+    expect($captured['content'])->toBe('page body');
+    expect($captured['slug'])->toBe('about-us');
 });
 
 test('create page appends incrementing suffix until slug is unique', function (): void {
@@ -159,12 +163,17 @@ test('create page appends incrementing suffix until slug is unique', function ()
     $repo->expects('findOneBySlug')->with('page-2')->andReturn(null);
 
     $captured = null;
+    $connection = Mockery::mock(Connection::class);
+    $connection->expects('insert')->once()->andReturnUsing(function (string $table, array $data) use (&$captured): int {
+        $captured = $data;
+
+        return 1;
+    });
+    $connection->allows('lastInsertId')->andReturn(3);
+
     $em = Mockery::mock(EntityManagerInterface::class);
     $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->expects('persist')->once()->andReturnUsing(function (CustomPage $page) use (&$captured): void {
-        $captured = $page;
-    });
-    $em->allows('flush');
+    $em->allows('getConnection')->andReturn($connection);
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -177,8 +186,7 @@ test('create page appends incrementing suffix until slug is unique', function ()
 
     $service->createPage('Page', '', '', 'content');
 
-    expect($captured)->toBeInstanceOf(CustomPage::class);
-    expect($captured->getSlug())->toBe('page-2');
+    expect($captured['slug'])->toBe('page-2');
 });
 
 test('update page throws when page not found', function (): void {
@@ -286,28 +294,33 @@ test('delete page by array delegates to bulk delete', function (): void {
 });
 
 test('create page retries on a concurrent slug conflict and succeeds on the next candidate', function (): void {
-    // Attempt 1: 'about' looks free, but a concurrent flush claims it (constraint violation).
+    // Attempt 1: 'about' looks free, but a concurrent insert claims it (constraint violation).
     // Attempt 2: generateUniqueSlug now sees 'about' taken and moves on to 'about-1'.
     $existing = Tests\Helpers\createEntity(CustomPage::class, ['id' => 9, 'slug' => 'about']);
 
     $repo = Mockery::mock(Box\Mod\Custompages\Repository\CustomPageRepository::class);
     $repo->shouldReceive('findOneBySlug')->andReturn(null, $existing, null);
 
+    $insertCount = 0;
     $captured = null;
-    $flushCount = 0;
-    $em = Mockery::mock(EntityManagerInterface::class);
-    $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->shouldReceive('persist')->twice()->andReturnUsing(function (CustomPage $page) use (&$captured): void {
-        $captured = $page;
-    });
-    $em->shouldReceive('clear')->once();
-    $em->shouldReceive('flush')->andReturnUsing(function () use (&$flushCount, &$captured) {
-        ++$flushCount;
-        if ($flushCount === 1) {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('insert')->andReturnUsing(function (string $table, array $data) use (&$insertCount, &$captured): int {
+        ++$insertCount;
+        $captured = $data;
+        if ($insertCount === 1) {
             throw Mockery::mock(UniqueConstraintViolationException::class);
         }
-        Tests\Helpers\accessPrivate($captured, 'id', 7);
+
+        return 1;
     });
+    $connection->expects('lastInsertId')->once()->andReturn(7);
+
+    $em = Mockery::mock(EntityManagerInterface::class);
+    $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
+    $em->allows('getConnection')->andReturn($connection);
+    $em->shouldNotReceive('persist');
+    $em->shouldNotReceive('flush');
+    $em->shouldNotReceive('clear');
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -319,18 +332,23 @@ test('create page retries on a concurrent slug conflict and succeeds on the next
     $service->setDi($di);
 
     expect($service->createPage('About', '', '', 'content'))->toBe(7);
-    expect($captured->getSlug())->toBe('about-1');
+    expect($captured['slug'])->toBe('about-1');
 });
 
 test('create page gives up after repeated slug conflicts', function (): void {
     $repo = Mockery::mock(Box\Mod\Custompages\Repository\CustomPageRepository::class);
     $repo->shouldReceive('findOneBySlug')->andReturn(null);
 
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('insert')->andThrow(Mockery::mock(UniqueConstraintViolationException::class));
+    $connection->shouldNotReceive('lastInsertId');
+
     $em = Mockery::mock(EntityManagerInterface::class);
     $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->shouldReceive('persist');
-    $em->shouldReceive('flush')->andThrow(Mockery::mock(UniqueConstraintViolationException::class));
-    $em->shouldReceive('clear');
+    $em->allows('getConnection')->andReturn($connection);
+    $em->shouldNotReceive('persist');
+    $em->shouldNotReceive('flush');
+    $em->shouldNotReceive('clear');
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -377,12 +395,17 @@ test('create page truncates a long title slug to fit varchar 255', function (): 
     $repo->expects('findOneBySlug')->with(str_repeat('a', 255))->andReturn(null);
 
     $captured = null;
+    $connection = Mockery::mock(Connection::class);
+    $connection->expects('insert')->once()->andReturnUsing(function (string $table, array $data) use (&$captured): int {
+        $captured = $data;
+
+        return 1;
+    });
+    $connection->allows('lastInsertId')->andReturn(1);
+
     $em = Mockery::mock(EntityManagerInterface::class);
     $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->expects('persist')->once()->andReturnUsing(function (CustomPage $page) use (&$captured): void {
-        $captured = $page;
-    });
-    $em->expects('flush')->once();
+    $em->allows('getConnection')->andReturn($connection);
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -395,7 +418,7 @@ test('create page truncates a long title slug to fit varchar 255', function (): 
 
     $service->createPage('Long Title', '', '', 'content');
 
-    expect(strlen($captured->getSlug()))->toBe(255);
+    expect(strlen($captured['slug']))->toBe(255);
 });
 
 test('create page reserves room for the suffix when truncating a conflicting long slug', function (): void {
@@ -408,12 +431,17 @@ test('create page reserves room for the suffix when truncating a conflicting lon
     $repo->shouldReceive('findOneBySlug')->andReturn($existing, null);
 
     $captured = null;
+    $connection = Mockery::mock(Connection::class);
+    $connection->expects('insert')->once()->andReturnUsing(function (string $table, array $data) use (&$captured): int {
+        $captured = $data;
+
+        return 1;
+    });
+    $connection->allows('lastInsertId')->andReturn(1);
+
     $em = Mockery::mock(EntityManagerInterface::class);
     $em->allows('getRepository')->with(CustomPage::class)->andReturn($repo);
-    $em->expects('persist')->once()->andReturnUsing(function (CustomPage $page) use (&$captured): void {
-        $captured = $page;
-    });
-    $em->expects('flush')->once();
+    $em->allows('getConnection')->andReturn($connection);
 
     $di = new Pimple\Container();
     $di['em'] = $em;
@@ -426,6 +454,6 @@ test('create page reserves room for the suffix when truncating a conflicting lon
 
     $service->createPage('Long Title', '', '', 'content');
 
-    expect($captured->getSlug())->toBe(str_repeat('a', 253) . '-1');
-    expect(strlen($captured->getSlug()))->toBe(255);
+    expect($captured['slug'])->toBe(str_repeat('a', 253) . '-1');
+    expect(strlen($captured['slug']))->toBe(255);
 });

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -1626,9 +1626,15 @@ class Service implements InjectionAwareInterface
                     $invoiceItemService->executeTask($model);
                 });
             } catch (\Exception $e) {
-                // Clear the identity map so subsequent iterations work with fresh, database-consistent entities.
-                $this->di['em']->clear();
                 $this->di['logger']->error($e->getMessage());
+
+                // A failed ORM flush closes the EntityManager and clear() can't reopen
+                // it; stop the batch instead of looping with a dead EM. Otherwise clear
+                // the identity map between iterations.
+                if (!$this->di['em']->isOpen()) {
+                    break;
+                }
+                $this->di['em']->clear();
             }
         }
         $this->di['logger']->info('Executed action to activate paid invoices.');

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -21,6 +21,7 @@ use Box\Mod\Invoice\Entity\Transaction;
 use Box\Mod\Invoice\Repository\InvoiceItemRepository;
 use Box\Mod\Invoice\Repository\InvoiceRepository;
 use Box\Mod\Order\Entity\Order;
+use Doctrine\ORM\EntityManagerInterface;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use FOSSBilling\Doctrine\EntityManagerFactory;
@@ -104,9 +105,14 @@ class Service implements InjectionAwareInterface
     protected function resetEntityManager(): void
     {
         unset($this->di['em']);
-        $this->di['em'] = EntityManagerFactory::create();
+        $this->di['em'] = $this->createEntityManager();
         $this->invoiceItemRepository = null;
         $this->invoiceRepository = null;
+    }
+
+    protected function createEntityManager(): EntityManagerInterface
+    {
+        return EntityManagerFactory::create();
     }
 
     public function getModulePermissions(): array

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -23,6 +23,7 @@ use Box\Mod\Invoice\Repository\InvoiceRepository;
 use Box\Mod\Order\Entity\Order;
 use Dompdf\Dompdf;
 use Dompdf\Options;
+use FOSSBilling\Doctrine\EntityManagerFactory;
 use FOSSBilling\Environment;
 use FOSSBilling\Http\ResponseFactory;
 use FOSSBilling\i18n;
@@ -98,6 +99,14 @@ class Service implements InjectionAwareInterface
         }
 
         return $this->invoiceRepository;
+    }
+
+    protected function resetEntityManager(): void
+    {
+        unset($this->di['em']);
+        $this->di['em'] = EntityManagerFactory::create();
+        $this->invoiceItemRepository = null;
+        $this->invoiceRepository = null;
     }
 
     public function getModulePermissions(): array
@@ -1629,9 +1638,12 @@ class Service implements InjectionAwareInterface
                 $this->di['logger']->error($e->getMessage());
 
                 // A failed ORM flush closes the EntityManager and clear() can't reopen
-                // it; stop the batch instead of looping with a dead EM. Otherwise clear
-                // the identity map between iterations.
+                // it. Replace it with a fresh instance so the rest of the cron run can
+                // keep writing, then stop the batch. Otherwise clear the identity map
+                // between iterations.
                 if (!$this->di['em']->isOpen()) {
+                    $this->resetEntityManager();
+
                     break;
                 }
                 $this->di['em']->clear();

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -2046,6 +2046,8 @@ test('handles exception during batch paid invoice activation', function (): void
         ->with('SELECT status FROM invoice_item WHERE id = :id FOR UPDATE', ['id' => 1])
         ->andReturn(InvoiceItem::STATUS_PENDING_SETUP);
     $em->shouldReceive('getConnection')->andReturn($connection);
+    // The exception did not close the EM, so recovery continues: clear and proceed.
+    $em->shouldReceive('isOpen')->once()->andReturn(true);
     $em->shouldReceive('clear')->once();
 
     $di = container();
@@ -2056,6 +2058,45 @@ test('handles exception during batch paid invoice activation', function (): void
     $service->setDi($di);
     $result = $service->doBatchPaidInvoiceActivation();
     expect($result)->toBeBool()->toBeTrue();
+});
+
+test('stops the batch when the EntityManager closes after a failure', function (): void {
+    $service = new Service();
+    $invoiceItemModel = createEntity(InvoiceItem::class, []);
+
+    $itemInvoiceServiceMock = Mockery::mock(ServiceInvoiceItem::class);
+    $itemInvoiceServiceMock->shouldReceive('getAllNotExecutePaidItems')
+        ->once()
+        ->andReturn([['id' => 1], ['id' => 2]]);
+    // Only the first item is attempted; the batch breaks before the second.
+    $itemInvoiceServiceMock->shouldReceive('executeTask')
+        ->once()
+        ->with($invoiceItemModel)
+        ->andThrow(new Exception('flush failure closed the EM'));
+
+    [$em, $invoiceItemRepo] = invoiceItemEmAndRepo();
+    $invoiceItemRepo->shouldReceive('find')
+        ->once()
+        ->andReturn($invoiceItemModel);
+
+    $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $connection->shouldReceive('transactional')
+        ->once()
+        ->andReturnUsing(fn (callable $func) => $func($connection));
+    $connection->shouldReceive('fetchOne')
+        ->with('SELECT status FROM invoice_item WHERE id = :id FOR UPDATE', ['id' => 1])
+        ->andReturn(InvoiceItem::STATUS_PENDING_SETUP);
+    $em->shouldReceive('getConnection')->andReturn($connection);
+    $em->shouldReceive('isOpen')->once()->andReturn(false);
+    $em->shouldNotReceive('clear');
+
+    $di = container();
+    $di['em'] = $em;
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $itemInvoiceServiceMock);
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $service->setDi($di);
+    expect($service->doBatchPaidInvoiceActivation())->toBeTrue();
 });
 
 test('skips invoice items already finalized by another process during batch activation', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -22,6 +22,7 @@ use Box\Mod\Invoice\Entity\PayGateway;
 use Box\Mod\Invoice\Entity\Subscription;
 use Box\Mod\Invoice\Entity\Transaction;
 use Box\Mod\Invoice\Repository\InvoiceItemRepository;
+use Box\Mod\Invoice\Repository\InvoiceRepository;
 use Box\Mod\Invoice\Repository\PayGatewayRepository;
 use Box\Mod\Invoice\Repository\SubscriptionRepository;
 use Box\Mod\Invoice\Repository\TransactionRepository;
@@ -2110,6 +2111,42 @@ test('resets the EntityManager when it closes mid-batch so later consumers keep 
     // The closed manager is gone; later cron consumers see the open replacement.
     expect($di['em'])->toBe($replacementEm);
     expect($di['em']->isOpen())->toBeTrue();
+});
+
+test('resetEntityManager invalidates both cached repositories so they re-resolve from the replacement', function (): void {
+    // Exercises the real resetEntityManager() body (only the factory seam is mocked),
+    // verifying that both lazily-cached repositories are dropped and re-resolve from
+    // the replacement EntityManager rather than the closed one.
+    $initialItemRepo = Mockery::mock(InvoiceItemRepository::class);
+    $initialInvoiceRepo = Mockery::mock(InvoiceRepository::class);
+    $initialEm = Mockery::mock(EntityManagerInterface::class);
+    $initialEm->shouldReceive('getRepository')->with(InvoiceItem::class)->andReturn($initialItemRepo);
+    $initialEm->shouldReceive('getRepository')->with(Invoice::class)->andReturn($initialInvoiceRepo);
+
+    $replacementItemRepo = Mockery::mock(InvoiceItemRepository::class);
+    $replacementInvoiceRepo = Mockery::mock(InvoiceRepository::class);
+    $replacementEm = Mockery::mock(EntityManagerInterface::class);
+    $replacementEm->shouldReceive('getRepository')->with(InvoiceItem::class)->andReturn($replacementItemRepo);
+    $replacementEm->shouldReceive('getRepository')->with(Invoice::class)->andReturn($replacementInvoiceRepo);
+
+    $di = container();
+    $di['em'] = $initialEm;
+
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('createEntityManager')->once()->andReturn($replacementEm);
+    $service->setDi($di);
+
+    // Prime both caches from the initial EM.
+    expect($service->getInvoiceItemRepository())->toBe($initialItemRepo);
+    expect($service->getInvoiceRepository())->toBe($initialInvoiceRepo);
+
+    // Trigger the real reset flow; only the factory seam is intercepted.
+    (new ReflectionMethod(Service::class, 'resetEntityManager'))->invoke($service);
+
+    // Both repositories now come from the replacement EntityManager.
+    expect($service->getInvoiceItemRepository())->toBe($replacementItemRepo);
+    expect($service->getInvoiceRepository())->toBe($replacementInvoiceRepo);
+    expect($di['em'])->toBe($replacementEm);
 });
 
 test('skips invoice items already finalized by another process during batch activation', function (): void {

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -2060,8 +2060,11 @@ test('handles exception during batch paid invoice activation', function (): void
     expect($result)->toBeBool()->toBeTrue();
 });
 
-test('stops the batch when the EntityManager closes after a failure', function (): void {
-    $service = new Service();
+test('resets the EntityManager when it closes mid-batch so later consumers keep working', function (): void {
+    // A flush failure inside executeTask closes the ORM EntityManager. The batch must
+    // stop, and the closed manager must be replaced so the rest of the cron run can
+    // keep writing (a later consumer reads from the replacement, not the dead EM).
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $invoiceItemModel = createEntity(InvoiceItem::class, []);
 
     $itemInvoiceServiceMock = Mockery::mock(ServiceInvoiceItem::class);
@@ -2090,13 +2093,23 @@ test('stops the batch when the EntityManager closes after a failure', function (
     $em->shouldReceive('isOpen')->once()->andReturn(false);
     $em->shouldNotReceive('clear');
 
+    $replacementEm = Mockery::mock(EntityManagerInterface::class);
+    $replacementEm->shouldReceive('isOpen')->andReturn(true);
+
     $di = container();
     $di['em'] = $em;
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $itemInvoiceServiceMock);
     $di['logger'] = new Tests\Helpers\TestLogger();
-
+    $service->shouldReceive('resetEntityManager')->once()->andReturnUsing(function () use ($di, $replacementEm): void {
+        unset($di['em']);
+        $di['em'] = $replacementEm;
+    });
     $service->setDi($di);
+
     expect($service->doBatchPaidInvoiceActivation())->toBeTrue();
+    // The closed manager is gone; later cron consumers see the open replacement.
+    expect($di['em'])->toBe($replacementEm);
+    expect($di['em']->isOpen())->toBeTrue();
 });
 
 test('skips invoice items already finalized by another process during batch activation', function (): void {

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -468,30 +468,36 @@ class Service implements InjectionAwareInterface
         $cronEmail = $this->di['tools']->generatePassword() . '@' . $this->di['tools']->generatePassword() . '.com';
         $cronEmail = filter_var($cronEmail, FILTER_SANITIZE_EMAIL);
 
-        $cronPass = $this->di['tools']->generatePassword(256, 4);
+        $cronPass = $this->di['password']->hashIt($this->di['tools']->generatePassword(256, 4));
 
-        $cron = new Admin();
-        $cron->setSystemName(Admin::SYSTEM_CRON);
-        $cron->setEmail($cronEmail);
-        $cron->setPass($this->di['password']->hashIt($cronPass));
-        $cron->setName('System Cron Job');
-        $cron->setSignature('');
-        $cron->setStatus(Admin::STATUS_ACTIVE);
+        // Two cron runs can race to create the cron admin. Insert via the DBAL
+        // connection (not an ORM flush) so a constraint violation doesn't close the
+        // EntityManager for the rest of this cron run; on conflict, re-read the
+        // winner's row below.
+        $now = date('Y-m-d H:i:s');
+        $connection = $this->di['em']->getConnection();
 
         try {
-            $this->di['em']->persist($cron);
-            $this->di['em']->flush();
+            $connection->insert('admin', [
+                'system_name' => Admin::SYSTEM_CRON,
+                'email' => $cronEmail,
+                'pass' => $cronPass,
+                'name' => 'System Cron Job',
+                'signature' => '',
+                'status' => Admin::STATUS_ACTIVE,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
         } catch (UniqueConstraintViolationException) {
-            $this->di['em']->clear();
-            $cron = $this->getAdminRepository()->findOneBy(['systemName' => Admin::SYSTEM_CRON]);
-            if ($cron instanceof Admin) {
-                return $cron;
-            }
-
-            throw new \FOSSBilling\Exception('The cron administrator account could not be created');
+            // A concurrent request created the cron admin; fall through to re-read it.
         }
 
-        return $cron;
+        $cron = $this->getAdminRepository()->findOneBy(['systemName' => Admin::SYSTEM_CRON]);
+        if ($cron instanceof Admin) {
+            return $cron;
+        }
+
+        throw new \FOSSBilling\Exception('The cron administrator account could not be created');
     }
 
     public function toApiArray(Admin $model, $deep = false): array

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -1016,25 +1016,72 @@ test('getCronAdmin returns existing cron admin', function (): void {
 });
 
 test('getCronAdmin creates and returns new cron admin', function (): void {
+    $adminModel = createEntity(Admin::class, ['id' => 7, 'system_name' => Admin::SYSTEM_CRON]);
+
     $adminRepository = Mockery::mock(AdminRepository::class);
-    $adminRepository->shouldReceive('findOneBy')->atLeast()->once()
-        ->andReturn(null);
+    // First lookup misses; after the DBAL insert the re-read returns the new row.
+    $adminRepository->expects('findOneBy')->with(['systemName' => Admin::SYSTEM_CRON])->twice()
+        ->andReturn(null, $adminModel);
 
     $passwordMock = Mockery::mock(FOSSBilling\PasswordManager::class);
-    $passwordMock->shouldReceive('hashIt')->atLeast()->once();
+    $passwordMock->expects('hashIt')->once()->andReturn('hashed-cron-password');
+
+    $captured = null;
+    $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $connection->expects('insert')->once()->andReturnUsing(function (string $table, array $data) use (&$captured): int {
+        expect($table)->toBe('admin');
+        $captured = $data;
+
+        return 1;
+    });
 
     $di = container();
     $di['em']->shouldReceive('getRepository')->with(Admin::class)->andReturn($adminRepository);
-    $di['em']->shouldReceive('persist')->atLeast()->once();
-    $di['em']->shouldReceive('flush')->atLeast()->once();
+    $di['em']->shouldReceive('getConnection')->andReturn($connection);
+    $di['em']->shouldNotReceive('persist');
+    $di['em']->shouldNotReceive('flush');
     $di['password'] = $passwordMock;
 
     $service = new Service();
     $service->setDi($di);
 
     $result = $service->getCronAdmin();
-    expect($result)->not->toBeEmpty();
-    expect($result)->toBeInstanceOf(Admin::class);
+    expect($result)->toBe($adminModel);
+    expect($captured['system_name'])->toBe(Admin::SYSTEM_CRON);
+    expect($captured['status'])->toBe(Admin::STATUS_ACTIVE);
+    expect($captured['pass'])->toBe('hashed-cron-password');
+    expect($captured['created_at'])->not->toBeEmpty();
+    expect($captured['updated_at'])->not->toBeEmpty();
+});
+
+test('getCronAdmin recovers from a concurrent-creation race', function (): void {
+    // A concurrent request won the race; the DBAL insert throws, the ORM EM stays
+    // open, and the re-read returns the winner's row.
+    $adminModel = createEntity(Admin::class, ['id' => 9, 'system_name' => Admin::SYSTEM_CRON]);
+
+    $adminRepository = Mockery::mock(AdminRepository::class);
+    $adminRepository->expects('findOneBy')->with(['systemName' => Admin::SYSTEM_CRON])->twice()
+        ->andReturn(null, $adminModel);
+
+    $passwordMock = Mockery::mock(FOSSBilling\PasswordManager::class);
+    $passwordMock->expects('hashIt')->once();
+
+    $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $connection->expects('insert')->once()
+        ->andThrow(Mockery::mock(Doctrine\DBAL\Exception\UniqueConstraintViolationException::class));
+
+    $di = container();
+    $di['em']->shouldReceive('getRepository')->with(Admin::class)->andReturn($adminRepository);
+    $di['em']->shouldReceive('getConnection')->andReturn($connection);
+    $di['em']->shouldNotReceive('persist');
+    $di['em']->shouldNotReceive('flush');
+    $di['em']->shouldNotReceive('clear');
+    $di['password'] = $passwordMock;
+
+    $service = new Service();
+    $service->setDi($di);
+
+    expect($service->getCronAdmin())->toBe($adminModel);
 });
 
 test('toApiArray returns admin array data', function (): void {


### PR DESCRIPTION
Replace ORM persist/flush with raw DBAL connection inserts in Custompages and Staff modules to prevent UniqueConstraintViolationException from closing the EntityManager. Fix Invoice batch activation to break the loop instead of calling clear() on a closed EM.