### PR TITLE
Add configurable auto-removal of stale unpaid orders

### DIFF
--- a/src/modules/Cron/Service.php
+++ b/src/modules/Cron/Service.php
@@ -85,6 +85,7 @@ class Service
                 'order_batch_send_suspension_warnings',
                 'order_batch_suspend_expired',
                 'order_batch_cancel_suspended',
+                'order_batch_cancel_unpaid',
                 'support_batch_ticket_auto_close',
                 'client_batch_expire_password_reminders',
                 'cart_batch_expire',

--- a/src/modules/Cron/tests/Unit/ServiceTest.php
+++ b/src/modules/Cron/tests/Unit/ServiceTest.php
@@ -139,6 +139,7 @@ test('runCrons isolates failures in core batch tasks', function (string $failedT
     'order suspension warning' => 'order_batch_send_suspension_warnings',
     'order suspension' => 'order_batch_suspend_expired',
     'order cancellation' => 'order_batch_cancel_suspended',
+    'order cancellation (unpaid)' => 'order_batch_cancel_unpaid',
     'support ticket auto-close' => 'support_batch_ticket_auto_close',
     'password reminder expiry' => 'client_batch_expire_password_reminders',
     'cart expiry' => 'cart_batch_expire',

--- a/src/modules/Order/Api/Admin.php
+++ b/src/modules/Order/Api/Admin.php
@@ -339,6 +339,19 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
+     * Remove pending-setup orders whose linked invoice has been unpaid past its due date for too long.
+     * Configure how many days an unpaid order should be kept before it is removed.
+     *
+     * @return bool
+     */
+    public function batch_cancel_unpaid($data)
+    {
+        $this->checkPermissions('order', 'manage');
+
+        return $this->getService()->batchCancelUnpaid();
+    }
+
+    /**
      * Update order config.
      *
      * @return bool

--- a/src/modules/Order/Repository/OrderRepository.php
+++ b/src/modules/Order/Repository/OrderRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Box\Mod\Order\Repository;
 
+use Box\Mod\Invoice\Entity\Invoice;
+use Box\Mod\Invoice\Entity\InvoiceItem;
 use Box\Mod\Order\Entity\Order;
 use Doctrine\ORM\EntityRepository;
 
@@ -150,5 +152,60 @@ class OrderRepository extends EntityRepository
     public function findAddons(int $masterOrderId): array
     {
         return $this->findBy(['groupId' => (string) $masterOrderId]);
+    }
+
+    /**
+     * Pending-setup orders that were never paid and have gone stale, either
+     * because their linked unpaid invoice has been overdue for more than the
+     * given number of days, or - if that invoice is no longer a live unpaid
+     * one (already removed by the invoice module's own "Remove Unpaid
+     * Invoices After" cleanup, canceled, refunded, or simply never linked) -
+     * because the order itself has sat untouched that long. Orders that any
+     * paid invoice ever referenced are excluded, since a paid order can
+     * legitimately stay pending_setup for a long time awaiting manual setup.
+     * Used by the cron cleanup that removes stale, never-paid orders.
+     *
+     * @return Order[]
+     */
+    public function getStaleUnpaid(int $days): array
+    {
+        $ids = $this->getEntityManager()->getConnection()->fetchFirstColumn(
+            <<<'SQL'
+                SELECT o.id
+                FROM client_order o
+                WHERE o.status = :status
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM invoice_item ii
+                      INNER JOIN invoice pi ON pi.id = ii.invoice_id
+                      WHERE ii.rel_id = o.id AND ii.type = :item_type AND pi.status = :paid_status
+                  )
+                  AND (
+                      EXISTS (
+                          SELECT 1 FROM invoice i
+                          WHERE i.id = o.unpaid_invoice_id
+                            AND i.status = :unpaid_status
+                            AND DATEDIFF(NOW(), i.due_at) > :days
+                      )
+                      OR (
+                          NOT EXISTS (
+                              SELECT 1 FROM invoice i
+                              WHERE i.id = o.unpaid_invoice_id AND i.status = :unpaid_status
+                          )
+                          AND DATEDIFF(NOW(), o.created_at) > :days
+                      )
+                  )
+                ORDER BY o.id
+                SQL,
+            [
+                'status' => Order::STATUS_PENDING_SETUP,
+                'item_type' => InvoiceItem::TYPE_ORDER,
+                'paid_status' => Invoice::STATUS_PAID,
+                'unpaid_status' => Invoice::STATUS_UNPAID,
+                'days' => $days,
+            ]
+        );
+
+        return $ids === [] ? [] : $this->findBy(['id' => array_map(intval(...), $ids)]);
     }
 }

