### PR TITLE
Require 64-bit PHP as an installer requirement

### DIFF
--- a/src/install/assets/install.html.twig
+++ b/src/install/assets/install.html.twig
@@ -64,6 +64,11 @@
                             <td class="{{ compatibility.php_version.isOk ? 'green' : 'red'}}">{{ compatibility.php_version.version }}</td>
                             <td>{% if not compatibility.php_version.isOk %}PHP {{ compatibility.php_version.min_version }} or newer is required.{% endif %}</td>
                         </tr>
+                        <tr>
+                            <td>PHP architecture</td>
+                            <td class="{{ compatibility.php_architecture.isOk ? 'green' : 'red'}}">{{ compatibility.php_architecture.isOk ? '64-bit' : '32-bit' }}</td>
+                            <td>{% if not compatibility.php_architecture.isOk %}FOSSBilling requires a 64-bit PHP build to safely store large database identifiers.{% endif %}</td>
+                        </tr>
                         {% for ext, loaded in compatibility.required_extensions %}
                             <tr>
                                 <td>PHP extension: <strong>{{ ext }}</strong></td>

--- a/src/library/FOSSBilling/Requirements.php
+++ b/src/library/FOSSBilling/Requirements.php
@@ -71,6 +71,21 @@ class Requirements
         return $ok;
     }
 
+    /**
+     * FOSSBilling stores several database identifiers as 64-bit integers (MySQL BIGINT).
+     * On 32-bit PHP builds, PHP's native int type can't represent the full range of those
+     * values without silent precision loss, so 64-bit PHP is a hard requirement.
+     */
+    public function isPhp64Bit(): bool
+    {
+        $ok = PHP_INT_SIZE === 8;
+        if (!$ok) {
+            $this->isOk = false;
+        }
+
+        return $ok;
+    }
+
     public function checkFile(string $path): bool
     {
         $writable = false;
@@ -150,6 +165,11 @@ class Requirements
             'isOk' => $this->isPhpVersionOk(),
             'version' => PHP_VERSION,
             'min_version' => $this->php_reqs['min_version'],
+        ];
+
+        $result['php_architecture'] = [
+            'isOk' => $this->isPhp64Bit(),
+            'int_size' => PHP_INT_SIZE,
         ];
 
         $result['can_install'] = $this->isOk;

--- a/tests/Unit/FOSSBilling/RequirementsTest.php
+++ b/tests/Unit/FOSSBilling/RequirementsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use FOSSBilling\Requirements;
+
+test('64-bit PHP check reflects the actual PHP_INT_SIZE of the running interpreter', function (): void {
+    // FOSSBilling stores several database identifiers as 64-bit integers (MySQL BIGINT),
+    // which a 32-bit PHP build can't represent natively without silent precision loss.
+    $requirements = new Requirements();
+
+    expect($requirements->isPhp64Bit())->toBe(PHP_INT_SIZE === 8);
+});
+
+test('checkCompat reports the PHP architecture alongside the PHP version', function (): void {
+    $requirements = new Requirements();
+    $result = $requirements->checkCompat();
+
+    expect($result['php_architecture'])->toBe([
+        'isOk' => PHP_INT_SIZE === 8,
+        'int_size' => PHP_INT_SIZE,
+    ]);
+});


### PR DESCRIPTION
## Summary

Follow-up to #4196. CodeRabbit flagged a real, pre-existing gap during that review: FOSSBilling stores several database identifiers as 64-bit integers (MySQL `BIGINT`), a set that #4196 widened to ~49 more entities. On 32-bit PHP builds, PHP's native `int` type can't represent the full range of those values without silent precision loss.

Rather than reworking every `BIGINT` entity's PHP-side id type to `int|string` (invasive, and inconsistent with the `?int` convention every pre-existing `BIGINT` entity already used before #4196), this adds a 64-bit PHP check to the installer's system requirements gate, alongside the existing PHP version and extension checks. It blocks installation outright on a 32-bit PHP build rather than letting one silently corrupt large ids later.

Composer has no platform constraint for word size, so this is enforced at install time via `Requirements::isPhp64Bit()`, surfaced in `checkCompat()` and the install requirements table — the same mechanism the existing PHP version check already uses.

## Test plan

- [x] `composer test` — all tests pass (2781 tests), including new coverage for `isPhp64Bit()`/`checkCompat()`
- [x] `composer phpstan` — clean
- [x] `composer cs:fix -- --dry-run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)