### PR TITLE
Fix core-update login lockout and mid-update file-swap race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /src/data/cache/*
 /src/data/uploads/*
 /src/data/update-finalization.json
+/src/.update-lock
 !/src/data/cache/.gitkeep
 /src/public/assets
 /src/vendor/*

--- a/cspell.json
+++ b/cspell.json
@@ -367,6 +367,8 @@
         "FileCacheExcption",
         "Autoloader",
         "autoloader",
+        "autoloading",
+        "autoloaded",
         "qwertyuiopasdfghjklzxccvbnm",
         "QWERTYUIOPASDFGHJKLZXCVBNM",
         "subkeys",

--- a/cspell.json
+++ b/cspell.json
@@ -61,7 +61,8 @@
         "previewable",
         "falsey",
         "unindexed",
-        "catchable"
+        "catchable",
+        "nelexa"
     ],
 
     "ignoreWords": [

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -22,6 +22,16 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class Update implements InjectionAwareInterface
 {
+    /**
+     * Name of the marker file that tells load.php to refuse all requests while
+     * performUpdate() is writing files to PATH_ROOT.
+     *
+     * This filename is duplicated as a literal string at the top of load.php,
+     * which has to check for the lock before the Composer autoloader (and
+     * therefore this class) is available. Keep both in sync if you change it.
+     */
+    public const string LOCK_FILENAME = '.update-lock';
+
     protected ?\Pimple\Container $di = null;
     private array $allowedDownloadPrefixes = [
         'https://github.com/FOSSBilling/FOSSBilling/releases/',
@@ -296,34 +306,52 @@ class Update implements InjectionAwareInterface
             'source' => 'auto-update',
         ]);
 
-        // Extract latest version archive on top of the current version.
+        /*
+         * From here until the lock is released below, files under PATH_ROOT are
+         * being overwritten in place while the site may still be serving other
+         * requests (this HTTP request is the only one that knows an update is
+         * running). A request that lands mid-extraction can autoload a mix of
+         * old and new class files and fatal out with an "incompatible
+         * declaration" error - see https://github.com/FOSSBilling/FOSSBilling/issues/4159.
+         *
+         * load.php refuses to serve any request while this lock file exists (and
+         * self-expires it in case this process dies before the `finally` below
+         * runs), so create it before touching any files and make sure PHP keeps
+         * running even if the client triggering the update disconnects mid-request.
+         */
+        $lockFile = Path::join(PATH_ROOT, self::LOCK_FILENAME);
+        $this->filesystem->dumpFile($lockFile, '');
+        ignore_user_abort(true);
+
         try {
-            $zip = new ZipFile();
-            $zip->openFile($archiveFile);
-            $zip->extractTo(PATH_ROOT);
-            $zip->close();
-        } catch (ZipException $e) {
-            error_log($e->getMessage());
+            // Extract latest version archive on top of the current version.
+            try {
+                $zip = new ZipFile();
+                $zip->openFile($archiveFile);
+                $zip->extractTo(PATH_ROOT);
+                $zip->close();
+            } catch (ZipException $e) {
+                error_log($e->getMessage());
 
-            throw new Exception('Failed to extract file, please check file and folder permissions. Further details are available in the error log.');
-        }
+                throw new Exception('Failed to extract file, please check file and folder permissions. Further details are available in the error log.');
+            }
 
