### PR TITLE
Renumber custom recurring billing periods patch to avoid 0.8-next collision

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','106',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','107',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -518,7 +518,6 @@ class UpdatePatcher implements InjectionAwareInterface
             95 => 'patch95',
             96 => 'patch96',
             97 => 'patch97',
-            98 => 'patch98',
             99 => 'patch99',
             100 => 'patch100',
             101 => 'patch101',
@@ -527,6 +526,12 @@ class UpdatePatcher implements InjectionAwareInterface
             104 => 'patch104',
             105 => 'patch105',
             106 => 'patch106',
+            // Intentionally out of sequence: 0.8-next (which main descended from) independently
+            // used patch number 98 for an unrelated migration (tld.periods, main's patch99) that
+            // was never ported here. An install upgrading from a 0.8-next-based release already
+            // has last_patch >= 98 from that patch, which would silently skip this migration if it
+            // kept number 98 — see https://github.com/FOSSBilling/FOSSBilling/issues/4188.
+            107 => 'patch107',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2641,7 +2646,7 @@ class UpdatePatcher implements InjectionAwareInterface
         }
     }
 
-    private function patch98(): void
+    private function patch107(): void
     {
         // Move product_payment's fixed w/m/q/b/a/bia/tria recurring pricing columns into a
         // proper one-row-per-period table, so admins can configure arbitrary billing periods

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -817,9 +817,10 @@ test('custom recurring billing periods patch is not skipped by 0.8-next installs
     // which never touched product_payment. An install coming from that lineage already has
     // last_patch = 98, so the migration must live at a number above 98 (not 98 itself) or it
     // would silently never run here. See https://github.com/FOSSBilling/FOSSBilling/issues/4188.
+    $allPatches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 0);
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 98);
 
-    expect($patches)->toHaveKey(107)
-        ->and($patches[107][1])->toBe('patch107')
-        ->and($patches)->not->toHaveKey(98);
+    expect($allPatches)->not->toHaveKey(98)
+        ->and($patches)->toHaveKey(107)
+        ->and($patches[107][1])->toBe('patch107');
 });

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -804,3 +804,22 @@ test('client group patch normalizes legacy zero group ids to null', function ():
     $patcher->setDi($di);
     (new ReflectionMethod($patcher, 'patch104'))->invoke($patcher);
 });
+
+test('custom recurring billing periods patch is numbered 107, out of sequence', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 106);
+
+    expect($patches)->toHaveKey(107)
+        ->and($patches[107][1])->toBe('patch107');
+});
+
+test('custom recurring billing periods patch is not skipped by 0.8-next installs already at patch level 98', function (): void {
+    // 0.8-next independently used patch number 98 for an unrelated migration (tld.periods),
+    // which never touched product_payment. An install coming from that lineage already has
+    // last_patch = 98, so the migration must live at a number above 98 (not 98 itself) or it
+    // would silently never run here. See https://github.com/FOSSBilling/FOSSBilling/issues/4188.
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 98);
+
+    expect($patches)->toHaveKey(107)
+        ->and($patches[107][1])->toBe('patch107')
+        ->and($patches)->not->toHaveKey(98);
+});


### PR DESCRIPTION
## Summary

Fixes #4188 ("Unknown column `t0.w_price`" on the order page).

`UpdatePatcher` tracks upgrade progress as a single integer (`setting.last_patch`) and just runs every patch numbered higher than it. `0.8-next` independently used patch number **98** for an unrelated migration (`tld.periods`, this branch's `patch99`), because the custom-recurring-billing-periods feature (#4102, this branch's `patch98`) was intentionally excluded from the `0.8.6` backport as a breaking change.

That collision breaks upgrades in both directions:
- An install descended from a `0.8-next`-based release already has `last_patch >= 98` from its own harmless `tld.periods` patch. Upgrading to `main` calls `getPatches(98)`, which silently **skips** this branch's `patch98` (`98` is not `> 98`) — `product_payment_period` never gets created, and the legacy `w_price`/`m_price`/... columns are never migrated away, orphaning any existing recurring pricing.
- Conversely, an install that *had* applied this branch's `patch98` (dropping those columns) and was later run against `0.8-next`/`0.8.6` code — which still expects them — hits `Unknown column 't0.w_price'` on every product/order page. That's the crash reported in #4188.

## Fix

Renumbers the migration from `patch98` → `patch107` (the next free slot after the current max). This is safe for every install: it no-ops wherever the migration already ran, and it now actually runs (instead of being silently skipped) for any install currently stuck between patch level 98 and 106 with `last_patch` already recorded.

No `0.8-next` change is needed — that branch never shipped the feature, so there's nothing to renumber there. The only way to hit the literal `w_price` error on `0.8-next` is running a `main`-tracking build and then reverting to `0.8-next`/`0.8.6` code, which isn't a path either branch's updater supports in either direction.