### PR TITLE
Fix several admin-panel fatal errors found in manual testing

### DIFF
--- a/src/modules/Email/Api/Admin.php
+++ b/src/modules/Email/Api/Admin.php
@@ -392,11 +392,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $email = [
             'code' => 'mod_email_test',
-            'to' => $currentUser->email ?? '',
-            'to_name' => $currentUser->name ?? '',
+            'to' => $currentUser?->getEmail() ?? '',
+            'to_name' => $currentUser?->getName() ?? '',
             'send_now' => true,
             'throw_exceptions' => true,
-            'staff_member_name' => $currentUser->name ?? '',
+            'staff_member_name' => $currentUser?->getName() ?? '',
         ];
 
         return $this->getService()->sendTemplate($email);

--- a/src/modules/Massmailer/Api/Admin.php
+++ b/src/modules/Massmailer/Api/Admin.php
@@ -275,8 +275,8 @@ Order our services at {{ "order"|url }}
             foreach ($clients as $client) {
                 $clientInfo = $clientService->get(['id' => $client['id']]);
                 $recipients[] = [
-                    'email' => $clientInfo->email,
-                    'name' => $clientInfo->first_name . ' ' . $clientInfo->last_name,
+                    'email' => $clientInfo->getEmail(),
+                    'name' => $clientInfo->getFirstName() . ' ' . $clientInfo->getLastName(),
                 ];
             }
         }

--- a/src/modules/Massmailer/templates/admin/mod_massmailer_message.html.twig
+++ b/src/modules/Massmailer/templates/admin/mod_massmailer_message.html.twig
@@ -50,9 +50,9 @@
                             <label class="form-label">{{ 'Client Status'|trans }}</label>
                             <div class="form-text mb-2">{{ 'Limit recipients to clients with these account states.'|trans }}</div>
                             <select class="form-select" name="filter[client_status][]" multiple="multiple" size="4">
-                                <option value="active" {% if 'active' in msg.filter.client_status %} selected="selected"{% endif %}>{{ 'Active'|trans }}</option>
-                                <option value="suspended" {% if 'suspended' in msg.filter.client_status %} selected="selected"{% endif %}>{{ 'Suspended'|trans }}</option>
-                                <option value="canceled" {% if 'canceled' in msg.filter.client_status %} selected="selected"{% endif %}>{{ 'Canceled'|trans }}</option>
+                                <option value="active" {% if 'active' in (msg.filter.client_status ?? []) %} selected="selected"{% endif %}>{{ 'Active'|trans }}</option>
+                                <option value="suspended" {% if 'suspended' in (msg.filter.client_status ?? []) %} selected="selected"{% endif %}>{{ 'Suspended'|trans }}</option>
+                                <option value="canceled" {% if 'canceled' in (msg.filter.client_status ?? []) %} selected="selected"{% endif %}>{{ 'Canceled'|trans }}</option>
                             </select>
                         </div>
                         <div class="col-lg-6">
@@ -60,7 +60,7 @@
                             <div class="form-text mb-2">{{ 'Target only clients assigned to these groups.'|trans }}</div>
                             <select class="form-select" name="filter[client_groups][]" multiple="multiple" size="4">
                                 {% for id,label in admin.client_group_get_pairs %}
-                                    <option value="{{id}}" {% if id in msg.filter.client_groups %} selected="selected"{% endif %}>{{label}}</option>
+                                    <option value="{{id}}" {% if id in (msg.filter.client_groups ?? []) %} selected="selected"{% endif %}>{{label}}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -69,7 +69,7 @@
                             <div class="form-text mb-2">{{ 'Match clients who have orders currently in these states.'|trans }}</div>
                             <select class="form-select" name="filter[has_order_with_status][]" multiple="multiple" size="6">
                                 {% for id,label in admin.order_get_status_pairs %}
-                                    <option value="{{id}}" {% if id in msg.filter.has_order_with_status %} selected="selected"{% endif %}>{{label}}</option>
+                                    <option value="{{id}}" {% if id in (msg.filter.has_order_with_status ?? []) %} selected="selected"{% endif %}>{{label}}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -78,7 +78,7 @@
                             <div class="form-text mb-2">{{ 'Match clients who have purchased any of these products.'|trans }}</div>
                             <select class="form-select" name="filter[has_order][]" multiple="multiple" size="6">
                                 {% for id,label in admin.product_get_pairs %}
