### PR TITLE
Fix ResellerClub domain availability check reporting registered domains as available

### DIFF
--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -76,23 +76,26 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     public function isDomainAvailable(Registrar_Domain $domain): bool
     {
+        $sld = strtolower((string) $domain->getSld());
+        $tld = strtolower((string) $domain->getTld());
+        $domainName = $sld . $tld;
+
         $params = [
-            'domain-name' => $domain->getSld(),
-            'tlds' => [$domain->getTld(false)],
+            'domain-name' => $sld,
+            'tlds' => [ltrim($tld, '.')],
             'suggest-alternative' => false,
         ];
 
         $result = $this->_makeRequest('domains/available', $params);
-        if (!isset($result[$domain->getName()])) {
-            return true;
+        // the response is keyed by domain name, but the casing of that key isn't guaranteed to match what we sent
+        $result = array_change_key_case((array) $result, CASE_LOWER);
+        if (!isset($result[$domainName]['status'])) {
+            $placeholders = [':action:' => 'domains/available', ':type:' => 'ResellerClub'];
+
+            throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
 
-        $check = $result[$domain->getName()];
-        if ($check && $check['status'] == 'available') {
-            return true;
-        }
-
-        return false;
+        return strtolower((string) $result[$domainName]['status']) === 'available';
     }
 
     public function isDomaincanBeTransferred(Registrar_Domain $domain): bool


### PR DESCRIPTION
## Summary

Fixes #3638.

`isDomainAvailable()` in `Registrar_Adapter_Resellerclub` looked up the ResellerClub API response by the exact-cased domain name it sent, but ResellerClub normalizes the response key to lowercase. Any mixed-case lookup (e.g. searching `Google.com`, per the reproduction steps in #3638) silently missed the response key. That miss fell through to `return true` — i.e. "available" — even when the domain was clearly registered.

This same `isDomainAvailable()` is inherited unchanged by `Registrar_Adapter_Resellerid`, `Registrar_Adapter_Netearthone`, and `Registrar_Adapter_Resellbiz`, so all four registrar adapters were affected.

## Fix

- Normalize casing on both sides of the lookup (lowercase the outgoing SLD/TLD, and `array_change_key_case()` the response) so the key always matches regardless of how the user typed the domain.
- Replace the fail-open "assume available" fallback with a `Registrar_Exception` when the response doesn't contain a usable status, matching the translatable-exception convention already used elsewhere in this adapter (`_makeRequest`'s `:action:`/`:type:` pattern).