### PR TITLE
Stop leaking sensitive fields from staff and client listing queries

### DIFF
--- a/src/modules/Client/Service.php
+++ b/src/modules/Client/Service.php
@@ -208,9 +208,11 @@ class Service implements InjectionAwareInterface
         return true;
     }
 
-    public function getSearchQuery($data, $selectStmt = 'SELECT c.*'): array
+    public function getSearchQuery($data, $selectStmt = null): array
     {
-        $sql = $selectStmt;
+        // `client` also holds `pass`, `salt`, and `api_token` - reuse EXPORTABLE_COLUMNS
+        // instead of `c.*` so listing never exposes them.
+        $sql = $selectStmt ?? 'SELECT c.' . implode(', c.', self::EXPORTABLE_COLUMNS);
         $sql .= ' FROM client as c left join client_group as cg on c.client_group_id = cg.id';
 
         $search = (isset($data['search']) && !empty($data['search'])) ? $data['search'] : null;

--- a/src/modules/Client/tests/Unit/ServiceTest.php
+++ b/src/modules/Client/tests/Unit/ServiceTest.php
@@ -179,7 +179,7 @@ test('onAfterClientSignUp handles exception gracefully', function (): void {
 });
 
 dataset('searchQueryData', [
-    [[], 'SELECT c.*', []],
+    [[], 'SELECT c.id, c.aid', []],
     [
         ['id' => 1],
         '(c.id = :client_id OR c.aid = :alt_client_id)',
@@ -261,6 +261,16 @@ test('getSearchQuery with custom select statement', function (): void {
     expect($result[1])->toBeArray();
 
     expect(str_contains((string) $result[0], $selectStmt))->toBeTrue($result[0]);
+});
+
+test('getSearchQuery never selects sensitive client columns', function (): void {
+    $service = new Box\Mod\Client\Service();
+    [$query] = $service->getSearchQuery([]);
+
+    expect(str_contains($query, '*'))->toBeFalse($query);
+    foreach (['pass', 'salt', 'api_token', 'hash', 'config'] as $sensitiveColumn) {
+        expect(preg_match('/\b' . preg_quote($sensitiveColumn, '/') . '\b/', $query))->toBe(0, "Query unexpectedly selects '$sensitiveColumn': $query");
+    }
 });
 
 test('getPairs returns array', function (): void {

--- a/src/modules/Staff/Service.php
+++ b/src/modules/Staff/Service.php
@@ -438,7 +438,9 @@ class Service implements InjectionAwareInterface
 
     public function getSearchQuery($data): array
     {
-        $query = 'SELECT * FROM admin';
+        // `admin` also holds `pass` and `api_token` - list columns explicitly instead of
+        // `SELECT *` so listing never exposes them.
+        $query = 'SELECT id, system_name, email, name, signature, status, timezone, created_at, updated_at FROM admin';
 
         $id = $data['id'] ?? null;
         $search = $data['search'] ?? null;

--- a/src/modules/Staff/tests/Unit/ServiceTest.php
+++ b/src/modules/Staff/tests/Unit/ServiceTest.php
@@ -1091,10 +1091,23 @@ dataset('searchFilters', fn (): array => [
     ],
     'do not filter by false no_cron' => [
         ['no_cron' => 'false'],
-        'SELECT * FROM admin',
+        'SELECT id, system_name, email, name, signature, status, timezone, created_at, updated_at FROM admin',
         [],
     ],
 ]);
+
+test('getSearchQuery never selects sensitive admin columns', function (): void {
+    $di = container();
+
+    $service = new Service();
+    $service->setDi($di);
+    [$query] = $service->getSearchQuery([]);
+
+    expect(str_contains($query, '*'))->toBeFalse($query);
+    foreach (['pass', 'salt', 'api_token', 'hash', 'config'] as $sensitiveColumn) {
+        expect(preg_match('/\b' . preg_quote($sensitiveColumn, '/') . '\b/', $query))->toBe(0, "Query unexpectedly selects '$sensitiveColumn': $query");
+    }
+});
 
 test('getSearchQuery returns correct query and params', function (array $data, string $expectedStr, array $expectedParams): void {
     $di = container();


### PR DESCRIPTION
## Summary

`Box\Mod\Staff\Service::getSearchQuery()` built `SELECT * FROM admin`, and `Box\Mod\Client\Service::getSearchQuery()` defaulted to `SELECT c.*`. Both include sensitive columns (`admin.pass`/`api_token`, `client.pass`/`salt`/`api_token`) that must never reach an API response; the same class of leak `FOSSBilling\Http\CsvResponseFactory::SENSITIVE_COLUMNS` already guards against for CSV exports.

- `Staff\Service::getSearchQuery()` now selects an explicit column whitelist instead of `*`.
- `Client\Service::getSearchQuery()` now defaults to the columns already whitelisted in `EXPORTABLE_COLUMNS` instead of `c.*`, reusing the existing CSV-export whitelist rather than duplicating it.
- Added tests asserting neither query ever selects `pass`, `salt`, `api_token`, `hash`, or `config`.