### PR TITLE
Fix several admin UI issues

### DIFF
--- a/frontend/tools/esbuild-helpers.mts
+++ b/frontend/tools/esbuild-helpers.mts
@@ -176,6 +176,8 @@ export async function purgeCssFile(cssFilePath: string, options: PurgeOptions) {
           /^collapse/,
           /^alert/,
           /^spinner/,
+          /^tooltip/,
+          /^popover/,
           /^active$/,
           /^show$/,
           /^fade$/,

--- a/src/modules/Client/templates/admin/mod_client_manage.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_manage.html.twig
@@ -138,7 +138,7 @@
                                         <td class="text-end">{{ 'Notes'|trans }}:</td>
                                         <td>
                                             <svg class="icon">
-                                                <use href="#headset" />
+                                                <use href="#notes" />
                                             </svg>
                                             {% if has_profile_edit_actions %}
                                                 <a href="#tab-profile" role="button" data-tab-jump>{{ client.notes }}</a>

--- a/src/modules/Client/templates/admin/mod_client_manage.html.twig
+++ b/src/modules/Client/templates/admin/mod_client_manage.html.twig
@@ -141,7 +141,7 @@
                                                 <use href="#headset" />
                                             </svg>
                                             {% if has_profile_edit_actions %}
-                                                <a href="#tab-profile" data-bs-toggle="tab" role="button">{{ client.notes }}</a>
+                                                <a href="#tab-profile" role="button" data-tab-jump>{{ client.notes }}</a>
                                             {% else %}
                                                 {{ client.notes }}
                                             {% endif %}

--- a/src/modules/Cookieconsent/templates/admin/mod_cookieconsent_index.html.twig
+++ b/src/modules/Cookieconsent/templates/admin/mod_cookieconsent_index.html.twig
@@ -16,8 +16,8 @@
 
                         <p>{{ 'Specify a message which will be shown to the user. The message will be shown until dismissed with the <strong>Close &times;</strong> button. An undismissed message does not effect functionality or prevent users from performing any actions.'|trans|raw }}</p>
                         <div class="alert alert-info" role="alert">
-                            <strong class="me-1">{{ 'Information:'|trans }}</strong>{{ 'If there is a need to change the way notification looks or is being displayed, you can do it by editing'|trans }}
-                            <code>{{ constant('PATH_ROOT') }}/modules/Cookieconsent/templates/client/mod_cookieconsent_index.html.twig</code>
+                            <strong class="me-1">{{ 'Information:'|trans }}</strong>
+                            <span>{{ 'If there is a need to change the way notification looks or is being displayed, you can do it by editing'|trans }} <code>{{ constant('PATH_ROOT') }}/modules/Cookieconsent/templates/client/mod_cookieconsent_index.html.twig</code></span>
                         </div>
                         {% set params = admin.extension_config_get({"ext":"mod_cookieconsent"}) %}
                         <textarea class="form-control" cols="5" rows="10" name="message" id="cookie-message"

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -18,6 +18,8 @@ use FOSSBilling\InjectionAwareInterface;
 
 class Service implements InjectionAwareInterface
 {
+    private const string BATCH_CONNECT_LOCK = 'fossbilling_hook_batch_connect';
+
     protected ?\Pimple\Container $di = null;
 
     public function setDi(\Pimple\Container $di): void
@@ -120,38 +122,54 @@ class Service implements InjectionAwareInterface
         $event->setReturnValue(true);
     }
 
+    /**
+     * Serializes batchConnect() runs so two concurrent callers (e.g. overlapping cron and
+     * on-demand rebuilds triggered by a login) cannot interleave connect()'s check-then-insert
+     * and create duplicate listener rows, or leave a partially rebuilt set visible in between.
+     */
     public function batchConnect($mod_name = null): bool
     {
-        // Clean up the existing list before we add to it
-        $this->_disconnectUnavailable();
-        $extensionService = $this->di['mod_service']('extension');
-
-        $mods = [];
-        if ($mod_name !== null) {
-            $mods[] = $mod_name;
-        } else {
-            $mods = $extensionService->getCoreAndActiveModules();
+        $connection = $this->di['em']->getConnection();
+        if ((int) $connection->fetchOne('SELECT GET_LOCK(:name, 5)', ['name' => self::BATCH_CONNECT_LOCK]) !== 1) {
+            // Another process is already rebuilding the listener set; let it finish rather
+            // than racing it.
+            return true;
         }
 
-        foreach ($mods as $m) {
-            $installed = $this->getExtensionRepository()->existsActiveByTypeAndName(Extension::TYPE_MOD, $m);
-            if (!$installed && !$extensionService->isCoreModule($m)) {
-                continue;
+        try {
+            // Clean up the existing list before we add to it
+            $this->_disconnectUnavailable();
+            $extensionService = $this->di['mod_service']('extension');
+
+            $mods = [];
+            if ($mod_name !== null) {
+                $mods[] = $mod_name;
+            } else {
+                $mods = $extensionService->getCoreAndActiveModules();
             }
 
-            $mod = $this->di['mod']($m);
-            if ($mod->hasService()) {
-                $class = $mod->getService();
-                $reflector = new \ReflectionClass($class);
-                foreach ($reflector->getMethods() as $method) {
-                    if ($this->canBeConnected($method)) {
-                        $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
+            foreach ($mods as $m) {
+                $installed = $this->getExtensionRepository()->existsActiveByTypeAndName(Extension::TYPE_MOD, $m);
+                if (!$installed && !$extensionService->isCoreModule($m)) {
+                    continue;
+                }
+
+                $mod = $this->di['mod']($m);
+                if ($mod->hasService()) {
+                    $class = $mod->getService();
+                    $reflector = new \ReflectionClass($class);
+                    foreach ($reflector->getMethods() as $method) {
+                        if ($this->canBeConnected($method)) {
+                            $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
+                        }
                     }
                 }
             }
-        }
 
-        return true;
+            return true;
+        } finally {
+            $connection->executeStatement('SELECT RELEASE_LOCK(:name)', ['name' => self::BATCH_CONNECT_LOCK]);
+        }
     }
 
     private function canBeConnected(\ReflectionMethod $method): bool

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -125,46 +125,55 @@ class Service implements InjectionAwareInterface
     /**
      * Serializes batchConnect() runs so two concurrent callers (e.g. overlapping cron and
      * on-demand rebuilds triggered by a login) cannot interleave connect()'s check-then-insert
-     * and create duplicate listener rows, or leave a partially rebuilt set visible in between.
+     * and create duplicate listener rows. The rebuild itself runs in a single DB transaction,
+     * so hasConnectedListeners() can only ever observe the previous complete set or the new
+     * complete set, never a partially rebuilt one.
+     *
+     * Returns false if the lock could not be acquired within the timeout, so a failure to
+     * initialize is never mistaken for success - callers that need listeners connected before
+     * proceeding should check the return value rather than assume this always succeeds.
      */
     public function batchConnect($mod_name = null): bool
     {
         $connection = $this->di['em']->getConnection();
         if ((int) $connection->fetchOne('SELECT GET_LOCK(:name, 5)', ['name' => self::BATCH_CONNECT_LOCK]) !== 1) {
-            // Another process is already rebuilding the listener set; let it finish rather
-            // than racing it.
-            return true;
+            // Another process is already rebuilding the listener set and holding the lock
+            // past our wait. Report failure rather than claiming a rebuild we didn't run or
+            // wait for actually completed.
+            return false;
         }
 
         try {
-            // Clean up the existing list before we add to it
-            $this->_disconnectUnavailable();
-            $extensionService = $this->di['mod_service']('extension');
+            $connection->transactional(function () use ($mod_name): void {
+                // Clean up the existing list before we add to it
+                $this->_disconnectUnavailable();
+                $extensionService = $this->di['mod_service']('extension');
 
-            $mods = [];
-            if ($mod_name !== null) {
-                $mods[] = $mod_name;
-            } else {
-                $mods = $extensionService->getCoreAndActiveModules();
-            }
-
-            foreach ($mods as $m) {
-                $installed = $this->getExtensionRepository()->existsActiveByTypeAndName(Extension::TYPE_MOD, $m);
-                if (!$installed && !$extensionService->isCoreModule($m)) {
-                    continue;
+                $mods = [];
+                if ($mod_name !== null) {
+                    $mods[] = $mod_name;
+                } else {
+                    $mods = $extensionService->getCoreAndActiveModules();
                 }
 
-                $mod = $this->di['mod']($m);
-                if ($mod->hasService()) {
-                    $class = $mod->getService();
-                    $reflector = new \ReflectionClass($class);
-                    foreach ($reflector->getMethods() as $method) {
-                        if ($this->canBeConnected($method)) {
-                            $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
+                foreach ($mods as $m) {
+                    $installed = $this->getExtensionRepository()->existsActiveByTypeAndName(Extension::TYPE_MOD, $m);
+                    if (!$installed && !$extensionService->isCoreModule($m)) {
+                        continue;
+                    }
+
+                    $mod = $this->di['mod']($m);
+                    if ($mod->hasService()) {
+                        $class = $mod->getService();
+                        $reflector = new \ReflectionClass($class);
+                        foreach ($reflector->getMethods() as $method) {
+                            if ($this->canBeConnected($method)) {
+                                $this->connect(['event' => $method->getName(), 'mod' => $mod->getName()]);
+                            }
                         }
                     }
                 }
-            }
+            });
 
             return true;
         } finally {

--- a/src/modules/Hook/Service.php
+++ b/src/modules/Hook/Service.php
@@ -63,6 +63,26 @@ class Service implements InjectionAwareInterface
         return [$q, []];
     }
 
+    /**
+     * Whether any module event listener has ever been connected.
+     *
+     * Listeners are normally (re)connected by the cron job's hook_batch_connect task.
+     * Before cron has run for the first time (e.g. right after a fresh install), this
+     * is false and every event fired by the application silently has no listeners.
+     */
+    public function hasConnectedListeners(): bool
+    {
+        $q = "SELECT 1
+            FROM extension_meta
+            WHERE extension = 'mod_hook'
+            AND rel_type = 'mod'
+            AND meta_key = 'listener'
+            LIMIT 1
+        ";
+
+        return (bool) $this->di['em']->getConnection()->fetchOne($q);
+    }
+
     public function toApiArray($row)
     {
         return $row;

--- a/src/modules/Hook/tests/Unit/ServiceTest.php
+++ b/src/modules/Hook/tests/Unit/ServiceTest.php
@@ -155,6 +155,9 @@ test('batch connects', function (): void {
     $expectation1->andReturn(false);
     $connection->shouldReceive('executeStatement')
         ->byDefault();
+    $connection->shouldReceive('transactional')
+        ->atLeast()->once()
+        ->andReturnUsing(fn (Closure $callback) => $callback($connection));
 
     $returnArr = [
         [
@@ -210,13 +213,14 @@ test('batch connects', function (): void {
     expect($result)->toBeTrue();
 });
 
-test('batch connect defers to another process already holding the lock', function (): void {
+test('batch connect reports failure when another process holds the lock', function (): void {
     $service = new Box\Mod\Hook\Service();
 
     $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
     $connection->shouldReceive('fetchOne')
         ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'GET_LOCK')), Mockery::any())
         ->andReturn(0);
+    $connection->shouldNotReceive('transactional');
     $connection->shouldNotReceive('fetchAllAssociative');
     $connection->shouldNotReceive('executeStatement')
         ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'RELEASE_LOCK')), Mockery::any());
@@ -227,5 +231,5 @@ test('batch connect defers to another process already holding the lock', functio
 
     $result = $service->batchConnect('activity');
 
-    expect($result)->toBeTrue();
+    expect($result)->toBeFalse();
 });

--- a/src/modules/Hook/tests/Unit/ServiceTest.php
+++ b/src/modules/Hook/tests/Unit/ServiceTest.php
@@ -145,8 +145,12 @@ test('batch connects', function (): void {
     $data['mods'] = [$mod];
 
     $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $connection->shouldReceive('fetchOne')
+        ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'GET_LOCK')), Mockery::any())
+        ->andReturn(1);
     /** @var Mockery\Expectation $expectation1 */
-    $expectation1 = $connection->shouldReceive('fetchOne');
+    $expectation1 = $connection->shouldReceive('fetchOne')
+        ->with(Mockery::on(fn ($sql) => !str_contains((string) $sql, 'GET_LOCK')), Mockery::any());
     $expectation1->atLeast()->once();
     $expectation1->andReturn(false);
     $connection->shouldReceive('executeStatement')
@@ -203,5 +207,25 @@ test('batch connects', function (): void {
     $di['validator'] = $validatorMock;
     $service->setDi($di);
     $result = $service->batchConnect($mod);
+    expect($result)->toBeTrue();
+});
+
+test('batch connect defers to another process already holding the lock', function (): void {
+    $service = new Box\Mod\Hook\Service();
+
+    $connection = Mockery::mock(Doctrine\DBAL\Connection::class);
+    $connection->shouldReceive('fetchOne')
+        ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'GET_LOCK')), Mockery::any())
+        ->andReturn(0);
+    $connection->shouldNotReceive('fetchAllAssociative');
+    $connection->shouldNotReceive('executeStatement')
+        ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'RELEASE_LOCK')), Mockery::any());
+
+    $di = container();
+    $di['em']->shouldReceive('getConnection')->andReturn($connection);
+    $service->setDi($di);
+
+    $result = $service->batchConnect('activity');
+
     expect($result)->toBeTrue();
 });

--- a/src/modules/Hook/tests/Unit/ServiceTest.php
+++ b/src/modules/Hook/tests/Unit/ServiceTest.php
@@ -155,6 +155,9 @@ test('batch connects', function (): void {
     $expectation1->andReturn(false);
     $connection->shouldReceive('executeStatement')
         ->byDefault();
+    $connection->shouldReceive('executeStatement')
+        ->with(Mockery::on(fn ($sql) => str_contains((string) $sql, 'RELEASE_LOCK')), Mockery::any())
+        ->once();
     $connection->shouldReceive('transactional')
         ->atLeast()->once()
         ->andReturnUsing(fn (Closure $callback) => $callback($connection));

--- a/src/modules/Invoice/templates/admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_transaction.html.twig
@@ -114,7 +114,7 @@
                                     <td class="text-end">{{ 'Note'|trans }}</td>
                                     <td>
                                         <svg class="icon">
-                                            <use href="#headset" />
+                                            <use href="#notes" />
                                         </svg>
                                         <a href="#tab-note" role="button" data-tab-jump>{{ transaction.note }}</a>
                                     </td>

--- a/src/modules/Invoice/templates/admin/mod_invoice_transaction.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_transaction.html.twig
@@ -116,7 +116,7 @@
                                         <svg class="icon">
                                             <use href="#headset" />
                                         </svg>
-                                        <a href="#tab-note" data-bs-toggle="tab" role="button">{{ transaction.note }}</a>
+                                        <a href="#tab-note" role="button" data-tab-jump>{{ transaction.note }}</a>
                                     </td>
                                 </tr>
                                 {% endif %}

--- a/src/modules/Order/templates/admin/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_manage.html.twig
@@ -547,7 +547,15 @@
         <div class="tab-pane fade" id="tab-service" role="tabpanel">
             {% if guest.system_template_exists({ 'file': service_partial }) %}
                 {% set service = admin.order_service({ 'id': order.id }) %}
-                {{ include(service_partial, { 'order': order, 'service': service }) }}
+                {% if service is not null %}
+                    {{ include(service_partial, { 'order': order, 'service': service }) }}
+                {% else %}
+                    <div class="p-3">
+                        <div class="alert alert-info mb-0" role="alert">
+                            {{ 'This order does not have a provisioned service yet.'|trans }}
+                        </div>
+                    </div>
+                {% endif %}
             {% elseif order.form_id and guest.extension_is_on({ 'mod': 'formbuilder' }) %}
                 {{ include('mod_formbuilder_manage.html.twig', order) }}
             {% else %}

--- a/src/modules/Order/templates/admin/mod_order_manage.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_manage.html.twig
@@ -114,7 +114,7 @@
                                         <td class="text-end">{{ 'Order Notes'|trans }}</td>
                                         <td>
                                             <svg class="icon">
-                                                <use href="#headset" />
+                                                <use href="#notes" />
                                             </svg>
                                             <a>{{ order.notes }}</a>
                                         </td>

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -123,9 +123,11 @@ class Service implements InjectionAwareInterface
         // connected by the cron job's hook_batch_connect task. Before cron has run for the
         // first time, no listeners are connected and the event fired below would silently do
         // nothing, so an admin's very first logins would go unrecorded. Connect them now so
-        // that gap does not exist.
+        // that gap does not exist. batchConnect() returns false if another process was still
+        // rebuilding the set when it gave up waiting; retry once rather than firing the event
+        // below against a set we know is incomplete.
         $hookService = $this->di['mod_service']('hook');
-        if (!$hookService->hasConnectedListeners()) {
+        if (!$hookService->hasConnectedListeners() && !$hookService->batchConnect()) {
             $hookService->batchConnect();
         }
 

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -125,10 +125,18 @@ class Service implements InjectionAwareInterface
         // nothing, so an admin's very first logins would go unrecorded. Connect them now so
         // that gap does not exist. batchConnect() returns false if another process was still
         // rebuilding the set when it gave up waiting; retry once rather than firing the event
-        // below against a set we know is incomplete.
+        // below against a set we know is incomplete. If both attempts fail, log it and let the
+        // login proceed anyway - failing the login itself over this housekeeping step would
+        // turn a rare missed audit entry into every admin being locked out while it's stuck.
         $hookService = $this->di['mod_service']('hook');
-        if (!$hookService->hasConnectedListeners() && !$hookService->batchConnect()) {
-            $hookService->batchConnect();
+        if (!$hookService->hasConnectedListeners()) {
+            $connected = $hookService->batchConnect();
+            if (!$connected) {
+                $connected = $hookService->batchConnect();
+            }
+            if (!$connected) {
+                $this->di['logger']->warning('Could not connect event listeners after two attempts; this login (and other events) may not be recorded.');
+            }
         }
 
         $this->di['events_manager']->fire(['event' => 'onAfterAdminLogin', 'params' => ['id' => $model->getId(), 'ip' => $ip]]);

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -119,6 +119,16 @@ class Service implements InjectionAwareInterface
             throw new \FOSSBilling\InformationException('Check your login details', null, 403);
         }
 
+        // Event listeners (e.g. this login being recorded in the login history) are normally
+        // connected by the cron job's hook_batch_connect task. Before cron has run for the
+        // first time, no listeners are connected and the event fired below would silently do
+        // nothing, so an admin's very first logins would go unrecorded. Connect them now so
+        // that gap does not exist.
+        $hookService = $this->di['mod_service']('hook');
+        if (!$hookService->hasConnectedListeners()) {
+            $hookService->batchConnect();
+        }
+
         $this->di['events_manager']->fire(['event' => 'onAfterAdminLogin', 'params' => ['id' => $model->getId(), 'ip' => $ip]]);
 
         $result = [

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -238,6 +238,66 @@ test('login retries connecting event listeners once before firing the login even
     ]);
 });
 
+test('login still succeeds, and logs a warning, when both attempts to connect event listeners fail', function (): void {
+    $email = 'email@domain.com';
+    $password = 'pass';
+    $ip = '127.0.0.1';
+
+    $admin = \Tests\Helpers\admin(['id' => 1, 'email' => $email, 'name' => 'Admin', 'pass' => 'hashedPassword']);
+
+    $emMock = Mockery::mock('\Box_EventManager');
+    $emMock->shouldReceive('fire')->atLeast()->once()
+        ->andReturn(true);
+
+    $adminRepository = Mockery::mock(AdminRepository::class);
+    $adminRepository->shouldReceive('findOneByEmailAndActive')->atLeast()->once()
+        ->with($email)
+        ->andReturn($admin);
+
+    $sessionMock = Mockery::mock(FOSSBilling\Session::class);
+    $sessionMock->shouldReceive('regenerateId')->atLeast()->once();
+    $sessionMock->shouldReceive('set')->atLeast()->once();
+
+    $passwordMock = Mockery::mock(FOSSBilling\PasswordManager::class);
+    $passwordMock->shouldReceive('verify')->atLeast()->once()
+        ->with($password, $admin->getPass())
+        ->andReturn(true);
+    $passwordMock->shouldReceive('needsRehash')->atLeast()->once()
+        ->andReturn(false);
+
+    // Both attempts fail to connect listeners, e.g. another process holding the rebuild lock
+    // for longer than either attempt's timeout. Login must still succeed - it must not become
+    // unavailable because of this housekeeping step.
+    $hookServiceMock = Mockery::mock(Box\Mod\Hook\Service::class);
+    $hookServiceMock->shouldReceive('hasConnectedListeners')->atLeast()->once()->andReturn(false);
+    $hookServiceMock->shouldReceive('batchConnect')->twice()->andReturn(false, false);
+
+    $loggerMock = new Tests\Helpers\TestLogger();
+
+    $di = container();
+    $di['events_manager'] = $emMock;
+    $di['em']->shouldReceive('getRepository')->with(Admin::class)->andReturn($adminRepository);
+    $di['session'] = $sessionMock;
+    $di['logger'] = $loggerMock;
+    $di['password'] = $passwordMock;
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'hook' ? $hookServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $service = new Service();
+    $service->setDi($di);
+
+    $result = $service->login($email, $password, $ip);
+
+    expect($result)->toBe([
+        'id' => 1,
+        'email' => $email,
+        'name' => 'Admin',
+    ])
+        ->and($loggerMock->calls)->toContain([
+            'method' => 'warning',
+            'params' => ['Could not connect event listeners after two attempts; this login (and other events) may not be recorded.'],
+        ]);
+});
+
 test('login throws exception when credentials are invalid', function (): void {
     $email = 'email@domain.com';
     $password = 'pass';

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -186,6 +186,58 @@ test('login returns admin details on successful login', function (): void {
     expect($result)->toBe($expected);
 });
 
+test('login retries connecting event listeners once before firing the login event', function (): void {
+    $email = 'email@domain.com';
+    $password = 'pass';
+    $ip = '127.0.0.1';
+
+    $admin = \Tests\Helpers\admin(['id' => 1, 'email' => $email, 'name' => 'Admin', 'pass' => 'hashedPassword']);
+
+    $emMock = Mockery::mock('\Box_EventManager');
+    $emMock->shouldReceive('fire')->atLeast()->once()
+        ->andReturn(true);
+
+    $adminRepository = Mockery::mock(AdminRepository::class);
+    $adminRepository->shouldReceive('findOneByEmailAndActive')->atLeast()->once()
+        ->with($email)
+        ->andReturn($admin);
+
+    $sessionMock = Mockery::mock(FOSSBilling\Session::class);
+    $sessionMock->shouldReceive('regenerateId')->atLeast()->once();
+    $sessionMock->shouldReceive('set')->atLeast()->once();
+
+    $passwordMock = Mockery::mock(FOSSBilling\PasswordManager::class);
+    $passwordMock->shouldReceive('verify')->atLeast()->once()
+        ->with($password, $admin->getPass())
+        ->andReturn(true);
+    $passwordMock->shouldReceive('needsRehash')->atLeast()->once()
+        ->andReturn(false);
+
+    // First attempt fails, as if another process held the rebuild lock past its timeout.
+    $hookServiceMock = Mockery::mock(Box\Mod\Hook\Service::class);
+    $hookServiceMock->shouldReceive('hasConnectedListeners')->atLeast()->once()->andReturn(false);
+    $hookServiceMock->shouldReceive('batchConnect')->twice()->andReturn(false, true);
+
+    $di = container();
+    $di['events_manager'] = $emMock;
+    $di['em']->shouldReceive('getRepository')->with(Admin::class)->andReturn($adminRepository);
+    $di['session'] = $sessionMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['password'] = $passwordMock;
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'hook' ? $hookServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $service = new Service();
+    $service->setDi($di);
+
+    $result = $service->login($email, $password, $ip);
+
+    expect($result)->toBe([
+        'id' => 1,
+        'email' => $email,
+        'name' => 'Admin',
+    ]);
+});
+
 test('login throws exception when credentials are invalid', function (): void {
     $email = 'email@domain.com';
     $password = 'pass';

--- a/src/modules/System/templates/admin/mod_system_update.html.twig
+++ b/src/modules/System/templates/admin/mod_system_update.html.twig
@@ -66,6 +66,13 @@
                         {% endif %}
                         {% if isPreviewBranch %}
                             <h4 class="mb-2">{{ 'Preview Build Updates'|trans }}</h4>
+                            {% if updateAvailable %}
+                                <p>{{ 'FOSSBilling %version% is available for download.'|trans({'%version%': update_info['version']}) }}</p>
+                            {% else %}
+                                <div class="alert alert-success" role="alert">
+                                    {{ 'You are already running the latest available preview build. You can still reinstall it below if needed.'|trans }}
+                                </div>
+                            {% endif %}
                             <div class="alert alert-warning" role="alert">
                                 {{ 'Preview builds track unreleased development changes and may be unstable. It is not recommended to use them in production environments.'|trans }}
                             </div>

--- a/src/modules/System/templates/admin/mod_system_update.html.twig
+++ b/src/modules/System/templates/admin/mod_system_update.html.twig
@@ -67,7 +67,7 @@
                         {% if isPreviewBranch %}
                             <h4 class="mb-2">{{ 'Preview Build Updates'|trans }}</h4>
                             {% if updateAvailable %}
-                                <p>{{ 'FOSSBilling %version% is available for download.'|trans({'%version%': update_info['version']}) }}</p>
+                                <p>{{ 'FOSSBilling'|trans }} <strong>{{ update_info['version'] }}</strong> {{ 'is available for download.'|trans }}</p>
                             {% else %}
                                 <div class="alert alert-success" role="alert">
                                     {{ 'You are already running the latest available preview build. You can still reinstall it below if needed.'|trans }}

--- a/src/themes/admin_default/assets/js/fossbilling.ts
+++ b/src/themes/admin_default/assets/js/fossbilling.ts
@@ -201,6 +201,26 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
      showTabById(nextTabId);
    });
 
+   //===== Jump-to-tab links outside the tab nav (e.g. a note referencing another tab) =====//
+   // These links point at a tab pane but aren't themselves part of the .nav tab list, so they
+   // must not carry data-bs-toggle="tab" - Bootstrap's Tab plugin assumes its trigger lives
+   // inside the real nav and throws when asked to activate one that doesn't. Reuse the same
+   // showTabById() helper used for hash deep-linking instead.
+   document.addEventListener('click', (event) => {
+     const trigger = event.target.closest('[data-tab-jump]');
+     if (!trigger) {
+       return;
+     }
+
+     const targetSelector = trigger.getAttribute('href');
+     if (!targetSelector || !targetSelector.startsWith('#')) {
+       return;
+     }
+
+     event.preventDefault();
+     showTabById(targetSelector.slice(1));
+   });
+
    //===== Discord community popover (shown once) =====//
    const discordBtn = document.getElementById('discord-community-btn');
    const isDiscordBtnVisible = () => {

--- a/src/themes/admin_default/assets/js/fossbilling.ts
+++ b/src/themes/admin_default/assets/js/fossbilling.ts
@@ -203,6 +203,10 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
 
    //===== Jump-to-tab links outside the tab nav (e.g. a note referencing another tab) =====//
    document.addEventListener('click', (event) => {
+     if (!(event.target instanceof Element)) {
+       return;
+     }
+
      const trigger = event.target.closest('[data-tab-jump]');
      if (!trigger) {
        return;

--- a/src/themes/admin_default/assets/js/fossbilling.ts
+++ b/src/themes/admin_default/assets/js/fossbilling.ts
@@ -202,10 +202,6 @@ globalThis.FOSSBilling = Object.assign(globalThis.FOSSBilling || {}, {
    });
 
    //===== Jump-to-tab links outside the tab nav (e.g. a note referencing another tab) =====//
-   // These links point at a tab pane but aren't themselves part of the .nav tab list, so they
-   // must not carry data-bs-toggle="tab" - Bootstrap's Tab plugin assumes its trigger lives
-   // inside the real nav and throws when asked to activate one that doesn't. Reuse the same
-   // showTabById() helper used for hash deep-linking instead.
    document.addEventListener('click', (event) => {
      const trigger = event.target.closest('[data-tab-jump]');
      if (!trigger) {

--- a/src/themes/admin_default/html/partial_admin_form_card.html.twig
+++ b/src/themes/admin_default/html/partial_admin_form_card.html.twig
@@ -24,7 +24,7 @@
     </div>
 
     {% if form_actions %}
-        <div class="card-footer d-flex justify-content-{{ footer_align|default('end') }}">
+        <div class="card-footer d-flex flex-wrap justify-content-{{ footer_align|default('end') }} gap-2">
             {{ form_actions|raw }}
         </div>
     {% endif %}

--- a/src/themes/admin_default/icon-manifest.json
+++ b/src/themes/admin_default/icon-manifest.json
@@ -42,6 +42,7 @@
     "mail",
     "moon",
     "note",
+    "notes",
     { "name": "package", "dynamic": true },
     "player-pause",
     { "name": "photo", "dynamic": true },


### PR DESCRIPTION
## Summary

A batch of small admin UI fixes found while testing the latest `main` build, plus one deeper fix uncovered along the way.

- **Button spacing** — `card-footer` action buttons (e.g. Go Back / Delete / Update) rendered with no gap between them across ~25 admin pages that share `partial_admin_form_card.html.twig`.
- **Cookie consent info banner** — the `.alert` component is `display:flex`, which turned a stray text node into its own flex column and broke the message layout on `/admin/cookieconsent`.
- **Crash on unprovisioned orders** — `/admin/order/manage/{id}` threw a fatal `Twig\Error\RuntimeError` for any order without a provisioned service yet (e.g. `pending_setup` domain orders), since `admin.order_service()` legitimately returns `null` and the service-type partial wasn't guarded for it.
- **Update page didn't reflect the dashboard's update notice** — the dashboard names the specific preview build available; the Update page always showed the same generic prompt regardless of whether an update was actually available.
- **Staff logins going unrecorded** — event listeners (login history, and every other `on*` hook in the app) are only connected by cron's `hook_batch_connect` task. Before cron has run once, every event silently no-ops, so a fresh install (or a dev/staging box without cron configured) loses its first logins with no record. Staff login now connects listeners on demand if none are connected yet.
- **`Illegal invocation` crash from note links** — the client Notes row and transaction Note row rendered their note as a `data-bs-toggle="tab"` trigger living outside the real `.nav` tab list, which crashes Bootstrap's `Tab` plugin on click.
- **Wrong icon on note fields** — client/transaction/order Notes rows used a headset (support-agent) icon; swapped to the `notes` icon.
- **Popovers/tooltips rendered unstyled** — PurgeCSS strips any class name that never appears literally in scanned `.twig`/`.js` source; `.popover-*`/`.tooltip-*` are injected by Bootstrap at runtime and were never safelisted (every other JS-injected Bootstrap component was). Fixed for both `admin_default` and `huraga`.
- **Update page version now bolded** for readability.