### PR TITLE
Add configurable Redis/Memcached cache backend

### DIFF
--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -171,6 +171,37 @@ return [
         // 'wait_timeout' => 28800,
     ],
 
+    /*
+     * Cache backend used for the general application cache, the rate limiter, and the
+     * Doctrine ORM metadata/query/result cache. This is unrelated to the 'twig' cache below.
+     */
+    'cache' => [
+        /*
+         * Supported values: 'filesystem' (default), 'redis', 'memcached'.
+         * 'redis' requires the PHP redis (or relay) extension, and 'memcached' requires the
+         * PHP memcached extension. Also configurable from the admin area under System > Settings > Cache.
+         */
+        'driver' => 'filesystem',
+
+        /*
+         * Used when 'driver' is set to 'redis'.
+         */
+        'redis' => [
+            'host' => '127.0.0.1',
+            'port' => 6379,
+            'password' => null,
+            'database' => 0,
+        ],
+
+        /*
+         * Used when 'driver' is set to 'memcached'.
+         */
+        'memcached' => [
+            'host' => '127.0.0.1',
+            'port' => 11211,
+        ],
+    ],
+
     'twig' => [
         'debug' => false,
         'auto_reload' => true,

--- a/src/di.php
+++ b/src/di.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
+use FOSSBilling\Cache\CacheFactory;
 use FOSSBilling\Config;
 use FOSSBilling\Doctrine\DriverManagerFactory;
 use FOSSBilling\Doctrine\EntityManagerFactory;
@@ -19,7 +20,7 @@ use FOSSBilling\Http\RequestFactory;
 use FOSSBilling\Security\AuthenticationRequiredException;
 use FOSSBilling\Security\EmailValidationRequiredException;
 use FOSSBilling\Version;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpClient\HttpClient;
@@ -263,15 +264,18 @@ $di['session'] = function () use ($di) {
 $di['request'] = $request;
 
 /*
+ * The general-purpose application cache. Backed by the filesystem by default; can be configured
+ * to use Redis or Memcached instead via the `cache` block in the FOSSBilling configuration file.
+ *
  * @param void
  *
- * @link https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html
+ * @link https://symfony.com/doc/current/components/cache.html
  *
- * @return FilesystemAdapter
+ * @return CacheItemPoolInterface
  */
-$di['cache'] = fn (): FilesystemAdapter => new FilesystemAdapter('sf_cache', 24 * 60 * 60, PATH_CACHE);
+$di['cache'] = fn (): CacheItemPoolInterface => CacheFactory::create(CacheFactory::NAMESPACE_APP, 24 * 60 * 60);
 
-$di['rate_limit_cache'] = fn (): FilesystemAdapter => new FilesystemAdapter('rate_limit', 24 * 60 * 60, PATH_CACHE);
+$di['rate_limit_cache'] = fn (): CacheItemPoolInterface => CacheFactory::create(CacheFactory::NAMESPACE_RATE_LIMIT, 24 * 60 * 60);
 
 $di['http_client'] = fn (): HttpClientInterface => HttpClient::create([
     'bindto' => BIND_TO,

--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2025 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling\Cache;
+
+use FOSSBilling\Config;
+use FOSSBilling\Exception;
+use FOSSBilling\Tools;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class CacheFactory
+{
+    /**
+     * List of supported cache drivers.
+     *
+     * @var string[]
+     */
+    public const SUPPORTED_DRIVERS = [
+        'filesystem',
+        'redis',
+        'memcached',
+    ];
+
+    /**
+     * Namespace used for the general-purpose application cache (`$di['cache']`).
+     */
+    public const NAMESPACE_APP = 'sf_cache';
+
+    /**
+     * Namespace used for the rate limiter's cache (`$di['rate_limit_cache']`).
+     */
+    public const NAMESPACE_RATE_LIMIT = 'rate_limit';
+
+    /**
+     * Namespace used for the Doctrine ORM metadata/query/result cache.
+     */
+    public const NAMESPACE_DOCTRINE = 'doctrine';
+
+    /**
+     * Namespace used only to validate a not-yet-saved cache configuration.
+     */
+    public const NAMESPACE_CONNECTION_TEST = 'connection_test';
+
+    /**
+     * All namespaces FOSSBilling uses, kept in one place so cache-wide invalidation
+     * (see {@see clearAll()}) doesn't drift out of sync with the pools above.
+     *
+     * @var string[]
+     */
+    private const ALL_NAMESPACES = [
+        self::NAMESPACE_APP,
+        self::NAMESPACE_RATE_LIMIT,
+        self::NAMESPACE_DOCTRINE,
+    ];
+
+    /**
+     * Builds a cache pool for the given namespace, based on the live configuration.
+     *
+     * This never throws: if the configured driver is unreachable or its PHP extension
+     * isn't installed, it logs a warning and falls back to the filesystem driver so that
+     * a cache problem never takes down the rest of the application.
+     */
+    public static function create(string $namespace, int $defaultLifetime = 0): CacheItemPoolInterface
+    {
+        try {
+            return self::createFromConfig(self::getCacheConfig(), $namespace, $defaultLifetime, fallbackOnFailure: true);
+        } catch (Exception) {
+            // Unsupported driver values are also treated as a soft failure at runtime; a hard failure
+            // here would otherwise break every feature that reads from $di['cache'].
+            return new FilesystemAdapter($namespace, $defaultLifetime, PATH_CACHE);
+        }
+    }
+
+    /**
+     * Builds a cache pool from an explicit (potentially not-yet-saved) configuration array.
+     *
+     * Used by the admin settings form to validate a driver before it's written to disk. When
+     * $fallbackOnFailure is false, connection/extension problems are thrown as a FOSSBilling
+     * Exception with a specific reason instead of silently degrading to filesystem.
+     *
+     * @throws Exception if the driver is unsupported, or (when $fallbackOnFailure is false) unreachable
+     */
+    public static function createFromConfig(array $cacheConfig, string $namespace, int $defaultLifetime, bool $fallbackOnFailure): CacheItemPoolInterface
+    {
+        $driver = $cacheConfig['driver'] ?? 'filesystem';
+
+        if (!in_array($driver, self::SUPPORTED_DRIVERS, true)) {
+            throw new Exception('Unsupported cache driver :driver. Supported drivers are: :supported.', [':driver' => $driver, ':supported' => implode(', ', self::SUPPORTED_DRIVERS)]);
+        }
+
+        if ($driver === 'filesystem') {
+            return new FilesystemAdapter($namespace, $defaultLifetime, PATH_CACHE);
+        }
+
+        try {
+            $pool = match ($driver) {
+                'redis' => self::createRedisAdapter($cacheConfig['redis'] ?? [], $namespace, $defaultLifetime),
+                'memcached' => self::createMemcachedAdapter($cacheConfig['memcached'] ?? [], $namespace, $defaultLifetime),
+            };
+
+            self::assertUsable($pool);
+
+            return $pool;
+        } catch (\Throwable $e) {
+            if (!$fallbackOnFailure) {
+                throw new Exception('Could not connect to the configured ":driver" cache backend: :message', [':driver' => $driver, ':message' => $e->getMessage()]);
+            }
+
+            error_log(sprintf('FOSSBilling: failed to initialize the "%s" cache driver (%s); falling back to the filesystem cache.', $driver, $e->getMessage()));
+
+            return new FilesystemAdapter($namespace, $defaultLifetime, PATH_CACHE);
+        }
+    }
+
+    /**
+     * Clears every cache pool FOSSBilling knows about. Best-effort: a misconfigured or
+     * unreachable backend must not prevent the rest of the cache from being cleared.
+     */
+    public static function clearAll(): void
+    {
+        foreach (self::ALL_NAMESPACES as $namespace) {
+            try {
+                self::create($namespace)->clear();
+            } catch (\Throwable) {
+                // Clearing the cache is best-effort; a failure here shouldn't halt execution.
+            }
+        }
+    }
+
+    /**
+     * Returns the `cache` configuration block, defaulting to the filesystem driver
+     * when unset so existing installs without a `cache` key keep their current behavior.
+     */
+    private static function getCacheConfig(): array
+    {
+        $cacheConfig = Config::getProperty('cache', []);
+
+        if (!is_array($cacheConfig)) {
+            throw new Exception('Cache configuration is invalid.');
+        }
+
+        $cacheConfig['driver'] ??= 'filesystem';
+
+        return $cacheConfig;
+    }
+
+    private static function createRedisAdapter(array $redisConfig, string $namespace, int $defaultLifetime): RedisAdapter
+    {
+        if (!class_exists(\Redis::class) && !class_exists(\Relay\Relay::class) && !class_exists(\RedisCluster::class)) {
+            throw new Exception('The "redis" cache driver requires the PHP redis (or relay) extension to be installed.');
+        }
+
+        $connection = RedisAdapter::createConnection(self::buildRedisDsn($redisConfig));
+
+        return new RedisAdapter($connection, $namespace, $defaultLifetime);
+    }
+
+    private static function createMemcachedAdapter(array $memcachedConfig, string $namespace, int $defaultLifetime): MemcachedAdapter
+    {
+        if (!class_exists(\Memcached::class)) {
+            throw new Exception('The "memcached" cache driver requires the PHP memcached extension to be installed.');
+        }
+
+        $connection = MemcachedAdapter::createConnection(self::buildMemcachedDsn($memcachedConfig));
+
+        return new MemcachedAdapter($connection, $namespace, $defaultLifetime);
+    }
+
+    private static function buildRedisDsn(array $redisConfig): string
+    {
+        $host = $redisConfig['host'] ?? '127.0.0.1';
+        $port = Tools::normalizePort($redisConfig['port'] ?? null, 6379);
+        $database = (int) ($redisConfig['database'] ?? 0);
+
+        $auth = '';
+        if (!empty($redisConfig['password'])) {
+            $auth = rawurlencode((string) $redisConfig['password']) . '@';
+        }
+
+        return sprintf('redis://%s%s:%d%s', $auth, $host, $port, $database !== 0 ? '/' . $database : '');
+    }
+
+    private static function buildMemcachedDsn(array $memcachedConfig): string
+    {
+        $host = $memcachedConfig['host'] ?? '127.0.0.1';
+        $port = Tools::normalizePort($memcachedConfig['port'] ?? null, 11211);
+
+        return sprintf('memcached://%s:%d', $host, $port);
+    }
+
+    /**
+     * Forces an eager connection attempt. Both RedisAdapter and MemcachedAdapter lazily
+     * connect on first use, so without this, a bad host/port/password would only surface
+     * the first time some unrelated feature happened to read from the cache.
+     *
+     * @throws \Throwable if the backend cannot be reached
+     */
+    private static function assertUsable(CacheItemPoolInterface&CacheInterface $pool): void
+    {
+        $testKey = '__fossbilling_cache_connection_test__';
+        $pool->get($testKey, static fn () => true);
+        $pool->delete($testKey);
+    }
+}

--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -94,6 +94,10 @@ class CacheFactory
      */
     public static function createFromConfig(array $cacheConfig, string $namespace, int $defaultLifetime, bool $fallbackOnFailure): CacheItemPoolInterface
     {
+        // Scope every pool to this installation, so installs that happen to share a Redis
+        // database or Memcached server don't collide on the same cache keys.
+        $namespace = self::scopeNamespaceToInstallation($namespace);
+
         $driver = $cacheConfig['driver'] ?? 'filesystem';
 
         if (!in_array($driver, self::SUPPORTED_DRIVERS, true)) {
@@ -154,6 +158,22 @@ class CacheFactory
         $cacheConfig['driver'] ??= 'filesystem';
 
         return $cacheConfig;
+    }
+
+    /**
+     * Appends this installation's stable instance ID to a namespace, so multiple FOSSBilling
+     * installs pointed at the same Redis/Memcached server don't read or overwrite each other's
+     * cache entries.
+     */
+    private static function scopeNamespaceToInstallation(string $namespace): string
+    {
+        $instanceId = (string) Config::getProperty('info.instance_id', '');
+
+        if ($instanceId === '') {
+            return $namespace;
+        }
+
+        return $namespace . '_' . preg_replace('/[^A-Za-z0-9_.-]/', '_', $instanceId);
     }
 
     private static function createRedisAdapter(array $redisConfig, string $namespace, int $defaultLifetime): RedisAdapter

--- a/src/library/FOSSBilling/Config.php
+++ b/src/library/FOSSBilling/Config.php
@@ -163,7 +163,7 @@ class Config
      *
      * @throws Exception if the number of recursive iterations passes this class's MAX_RECURSION_LEVEL
      */
-    private static function recursivelyIdentAndFormat(array|string|bool|float|int $value, $level = 1): string
+    private static function recursivelyIdentAndFormat(array|string|bool|float|int|null $value, $level = 1): string
     {
         if ($level > self::MAX_RECURSION_LEVEL) {
             throw new Exception('Too many iterations were performed while formatting the config file');

--- a/src/library/FOSSBilling/Config.php
+++ b/src/library/FOSSBilling/Config.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FOSSBilling;
 
+use FOSSBilling\Cache\CacheFactory;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -128,6 +129,11 @@ class Config
             } catch (\Exception) {
                 // We shouldn't need to halt execution if there was an error when clearing the cache
             }
+
+            // Also flush the configured application/rate-limiter/Doctrine cache pools. The filesystem
+            // wipe above only clears Twig's cache and Doctrine's proxy classes; it won't reach a
+            // Redis/Memcached-backed pool.
+            CacheFactory::clearAll();
         }
     }
 

--- a/src/library/FOSSBilling/Doctrine/EntityManagerFactory.php
+++ b/src/library/FOSSBilling/Doctrine/EntityManagerFactory.php
@@ -16,8 +16,8 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Proxy\ProxyFactory;
+use FOSSBilling\Cache\CacheFactory;
 use FOSSBilling\Environment;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
@@ -33,7 +33,11 @@ class EntityManagerFactory
         );
         $moduleEntityPaths = array_values($moduleEntityPaths);
 
-        $cache = new FilesystemAdapter('doctrine', 0, PATH_CACHE);
+        // ORMSetup uses this as the metadata, query, AND result cache. Always pass an explicit,
+        // non-null pool here: if `cache` is omitted, Doctrine silently probes for APCu/Memcached/Redis
+        // on localhost with no authentication (see ORMSetup::createCacheInstance()), which would let
+        // whatever happens to be installed on the host override the admin's configured cache driver.
+        $cache = CacheFactory::create(CacheFactory::NAMESPACE_DOCTRINE);
 
         $config = ORMSetup::createAttributeMetadataConfig(
             paths: $moduleEntityPaths,

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Box\Mod\System\Api;
 
+use FOSSBilling\Cache\CacheFactory;
 use FOSSBilling\Config;
 use FOSSBilling\Tools;
 use FOSSBilling\Validation\Api\RequiredParams;
@@ -74,6 +75,76 @@ class Admin extends \FOSSBilling\Api\AbstractApi
         }
 
         Config::setProperty('i18n.auto_detect_locale', Tools::normalizeBoolean($data['auto_detect_locale'] ?? true, true));
+
+        return true;
+    }
+
+    /**
+     * Returns the cache backend settings stored in the FOSSBilling config file.
+     * The Redis password, if set, is never returned.
+     */
+    public function cache_settings(): array
+    {
+        $this->checkPermissions('system', 'manage_settings');
+
+        return [
+            'driver' => (string) Config::getProperty('cache.driver', 'filesystem'),
+            'redis_host' => (string) Config::getProperty('cache.redis.host', '127.0.0.1'),
+            'redis_port' => (int) Config::getProperty('cache.redis.port', 6379),
+            'redis_password_set' => Config::getProperty('cache.redis.password') !== null,
+            'redis_database' => (int) Config::getProperty('cache.redis.database', 0),
+            'memcached_host' => (string) Config::getProperty('cache.memcached.host', '127.0.0.1'),
+            'memcached_port' => (int) Config::getProperty('cache.memcached.port', 11211),
+        ];
+    }
+
+    /**
+     * Updates the cache backend settings stored in the FOSSBilling config file.
+     *
+     * The new settings are validated by attempting to connect to the configured backend before
+     * anything is saved, so a mistyped host/port/password is rejected with a clear reason rather
+     * than being written and silently falling back to the filesystem cache later.
+     *
+     * @throws \FOSSBilling\Exception
+     */
+    public function update_cache_settings($data): bool
+    {
+        $this->checkPermissions('system', 'update_params');
+
+        $driver = $data['driver'] ?? 'filesystem';
+        if (!in_array($driver, CacheFactory::SUPPORTED_DRIVERS, true)) {
+            throw new \FOSSBilling\Exception('Unsupported cache driver: :driver', [':driver' => $driver]);
+        }
+
+        // Keep the existing password when the admin doesn't provide a new one, so re-saving the
+        // other Redis fields doesn't require re-entering it.
+        $redisPassword = $data['redis_password'] ?? '';
+        if ($redisPassword === '') {
+            $redisPassword = Config::getProperty('cache.redis.password');
+        }
+
+        $newCacheConfig = [
+            'driver' => $driver,
+            'redis' => [
+                'host' => $data['redis_host'] ?? '127.0.0.1',
+                'port' => Tools::normalizePort($data['redis_port'] ?? null, 6379),
+                'password' => $redisPassword ?: null,
+                'database' => (int) ($data['redis_database'] ?? 0),
+            ],
+            'memcached' => [
+                'host' => $data['memcached_host'] ?? '127.0.0.1',
+                'port' => Tools::normalizePort($data['memcached_port'] ?? null, 11211),
+            ],
+        ];
+
+        // Filesystem can't fail to connect, so only redis/memcached need the eager check.
+        if ($driver !== 'filesystem') {
+            CacheFactory::createFromConfig($newCacheConfig, CacheFactory::NAMESPACE_CONNECTION_TEST, 60, fallbackOnFailure: false);
+        }
+
+        $config = Config::getConfig();
+        $config['cache'] = $newCacheConfig;
+        Config::setConfig($config);
 
         return true;
     }

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -116,10 +116,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
             throw new \FOSSBilling\Exception('Unsupported cache driver: :driver', [':driver' => $driver]);
         }
 
-        // Keep the existing password when the admin doesn't provide a new one, so re-saving the
-        // other Redis fields doesn't require re-entering it.
+        // Keep the existing password when the admin leaves the field blank, so re-saving the
+        // other Redis fields doesn't require re-entering it. The explicit "clear" checkbox is
+        // what lets an admin actually remove a previously-set password.
         $redisPassword = $data['redis_password'] ?? '';
-        if ($redisPassword === '') {
+        if ($redisPassword === '' && !Tools::normalizeBoolean($data['redis_password_clear'] ?? false, false)) {
             $redisPassword = Config::getProperty('cache.redis.password');
         }
 

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -16,6 +16,7 @@ use Box\Mod\System\Repository\SettingRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use FOSSBilling\Cache\CacheFactory;
 use FOSSBilling\Config;
 use FOSSBilling\Environment;
 use FOSSBilling\GeoIP\Reader;
@@ -586,6 +587,10 @@ class Service
         $path = $cachePath ?? PATH_CACHE;
         $this->filesystem->remove($path);
         $this->filesystem->mkdir($path);
+
+        // Also flush the configured application/rate-limiter/Doctrine cache pools, which may be
+        // backed by Redis or Memcached rather than the filesystem path cleared above.
+        CacheFactory::clearAll();
 
         return true;
     }

--- a/src/modules/System/templates/admin/mod_system_settings.html.twig
+++ b/src/modules/System/templates/admin/mod_system_settings.html.twig
@@ -293,6 +293,13 @@
                                         <label class="form-label" for="redis_password">{{ 'Password'|trans }}</label>
                                         <input class="form-control" id="redis_password" type="password" name="redis_password" placeholder="{% if cache_settings.redis_password_set %}{{ '(unchanged)'|trans }}{% endif %}">
                                         <div class="form-hint">{{ 'Leave blank to keep the current password.'|trans }}</div>
+                                        {% if cache_settings.redis_password_set %}
+                                            <label class="form-check mt-1">
+                                                <input type="hidden" name="redis_password_clear" value="0">
+                                                <input class="form-check-input" type="checkbox" name="redis_password_clear" value="1">
+                                                <span class="form-check-label">{{ 'Clear the saved password'|trans }}</span>
+                                            </label>
+                                        {% endif %}
                                     </div>
                                     <div class="col-lg-6">
                                         <label class="form-label" for="redis_database">{{ 'Database Index'|trans }}</label>

--- a/src/modules/System/templates/admin/mod_system_settings.html.twig
+++ b/src/modules/System/templates/admin/mod_system_settings.html.twig
@@ -26,6 +26,7 @@
     {% set new_params = admin.extension_config_get({ 'ext': 'mod_system' }) %}
     {% set params = admin.system_get_params %}
     {% set localization = admin.system_localization_settings %}
+    {% set cache_settings = admin.system_cache_settings %}
     {% set can_update_params = has_permission('system', 'update_params') %}
     {% set can_invalidate_cache = has_permission('system', 'invalidate_cache') %}
     {% set can_toggle_error_reporting = has_permission('system', 'toggle_error_reporting') %}
@@ -258,7 +259,71 @@
                 </div>
 
                 <div class="tab-pane fade" id="tab-cache" role="tabpanel">
-                    <div class="card-body d-flex align-items-center justify-content-between gap-3">
+                    <div class="card-body">
+                        <h4 class="card-title mb-2">{{ 'Cache Backend'|trans }}</h4>
+                        <p class="text-secondary">{{ 'Choose the backend used for the application cache, rate limiter, and Doctrine ORM cache. Redis and Memcached require the corresponding PHP extension to be installed on the server.'|trans }}</p>
+                        <form method="post" action="{{ 'system/update_cache_settings'|api_url }}" {{ fb_api_form({ message: 'Cache settings updated'|trans }) }}>
+                            <div class="d-flex flex-wrap gap-3 mb-3" id="cache-driver">
+                                <div class="form-check">
+                                    <input class="form-check-input" id="radioCacheFilesystem" type="radio" name="driver" value="filesystem"{% if cache_settings.driver == 'filesystem' %} checked{% endif %}>
+                                    <label class="form-check-label" for="radioCacheFilesystem">{{ 'Filesystem'|trans }}</label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" id="radioCacheRedis" type="radio" name="driver" value="redis"{% if cache_settings.driver == 'redis' %} checked{% endif %}>
+                                    <label class="form-check-label" for="radioCacheRedis">{{ 'Redis'|trans }}</label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" id="radioCacheMemcached" type="radio" name="driver" value="memcached"{% if cache_settings.driver == 'memcached' %} checked{% endif %}>
+                                    <label class="form-check-label" for="radioCacheMemcached">{{ 'Memcached'|trans }}</label>
+                                </div>
+                            </div>
+
+                            <fieldset class="cache-redis"{% if cache_settings.driver != 'redis' %} style="display:none;"{% endif %}>
+                                <legend class="h5 mb-3">{{ 'Redis Settings'|trans }}</legend>
+                                <div class="row g-3">
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="redis_host">{{ 'Host'|trans }}</label>
+                                        <input class="form-control" id="redis_host" type="text" name="redis_host" value="{{ cache_settings.redis_host }}" placeholder="127.0.0.1">
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="redis_port">{{ 'Port'|trans }}</label>
+                                        <input class="form-control" id="redis_port" type="text" name="redis_port" value="{{ cache_settings.redis_port }}" placeholder="6379">
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="redis_password">{{ 'Password'|trans }}</label>
+                                        <input class="form-control" id="redis_password" type="password" name="redis_password" placeholder="{% if cache_settings.redis_password_set %}{{ '(unchanged)'|trans }}{% endif %}">
+                                        <div class="form-hint">{{ 'Leave blank to keep the current password.'|trans }}</div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="redis_database">{{ 'Database Index'|trans }}</label>
+                                        <input class="form-control" id="redis_database" type="text" name="redis_database" value="{{ cache_settings.redis_database }}" placeholder="0">
+                                    </div>
+                                </div>
+                                <div class="form-hint mt-2">{{ 'Requires the PHP redis (or relay) extension.'|trans }}</div>
+                            </fieldset>
+
+                            <fieldset class="cache-memcached"{% if cache_settings.driver != 'memcached' %} style="display:none;"{% endif %}>
+                                <legend class="h5 mb-3">{{ 'Memcached Settings'|trans }}</legend>
+                                <div class="row g-3">
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="memcached_host">{{ 'Host'|trans }}</label>
+                                        <input class="form-control" id="memcached_host" type="text" name="memcached_host" value="{{ cache_settings.memcached_host }}" placeholder="127.0.0.1">
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="memcached_port">{{ 'Port'|trans }}</label>
+                                        <input class="form-control" id="memcached_port" type="text" name="memcached_port" value="{{ cache_settings.memcached_port }}" placeholder="11211">
+                                    </div>
+                                </div>
+                                <div class="form-hint mt-2">{{ 'Requires the PHP memcached extension.'|trans }}</div>
+                            </fieldset>
+
+                            <div class="mt-3">
+                                <button class="btn btn-primary" type="submit"{% if not can_update_params %} disabled aria-disabled="true"{% endif %}>{{ 'Update Settings'|trans }}</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <div class="card-body d-flex align-items-center justify-content-between gap-3 border-top">
                         <div>
                             <h4 class="card-title mb-2">{{ 'Cache Control'|trans }}</h4>
                             <p class="text-secondary mb-0">{{ 'Clear compiled templates and cached system state when you need configuration or theme changes to take effect immediately.'|trans }}</p>
@@ -501,6 +566,18 @@
         FOSSBilling.message(`{{ 'Network interface updated.'|trans }}`);
         updateExternalIP();
     }