--- a/src/modules/Order/Repository/OrderRepository.php
+++ b/src/modules/Order/Repository/OrderRepository.php
@@ -157,13 +157,14 @@ class OrderRepository extends EntityRepository
     /**
      * Pending-setup orders that were never paid and have gone stale, either
      * because their linked unpaid invoice has been overdue for more than the
-     * given number of days, or - if that invoice is no longer a live unpaid
-     * one (already removed by the invoice module's own "Remove Unpaid
-     * Invoices After" cleanup, canceled, refunded, or simply never linked) -
-     * because the order itself has sat untouched that long. Orders that any
-     * paid invoice ever referenced are excluded, since a paid order can
-     * legitimately stay pending_setup for a long time awaiting manual setup.
-     * Used by the cron cleanup that removes stale, never-paid orders.
+     * given number of days (falling back to the order's own creation date if
+     * that invoice has no due date set), or - if that invoice is no longer a
+     * live unpaid one (already removed by the invoice module's own "Remove
+     * Unpaid Invoices After" cleanup, canceled, refunded, or simply never
+     * linked) - because the order itself has sat untouched that long. Orders
+     * that any paid invoice ever referenced are excluded, since a paid order
+     * can legitimately stay pending_setup for a long time awaiting manual
+     * setup. Used by the cron cleanup that removes stale, never-paid orders.
      *
      * @return Order[]
      */
@@ -185,7 +186,7 @@ class OrderRepository extends EntityRepository
                           SELECT 1 FROM invoice i
                           WHERE i.id = o.unpaid_invoice_id
                             AND i.status = :unpaid_status
-                            AND DATEDIFF(NOW(), i.due_at) > :days
+                            AND DATEDIFF(NOW(), COALESCE(i.due_at, o.created_at)) > :days
                       )
                       OR (
                           NOT EXISTS (

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1726,11 +1726,7 @@ class Service implements InjectionAwareInterface
         }
 
         $reason = $config['batch_cancel_suspended_reason'] ?? null;
-        $days = isset($config['batch_cancel_suspended_after_days']) ? (int) $config['batch_cancel_suspended_after_days'] : 7;
-
-        if ($days < 0) {
-            $days = 7;
-        }
+        $days = $this->resolveBatchAfterDays($config['batch_cancel_suspended_after_days'] ?? null);
 
         $sql = "
             SELECT id, suspended_at, DATEDIFF(NOW(), suspended_at) as days_passed_since_suspension
@@ -1759,6 +1755,101 @@ class Service implements InjectionAwareInterface
         $this->di['logger']->info('Executed action to cancel suspended orders');
 
         return true;
+    }
+
+    public function batchCancelUnpaid(): bool
+    {
+        $this->di['events_manager']->fire(['event' => 'onBeforeAdminBatchCancelUnpaidOrders']);
+
+        $mod = $this->di['mod']('order');
+        $config = $mod->getConfig();
+        if (!isset($config['batch_cancel_unpaid']) || !$config['batch_cancel_unpaid']) {
+            return false;
+        }
+
+        $days = $this->resolveBatchAfterDays($config['batch_cancel_unpaid_after_days'] ?? null);
+
+        $staleOrders = $this->getOrderRepository()->getStaleUnpaid($days);
+
+        $invoiceService = $this->di['mod_service']('Invoice');
+
+        // A single invoice can cover several orders from one cart checkout
+        // (Cart\Service sets the same unpaid_invoice_id on all of them), so
+        // they're batch-loaded once up front rather than once per order.
+        $invoiceIds = array_values(array_unique(array_filter(
+            array_map(static fn (Order $order): ?int => $order->getUnpaidInvoiceId(), $staleOrders),
+            static fn (?int $id): bool => $id !== null
+        )));
+        $invoicesById = [];
+        foreach ($invoiceIds === [] ? [] : $invoiceService->getInvoiceRepository()->findBy(['id' => $invoiceIds]) as $invoice) {
+            $invoicesById[$invoice->getId()] = $invoice;
+        }
+
+        // Whether each invoice's group may proceed to order deletion - set only
+        // after deleteInvoiceByAdmin() succeeds, so a failed deletion leaves the
+        // invoice unresolved for a sibling order to retry, instead of wrongly
+        // treating the group as already handled.
+        $invoiceHandled = [];
+
+        // Pending-setup orders were never provisioned, so cancelFromOrder() (which
+        // tears down an active service) explicitly rejects them. deleteFromOrder()
+        // is the same path an admin uses to manually remove one. The linked unpaid
+        // invoice is removed first via deleteInvoiceByAdmin() so it doesn't linger
+        // empty and still eligible for reminder emails after the order it belongs
+        // to is gone.
+        foreach ($staleOrders as $order) {
+            try {
+                $invoiceId = $order->getUnpaidInvoiceId();
+                if ($invoiceId !== null) {
+                    if (!array_key_exists($invoiceId, $invoiceHandled)) {
+                        $invoice = $invoicesById[$invoiceId] ?? null;
+                        $stillUnpaid = $invoice instanceof Invoice && $invoice->getStatus() === Invoice::STATUS_UNPAID;
+                        if ($stillUnpaid) {
+                            $invoiceService->deleteInvoiceByAdmin($invoice);
+                        }
+                        $invoiceHandled[$invoiceId] = $stillUnpaid;
+                    }
+
+                    if (!$invoiceHandled[$invoiceId]) {
+                        // The invoice was paid (or its removal just failed and will be
+                        // retried) since getStaleUnpaid() ran - leave this order alone
+                        // instead of deleting it out from under that outcome.
+                        continue;
+                    }
+                }
+
+                // Re-check the order's current status right before deleting it:
+                // deleteFromOrder() has no status guard of its own, and this order
+                // may have been activated or otherwise moved on while earlier orders
+                // in this same run were being processed.
+                $this->di['em']->refresh($order);
+                if ($order->getStatus() !== Order::STATUS_PENDING_SETUP) {
+                    continue;
+                }
+
+                $this->deleteFromOrder($order);
+            } catch (\Exception $e) {
+                $this->di['logger']->info($e->getMessage());
+            }
+        }
+
+        $this->di['events_manager']->fire(['event' => 'onAfterAdminBatchCancelUnpaidOrders']);
+
+        $this->di['logger']->info('Executed action to remove stale unpaid orders');
+
+        return true;
+    }
+
+    /**
+     * Parses a "cancel/remove after N days" batch-job setting. A blank form field is
+     * submitted as '', which isset() treats as present - so this is not just `(int) $value`,
+     * which would silently turn a blank field into 0 instead of the intended default.
+     */
+    private function resolveBatchAfterDays(mixed $configValue, int $default = 7): int
+    {
+        $days = ($configValue === null || $configValue === '') ? $default : (int) $configValue;
+
+        return $days < 0 ? $default : $days;
     }
 
     public function updateOrderConfig(Order $order, array $config): bool