-        // Clear the cache folder to reduce chances of errors
-        try {
-            $this->filesystem->remove(PATH_CACHE);
-            $this->filesystem->mkdir(PATH_CACHE, 0o755);
-        } catch (\Exception) {
-            // This step is rarely important, we can safely ignore an error here
-        }
-
-        // Clear cache and remove the install folder.
-        try {
-            $this->filesystem->remove([PATH_CACHE, Path::join(PATH_ROOT, 'install')]);
-            $this->filesystem->mkdir(PATH_CACHE, 0o755);
-        } catch (IOException $e) {
-            error_log($e->getMessage());
-
-            throw new Exception('Unable to clear cache and/or remove install folder. Further details are available in the error log.');
+            /*
+             * Apply pending config/database patches and remove the install folder
+             * now, while the admin who triggered the update is still authenticated.
+             *
+             * This must happen before the session is destroyed below: the login
+             * screen (and the Doctrine queries it runs to authenticate the admin)
+             * is generated against the newly extracted code, which can expect
+             * database columns that only the patches below create. Deferring this
+             * work until after the forced logout would leave the admin unable to
+             * log back in - and therefore unable to reach the finalization screen -
+             * until the schema is patched. See the class docblock on
+             * UpdateFinalization for the rest of the finalization flow.
+             */
+            $finalization->finalizeUpdate();
+        } finally {
+            $this->filesystem->remove($lockFile);
         }
 
         // Log off the current user and destroy the session.

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -406,8 +406,21 @@ class Update implements InjectionAwareInterface
     public static function isSafeArchiveEntry(string $entryName): bool
     {
         $normalized = str_replace('\\', '/', $entryName);
-        $segments = explode('/', $normalized);
 
-        return !str_starts_with($normalized, '/') && !preg_match('#^[a-zA-Z]:#', $normalized) && !in_array('..', $segments, true);
+        if (str_starts_with($normalized, '/') || preg_match('#^[a-zA-Z]:#', $normalized)) {
+            return false;
+        }
+
+        foreach (explode('/', $normalized) as $segment) {
+            // Windows strips trailing spaces and periods from path components, so
+            // '.. .' or '...' resolve to '..' at extraction time even though they
+            // don't match it literally here. Reject any segment that is nothing
+            // but dots and/or spaces rather than just the exact '..' segment.
+            if ($segment !== '' && trim($segment, ' .') === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/library/FOSSBilling/Update.php
+++ b/src/library/FOSSBilling/Update.php
@@ -32,6 +32,13 @@ class Update implements InjectionAwareInterface
      */
     public const string LOCK_FILENAME = '.update-lock';
 
+    /**
+     * How long a lock file is honored before it's treated as abandoned - see the
+     * comment above isCoreUpdateLockActive() in load.php, which applies the same
+     * window to decide whether to keep refusing requests.
+     */
+    private const int LOCK_STALE_SECONDS = 600;
+
     protected ?\Pimple\Container $di = null;
     private array $allowedDownloadPrefixes = [
         'https://github.com/FOSSBilling/FOSSBilling/releases/',
@@ -318,9 +325,27 @@ class Update implements InjectionAwareInterface
          * self-expires it in case this process dies before the `finally` below
          * runs), so create it before touching any files and make sure PHP keeps
          * running even if the client triggering the update disconnects mid-request.
+         *
+         * The create is exclusive (fails if the file already exists) so two
+         * updates triggered at the same time can't both extract into PATH_ROOT
+         * concurrently - the loser is turned away instead of corrupting the
+         * extraction. A leftover lock from a run that never reached the
+         * `finally` below (the process was killed outright) is treated as
+         * abandoned once it's older than LOCK_STALE_SECONDS.
          */
         $lockFile = Path::join(PATH_ROOT, self::LOCK_FILENAME);
-        $this->filesystem->dumpFile($lockFile, '');
+        if ($this->filesystem->exists($lockFile) && (time() - (int) @filemtime($lockFile)) > self::LOCK_STALE_SECONDS) {
+            $this->filesystem->remove($lockFile);
+        }
+
+        // fopen(..., 'x') rather than Filesystem here: it's the only way to make the
+        // create atomic (it fails if the file already exists), which is what makes
+        // this a real mutex against two updates racing each other below.
+        $lockHandle = @fopen($lockFile, 'x');
+        if ($lockHandle === false) {
+            throw new InformationException('Another update appears to already be in progress. Please wait for it to finish before trying again.');
+        }
+        fclose($lockHandle);
         ignore_user_abort(true);
 
         try {
@@ -328,6 +353,11 @@ class Update implements InjectionAwareInterface
             try {
                 $zip = new ZipFile();
                 $zip->openFile($archiveFile);
+                foreach ($zip->getListFiles() as $entryName) {
+                    if (!self::isSafeArchiveEntry($entryName)) {
+                        throw new Exception('The update archive contains an unsafe file path and cannot be extracted.');
+                    }
+                }
                 $zip->extractTo(PATH_ROOT);
                 $zip->close();
             } catch (ZipException $e) {
@@ -335,6 +365,11 @@ class Update implements InjectionAwareInterface
 
                 throw new Exception('Failed to extract file, please check file and folder permissions. Further details are available in the error log.');
             }
+
+            // Extraction is the slow part; refresh the lock now so a legitimately
+            // long-running update isn't mistaken for an abandoned one while the
+            // patches below are still applying.
+            $this->filesystem->touch($lockFile);
 
             /*
              * Apply pending config/database patches and remove the install folder
@@ -356,5 +391,23 @@ class Update implements InjectionAwareInterface
 
         // Log off the current user and destroy the session.
         $this->di['session']->destroy('admin');
+    }
+
+    /**
+     * Whether a release archive entry name is safe to extract under PATH_ROOT
+     * (Zip Slip / CWE-22 guard).
+     *
+     * nelexa/zip normalizes entry names by splitting on '/' only, so on a
+     * Windows host an entry such as `..\..\poc.php` isn't recognized as
+     * traversal and extractTo() can write outside PATH_ROOT (CVE-2026-16767).
+     * Normalizing backslashes to forward slashes before checking for '..'
+     * segments and absolute paths closes that gap on every platform.
+     */
+    public static function isSafeArchiveEntry(string $entryName): bool
+    {
+        $normalized = str_replace('\\', '/', $entryName);
+        $segments = explode('/', $normalized);
+
+        return !str_starts_with($normalized, '/') && !preg_match('#^[a-zA-Z]:#', $normalized) && !in_array('..', $segments, true);
     }
 }

--- a/src/load.php
+++ b/src/load.php
@@ -185,15 +185,16 @@ function exceptionHandler(Exception|Error $e): void
  * failsafe for the rare case that PHP is killed outright (host timeout, OOM)
  * before that block can run.
  */
-function isCoreUpdateLockActive(): bool
+function isCoreUpdateLockActive(?int $now = null): bool
 {
     $mtime = @filemtime(PATH_ROOT . DIRECTORY_SEPARATOR . '.update-lock');
+    $now ??= time();
 
     // No lock file, or it's old enough that the process which created it must
     // have died without cleaning up (e.g. a host-side request timeout killed
     // it before the update's `finally` block could run). Treat an old lock as
     // abandoned rather than blocking the site forever.
-    return $mtime !== false && (time() - $mtime) <= 600;
+    return $mtime !== false && ($now - $mtime) <= 600;
 }
 
 function blockWhileCoreUpdateIsRunning(): void

--- a/src/load.php
+++ b/src/load.php
@@ -167,12 +167,67 @@ function exceptionHandler(Exception|Error $e): void
 }
 
 /*
+ * Refuse to serve this request while FOSSBilling\Update::performUpdate() is
+ * actively writing files to PATH_ROOT.
+ *
+ * This intentionally runs before the Composer autoloader is loaded, and
+ * before any FOSSBilling class is referenced: while a core update is
+ * extracting a release archive on top of the live codebase, a concurrent
+ * request that starts autoloading classes mid-swap can see a torn mix of old
+ * and new files and fatal out with an "incompatible declaration" error.
+ * See https://github.com/FOSSBilling/FOSSBilling/issues/4159.
+ *
+ * The lock filename below is duplicated as a literal (see
+ * Update::LOCK_FILENAME) because this check has to run before that class -
+ * or anything else - can be autoloaded. Keep both copies in sync if it
+ * changes. The 600-second staleness window only exists here; performUpdate()
+ * always removes the lock itself via a `finally` block, so this is purely a
+ * failsafe for the rare case that PHP is killed outright (host timeout, OOM)
+ * before that block can run.
+ */
+function isCoreUpdateLockActive(): bool
+{
+    $mtime = @filemtime(PATH_ROOT . DIRECTORY_SEPARATOR . '.update-lock');
+
+    // No lock file, or it's old enough that the process which created it must
+    // have died without cleaning up (e.g. a host-side request timeout killed
+    // it before the update's `finally` block could run). Treat an old lock as
+    // abandoned rather than blocking the site forever.
+    return $mtime !== false && (time() - $mtime) <= 600;
+}
+
+function blockWhileCoreUpdateIsRunning(): void
+{
+    if (!isCoreUpdateLockActive()) {
+        return;
+    }
+
+    if (PHP_SAPI === 'cli') {
+        fwrite(STDERR, "FOSSBilling is currently applying a core update. Please try again in a few moments.\n");
+        exit(1);
+    }
+
+    http_response_code(503);
+    header('Retry-After: 5');
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!doctype html><html><head><meta charset="utf-8"><title>Updating&hellip;</title></head>'
+        . '<body style="font-family:sans-serif;text-align:center;padding:4rem 1rem;">'
+        . '<h1>FOSSBilling is updating</h1>'
+        . '<p>This installation is being updated and will be back in a moment. This page will retry automatically.</p>'
+        . '<script>setTimeout(function () { location.reload(); }, 5000);</script>'
+        . '</body></html>';
+    exit;
+}
+
+/*
  * Pre-initialization.
  */
 function preInit(): void
 {
     // Define root path.
     define('PATH_ROOT', __DIR__);
+
+    blockWhileCoreUpdateIsRunning();
 
     // Check vendor folder exists and load Composer autoloader.
     define('PATH_VENDOR', PATH_ROOT . DIRECTORY_SEPARATOR . 'vendor');

--- a/tests/Unit/FOSSBilling/UpdateTest.php
+++ b/tests/Unit/FOSSBilling/UpdateTest.php
@@ -27,3 +27,15 @@ test('isSafeArchiveEntry rejects a Unix absolute path', function (): void {
 test('isSafeArchiveEntry rejects a Windows drive-letter absolute path', function (): void {
     expect(Update::isSafeArchiveEntry('C:\\Windows\\System32\\evil.dll'))->toBeFalse();
 });
+
+test('isSafeArchiveEntry rejects a trailing-space-and-dot segment Windows normalizes to a parent traversal', function (): void {
+    expect(Update::isSafeArchiveEntry('.. .\\outside.php'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry rejects an all-dots segment', function (): void {
+    expect(Update::isSafeArchiveEntry('.../outside.php'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry accepts a filename that legitimately contains spaces and periods', function (): void {
+    expect(Update::isSafeArchiveEntry('src/data/my file v1.2.3.txt'))->toBeTrue();
+});

--- a/tests/Unit/FOSSBilling/UpdateTest.php
+++ b/tests/Unit/FOSSBilling/UpdateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use FOSSBilling\Update;
+
+test('isSafeArchiveEntry accepts a normal relative entry', function (): void {
+    expect(Update::isSafeArchiveEntry('src/library/FOSSBilling/Update.php'))->toBeTrue();
+});
+
+test('isSafeArchiveEntry rejects a forward-slash traversal segment', function (): void {
+    expect(Update::isSafeArchiveEntry('../../etc/passwd'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry rejects a backslash traversal segment', function (): void {
+    expect(Update::isSafeArchiveEntry('..\\..\\poc.php'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry rejects a mixed-separator traversal segment', function (): void {
+    expect(Update::isSafeArchiveEntry('src\\..\\..\\poc.php'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry rejects a Unix absolute path', function (): void {
+    expect(Update::isSafeArchiveEntry('/etc/passwd'))->toBeFalse();
+});
+
+test('isSafeArchiveEntry rejects a Windows drive-letter absolute path', function (): void {
+    expect(Update::isSafeArchiveEntry('C:\\Windows\\System32\\evil.dll'))->toBeFalse();
+});

--- a/tests/Unit/LoadCoreUpdateLockTest.php
+++ b/tests/Unit/LoadCoreUpdateLockTest.php
@@ -63,8 +63,15 @@ test('isCoreUpdateLockActive is true just under the staleness window', function 
 });
 
 test('isCoreUpdateLockActive is true exactly at the staleness boundary', function (): void {
-    withCoreUpdateLock(time() - 600, function (): void {
-        expect(isCoreUpdateLockActive())->toBeTrue();
+    // The boundary is exact (<=600), so this asserts a fixed reference time
+    // against a fixed mtime instead of two separate time() calls - otherwise a
+    // clock tick between writing the lock and checking it could flip a
+    // legitimately-600-second-old lock to 601 and fail this on production code
+    // that's still correct.
+    $now = time();
+
+    withCoreUpdateLock($now - 600, function () use ($now): void {
+        expect(isCoreUpdateLockActive($now))->toBeTrue();
     });
 });
 

--- a/tests/Unit/LoadCoreUpdateLockTest.php
+++ b/tests/Unit/LoadCoreUpdateLockTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use FOSSBilling\Update;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * isCoreUpdateLockActive() reads a real, fixed path (PATH_ROOT/.update-lock) rather than
@@ -17,23 +18,24 @@ function lockFilePath(): string
 
 function withCoreUpdateLock(?int $mtime, Closure $callback): void
 {
+    $filesystem = new Filesystem();
     $path = lockFilePath();
-    $existed = file_exists($path);
+    $existed = $filesystem->exists($path);
     $originalMtime = $existed ? filemtime($path) : null;
 
     try {
         if ($mtime === null) {
-            @unlink($path);
+            $filesystem->remove($path);
         } else {
-            touch($path, $mtime);
+            $filesystem->touch($path, $mtime);
         }
 
         $callback();
     } finally {
         if ($existed) {
-            touch($path, (int) $originalMtime);
+            $filesystem->touch($path, (int) $originalMtime);
         } else {
-            @unlink($path);
+            $filesystem->remove($path);
         }
     }
 }
@@ -56,6 +58,12 @@ test('isCoreUpdateLockActive is true for a freshly written lock file', function 
 
 test('isCoreUpdateLockActive is true just under the staleness window', function (): void {
     withCoreUpdateLock(time() - 599, function (): void {
+        expect(isCoreUpdateLockActive())->toBeTrue();
+    });
+});
+
+test('isCoreUpdateLockActive is true exactly at the staleness boundary', function (): void {
+    withCoreUpdateLock(time() - 600, function (): void {
         expect(isCoreUpdateLockActive())->toBeTrue();
     });
 });

--- a/tests/Unit/LoadCoreUpdateLockTest.php
+++ b/tests/Unit/LoadCoreUpdateLockTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use FOSSBilling\Update;
+
+/**
+ * isCoreUpdateLockActive() reads a real, fixed path (PATH_ROOT/.update-lock) rather than
+ * anything injectable: it has to run in load.php before the Composer autoloader (and any
+ * config/DI) is available. These tests write/remove that one file directly and always clean
+ * up, mirroring how LoadCheckInstallerTest exercises load.php's other bootstrap guards.
+ */
+function lockFilePath(): string
+{
+    return PATH_ROOT . DIRECTORY_SEPARATOR . '.update-lock';
+}
+
+function withCoreUpdateLock(?int $mtime, Closure $callback): void
+{
+    $path = lockFilePath();
+    $existed = file_exists($path);
+    $originalMtime = $existed ? filemtime($path) : null;
+
+    try {
+        if ($mtime === null) {
+            @unlink($path);
+        } else {
+            touch($path, $mtime);
+        }
+
+        $callback();
+    } finally {
+        if ($existed) {
+            touch($path, (int) $originalMtime);
+        } else {
+            @unlink($path);
+        }
+    }
+}
+
+test('the lock filename load.php checks for matches Update::LOCK_FILENAME', function (): void {
+    expect(basename(lockFilePath()))->toBe(Update::LOCK_FILENAME);
+});
+
+test('isCoreUpdateLockActive is false when no lock file exists', function (): void {
+    withCoreUpdateLock(null, function (): void {
+        expect(isCoreUpdateLockActive())->toBeFalse();
+    });
+});
+
+test('isCoreUpdateLockActive is true for a freshly written lock file', function (): void {
+    withCoreUpdateLock(time(), function (): void {
+        expect(isCoreUpdateLockActive())->toBeTrue();
+    });
+});
+
+test('isCoreUpdateLockActive is true just under the staleness window', function (): void {
+    withCoreUpdateLock(time() - 599, function (): void {
+        expect(isCoreUpdateLockActive())->toBeTrue();
+    });
+});
+
+test('isCoreUpdateLockActive treats a lock past the staleness window as abandoned', function (): void {
+    withCoreUpdateLock(time() - 601, function (): void {
+        expect(isCoreUpdateLockActive())->toBeFalse();
+    });
+});


### PR DESCRIPTION
Fixes #4159. After clicking "Update" in the admin panel, admins could get permanently locked out with `SQLSTATE[42S22]: Column not found` on the login screen, with no way back in through the web UI.

1. **Login lockout**: run `UpdateFinalization::finalizeUpdate()` (applies config/DB patches, removes `install/`) *before* destroying the session in `performUpdate()`, instead of after. The DB is already patched by the time the admin needs to log back in; the existing finalize/complete review screen still runs afterward for restoring maintenance mode.
2. **File-swap race**: write a `.update-lock` marker before extraction/patching; `load.php` refuses to serve *any* request while it exists, checked before the Composer autoloader (and therefore any FOSSBilling class) is loaded. The lock is removed in a `finally` block and self-expires after 10 minutes as a failsafe if the process is killed outright (host timeout, OOM) before that can run.