-                                    <option value="{{id}}" {% if id in msg.filter.has_order %} selected="selected"{% endif %}>{{label}}</option>
+                                    <option value="{{id}}" {% if id in (msg.filter.has_order ?? []) %} selected="selected"{% endif %}>{{label}}</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
+++ b/src/modules/Orderbutton/templates/admin/mod_orderbutton_settings.html.twig
@@ -105,6 +105,8 @@
                                     <div class="col-lg-4">
                                         <label class="form-label" for="background_color">{{ 'Color'|trans }}</label>
                                         <div class="input-group">
+                                            <input type="color" class="form-control form-control-color" name="background_color" id="background_color"
+                                                   value="{{ params.background_color|default('#000000') }}" title="{{ 'Choose color'|trans }}">
                                             <input type="text" class="form-control" id="background_color_hex"
                                                    value="{{ params.background_color|default('#000000') }}" maxlength="7" autocomplete="off" spellcheck="false" inputmode="text" aria-label="{{ 'Hex color value'|trans }}">
                                         </div>

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -216,7 +216,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $this->validateOrderData($c);
 
         [$sld, $tld] = $this->_getTuple($c);
-        $years = $c['register_years'] ?? 1;
+        $years = (int) ($c['register_years'] ?? 1);
 
         // @todo ?
         $systemService = $this->di['mod_service']('system');

--- a/src/modules/Servicedomain/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicedomain/tests/Unit/ServiceTest.php
@@ -300,7 +300,7 @@ test('rejects a crafted order for an inactive tld before contacting the registra
         ->toThrow(FOSSBilling\InformationException::class, 'TLD is not active');
 })->with(['register', 'transfer']);
 
-test('creates action', function (): void {
+test('creates action', function (int|string $registerYears): void {
     $service = new Service();
     $tldModel = new Tld();
     $tldModel->setRegistrar(new TldRegistrar());
@@ -309,7 +309,7 @@ test('creates action', function (): void {
         'action' => 'register',
         'register_sld' => 'example',
         'register_tld' => '.com',
-        'register_years' => 2,
+        'register_years' => $registerYears,
         'ns2' => 'custom-ns2.example.com',
     ];
 
@@ -372,7 +372,11 @@ test('creates action', function (): void {
     $result = $serviceMock->action_create($order);
     expect($result)->toBeInstanceOf(ServiceDomain::class);
     expect($result->getNs2())->toBe('custom-ns2.example.com');
-});
+    expect($result->getPeriod())->toBe(2);
+})->with([
+    'int register_years' => [2],
+    'string register_years' => ['2'],
+]);
 
 test('throws exception when creating action with missing nameservers', function (): void {
     $service = new Service();

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -870,7 +870,7 @@ class Service implements InjectionAwareInterface
             return;
         }
 
-        if (!in_array((int) $group->getId(), $this->adminGroupRepository->getDescendantIdsForGroups($this->adminGroupMemberRepository->getGroupIdsForAdmin((int) $actor->id)), true)) {
+        if (!in_array((int) $group->getId(), $this->adminGroupRepository->getDescendantIdsForGroups($this->adminGroupMemberRepository->getGroupIdsForAdmin((int) $actor->getId())), true)) {
             throw new \FOSSBilling\InformationException('You can only manage lower staff groups');
         }
     }

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -12,7 +12,7 @@
     <title>{{ page_title }}</title>
     <meta name="color-scheme" content="light dark">
 
-    <meta name="description" content="{% block meta_description %}{{ meta_description }}{% endblock %}">
+    <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
     <meta name="keywords" content="{{ settings.meta_keywords }}">
     <meta name="robots" content="{{ settings.meta_robots }}">
     <meta name="author" content="{{ settings.meta_author }}">


### PR DESCRIPTION
A batch of fatal-error and correctness fixes found while manually testing several admin-panel screens on `main`. Each is an independent bug in its own commit.

- **Massmailer**: fatal error viewing a message with no filters set (`strict_variables` + missing filter keys)
- **Massmailer**: fatal error generating a preview's recipient list (bare property access on the `Client` entity instead of getters)
- **Email**: test emails always sent with an empty `to` address (bare property access on the `Admin` entity instead of getters)
- **Staff**: fatal error managing staff groups as a non-super-admin (`$actor->id` instead of `$actor->getId()`)
- **Servicedomain**: `TypeError` creating a domain registration order (`register_years` from order config passed as a string into a `?int` setter)
- **Orderbutton**: JS error on the settings page ("Try Your Popup" and page load) from a missing `background_color` input that the script and label already referenced
- **Huraga theme**: fatal error on public pages that don't override `meta_description` (circular block/variable reference)