--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -1786,9 +1786,9 @@ class Service implements InjectionAwareInterface
         }
 
         // Whether each invoice's group may proceed to order deletion - set only
-        // after deleteInvoiceByAdmin() succeeds, so a failed deletion leaves the
-        // invoice unresolved for a sibling order to retry, instead of wrongly
-        // treating the group as already handled.
+        // once the invoice is confirmed gone or removed, so a failed removal
+        // leaves it unresolved for a sibling order to retry rather than
+        // wrongly treating the group as already handled.
         $invoiceHandled = [];
 
         // Pending-setup orders were never provisioned, so cancelFromOrder() (which
@@ -1799,32 +1799,39 @@ class Service implements InjectionAwareInterface
         // to is gone.
         foreach ($staleOrders as $order) {
             try {
+                // Re-check the order's current status before touching anything for
+                // it: deleteFromOrder() has no status guard of its own, and this
+                // order may have been activated or otherwise moved on while earlier
+                // orders in this same run were being processed.
+                $this->di['em']->refresh($order);
+                if ($order->getStatus() !== Order::STATUS_PENDING_SETUP) {
+                    continue;
+                }
+
                 $invoiceId = $order->getUnpaidInvoiceId();
                 if ($invoiceId !== null) {
                     if (!array_key_exists($invoiceId, $invoiceHandled)) {
                         $invoice = $invoicesById[$invoiceId] ?? null;
-                        $stillUnpaid = $invoice instanceof Invoice && $invoice->getStatus() === Invoice::STATUS_UNPAID;
-                        if ($stillUnpaid) {
-                            $invoiceService->deleteInvoiceByAdmin($invoice);
+                        $status = $invoice instanceof Invoice ? $invoice->getStatus() : null;
+
+                        if ($status === Invoice::STATUS_PAID) {
+                            // Paid since getStaleUnpaid() ran - leave every order tied
+                            // to it alone instead of deleting one out from under that.
+                            $invoiceHandled[$invoiceId] = false;
+                        } else {
+                            if ($status === Invoice::STATUS_UNPAID) {
+                                $invoiceService->deleteInvoiceByAdmin($invoice);
+                            }
+                            // Already gone, or canceled/refunded/some other non-live
+                            // status - either way it's no longer a live unpaid invoice,
+                            // so the orders that reference it may proceed.
+                            $invoiceHandled[$invoiceId] = true;
                         }
-                        $invoiceHandled[$invoiceId] = $stillUnpaid;
                     }
 
                     if (!$invoiceHandled[$invoiceId]) {
-                        // The invoice was paid (or its removal just failed and will be
-                        // retried) since getStaleUnpaid() ran - leave this order alone
-                        // instead of deleting it out from under that outcome.
                         continue;
                     }
-                }
-
-                // Re-check the order's current status right before deleting it:
-                // deleteFromOrder() has no status guard of its own, and this order
-                // may have been activated or otherwise moved on while earlier orders
-                // in this same run were being processed.
-                $this->di['em']->refresh($order);
-                if ($order->getStatus() !== Order::STATUS_PENDING_SETUP) {
-                    continue;
                 }
 
                 $this->deleteFromOrder($order);

--- a/src/modules/Order/templates/admin/mod_order_settings.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_settings.html.twig
@@ -105,11 +105,12 @@
                         </select>
                     </div>
                     <div class="col-lg-6">
-                        <label class="form-label" for="batch_cancel_unpaid_after_days">{{ 'Remove After Invoice Due Date'|trans }}</label>
+                        <label class="form-label" for="batch_cancel_unpaid_after_days">{{ 'Remove After'|trans }}</label>
                         <div class="input-group">
                             <input class="form-control" id="batch_cancel_unpaid_after_days" type="number" min="0" name="batch_cancel_unpaid_after_days" value="{{ params.batch_cancel_unpaid_after_days|default('') }}" placeholder="7">
                             <span class="input-group-text">{{ 'days'|trans }}</span>
                         </div>
+                        <small class="form-hint">{{ 'Counted from the invoice due date. If no unpaid invoice remains, counted from the order creation date instead. Defaults to 7 days when left blank.'|trans }}</small>
                     </div>
                 </div>
             </div>

--- a/src/modules/Order/templates/admin/mod_order_settings.html.twig
+++ b/src/modules/Order/templates/admin/mod_order_settings.html.twig
@@ -32,7 +32,7 @@
         <form method="post" action="{{ 'extension/config_save'|api_url }}" {{ fb_api_form({message: 'Settings Updated'|trans}) }}>
             <div class="card-body">
                 <div class="alert alert-info" role="alert">
-                    <strong class="me-1">{{ 'Information:'|trans }}</strong>{{ 'These settings affect renewal timing, how addon orders appear in lists, and how suspended orders are automatically cleaned up.'|trans }}
+                    <strong class="me-1">{{ 'Information:'|trans }}</strong>{{ 'These settings affect renewal timing, how addon orders appear in lists, and how suspended or unpaid orders are automatically cleaned up.'|trans }}
                 </div>
 
                 <h4 class="card-title mb-2">{{ 'Renewal Logic'|trans }}</h4>
@@ -90,6 +90,26 @@
                     <div class="col-12">
                         <label class="form-label" for="suspend_reason_list">{{ 'Suspension Reasons'|trans }}</label>
                         <textarea class="form-control" id="suspend_reason_list" name="suspend_reason_list" rows="3">{{ params.suspend_reason_list|default('') }}</textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body border-top">
+                <h4 class="card-title mb-2">{{ 'Unpaid Orders'|trans }}</h4>
+                <p class="text-secondary mb-3">{{ 'Define when orders that were never paid, and never set up, should be automatically removed.'|trans }}</p>
+                <div class="row g-3">
+                    <div class="col-lg-6">
+                        <label class="form-label" for="batch_cancel_unpaid">{{ 'Auto Removal Policy'|trans }}</label>
+                        <select class="form-select" id="batch_cancel_unpaid" name="batch_cancel_unpaid">
+                            <option value="1" {{ params.batch_cancel_unpaid|default('0') ? 'selected' : '' }}>{{ 'Remove Unpaid Orders'|trans }}</option>
+                            <option value="0" {{ params.batch_cancel_unpaid|default('0') ? '' : 'selected' }}>{{ 'Do Not Remove Unpaid Orders'|trans }}</option>
+                        </select>
+                    </div>
+                    <div class="col-lg-6">
+                        <label class="form-label" for="batch_cancel_unpaid_after_days">{{ 'Remove After Invoice Due Date'|trans }}</label>
+                        <div class="input-group">
+                            <input class="form-control" id="batch_cancel_unpaid_after_days" type="number" min="0" name="batch_cancel_unpaid_after_days" value="{{ params.batch_cancel_unpaid_after_days|default('') }}" placeholder="7">
+                            <span class="input-group-text">{{ 'days'|trans }}</span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/modules/Order/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Order/tests/Unit/Api/AdminTest.php
@@ -539,6 +539,20 @@ test('batch cancels suspended orders', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('batch cancels unpaid orders', function (): void {
+    $api = apiEndpoint(new Admin());
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('batchCancelUnpaid')->atLeast()->once()->andReturn(true);
+
+    $api->setService($serviceMock);
+
+    $data = [];
+    $result = $api->batch_cancel_unpaid($data);
+
+    expect($result)->toBeTrue();
+});
+
 test('updates order config', function (): void {
     $order = createEntity(Box\Mod\Order\Entity\Order::class);
 

--- a/src/modules/Order/tests/Unit/Repository/OrderRepositoryTest.php
+++ b/src/modules/Order/tests/Unit/Repository/OrderRepositoryTest.php
@@ -10,6 +10,8 @@
 
 declare(strict_types=1);
 
+use Box\Mod\Invoice\Entity\Invoice;
+use Box\Mod\Invoice\Entity\InvoiceItem;
 use Box\Mod\Order\Entity\Order;
 use Box\Mod\Order\Repository\OrderRepository;
 use Doctrine\DBAL\Connection;
@@ -68,4 +70,42 @@ test('suspension warnings use positive grace periods in the final 24 hour window
     expect($repository->getDueSuspensionWarnings())->toBe([
         ['id' => 8, 'suspension_at' => '2026-08-01 12:00:00'],
     ]);
+});
+
+test('stale unpaid orders are matched by pending-setup status, unpaid invoice overdue days, or an orphaned order past its own age', function (): void {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('fetchFirstColumn')
+        ->once()
+        ->withArgs(function (string $sql, array $parameters): bool {
+            $sql = normalizeOrderRepositorySql($sql);
+            $subqueryCount = substr_count($sql, 'FROM invoice i');
+
+            return $parameters === [
+                'status' => Order::STATUS_PENDING_SETUP,
+                'item_type' => InvoiceItem::TYPE_ORDER,
+                'paid_status' => Invoice::STATUS_PAID,
+                'unpaid_status' => Invoice::STATUS_UNPAID,
+                'days' => 5,
+            ]
+                // Orders any paid invoice ever covered are never touched.
+                && str_contains($sql, 'NOT EXISTS')
+                && str_contains($sql, 'ii.rel_id = o.id AND ii.type = :item_type AND pi.status = :paid_status')
+                // Still linked to a live, overdue unpaid invoice.
+                && str_contains($sql, 'i.id = o.unpaid_invoice_id')
+                && str_contains($sql, 'i.status = :unpaid_status')
+                && str_contains($sql, 'DATEDIFF(NOW(), i.due_at) > :days')
+                // Or it no longer has one (removed, canceled, refunded, or never linked),
+                // judged instead by the order's own age. Checked in a second subquery
+                // against unpaid_invoice_id, distinct from the overdue-invoice one above.
+                && $subqueryCount === 2
+                && str_contains($sql, 'DATEDIFF(NOW(), o.created_at) > :days');
+        })
+        ->andReturn([]);
+
+    $entityManager = Mockery::mock(EntityManagerInterface::class);
+    $entityManager->shouldReceive('getConnection')->once()->andReturn($connection);
+
+    $repository = new OrderRepository($entityManager, new ClassMetadata(Order::class));
+
+    expect($repository->getStaleUnpaid(5))->toBe([]);
 });

--- a/src/modules/Order/tests/Unit/Repository/OrderRepositoryTest.php
+++ b/src/modules/Order/tests/Unit/Repository/OrderRepositoryTest.php
@@ -90,10 +90,11 @@ test('stale unpaid orders are matched by pending-setup status, unpaid invoice ov
                 // Orders any paid invoice ever covered are never touched.
                 && str_contains($sql, 'NOT EXISTS')
                 && str_contains($sql, 'ii.rel_id = o.id AND ii.type = :item_type AND pi.status = :paid_status')
-                // Still linked to a live, overdue unpaid invoice.
+                // Still linked to a live, overdue unpaid invoice - falling back to the
+                // order's own creation date if that invoice has no due date set.
                 && str_contains($sql, 'i.id = o.unpaid_invoice_id')
                 && str_contains($sql, 'i.status = :unpaid_status')
-                && str_contains($sql, 'DATEDIFF(NOW(), i.due_at) > :days')
+                && str_contains($sql, 'DATEDIFF(NOW(), COALESCE(i.due_at, o.created_at)) > :days')
                 // Or it no longer has one (removed, canceled, refunded, or never linked),
                 // judged instead by the order's own age. Checked in a second subquery
                 // against unpaid_invoice_id, distinct from the overdue-invoice one above.

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -3956,7 +3956,7 @@ test('batchCancelUnpaid does not delete a sibling order when removing the shared
 
     $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
     $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
-    $emMock->shouldReceive('refresh')->once()->with($orderB);
+    $emMock->shouldReceive('refresh')->twice();
 
     $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
     $invoiceRepositoryMock->shouldReceive('findBy')
@@ -4003,7 +4003,7 @@ test('batchCancelUnpaid does not delete a sibling order when removing the shared
 test('batchCancelUnpaid leaves the order alone when its invoice was paid since selection', function (): void {
     $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
 
-    $order = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55]);
+    $order = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
     $invoiceModel = orderServiceCreateInvoiceModel(55);
     $invoiceModel->setStatus(Invoice::STATUS_PAID);
 
@@ -4014,6 +4014,7 @@ test('batchCancelUnpaid leaves the order alone when its invoice was paid since s
 
     $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
     $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->once();
 
     $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
     $invoiceRepositoryMock->shouldReceive('findBy')->once()->with(['id' => [55]])->andReturn([$invoiceModel]);
@@ -4035,6 +4036,51 @@ test('batchCancelUnpaid leaves the order alone when its invoice was paid since s
     $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
 
     $serviceMock->shouldNotReceive('deleteFromOrder');
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid removes the order without touching the invoice when it was canceled rather than paid', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    // getStaleUnpaid() already includes this order because its invoice is no
+    // longer a live unpaid one - it must actually be removed, not skipped
+    // forever the way a still-unpaid-but-just-paid invoice would be.
+    $order = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $invoiceModel = orderServiceCreateInvoiceModel(55);
+    $invoiceModel->setStatus(Invoice::STATUS_CANCELED);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$order]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->once();
+
+    $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
+    $invoiceRepositoryMock->shouldReceive('findBy')->once()->with(['id' => [55]])->andReturn([$invoiceModel]);
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('getInvoiceRepository')->once()->andReturn($invoiceRepositoryMock);
+    $invoiceServiceMock->shouldNotReceive('deleteInvoiceByAdmin');
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($order);
 
     $serviceMock->setDi($di);
 

--- a/src/modules/Order/tests/Unit/ServiceTest.php
+++ b/src/modules/Order/tests/Unit/ServiceTest.php
@@ -3760,6 +3760,363 @@ test('getExpiredOrders delegates grace-aware selection to the repository', funct
     expect($service->getExpiredOrders())->toBe([]);
 });
 
+test('batchCancelUnpaid returns false and does not query orders when auto removal is disabled', function (): void {
+    $service = new Service();
+
+    $di = container();
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return [];
+        }
+    });
+
+    $service->setDi($di);
+
+    expect($service->batchCancelUnpaid())->toBeFalse();
+});
+
+test('batchCancelUnpaid removes each stale unpaid order and fires events', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $orderA = createEntity(Order::class, ['id' => 1, 'status' => Order::STATUS_PENDING_SETUP]);
+    $orderB = createEntity(Order::class, ['id' => 2, 'status' => Order::STATUS_PENDING_SETUP]);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->with(10)
+        ->andReturn([$orderA, $orderB]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->twice();
+
+    $eventsManager = Mockery::mock('\Box_EventManager');
+    $eventsManager->shouldReceive('fire')->once()->with(['event' => 'onBeforeAdminBatchCancelUnpaidOrders']);
+    $eventsManager->shouldReceive('fire')->once()->with(['event' => 'onAfterAdminBatchCancelUnpaidOrders']);
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = $eventsManager;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => '1', 'batch_cancel_unpaid_after_days' => 10];
+        }
+    });
+
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderA);
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderB);
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid falls back to the 7 day default when the configured value is blank', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->with(7)
+        ->andReturn([]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            // An admin who enables the setting but leaves the days field
+            // untouched submits it as an empty string, not an absent key.
+            return ['batch_cancel_unpaid' => '1', 'batch_cancel_unpaid_after_days' => ''];
+        }
+    });
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid removes the linked unpaid invoice before deleting the order', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $order = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $invoiceModel = orderServiceCreateInvoiceModel(55);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$order]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->once();
+
+    $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
+    $invoiceRepositoryMock->shouldReceive('findBy')
+        ->once()
+        ->with(['id' => [55]])
+        ->andReturn([$invoiceModel]);
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('getInvoiceRepository')
+        ->once()
+        ->andReturn($invoiceRepositoryMock);
+    $invoiceServiceMock->shouldReceive('deleteInvoiceByAdmin')
+        ->once()
+        ->with($invoiceModel)
+        ->andReturn(true);
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($order);
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid resolves a shared invoice once and still removes every sibling order', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    // Two orders from the same cart checkout, both referencing the same invoice.
+    $orderA = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $orderB = createEntity(Order::class, ['id' => 2, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $invoiceModel = orderServiceCreateInvoiceModel(55);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$orderA, $orderB]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->twice();
+
+    $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
+    $invoiceRepositoryMock->shouldReceive('findBy')
+        ->once() // resolved once, not once per sibling order
+        ->with(['id' => [55]])
+        ->andReturn([$invoiceModel]);
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('getInvoiceRepository')->once()->andReturn($invoiceRepositoryMock);
+    $invoiceServiceMock->shouldReceive('deleteInvoiceByAdmin')->once()->with($invoiceModel)->andReturn(true);
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderA);
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderB);
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid does not delete a sibling order when removing the shared invoice fails', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    // Two orders from the same cart checkout, both referencing the same invoice.
+    $orderA = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $orderB = createEntity(Order::class, ['id' => 2, 'unpaid_invoice_id' => 55, 'status' => Order::STATUS_PENDING_SETUP]);
+    $invoiceModel = orderServiceCreateInvoiceModel(55);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$orderA, $orderB]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->once()->with($orderB);
+
+    $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
+    $invoiceRepositoryMock->shouldReceive('findBy')
+        ->once()
+        ->with(['id' => [55]])
+        ->andReturn([$invoiceModel]);
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('getInvoiceRepository')->once()->andReturn($invoiceRepositoryMock);
+    // The first attempt (while processing orderA) fails; the retry while
+    // processing orderB is the second, successful attempt.
+    $invoiceServiceMock->shouldReceive('deleteInvoiceByAdmin')
+        ->once()
+        ->with($invoiceModel)
+        ->andThrow(new FOSSBilling\Exception('db went away'));
+    $invoiceServiceMock->shouldReceive('deleteInvoiceByAdmin')
+        ->once()
+        ->with($invoiceModel)
+        ->andReturn(true);
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    // orderA is left alone this round since the invoice removal that would have
+    // covered it failed; orderB retries the same invoice and, once it succeeds,
+    // is removed.
+    $serviceMock->shouldNotReceive('deleteFromOrder')->with($orderA);
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderB);
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid leaves the order alone when its invoice was paid since selection', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $order = createEntity(Order::class, ['id' => 1, 'unpaid_invoice_id' => 55]);
+    $invoiceModel = orderServiceCreateInvoiceModel(55);
+    $invoiceModel->setStatus(Invoice::STATUS_PAID);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$order]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+
+    $invoiceRepositoryMock = Mockery::mock(Box\Mod\Invoice\Repository\InvoiceRepository::class);
+    $invoiceRepositoryMock->shouldReceive('findBy')->once()->with(['id' => [55]])->andReturn([$invoiceModel]);
+
+    $invoiceServiceMock = Mockery::mock(Box\Mod\Invoice\Service::class);
+    $invoiceServiceMock->shouldReceive('getInvoiceRepository')->once()->andReturn($invoiceRepositoryMock);
+    $invoiceServiceMock->shouldNotReceive('deleteInvoiceByAdmin');
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+    $di['mod_service'] = $di->protect(fn (string $name = ''): object => strtolower($name) === 'invoice' ? $invoiceServiceMock : Mockery::mock()->shouldIgnoreMissing());
+
+    $serviceMock->shouldNotReceive('deleteFromOrder');
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid logs and continues when removing one stale order fails', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $orderA = createEntity(Order::class, ['id' => 1, 'status' => Order::STATUS_PENDING_SETUP]);
+    $orderB = createEntity(Order::class, ['id' => 2, 'status' => Order::STATUS_PENDING_SETUP]);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$orderA, $orderB]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    $emMock->shouldReceive('refresh')->twice();
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+
+    $serviceMock->shouldReceive('deleteFromOrder')
+        ->once()
+        ->with($orderA)
+        ->andThrow(new FOSSBilling\Exception('boom'));
+    $serviceMock->shouldReceive('deleteFromOrder')->once()->with($orderB);
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
+test('batchCancelUnpaid skips an order that changed status while the batch was running', function (): void {
+    $serviceMock = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+    $order = createEntity(Order::class, ['id' => 1, 'status' => Order::STATUS_PENDING_SETUP]);
+
+    $orderRepository = Mockery::mock(OrderRepository::class)->shouldIgnoreMissing();
+    $orderRepository->shouldReceive('getStaleUnpaid')
+        ->once()
+        ->andReturn([$order]);
+
+    $emMock = Mockery::mock(Doctrine\ORM\EntityManagerInterface::class);
+    $emMock->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepository);
+    // The refresh reveals the order was activated by something else (e.g. a
+    // concurrent payment webhook) since getStaleUnpaid() selected it.
+    $emMock->shouldReceive('refresh')
+        ->once()
+        ->with($order)
+        ->andReturnUsing(function (Order $order): void {
+            $order->setStatus(Order::STATUS_ACTIVE);
+        });
+
+    $di = container();
+    $di['em'] = $emMock;
+    $di['events_manager'] = Mockery::mock('\Box_EventManager')->shouldIgnoreMissing();
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['mod'] = $di->protect(fn (string $name): object => new class {
+        public function getConfig(): array
+        {
+            return ['batch_cancel_unpaid' => true, 'batch_cancel_unpaid_after_days' => 7];
+        }
+    });
+
+    $serviceMock->shouldNotReceive('deleteFromOrder');
+
+    $serviceMock->setDi($di);
+
+    expect($serviceMock->batchCancelUnpaid())->toBeTrue();
+});
+
 test('batchSendSuspensionWarnings claims and queues each warning once', function (): void {
     $order = createEntity(Order::class, ['id' => 8, 'client_id' => 12]);
     $repository = Mockery::mock(OrderRepository::class);


### PR DESCRIPTION
## What
Follow-up to #4178 / #4180: implements the secondary ask from that issue — a configurable "Cancel unpaid orders after N days" policy so stale `pending_setup` orders that were never paid can be removed automatically, instead of sitting around indefinitely (including ones whose unpaid invoice was already cleaned up separately by the invoice module's own "Remove Unpaid Invoices After" setting).

## How it works
- **`OrderRepository::getStaleUnpaid(int $days)`** selects `pending_setup` orders that are either:
  - still linked to a live, overdue unpaid invoice, **or**
  - no longer linked to a live unpaid invoice at all (already removed, canceled, refunded, or never linked) **and** have themselves sat untouched that long.

  Orders that any **paid** invoice ever covered are always excluded — a paid order can legitimately stay `pending_setup` for a long time awaiting manual setup, and this must never be touched.
- **`Order\Service::batchCancelUnpaid()`** removes each match via `deleteFromOrder()` — `cancelFromOrder()` explicitly rejects `pending_setup` orders since they were never provisioned, so there's nothing to "cancel"; `deleteFromOrder()` is the same path an admin uses to manually remove one. The linked invoice (if still unpaid) is removed first via `deleteInvoiceByAdmin()`.
  - A single invoice can cover several orders from one cart checkout (`Cart\Service` sets the same `unpaid_invoice_id` on all of them), so each distinct invoice is resolved and removed only **once** per run, not once per order.
  - If removing an invoice fails, that's tracked so a sibling order sharing it retries the removal instead of the failure being silently treated as "handled."
  - Each order's status is re-checked immediately before deletion (in case it was activated by a concurrent action while the batch was still working through a large backlog).
- Registered as the `order_batch_cancel_unpaid` cron task (`Cron\Service::runCrons()`), alongside the existing `order_batch_cancel_suspended`.
- New **"Unpaid Orders"** section in the Order settings page (`Auto Removal Policy`, `Remove After Invoice Due Date`), defaulting to **disabled** (unlike the sibling "cancel suspended orders" setting, which defaults on) since this is a destructive, irreversible action on historical order data.

## Also fixed
While implementing this, found and fixed a **latent bug in the sibling `batchCancelSuspended()`**: a blank "after days" form field is submitted as `''`, which `isset()` treats as present, so it silently became `(int) '' = 0` instead of falling back to the intended 7-day default — meaning suspended orders could get cancelled immediately instead of after the configured grace period. Extracted the fix into a shared `resolveBatchAfterDays()` helper used by both methods.