### PR TITLE
Fix client page and order search errors for clients with legacy group id 0

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','103',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','104',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -513,6 +513,7 @@ class UpdatePatcher implements InjectionAwareInterface
             101 => 'patch101',
             102 => 'patch102',
             103 => 'patch103',
+            104 => 'patch104',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -3090,6 +3091,17 @@ class UpdatePatcher implements InjectionAwareInterface
                 }
             }
         }
+    }
+
+    private function patch104(): void
+    {
+        // Legacy RedBeanPHP installs stored `0` rather than NULL for clients with no
+        // group, since group ids start at 1. The Client entity's ClientGroup
+        // association only tolerates NULL, so Doctrine throws "Entity of type
+        // '...ClientGroup' for IDs id(0) was not found" the moment it tries to load
+        // the association for these clients.
+        // @see https://github.com/FOSSBilling/FOSSBilling/issues/4160
+        $this->executeSql('UPDATE `client` SET `client_group_id` = NULL WHERE `client_group_id` = 0;');
     }
 
     /**

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -736,3 +736,27 @@ test('custom pages slug unique patch is a no-op when the index already exists', 
     $patcher->setDi($di);
     (new ReflectionMethod($patcher, 'patch102'))->invoke($patcher);
 });
+
+test('client group patch follows the money column decimal patch', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 103);
+
+    expect($patches)->toHaveKey(104)
+        ->and($patches[104][1])->toBe('patch104');
+});
+
+test('client group patch normalizes legacy zero group ids to null', function (): void {
+    $statement = Mockery::mock(PDOStatement::class);
+    $statement->expects('execute')->with([])->andReturnTrue();
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->expects('prepare')
+        ->with('UPDATE `client` SET `client_group_id` = NULL WHERE `client_group_id` = 0;')
+        ->andReturn($statement);
+
+    $di = new Pimple\Container();
+    $di['pdo'] = $pdo;
+
+    $patcher = new UpdatePatcher();
+    $patcher->setDi($di);
+    (new ReflectionMethod($patcher, 'patch104'))->invoke($patcher);
+});


### PR DESCRIPTION
Add `patch104` to `UpdatePatcher`, following the existing "normalize legacy values" convention (same pattern as `patch46`'s gender-enum cleanup), to set `client_group_id` to `NULL` wherever it is currently `0` on existing installs. Bumped the fresh-install `last_patch` seed in `content.sql` to `104` to match.

Fixes #4160.