+
+    const cacheDriverInputs = document.querySelectorAll('#cache-driver input');
+
+    cacheDriverInputs.forEach(input => {
+        input.addEventListener('click', function() {
+            const redisFieldset = document.querySelector('fieldset.cache-redis');
+            const memcachedFieldset = document.querySelector('fieldset.cache-memcached');
+
+            redisFieldset.style.display = this.value === 'redis' ? 'block' : 'none';
+            memcachedFieldset.style.display = this.value === 'memcached' ? 'block' : 'none';
+        });
+    });
 </script>
 {% endblock %}
 

--- a/src/modules/System/tests/Unit/Api/AdminTest.php
+++ b/src/modules/System/tests/Unit/Api/AdminTest.php
@@ -10,6 +10,8 @@
 
 declare(strict_types=1);
 
+use FOSSBilling\Config;
+
 use function Tests\Helpers\container;
 
 test('dependency injection', function (): void {
@@ -51,6 +53,27 @@ test('update params', function (): void {
     $result = $api->update_params($data);
     expect($result)->toBeBool();
     expect($result)->toBeTrue();
+});
+
+test('update cache settings clears the saved redis password only when explicitly requested', function (): void {
+    $api = apiEndpoint(new Box\Mod\System\Api\Admin());
+    $originalConfig = Config::getConfig();
+
+    try {
+        // Saving a password stores it.
+        $api->update_cache_settings(['driver' => 'filesystem', 'redis_password' => 'secret']);
+        expect(Config::getProperty('cache.redis.password'))->toBe('secret');
+
+        // Leaving the field blank on a later save keeps the existing password.
+        $api->update_cache_settings(['driver' => 'filesystem']);
+        expect(Config::getProperty('cache.redis.password'))->toBe('secret');
+
+        // The explicit "clear" checkbox is what actually removes it.
+        $api->update_cache_settings(['driver' => 'filesystem', 'redis_password_clear' => '1']);
+        expect(Config::getProperty('cache.redis.password'))->toBeNull();
+    } finally {
+        Config::setConfig($originalConfig, false);
+    }
 });
 
 test('messages', function (): void {

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+use FOSSBilling\Cache\CacheFactory;
+use FOSSBilling\Config;
+use FOSSBilling\Exception;
+use Psr\Cache\CacheItemPoolInterface;
+
+beforeEach(function (): void {
+    $this->cacheFactoryOriginalConfig = Config::getConfig();
+});
+
+afterEach(function (): void {
+    // $clearCache=false: none of these tests need the full cache-clearing side effects,
+    // and skipping it keeps the suite from depending on any real Redis/Memcached backend.
+    Config::setConfig($this->cacheFactoryOriginalConfig, false);
+});
+
+function hasRedisExtension(): bool
+{
+    return class_exists(Redis::class) || class_exists(Relay\Relay::class) || class_exists(RedisCluster::class);
+}
+
+function setCacheConfig(?array $cacheConfig): void
+{
+    $config = Config::getConfig();
+    if ($cacheConfig === null) {
+        unset($config['cache']);
+    } else {
+        $config['cache'] = $cacheConfig;
+    }
+    Config::setConfig($config, false);
+}
+
+test('defaults to a working filesystem cache when no cache configuration is set', function (): void {
+    setCacheConfig(null);
+
+    $pool = CacheFactory::create('cache_factory_test');
+
+    expect($pool)->toBeInstanceOf(CacheItemPoolInterface::class);
+
+    $item = $pool->getItem('probe');
+    $item->set('value');
+    $pool->save($item);
+
+    expect($pool->getItem('probe')->get())->toBe('value');
+
+    $pool->deleteItem('probe');
+});
+
+test('rejects an unsupported cache driver', function (): void {
+    expect(fn () => CacheFactory::createFromConfig(['driver' => 'memory'], 'cache_factory_test', 0, true))
+        ->toThrow(Exception::class, 'Unsupported cache driver');
+});
+
+test('falls back to the filesystem cache at runtime when the configured driver is unreachable', function (): void {
+    if (hasRedisExtension()) {
+        $this->markTestSkipped('This test requires an environment without the redis/relay extension.');
+    }
+
+    setCacheConfig(['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]]);
+
+    $pool = CacheFactory::create('cache_factory_test');
+
+    $item = $pool->getItem('probe');
+    $item->set('value');
+    $pool->save($item);
+
+    expect($pool->getItem('probe')->get())->toBe('value');
+
+    $pool->deleteItem('probe');
+});
+
+test('rejects saving a redis configuration when the redis extension is unavailable', function (): void {
+    if (hasRedisExtension()) {
+        $this->markTestSkipped('This test requires an environment without the redis/relay extension.');
+    }
+
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, 'requires the PHP redis');
+});
+
+test('rejects saving a memcached configuration when the memcached extension is unavailable', function (): void {
+    if (class_exists(Memcached::class)) {
+        $this->markTestSkipped('This test requires an environment without the memcached extension.');
+    }
+
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'memcached', 'memcached' => ['host' => '127.0.0.1', 'port' => 11211]],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, 'requires the PHP memcached');
+});
+
+test('clearAll never throws even with a misconfigured driver', function (): void {
+    if (hasRedisExtension()) {
+        $this->markTestSkipped('This test requires an environment without the redis/relay extension.');
+    }
+
+    setCacheConfig(['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]]);
+
+    CacheFactory::clearAll();
+})->expectNotToPerformAssertions();

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -40,6 +40,13 @@ function setCacheConfig(?array $cacheConfig): void
     Config::setConfig($config, false);
 }
 
+function setInstanceId(string $instanceId): void
+{
+    $config = Config::getConfig();
+    $config['info']['instance_id'] = $instanceId;
+    Config::setConfig($config, false);
+}
+
 test('defaults to a working filesystem cache when no cache configuration is set', function (): void {
     setCacheConfig(null);
 
@@ -103,6 +110,24 @@ test('rejects saving a memcached configuration when the memcached extension is u
         0,
         false,
     ))->toThrow(Exception::class, 'requires the PHP memcached');
+});
+
+test('cache pools are isolated per installation instance id', function (): void {
+    setInstanceId('install-a');
+    $poolA = CacheFactory::create('cache_factory_test');
+    $item = $poolA->getItem('shared-key');
+    $item->set('value-a');
+    $poolA->save($item);
+
+    setInstanceId('install-b');
+    $poolB = CacheFactory::create('cache_factory_test');
+    expect($poolB->getItem('shared-key')->isHit())->toBeFalse();
+
+    setInstanceId('install-a');
+    $poolA2 = CacheFactory::create('cache_factory_test');
+    expect($poolA2->getItem('shared-key')->get())->toBe('value-a');
+
+    $poolA2->deleteItem('shared-key');
 });
 
 test('clearAll never throws even with a misconfigured driver', function (): void {


### PR DESCRIPTION
## Summary

Closes #3756. The RedBeanPHP → Doctrine migration this issue was blocked on is now complete.

- Adds a `cache` config block (`driver`: `filesystem` (default) / `redis` / `memcached`) to `config-sample.php`.
- Adds `FOSSBilling\Cache\CacheFactory`, which builds the app cache (`$di['cache']`), rate limiter cache (`$di['rate_limit_cache']`), and Doctrine ORM cache pools from that config, replacing the previously hardcoded `FilesystemAdapter` instances.
- `EntityManagerFactory` still always passes an explicit cache object to `ORMSetup::createAttributeMetadataConfig()` — this matters because Doctrine silently auto-probes for APCu/Memcached/Redis on `127.0.0.1` with no auth when `cache` is omitted (see `ORMSetup::createCacheInstance()`); passing an explicit pool (as before) avoids that footgun regardless of what's installed on the host.
- That same cache object is also Doctrine's query and result cache (`ORMSetup::createConfig()` wires all three from one pool), so this gets those onto Redis/Memcached too, for free.
- Redis/Memcached configs are validated eagerly when saved (a real connection attempt) and rejected with a clear error if unreachable; at runtime, an unreachable/misconfigured backend logs a warning and falls back to filesystem instead of breaking the app.
- Centralizes cache invalidation (`Config::setConfig()`, `System\Service::clearCache()`) so switching drivers or clearing the cache flushes whichever backend is actually active, not just the filesystem path.
- Adds a cache driver picker to admin **System Settings > Cache**, backed by new `system/cache_settings` (read) and `system/update_cache_settings` (write) API endpoints.