### PR TITLE
Renumber two more UpdatePatcher patches colliding with 0.8-next

### DIFF
--- a/src/install/sql/content.sql
+++ b/src/install/sql/content.sql
@@ -304,7 +304,7 @@ LOCK TABLES `setting` WRITE;
 
 INSERT INTO `setting` (`id`, `param`, `value`, `public`, `category`, `hash`, `created_at`, `updated_at`)
 VALUES
-	(1,'last_patch','107',0,NULL,NULL,NOW(),NOW()),
+	(1,'last_patch','109',0,NULL,NULL,NOW(),NOW()),
 	(2,'company_name','Company Name',0,NULL,NULL,NOW(),NOW()),
 	(3,'company_email','support@yourcompany.com',0,NULL,NULL,NOW(),NOW()),
 	(4,'company_signature','FOSSBilling.org - Client Management, Invoicing and Support Software',0,NULL,NULL,NOW(),NOW()),

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -512,10 +512,8 @@ class UpdatePatcher implements InjectionAwareInterface
             89 => 'patch89',
             90 => 'patch90',
             91 => 'patch91',
-            92 => 'patch92',
             93 => 'patch93',
             94 => 'patch94',
-            95 => 'patch95',
             96 => 'patch96',
             97 => 'patch97',
             99 => 'patch99',
@@ -532,6 +530,13 @@ class UpdatePatcher implements InjectionAwareInterface
             // has last_patch >= 98 from that patch, which would silently skip this migration if it
             // kept number 98 — see https://github.com/FOSSBilling/FOSSBilling/issues/4188.
             107 => 'patch107',
+            // Same 0.8-next collision as patch107, found auditing the rest of the sequence: these
+            // two features (multi-file downloads, order suspension grace days) don't exist on
+            // 0.8-next at all, but their original numbers (92, 95) were reused there for unrelated
+            // migrations. An install descended from a fully-patched 0.8-next release (last_patch
+            // 98) would silently skip both forever if they kept their original numbers.
+            108 => 'patch108',
+            109 => 'patch109',
         ];
         ksort($patches, SORT_NATURAL);
 
@@ -2468,7 +2473,7 @@ class UpdatePatcher implements InjectionAwareInterface
         );
     }
 
