### PR TITLE
Restore Order Service::assertOrderUsable()

### DIFF
--- a/src/modules/Order/Service.php
+++ b/src/modules/Order/Service.php
@@ -248,6 +248,23 @@ class Service implements InjectionAwareInterface
     }
 
     /**
+     * Guards against interacting with a service on an expired order.
+     *
+     * @throws InformationException if the order has an expiry date in the past
+     */
+    public function assertOrderUsable(Order $order): void
+    {
+        $expiresAt = $order->getExpiresAt();
+        if ($expiresAt === null) {
+            return;
+        }
+
+        if ($expiresAt->getTimestamp() <= time()) {
+            throw new InformationException('Subscription expired');
+        }
+    }
+
+    /**
      * Returns the service backing an order.
      *
      * Built-in service types return their Doctrine entity (or null when the


### PR DESCRIPTION
## Summary

Fixes #4187.

PR #4027 added `assertOrderUsable()` to `Box\Mod\Order\Service` and wired it into the client-facing service APIs (Servicehosting, Servicedomain, Servicedownloadable, Servicelicense, Servicecustom). During the Order RedBeanPHP-to-Doctrine migration (#4131), the method was dropped from `Order/Service.php` while the callers — and their existing unit tests — were left untouched. This breaks client service endpoints with:

```
Call to undefined method Box\Mod\Order\Service::assertOrderUsable() (9998)
```

for example when an active hosting client clicks **Login to Control Panel**.

## Fix

Restores `assertOrderUsable()` on `Box\Mod\Order\Service`, validating the order's `expires_at` against the current time and throwing `InformationException('Subscription expired')` when it has passed (matching the original pre-migration behavior).

All current callers on `main` already pass the Doctrine `Order` entity (this part of the migration is complete), so the signature only needs to accept `Order`, using `getExpiresAt()`.