### PR TITLE
Add manual domain sync with registrar

### DIFF
--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -113,6 +113,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * @return bool
      */
+    #[RequiredParams(['order_id' => 'Order ID is missing'])]
     public function sync($data)
     {
         $this->checkPermissions('servicedomain', 'manage_domains');

--- a/src/modules/Servicedomain/Api/Admin.php
+++ b/src/modules/Servicedomain/Api/Admin.php
@@ -109,6 +109,21 @@ class Admin extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
+     * Synchronize domain registration details with the registrar.
+     *
+     * @return bool
+     */
+    public function sync($data)
+    {
+        $this->checkPermissions('servicedomain', 'manage_domains');
+
+        $s = $this->_getService($data);
+        $this->getService()->synchronizeDomain($s);
+
+        return true;
+    }
+
+    /**
      * Get domain transfer code.
      *
      * @return bool

--- a/src/modules/Servicedomain/Api/Client.php
+++ b/src/modules/Servicedomain/Api/Client.php
@@ -77,6 +77,19 @@ class Client extends \FOSSBilling\Api\AbstractApi
     }
 
     /**
+     * Synchronize domain registration details with the registrar.
+     *
+     * @return true
+     */
+    public function sync($data)
+    {
+        $s = $this->_getService($data);
+        $this->getService()->synchronizeDomain($s);
+
+        return true;
+    }
+
+    /**
      * Retrieve domain transfer code.
      *
      * @return string - transfer code

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -386,8 +386,19 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->setDetails(serialize($whois));
         $model->setExpiresAt($this->formatRegistrarTimestamp($whois->getExpirationTime()));
         $model->setRegisteredAt($this->formatRegistrarTimestamp($whois->getRegistrationTime()));
+        $model->setSyncedAt(new \DateTime());
 
         $this->di['em']->flush();
+    }
+
+    public function synchronizeDomain(ServiceDomain $model): void
+    {
+        $order = $this->di['mod_service']('order')->getServiceOrder($model);
+        if (!$order instanceof Order) {
+            throw new \FOSSBilling\Exception('Domain order not found');
+        }
+
+        $this->syncWhois($model, $order);
     }
 
     public function updateNameservers(ServiceDomain $model, $data): bool
@@ -620,6 +631,7 @@ class Service implements \FOSSBilling\InjectionAwareInterface
             'locked' => $model->isLocked(),
             'registered_at' => $this->formatDateTime($model->getRegisteredAt()),
             'expires_at' => $this->formatDateTime($model->getExpiresAt()),
+            'synced_at' => $this->formatDateTime($model->getSyncedAt()),
             'contact' => [
                 'first_name' => $model->getContactFirstName(),
                 'last_name' => $model->getContactLastName(),

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_manage.html.twig
@@ -73,12 +73,12 @@
             <div class="btn-list justify-content-center">
                 {{ order_actions|default('') }}
                 {% if order.status == 'active' %}
-                <a class="btn btn-secondary" type="button" id="domain-sync">
+                <button class="btn btn-secondary" type="button" id="domain-sync">
                     <svg class="icon">
                         <use href="#refresh" />
                     </svg>
                     <span>{{ 'Sync Now'|trans }}</span>
-                </a>
+                </button>
                 <a class="btn btn-primary" type="button" id="get-epp">
                     <svg class="icon">
                         <use href="#key" />

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_manage.html.twig
@@ -61,6 +61,10 @@
                         <td class="text-end">{{ 'Expires At'|trans }}:</td>
                         <td>{{ service.expires_at|format_date }}</td>
                     </tr>
+                    <tr>
+                        <td class="text-end">{{ 'Last Synced'|trans }}:</td>
+                        <td id="synced-at-value">{{ service.synced_at ? service.synced_at|format_date : 'Never'|trans }}</td>
+                    </tr>
                 </tbody>
             </table>
         </div>
@@ -69,6 +73,12 @@
             <div class="btn-list justify-content-center">
                 {{ order_actions|default('') }}
                 {% if order.status == 'active' %}
+                <a class="btn btn-secondary" type="button" id="domain-sync">
+                    <svg class="icon">
+                        <use href="#refresh" />
+                    </svg>
+                    <span>{{ 'Sync Now'|trans }}</span>
+                </a>
                 <a class="btn btn-primary" type="button" id="get-epp">
                     <svg class="icon">
                         <use href="#key" />
@@ -293,6 +303,14 @@
             FOSSBilling.api.admin.post('servicedomain/get_transfer_code', { order_id: {{ order.id}} },
                 (result) => {
                     FOSSBilling.message("{{ 'Domain transfer code is: '|trans }}" + result);
+                });
+        });
+
+        document.getElementById('domain-sync').addEventListener('click', function(event) {
+            FOSSBilling.api.admin.post('servicedomain/sync', { order_id: {{ order.id }} },
+                (result) => {
+                    FOSSBilling.message("{{ 'Domain synchronized with registrar'|trans }}");
+                    window.location.reload();
                 });
         });
     });

--- a/src/modules/Servicedomain/templates/client/mod_servicedomain_manage.html.twig
+++ b/src/modules/Servicedomain/templates/client/mod_servicedomain_manage.html.twig
@@ -38,6 +38,16 @@
                             <span class="fs-4">{{ service.registered_at|format_date(pattern="MMM dd, yyyy") }}</span>
                         </div>
                     </div>
+                    <div class="d-flex flex-column align-items-center text-center pb-3">
+                        <span class="small text-muted mb-2" id="synced-at-value">
+                            {% if service.synced_at %}
+                                {{ 'Last synced with registrar on %date%'|trans({'%date%': service.synced_at|format_date(pattern="MMM dd, yyyy HH:mm")}) }}
+                            {% else %}
+                                {{ 'Never synced with registrar'|trans }}
+                            {% endif %}
+                        </span>
+                        <button class="btn btn-secondary btn-sm" type="button" id="domain-sync">{{ 'Sync Now'|trans }}</button>
+                    </div>
                 </div>
             </div>
 
@@ -271,6 +281,16 @@
                     FOSSBilling.api.client.post('servicedomain/get_transfer_code', { order_id: {{ order.id }} },
                         (result) => {
                             FOSSBilling.message('Domain transfer code is: ' + result);
+                        });
+                });
+
+                document.getElementById('domain-sync').addEventListener('click', function(event) {
+                    event.preventDefault();
+
+                    FOSSBilling.api.client.post('servicedomain/sync', { order_id: {{ order.id }} },
+                        () => {
+                            FOSSBilling.message('{{ 'Domain synchronized with registrar'|trans }}');
+                            window.location.reload();
                         });
                 });
             });

--- a/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
@@ -142,6 +142,29 @@ test('disables privacy protection', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('synchronizes domain with registrar', function (): void {
+    $adminApi = apiEndpoint(new Admin());
+    $api = apiEndpoint(new Admin());
+    $model = new ServiceDomain();
+
+    $adminApiMock = apiEndpoint(Mockery::mock(Admin::class)->makePartial()->shouldAllowMockingProtectedMethods());
+    $adminApiMock->shouldReceive('_getService')
+        ->atLeast()->once()
+        ->andReturn($model);
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('synchronizeDomain')
+        ->atLeast()->once()
+        ->with($model);
+
+    $adminApiMock->setService($serviceMock);
+
+    $data = [];
+    $result = $adminApiMock->sync($data);
+
+    expect($result)->toBeTrue();
+});
+
 test('gets transfer code', function (): void {
     $adminApi = apiEndpoint(new Admin());
     $api = apiEndpoint(new Admin());

--- a/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/AdminTest.php
@@ -165,6 +165,15 @@ test('synchronizes domain with registrar', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('throws exception when synchronizing domain without order_id', function (): void {
+    $adminApi = apiEndpoint(new Admin());
+    $api = apiEndpoint(new Admin());
+    $dispatcher = new FOSSBilling\Api\Dispatcher();
+
+    expect(fn () => $dispatcher->validateRequiredParams($adminApi, 'sync', []))
+        ->toThrow(FOSSBilling\InformationException::class);
+});
+
 test('gets transfer code', function (): void {
     $adminApi = apiEndpoint(new Admin());
     $api = apiEndpoint(new Admin());

--- a/src/modules/Servicedomain/tests/Unit/Api/ClientTest.php
+++ b/src/modules/Servicedomain/tests/Unit/Api/ClientTest.php
@@ -119,6 +119,29 @@ test('disables privacy protection', function (): void {
     expect($result)->toBeTrue();
 });
 
+test('synchronizes domain with registrar', function (): void {
+    $clientApi = apiEndpoint(new Client());
+    $api = apiEndpoint(new Client());
+    $model = new ServiceDomain();
+
+    $clientApiMock = apiEndpoint(Mockery::mock(Client::class)->makePartial()->shouldAllowMockingProtectedMethods());
+    $clientApiMock->shouldReceive('_getService')
+        ->atLeast()->once()
+        ->andReturn($model);
+
+    $serviceMock = Mockery::mock(Service::class);
+    $serviceMock->shouldReceive('synchronizeDomain')
+        ->atLeast()->once()
+        ->with($model);
+
+    $clientApiMock->setService($serviceMock);
+
+    $data = [];
+    $result = $clientApiMock->sync($data);
+
+    expect($result)->toBeTrue();
+});
+
 test('gets transfer code', function (): void {
     $clientApi = apiEndpoint(new Client());
     $api = apiEndpoint(new Client());

--- a/src/modules/Servicedomain/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicedomain/tests/Unit/ServiceTest.php
@@ -1032,7 +1032,48 @@ test('syncWhois stores null dates when registrar dates are unavailable', functio
     $service->syncWhoisPublic($model, $order);
 
     expect($model->getExpiresAt())->toBeNull()
-        ->and($model->getRegisteredAt())->toBeNull();
+        ->and($model->getRegisteredAt())->toBeNull()
+        ->and($model->getSyncedAt())->not->toBeNull();
+});
+
+test('synchronizes domain with registrar', function (): void {
+    $model = new ServiceDomain();
+    $order = createEntity(Order::class);
+
+    $orderServiceMock = Mockery::mock(OrderService::class);
+    $orderServiceMock->shouldReceive('getServiceOrder')
+        ->once()
+        ->with($model)
+        ->andReturn($order);
+
+    $service = Mockery::mock(Service::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('syncWhois')
+        ->once()
+        ->with($model, $order);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn ($name): Mockery\MockInterface => $orderServiceMock);
+    $service->setDi($di);
+
+    $service->synchronizeDomain($model);
+});
+
+test('throws when synchronizing a domain without an order', function (): void {
+    $model = new ServiceDomain();
+
+    $orderServiceMock = Mockery::mock(OrderService::class);
+    $orderServiceMock->shouldReceive('getServiceOrder')
+        ->once()
+        ->with($model)
+        ->andReturn(null);
+
+    $service = new Service();
+    $di = container();
+    $di['mod_service'] = $di->protect(fn ($name): Mockery\MockInterface => $orderServiceMock);
+    $service->setDi($di);
+
+    expect(fn () => $service->synchronizeDomain($model))
+        ->toThrow(FOSSBilling\Exception::class);
 });
 
 test('converts to api array', function (?Box\Mod\Staff\Entity\Admin $identity, string $dbLoadCalled): void {
@@ -1050,6 +1091,7 @@ test('converts to api array', function (?Box\Mod\Staff\Entity\Admin $identity, s
     $model->setLocked(true);
     $model->setRegisteredAt(new DateTime(date('Y-m-d H:i:s')));
     $model->setExpiresAt(new DateTime(date('Y-m-d H:i:s')));
+    $model->setSyncedAt(new DateTime(date('Y-m-d H:i:s')));
 
     $model->setContactFirstName('first_name');
     $model->setContactLastName('last_name');
@@ -1088,6 +1130,7 @@ test('converts to api array', function (?Box\Mod\Staff\Entity\Admin $identity, s
     expect($result)->toHaveKey('locked');
     expect($result)->toHaveKey('registered_at');
     expect($result)->toHaveKey('expires_at');
+    expect($result)->toHaveKey('synced_at');
     expect($result)->toHaveKey('contact');
 
     $contact = $result['contact'];


### PR DESCRIPTION
## Summary

Adds a "Sync Now" action for domain services so admins and clients can refresh locked/privacy status, WHOIS contact details, and registration/expiry dates from the registrar on demand, instead of only relying on the cached values in `service_domain`.

- `Servicedomain\Service::synchronizeDomain()` resolves the domain's order and triggers a full `syncWhois()` pass.
- `syncWhois()` now stamps the existing (previously unused) `synced_at` column, and `toApiArray()` exposes it as `synced_at`.
- New `servicedomain/sync` API endpoint for both Admin and Client.
- Admin Service Management tab and client domain details page gain a "Sync Now" button and a "Last Synced" timestamp.

Closes #2324.