-    private function patch92(): void
+    private function patch108(): void
     {
         if (!$this->tableExists('service_downloadable_file')) {
             $this->executeSql(
@@ -2608,7 +2613,7 @@ class UpdatePatcher implements InjectionAwareInterface
         }
     }
 
-    private function patch95(): void
+    private function patch109(): void
     {
         if (!$this->tableHasColumn('product', 'suspension_grace_days')) {
             $this->executeSql("ALTER TABLE `product` ADD COLUMN `suspension_grace_days` int(11) NOT NULL DEFAULT '0' AFTER `quantity_in_stock`");

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -6,15 +6,14 @@ use FOSSBilling\UpdatePatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-test('downloadable file migration follows the client balance gateway repair', function (): void {
+test('currency formatting patch follows the client balance gateway repair', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 89);
 
     expect($patches)->toHaveKey(90)
         ->and($patches[90][1])->toBe('patch90')
         ->and($patches)->toHaveKey(91)
         ->and($patches[91][1])->toBe('patch91')
-        ->and($patches)->toHaveKey(92)
-        ->and($patches[92][1])->toBe('patch92')
+        ->and($patches)->not->toHaveKey(92)
         ->and($patches)->toHaveKey(93)
         ->and($patches[93][1])->toBe('patch93');
 });
@@ -40,14 +39,15 @@ test('manual currency rate patch follows the currency formatting patch', functio
         ->and($patches[94][1])->toBe('patch94');
 });
 
-test('suspension grace patch follows the manual currency rate patch', function (): void {
+test('client balance unique credit patch follows the manual currency rate patch, skipping the removed number 95', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 94);
 
-    expect($patches)->toHaveKey(95)
-        ->and($patches[95][1])->toBe('patch95');
+    expect($patches)->not->toHaveKey(95)
+        ->and($patches)->toHaveKey(96)
+        ->and($patches[96][1])->toBe('patch96');
 });
 
-test('client balance unique credit patch follows the suspension grace patch', function (): void {
+test('client balance unique credit patch is still offered to installs already at patch level 95', function (): void {
     $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 95);
 
     expect($patches)->toHaveKey(96)
@@ -241,7 +241,7 @@ test('suspension grace patch indexes existing order tables', function (): void {
 
     $patcher = new UpdatePatcher();
     $patcher->setDi($di);
-    (new ReflectionMethod($patcher, 'patch95'))->invoke($patcher);
+    (new ReflectionMethod($patcher, 'patch109'))->invoke($patcher);
 });
 
 test('client balance gateway patch restores one-time payments', function (): void {
@@ -823,4 +823,29 @@ test('custom recurring billing periods patch is not skipped by 0.8-next installs
     expect($allPatches)->not->toHaveKey(98)
         ->and($patches)->toHaveKey(107)
         ->and($patches[107][1])->toBe('patch107');
+});
+
+test('downloadable file and suspension grace patches are numbered 108 and 109, out of sequence', function (): void {
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 107);
+
+    expect($patches)->toHaveKey(108)
+        ->and($patches[108][1])->toBe('patch108')
+        ->and($patches)->toHaveKey(109)
+        ->and($patches[109][1])->toBe('patch109');
+});
+
+test('downloadable file and suspension grace patches are not skipped by 0.8-next installs already at patch level 98', function (): void {
+    // Same collision as patch107 (see above), found auditing the rest of the sequence: 0.8-next
+    // reused numbers 92 and 95 for unrelated migrations, but never ported the downloadable-file
+    // table or suspension-grace-days columns at all. An install coming from that lineage already
+    // has last_patch = 98, so both migrations must live above 98 or they'd never run here.
+    $allPatches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 0);
+    $patches = (new ReflectionMethod(UpdatePatcher::class, 'getPatches'))->invoke(new UpdatePatcher(), 98);
+
+    expect($allPatches)->not->toHaveKey(92)
+        ->and($allPatches)->not->toHaveKey(95)
+        ->and($patches)->toHaveKey(108)
+        ->and($patches[108][1])->toBe('patch108')
+        ->and($patches)->toHaveKey(109)
+        ->and($patches[109][1])->toBe('patch109');
 });


### PR DESCRIPTION
## Summary

Follow-up to #4189. That PR fixed one instance of a class of bug (`main`/`0.8-next` reusing the same `UpdatePatcher` patch number for two different migrations). Auditing the full patch sequence for other instances — diffing every patch method's actual body, not just its number, between `main` and `origin/0.8-next` — turned up two more real collisions:

- **`patch92`**: on `main`, creates `service_downloadable_file` and migrates existing downloadable-product data into it (multi-file downloads). On `0.8-next`, number 92 is an unrelated `custom_pages` slug-uniqueness fix. The downloadable-file table/migration doesn't exist anywhere in `0.8-next`.
- **`patch95`**: on `main`, adds `product.suspension_grace_days` / `client_order.suspension_grace_days` plus an index. On `0.8-next`, number 95 is a duplicate of the currency-formatting migration (itself just `main`'s `patch93` under a different number — harmless, see below). `suspension_grace_days` doesn't exist anywhere in `0.8-next`.

Same failure mode as #4188: an install descended from a fully-patched `0.8-next` release (`last_patch >= 98`) upgrading to `main` calls `getPatches(98)`, which only returns patch numbers `> 98` — silently skipping both of these forever, since their numbers (92, 95) are below that watermark.

## Fix

Same approach as #4189: renumber both to `108` and `109` (next free slots past the current max `107`). Safe for every install — no-ops wherever already applied, and now actually runs (instead of being silently skipped) for any install currently stuck with `last_patch` between 92/95 and 106.