### PR TITLE
Harden ResellerClub bare-scalar response handling

### DIFF
--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -617,12 +617,22 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         }
 
         $content = $result->getContent(false);
-        if (in_array($content, ['true', 'false'], true)) {
-            return $content;
+        $trimmedContent = trim($content);
+
+        // Some endpoints (e.g. domains/validate-transfer, domains/orderid) respond with a bare
+        // scalar instead of a JSON object, which would make toArray() below throw "JSON content
+        // was expected to decode to an array". Match booleans case-insensitively and trimmed,
+        // since the registrar isn't consistent about formatting - see
+        // https://github.com/FOSSBilling/FOSSBilling/issues/2939.
+        if (in_array(strtolower($trimmedContent), ['true', 'false'], true)) {
+            return strtolower($trimmedContent);
         }
-        if (is_numeric($content)) {
-            return $content;
+
+        $decoded = json_decode($trimmedContent, true);
+        if (json_last_error() === JSON_ERROR_NONE && !is_array($decoded)) {
+            return $trimmedContent;
         }
+
         $json = $result->toArray(false);
 
         if (isset($json['status']) && $json['status'] == 'ERROR') {

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -629,7 +629,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         }
 
         $decoded = json_decode($trimmedContent, true);
-        if (json_last_error() === JSON_ERROR_NONE && !is_array($decoded)) {
+        if (json_last_error() === JSON_ERROR_NONE && is_scalar($decoded)) {
             return $trimmedContent;
         }
 

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+function createResellerclubAdapter(HttpClientInterface $httpClient): Registrar_Adapter_Resellerclub
+{
+    return new class(['userid' => '12345', 'api-key' => 'secret'], $httpClient) extends Registrar_Adapter_Resellerclub {
+        public function __construct(array $options, private readonly HttpClientInterface $httpClient)
+        {
+            parent::__construct($options);
+        }
+
+        public function getHttpClient(): HttpClientInterface
+        {
+            return $this->httpClient;
+        }
+    };
+}
+
+function createResellerclubDomain(string $sld = 'example', string $tld = '.com'): Registrar_Domain
+{
+    return (new Registrar_Domain())->setSld($sld)->setTld($tld);
+}
+
+test('isDomaincanBeTransferred returns false for a bare "false" response instead of throwing', function (): void {
+    // Regression test for #2939: the ResellerClub-style API responds to domains/validate-transfer.json
+    // with a bare JSON boolean (no wrapping object). Symfony's toArray() throws "JSON content was
+    // expected to decode to an array" for a non-array JSON body, so _makeRequest() must short-circuit
+    // before reaching toArray() for this case.
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('false'));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect($adapter->isDomaincanBeTransferred(createResellerclubDomain()))->toBeFalse();
+});
+
+test('isDomaincanBeTransferred returns true for a bare "true" response', function (): void {
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('true'));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect($adapter->isDomaincanBeTransferred(createResellerclubDomain()))->toBeTrue();
+});
+
+test('isDomaincanBeTransferred tolerates trailing whitespace and mixed casing in the raw response', function (): void {
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse("True\n"));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect($adapter->isDomaincanBeTransferred(createResellerclubDomain()))->toBeTrue();
+});
+
+test('a bare numeric response (e.g. domains/orderid) is still returned as-is', function (): void {
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('98765'));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    $reflection = new ReflectionMethod($adapter, '_getDomainOrderId');
+    $result = $reflection->invoke($adapter, createResellerclubDomain());
+
+    expect($result)->toBe('98765');
+});
+
+test('an error-object response still throws a Registrar_Exception', function (): void {
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse(json_encode([
+        'status' => 'ERROR',
+        'message' => 'Invalid API key',
+    ])));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect(fn () => $adapter->isDomaincanBeTransferred(createResellerclubDomain()))
+        ->toThrow(Registrar_Exception::class);
+});

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -61,6 +61,17 @@ test('a bare numeric response (e.g. domains/orderid) is still returned as-is', f
     expect($result)->toBe('98765');
 });
 
+test('a bare "null" response is not silently treated as a scalar', function (): void {
+    // Regression guard for the scalar short-circuit above: json_decode('null') also returns
+    // null with no decode error, but null isn't a usable scalar result (e.g. getDomainDetails()
+    // would go on to index it like an array), so it must fall through to toArray() instead.
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('null'));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect(fn () => $adapter->isDomaincanBeTransferred(createResellerclubDomain()))
+        ->toThrow(Symfony\Component\HttpClient\Exception\JsonException::class);
+});
+
 test('an error-object response still throws a Registrar_Exception', function (): void {
     $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse(json_encode([
         'status' => 'ERROR',


### PR DESCRIPTION
## Context

While investigating #2939 ("Domain Transfer Request Ends Up In Error"), confirmed the originally reported crash is already fixed on `main` by #3801 (`f47617c7a`), which added the missing `'false'` case to the raw-content short-circuit in `Registrar_Adapter_Resellerclub::_makeRequest()`.

## What this PR does

That guard is still an **exact string match** against `'true'`/`'false'`, so any whitespace or casing difference in what the registrar's API returns (e.g. `"true\n"`, `"False"`) would still hit the same `toArray()` crash. This hardens the check:

- Normalizes the bare boolean check (trim + case-insensitive) instead of exact string matching.
- Generalizes the fallback to any bare JSON scalar (not just booleans/numbers) via `json_decode`, so future endpoints that return a bare scalar don't need another one-off literal check.
- Adds `tests/Unit/Registrar/Adapter/ResellerclubTest.php` with regression coverage (bare `true`/`false`, whitespace/casing variants, bare numeric response, and confirms error-object responses still throw `Registrar_Exception`), following the `MockHttpClient` pattern already used by the `Server/Manager` adapter tests.