### PR TITLE
Fix WHM reseller accounts always getting an empty ACL list

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -559,7 +559,13 @@
         "nemailr",
         "spamfilter",
         "sysinfo",
-        "unemailml"
+        "unemailml",
+        "listpkgs",
+        "addpkg",
+        "createacct",
+        "setupreseller",
+        "setacls",
+        "acllist"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/src/library/Server/Manager/Whm.php
+++ b/src/library/Server/Manager/Whm.php
@@ -234,7 +234,8 @@ class Server_Manager_Whm extends Server_Manager
     /**
      * Creates a new account on the WHM server.
      * Sends a request to the WHM server to create a new account with the details provided in the Server_Account object.
-     * If the account is a reseller account, it also sets up the reseller and assigns the appropriate ACL list.
+     * If the account is a reseller account, it also sets up the reseller and, if the hosting plan defines an
+     * 'acl' custom value, assigns that ACL list to it.
      *
      * @param Server_Account $account The account to be created. This object should contain all the necessary details for the new account.
      *
@@ -274,7 +275,7 @@ class Server_Manager_Whm extends Server_Manager
         $json = $this->request($action, $varHash);
         $result = ($json->result[0]->status == 1);
 
-        // If the account is a reseller account and was successfully created, set up the reseller and assign the ACL list
+        // If the account is a reseller account and was successfully created, set up the reseller and, if the hosting plan defines a custom 'acl' value, assign that ACL list to it
         if ($result && $account->getReseller()) {
             $params = [
                 'user' => $account->getUsername(),
@@ -282,11 +283,14 @@ class Server_Manager_Whm extends Server_Manager
             ];
             $this->request('setupreseller', $params);
 
-            $params = [
-                'reseller' => $account->getUsername(),
-                'acllist' => $package->getAcllist(),
-            ];
-            $this->request('setacls', $params);
+            $acl = $package->getCustomValue('acl');
+            if (!empty($acl)) {
+                $params = [
+                    'reseller' => $account->getUsername(),
+                    'acllist' => $acl,
+                ];
+                $this->request('setacls', $params);
+            }
         }
 
         // Return the result of the account creation

--- a/tests/Unit/Server/Manager/WhmTest.php
+++ b/tests/Unit/Server/Manager/WhmTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+function createWhmManager(HttpClientInterface $httpClient): Server_Manager_Whm
+{
+    return new class(['host' => 'whm.example.com', 'username' => 'admin', 'password' => 'secret'], $httpClient) extends Server_Manager_Whm {
+        public function __construct(array $options, private readonly HttpClientInterface $httpClient)
+        {
+            parent::__construct($options);
+        }
+
+        public function getHttpClient(): HttpClientInterface
+        {
+            return $this->httpClient;
+        }
+    };
+}
+
+function createWhmAccount(Server_Package $package, bool $reseller): Server_Account
+{
+    return (new Server_Account())
+        ->setUsername('example')
+        ->setDomain('example.com')
+        ->setPassword('secret')
+        ->setClient((new Server_Client())->setEmail('client@example.com'))
+        ->setPackage($package)
+        ->setReseller($reseller);
+}
+
+function actionOf(array $request): string
+{
+    return basename((string) parse_url($request['url'], PHP_URL_PATH));
+}
+
+function createWhmAccountCreationClient(array &$requests): MockHttpClient
+{
+    return new MockHttpClient(function (string $method, string $url, array $options) use (&$requests): MockResponse {
+        $requests[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+        if (str_contains($url, 'listpkgs')) {
+            return new MockResponse(json_encode(['package' => []]));
+        }
+
+        if (str_contains($url, 'createacct')) {
+            return new MockResponse(json_encode(['result' => [['status' => 1]]]));
+        }
+
+        return new MockResponse(json_encode(['status' => 1]));
+    });
+}
+
+test('createAccount sets up the reseller but does not touch the ACL list when the plan has no acl custom value', function (): void {
+    $requests = [];
+    $manager = createWhmManager(createWhmAccountCreationClient($requests));
+    $account = createWhmAccount(new Server_Package(), true);
+
+    expect($manager->createAccount($account))->toBeTrue();
+
+    $actions = array_map(actionOf(...), $requests);
+
+    // Calling "setacls" with an empty acllist would strip the initial privileges "setupreseller"
+    // just granted, so it must be skipped when the plan has no 'acl' custom value.
+    expect($actions)->toBe(['listpkgs', 'addpkg', 'createacct', 'setupreseller'])
+        ->and($actions)->not->toContain('setacls');
+});
+
+test('createAccount assigns the plan\'s acl custom value to the reseller via setacls', function (): void {
+    $requests = [];
+    $manager = createWhmManager(createWhmAccountCreationClient($requests));
+    $package = (new Server_Package())->setCustomValues(['acl' => 'reseller_basic']);
+    $account = createWhmAccount($package, true);
+
+    expect($manager->createAccount($account))->toBeTrue();
+
+    $actions = array_map(actionOf(...), $requests);
+    expect($actions)->toBe(['listpkgs', 'addpkg', 'createacct', 'setupreseller', 'setacls']);
+
+    $setaclsRequest = $requests[array_search('setacls', $actions, true)];
+    parse_str((string) $setaclsRequest['options']['body'], $fields);
+
+    expect($fields)->toMatchArray([
+        'reseller' => 'example',
+        'acllist' => 'reseller_basic',
+    ]);
+});
+
+test('createAccount never calls setupreseller or setacls for a non-reseller account', function (): void {
+    $requests = [];
+    $manager = createWhmManager(createWhmAccountCreationClient($requests));
+    $package = (new Server_Package())->setCustomValues(['acl' => 'reseller_basic']);
+    $account = createWhmAccount($package, false);
+
+    expect($manager->createAccount($account))->toBeTrue();
+
+    $actions = array_map(actionOf(...), $requests);
+    expect($actions)->toBe(['listpkgs', 'addpkg', 'createacct']);
+});


### PR DESCRIPTION
## Summary

- Replaced the nonexistent `getAcllist()` call with the existing custom-value mechanism (`$package->getCustomValue('acl')`) — the same pattern already used for `cgi`, `cpmod`, `maxlst`, and `hasshell` in this file. Admins can now set an `acl` value via the hosting plan's existing "Special Custom Parameters" editor and have it actually reach WHM.
- When no `acl` value is configured, `setacls` is skipped entirely instead of being called with an empty list, so the reseller keeps WHM's default privileges rather than having them stripped.

Fixes #4173.