### PR TITLE
Fix fatal error when clients press "Renew Now"

### DIFF
--- a/src/modules/Invoice/Api/Client.php
+++ b/src/modules/Invoice/Api/Client.php
@@ -78,10 +78,10 @@ class Client extends \FOSSBilling\Api\AbstractApi
         }
         $service = $this->getService();
         $invoice = $service->generateForOrder($model);
-        $service->approveInvoice($invoice, ['id' => $invoice->id, 'use_credits' => true]);
-        $this->getDi()['logger']->info('Generated new renewal invoice #%s', $invoice->id);
+        $service->approveInvoice($invoice, ['id' => $invoice->getId(), 'use_credits' => true]);
+        $this->getDi()['logger']->info('Generated new renewal invoice #%s', $invoice->getId());
 
-        return $invoice->hash;
+        return $invoice->getHash();
     }
 
     /**
@@ -99,10 +99,10 @@ class Client extends \FOSSBilling\Api\AbstractApi
 
         $service = $this->getService();
         $invoice = $service->generateFundsInvoice($this->getIdentity(), $data['amount']);
-        $service->approveInvoice($invoice, ['id' => $invoice->id]);
-        $this->getDi()['logger']->info('Generated add funds invoice #%s', $invoice->id);
+        $service->approveInvoice($invoice, ['id' => $invoice->getId()]);
+        $this->getDi()['logger']->info('Generated add funds invoice #%s', $invoice->getId());
 
-        return $invoice->hash;
+        return $invoice->getHash();
     }
 
     /**

--- a/src/modules/Invoice/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Invoice/tests/Unit/Api/ClientTest.php
@@ -143,6 +143,44 @@ test('creates renewal invoice', function (): void {
     expect($result)->toBeString()->toBe($generatedHash);
 });
 
+test('creates renewal invoice from a real invoice entity without accessing private properties', function (): void {
+    // Regression test: renewal_invoice() used to read $invoice->id and
+    // $invoice->hash directly, which are private on the Doctrine entity and
+    // fatal with "Cannot access private property". createEntity() below
+    // masks that with magic getters/setters, so this uses a real Invoice
+    // instance instead.
+    $api = apiEndpoint(new Client());
+    $generatedHash = 'generatedHashString';
+
+    $model = new Invoice();
+    $model->setId(1);
+    $model->setHash($generatedHash);
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('generateForOrder')
+        ->atLeast()->once()
+        ->andReturn($model);
+    $serviceMock->shouldReceive('approveInvoice');
+
+    $orderRepoMock = Mockery::mock(OrderRepository::class);
+    $orderRepoMock->shouldReceive('findOneBy')
+        ->atLeast()->once()
+        ->andReturn(createEntity(Order::class, ['price' => 10]));
+
+    $di = container();
+    $di['em']->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepoMock);
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $api->setDi($di);
+    $api->setService($serviceMock);
+    $identity = \Tests\Helpers\admin();
+    $api->setIdentity($identity);
+
+    $data['order_id'] = 1;
+    $result = $api->renewal_invoice($data);
+    expect($result)->toBeString()->toBe($generatedHash);
+});
+
 test('creates renewal invoice for free order', function (): void {
     $api = apiEndpoint(new Client());
     $generatedHash = 'generatedHashString';
@@ -203,6 +241,35 @@ test('creates funds invoice', function (): void {
     $model = createEntity(Invoice::class);
 
     $model->hash = $generatedHash;
+    $serviceMock->shouldReceive('generateFundsInvoice')
+        ->atLeast()->once()
+        ->andReturn($model);
+    $serviceMock->shouldReceive('approveInvoice');
+
+    $di = container();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+
+    $api->setDi($di);
+    $api->setService($serviceMock);
+    $identity = createEntity(Box\Mod\Client\Entity\Client::class);
+    $api->setIdentity($identity);
+
+    $data['amount'] = 10;
+    $result = $api->funds_invoice($data);
+    expect($result)->toBeString()->toBe($generatedHash);
+});
+
+test('creates funds invoice from a real invoice entity without accessing private properties', function (): void {
+    // Regression test: same as the renewal_invoice() case above - funds_invoice()
+    // also read $invoice->id and $invoice->hash directly.
+    $api = apiEndpoint(new Client());
+    $generatedHash = 'generatedHashString';
+
+    $model = new Invoice();
+    $model->setId(1);
+    $model->setHash($generatedHash);
+
+    $serviceMock = Mockery::mock(Service::class);
     $serviceMock->shouldReceive('generateFundsInvoice')
         ->atLeast()->once()
         ->andReturn($model);


### PR DESCRIPTION
Use the entity's `getId()` / `getHash()` getters instead of direct property access.

Fixes #4156.