### PR TITLE
Fix exception status-code crash and installer cleanup on default deploys

### DIFF
--- a/src/library/FOSSBilling/Http/ExceptionResponseFactory.php
+++ b/src/library/FOSSBilling/Http/ExceptionResponseFactory.php
@@ -68,8 +68,9 @@ final readonly class ExceptionResponseFactory
 
     private function getStatusCode(\Throwable $exception): int
     {
+        // getCode() is documented as int, but e.g. PDOException returns a string SQLSTATE.
         $code = $exception->getCode();
 
-        return $code >= 400 && $code <= 599 ? $code : Response::HTTP_INTERNAL_SERVER_ERROR;
+        return is_int($code) && $code >= 400 && $code <= 599 ? $code : Response::HTTP_INTERNAL_SERVER_ERROR;
     }
 }

--- a/src/library/FOSSBilling/UpdateFinalization.php
+++ b/src/library/FOSSBilling/UpdateFinalization.php
@@ -185,7 +185,9 @@ class UpdateFinalization implements InjectionAwareInterface
             $patcher->applyConfigPatches(force: true);
             $patcher->applyCorePatches(force: true);
 
-            $this->filesystem->remove(Path::join(PATH_ROOT, 'install'));
+            if ($this->shouldRemoveInstallDirectory()) {
+                $this->filesystem->remove(Path::join(PATH_ROOT, 'install'));
+            }
             $this->clearCache();
         } catch (IOException $e) {
             $this->logUpdateError($e->getMessage());
@@ -342,6 +344,16 @@ class UpdateFinalization implements InjectionAwareInterface
             static fn (string $path): string => $adminPrefix . '/' . $path,
             self::ALLOWED_ADMIN_PATHS
         );
+    }
+
+    /**
+     * Mirrors checkInstaller()'s guard in load.php: skipped for explicit dev/test
+     * environments and while debugging, so those instances keep the installer.
+     */
+    private function shouldRemoveInstallDirectory(): bool
+    {
+        // @phpstan-ignore booleanNot.alwaysTrue (DEBUG is a runtime constant)
+        return Environment::isProduction() && !DEBUG;
     }
 
     private function getAvailablePatchCount(): ?int

--- a/src/load.php
+++ b/src/load.php
@@ -56,9 +56,9 @@ function checkInstaller(): void
     }
 
     // If the config file exists and not install.php, but the install folder does, perform some cleanup.
-    // This delete is irreversible, so it requires an explicit APP_ENV=prod rather than the ambiguous default above.
+    // The guard above already excludes dev/test, so this only skips DEBUG instances.
     // @phpstan-ignore booleanNot.alwaysTrue (DEBUG is a runtime constant)
-    if (Environment::isExplicitlyProduction() && $filesystem->exists(PATH_CONFIG) && $filesystem->exists(Path::normalize('install')) && !DEBUG) {
+    if ($filesystem->exists(PATH_CONFIG) && $filesystem->exists(Path::normalize('install')) && !DEBUG) {
         // Bootstrap runs before the DI logger and PHP error log are configured.
         error_log('Removing the install directory now that installation is complete.');
         $filesystem->remove('install');

--- a/tests/Unit/FOSSBilling/ExceptionResponseFactoryTest.php
+++ b/tests/Unit/FOSSBilling/ExceptionResponseFactoryTest.php
@@ -32,6 +32,18 @@ test('exception response factory creates FOSSBilling error pages outside testing
         ->and($response->getContent())->toContain('Your Configuration is Empty');
 });
 
+test('exception response factory falls back to 500 for non-integer exception codes', function (): void {
+    // PDOException's $code property is untyped, so PDO can set it to a string SQLSTATE.
+    $exception = new PDOException('Unknown column');
+    $codeProperty = new ReflectionProperty($exception, 'code');
+    $codeProperty->setAccessible(true);
+    $codeProperty->setValue($exception, '42S22');
+
+    $response = (new ExceptionResponseFactory())->create($exception);
+
+    expect($response->getStatusCode())->toBe(Response::HTTP_INTERNAL_SERVER_ERROR);
+});
+
 test('error page can render without sending output', function (): void {
     $page = (new ErrorPage())->renderPage(404, 'Missing route');
 

--- a/tests/Unit/FOSSBilling/UpdateFinalizationTest.php
+++ b/tests/Unit/FOSSBilling/UpdateFinalizationTest.php
@@ -122,6 +122,17 @@ test('serializes finalization with an exclusive lock', function (): void {
     expect($lockHeld)->toBeTrue();
 });
 
+test('removes the install directory unless the environment is explicitly dev or test', function (): void {
+    $shouldRemove = new ReflectionMethod(UpdateFinalization::class, 'shouldRemoveInstallDirectory');
+    $finalization = new UpdateFinalization();
+
+    withAppEnv(null, fn () => expect($shouldRemove->invoke($finalization))->toBeTrue());
+    withAppEnv('staging', fn () => expect($shouldRemove->invoke($finalization))->toBeTrue());
+    withAppEnv('prod', fn () => expect($shouldRemove->invoke($finalization))->toBeTrue());
+    withAppEnv('dev', fn () => expect($shouldRemove->invoke($finalization))->toBeFalse());
+    withAppEnv('test', fn () => expect($shouldRemove->invoke($finalization))->toBeFalse());
+});
+
 test('completion restores captured maintenance mode and records the current version', function (): void {
     $config = Config::getConfig();
     $config['maintenance_mode'] = [

--- a/tests/Unit/LoadCheckInstallerTest.php
+++ b/tests/Unit/LoadCheckInstallerTest.php
@@ -40,12 +40,12 @@ function runCheckInstallerWithStubbedFilesystem(bool $expectRemoval): void
     }
 }
 
-test('checkInstaller does not delete the install directory when APP_ENV is unset', function (): void {
-    withAppEnv(null, fn () => runCheckInstallerWithStubbedFilesystem(expectRemoval: false));
+test('checkInstaller deletes the install directory when APP_ENV is unset', function (): void {
+    withAppEnv(null, fn () => runCheckInstallerWithStubbedFilesystem(expectRemoval: true));
 });
 
-test('checkInstaller does not delete the install directory when APP_ENV holds an unrecognized value', function (): void {
-    withAppEnv('staging', fn () => runCheckInstallerWithStubbedFilesystem(expectRemoval: false));
+test('checkInstaller deletes the install directory when APP_ENV holds an unrecognized value', function (): void {
+    withAppEnv('staging', fn () => runCheckInstallerWithStubbedFilesystem(expectRemoval: true));
 });
 
 test('checkInstaller does not delete the install directory when APP_ENV is dev or test', function (): void {


### PR DESCRIPTION
## What

Two related fixes found while testing #4169:

1. **`ExceptionResponseFactory::getStatusCode()` crashed the exception handler itself.** It's typed to return `int` but returned `Throwable::getCode()` unchecked. `PDOException` sets its internal (untyped) `$code` property to the driver's SQLSTATE string, so a `PDOException` (e.g. one raised during session handling) turned into a `TypeError` in the error handler instead of surfacing the real error.

2. **The install directory was never auto-removed on a default, unconfigured deploy.** Both `checkInstaller()` (`load.php`) and `UpdateFinalization::finalizeUpdateLocked()` gated the delete behind an explicit `APP_ENV=prod`. Nothing in the actual shipped deployment path — the official `Dockerfile`, or a typical shared-hosting unzip-and-run install — ever sets `APP_ENV`, so cleanup silently never ran, even though the installer's own completion screen says "The `./install/` folder is normally deleted automatically." Flipped the policy to match `Environment::isProduction()` (already used everywhere else in the app, treats unset/unrecognized `APP_ENV` as production): the directory is now removed unless the environment is explicitly `dev` or `test`, or `DEBUG` is enabled.