### PR TITLE
Replace WHOIS availability lookups with RDAP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "dompdf/dompdf": "^3.1.4",
         "egulias/email-validator": "^4.0.4",
         "filp/whoops": "^2.18.4",
-        "io-developer/php-whois": "^4.1.10",
         "league/commonmark": "^2.8",
         "league/csv": "^9.28",
         "liborm85/composer-vendor-cleaner": "^1.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8626cb3f548d4a3b71a57a1b99fac90d",
+    "content-hash": "d06e97ea89cdac82fc7068623c923f48",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1345,68 +1345,6 @@
                 }
             ],
             "time": "2026-07-20T13:48:31+00:00"
-        },
-        {
-            "name": "io-developer/php-whois",
-            "version": "4.1.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/io-developer/php-whois.git",
-                "reference": "ea4cf52832fe8ff56fc4937138467819aa2829c1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/io-developer/php-whois/zipball/ea4cf52832fe8ff56fc4937138467819aa2829c1",
-                "reference": "ea4cf52832fe8ff56fc4937138467819aa2829c1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": ">=7.2",
-                "symfony/polyfill-intl-idn": "^1.27"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Iodev\\": "src/Iodev/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Sergey Sedyshev",
-                    "email": "i.o.developer@gmail.com",
-                    "homepage": "https://github.com/io-developer"
-                }
-            ],
-            "description": "PHP WHOIS provides parsed and raw whois lookup of domains and ASN routes. PHP 5.4+ and 7+ compatible ",
-            "homepage": "https://github.com/io-developer/php-whois",
-            "keywords": [
-                "asn",
-                "domain",
-                "info",
-                "lookup",
-                "parser",
-                "php",
-                "query",
-                "routes",
-                "tld",
-                "whois",
-                "црщшы"
-            ],
-            "support": {
-                "issues": "https://github.com/io-developer/php-whois/issues",
-                "source": "https://github.com/io-developer/php-whois/tree/4.1.10"
-            },
-            "time": "2023-01-25T14:42:45+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/cspell.json
+++ b/cspell.json
@@ -225,6 +225,7 @@
         "copyfields",
         "mydomain",
         "WHOIS",
+        "RDAP",
         "supportticket",
         "massmailer",
         "kbcategories",

--- a/cspell.json
+++ b/cspell.json
@@ -226,6 +226,7 @@
         "mydomain",
         "WHOIS",
         "RDAP",
+        "exämple",
         "supportticket",
         "massmailer",
         "kbcategories",

--- a/src/library/Registrar/Adapter/Custom.php
+++ b/src/library/Registrar/Adapter/Custom.php
@@ -8,20 +8,15 @@ declare(strict_types=1);
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-use Iodev\Whois\Factory;
-
 class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
 {
     public $config = [
-        'use_whois' => false,
+        'use_rdap' => false,
     ];
 
     public function __construct($options)
     {
-        if (isset($options['use_whois'])) {
-            $this->config['use_whois'] = (bool) $options['use_whois'];
-        }
+        $this->config['use_rdap'] = (bool) ($options['use_rdap'] ?? $options['use_whois'] ?? false);
     }
 
     public static function getConfig(): array
@@ -29,9 +24,9 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
         return [
             'label' => 'Custom Registrar always responds with positive results. Useful if no other registrar is suitable.',
             'form' => [
-                'use_whois' => ['radio', [
+                'use_rdap' => ['radio', [
                     'multiOptions' => ['1' => 'Yes', '0' => 'No'],
-                    'label' => 'Use WHOIS to Check for Domain Availability',
+                    'label' => 'Use RDAP Registry Lookups to Check for Domain Availability',
                 ],
                 ],
             ],
@@ -49,13 +44,11 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Checking domain availability: ' . $domain->getName());
 
-        if ($this->config['use_whois']) {
-            $whois = Factory::get()->createWhois();
-
-            return $whois->isDomainAvailable($domain->getName());
+        if (!$this->config['use_rdap']) {
+            return true;
         }
 
-        return true;
+        return $this->getRdap()->isDomainAvailable($domain->getName()) ?? true;
     }
 
     public function modifyNs(Registrar_Domain $domain): bool
@@ -79,7 +72,7 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
 
     public function getDomainDetails(Registrar_Domain $domain)
     {
-        $this->getLog()->debug('Getting whois: ' . $domain->getName());
+        $this->getLog()->debug('Getting domain details: ' . $domain->getName());
 
         if (!$domain->getRegistrationTime()) {
             $domain->setRegistrationTime(time());

--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -8,9 +8,6 @@ declare(strict_types=1);
  * @copyright FOSSBilling (https://www.fossbilling.org)
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
-
-use Iodev\Whois\Factory;
-
 class Registrar_Adapter_Email extends Registrar_AdapterAbstract
 {
     protected $config;
@@ -24,12 +21,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
             throw new Registrar_Exception('The ":domain_registrar" domain registrar is not fully configured. Please configure the :missing', [':domain_registrar' => 'Email', ':missing' => 'email'], 3001);
         }
 
-        if (isset($options['use_whois'])) {
-            $this->config['use_whois'] = (bool) $options['use_whois'];
-        } else {
-            $this->config['use_whois'] = false;
-        }
-
+        $this->config['use_rdap'] = (bool) ($options['use_rdap'] ?? $options['use_whois'] ?? false);
         $this->config['from'] = $this->config['email'];
     }
 
@@ -43,9 +35,9 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
                     'description' => 'Email to Send Domain Change Notifications',
                 ],
                 ],
-                'use_whois' => ['radio', [
+                'use_rdap' => ['radio', [
                     'multiOptions' => ['1' => 'Yes', '0' => 'No'],
-                    'label' => 'Use WHOIS to Check for Domain Availability',
+                    'label' => 'Use RDAP Registry Lookups to Check for Domain Availability',
                 ],
                 ],
             ],
@@ -56,13 +48,16 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Checking domain availability: ' . $domain->getName());
 
-        if ($this->config['use_whois']) {
-            $whois = Factory::get()->createWhois();
-
-            return $whois->isDomainAvailable($domain->getName());
+        if (!$this->config['use_rdap']) {
+            throw new Registrar_Exception(':type: registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain availability']);
         }
 
-        throw new Registrar_Exception(':type: registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain availability']);
+        $result = $this->getRdap()->isDomainAvailable($domain->getName());
+        if ($result !== null) {
+            return $result;
+        }
+
+        throw new Registrar_Exception('Unable to determine the availability of :domain via RDAP', [':domain' => $domain->getName()]);
     }
 
     public function isDomaincanBeTransferred(Registrar_Domain $domain): never

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -225,6 +225,14 @@ abstract class Registrar_AdapterAbstract
     }
 
     /**
+     * Creates an RDAP client for registry-based domain availability lookups.
+     */
+    protected function getRdap(): Registrar_Rdap
+    {
+        return new Registrar_Rdap($this->getHttpClient(), $this->getLog());
+    }
+
+    /**
      * Enables test mode for the adapter.
      *
      * @return Registrar_AdapterAbstract the current adapter object, for method chaining

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -25,6 +25,11 @@ abstract class Registrar_AdapterAbstract
     protected ?Box\Mod\Order\Entity\Order $_order = null;
 
     /**
+     * Lazily created RDAP client, shared by all availability checks of the adapter.
+     */
+    protected ?Registrar_Rdap $_rdap = null;
+
+    /**
      * Return array with configuration.
      *
      * Must be overridden in adapter class
@@ -229,7 +234,7 @@ abstract class Registrar_AdapterAbstract
      */
     protected function getRdap(): Registrar_Rdap
     {
-        return new Registrar_Rdap($this->getHttpClient(), $this->getLog());
+        return $this->_rdap ??= new Registrar_Rdap($this->getHttpClient(), $this->getLog());
     }
 
     /**

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -53,9 +53,11 @@ class Registrar_Rdap
     public function isDomainAvailable(string $domain): ?bool
     {
         $domain = strtolower(trim($domain));
-        $ascii = idn_to_ascii($domain);
-        if ($ascii !== false) {
-            $domain = rtrim($ascii, '.');
+        if ($domain !== '') {
+            $ascii = idn_to_ascii($domain);
+            if ($ascii !== false) {
+                $domain = rtrim($ascii, '.');
+            }
         }
 
         if ($domain === '' || !str_contains($domain, '.') || str_starts_with($domain, '.') || str_ends_with($domain, '.')) {

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -61,14 +61,15 @@ class Registrar_Rdap
     public function isDomainAvailable(string $domain): ?bool
     {
         $domain = strtolower(trim($domain));
-        if ($domain !== '') {
-            $ascii = idn_to_ascii($domain);
-            if ($ascii !== false) {
-                $domain = rtrim($ascii, '.');
-            }
+        $ascii = $domain === '' ? false : idn_to_ascii($domain);
+        if ($ascii === false) {
+            return null;
         }
 
-        if ($domain === '' || !str_contains($domain, '.') || str_starts_with($domain, '.') || str_ends_with($domain, '.')) {
+        $domain = rtrim($ascii, '.');
+
+        $labels = explode('.', $domain);
+        if (count($labels) < 2 || in_array('', $labels, true)) {
             return null;
         }
 

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -61,7 +61,7 @@ class Registrar_Rdap
     public function isDomainAvailable(string $domain): ?bool
     {
         $domain = strtolower(trim($domain));
-        $ascii = $domain === '' ? false : idn_to_ascii($domain);
+        $ascii = $domain === '' ? false : idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII | IDNA_USE_STD3_RULES);
         if ($ascii === false) {
             return null;
         }

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -146,13 +146,49 @@ class Registrar_Rdap
             return $this->bootstrap = [];
         }
 
+        $services = is_array($data) ? $data['services'] ?? [] : null;
+        if (!is_array($services)) {
+            return $this->rejectBootstrap('The RDAP bootstrap registry response is malformed');
+        }
+
         $map = [];
-        foreach ($data['services'] ?? [] as [$labels, $servers]) {
-            foreach ($labels ?? [] as $label) {
-                $map[strtolower($label)] = $servers;
+        foreach ($services as $service) {
+            if (!$this->isValidServiceEntry($service)) {
+                return $this->rejectBootstrap('The RDAP bootstrap registry response is malformed');
+            }
+
+            foreach ($service[0] as $label) {
+                $map[strtolower($label)] = array_values($service[1]);
             }
         }
 
         return $this->bootstrap = $map;
+    }
+
+    private function rejectBootstrap(string $message): array
+    {
+        $this->logger?->warning($message);
+
+        return $this->bootstrap = [];
+    }
+
+    /**
+     * Validates one [labels, servers] entry of the bootstrap registry.
+     *
+     * @param mixed $entry
+     */
+    private function isValidServiceEntry($entry): bool
+    {
+        if (!is_array($entry) || count($entry) !== 2 || !is_array($entry[0]) || !is_array($entry[1])) {
+            return false;
+        }
+
+        foreach ([...$entry[0], ...$entry[1]] as $value) {
+            if (!is_string($value) || $value === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -27,6 +27,14 @@ class Registrar_Rdap
 {
     final public const BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
 
+    /**
+     * Bounds applied to every request so a slow registry cannot occupy a worker indefinitely.
+     */
+    private const REQUEST_OPTIONS = [
+        'timeout' => 10,
+        'max_duration' => 15,
+    ];
+
     private HttpClientInterface $httpClient;
 
     /**
@@ -40,11 +48,7 @@ class Registrar_Rdap
         ?HttpClientInterface $httpClient = null,
         private readonly ?Psr\Log\LoggerInterface $logger = null,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create([
-            'bindto' => BIND_TO,
-            'timeout' => 10,
-            'max_duration' => 15,
-        ]);
+        $this->httpClient = ($httpClient ?? HttpClient::create(['bindto' => BIND_TO]))->withOptions(self::REQUEST_OPTIONS);
     }
 
     /**

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * RDAP (RFC 7480-7484) client for domain availability lookups.
+ *
+ * The authoritative RDAP service for a TLD is resolved through the IANA DNS
+ * bootstrap registry (RFC 9224). Availability is determined from the HTTP
+ * status of the domain query: 404 means the domain is unregistered, any other
+ * successful status means it is registered. Null is returned when no RDAP
+ * service exists for the TLD or every query fails, so callers can decide how
+ * to handle an indeterminate result.
+ */
+class Registrar_Rdap
+{
+    final public const BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
+
+    private HttpClientInterface $httpClient;
+
+    /**
+     * Map of lowercase TLD labels to their RDAP base URLs.
+     *
+     * @var array<string, list<string>>|null
+     */
+    private ?array $bootstrap = null;
+
+    public function __construct(
+        ?HttpClientInterface $httpClient = null,
+        private readonly ?Psr\Log\LoggerInterface $logger = null,
+    ) {
+        $this->httpClient = $httpClient ?? HttpClient::create(['bindto' => BIND_TO]);
+    }
+
+    /**
+     * Checks if a domain name is available for registration.
+     *
+     * @param string $domain a fully qualified domain name, e.g. "example.com"
+     *
+     * @return bool true when the domain appears unregistered, false when it is registered, null when availability cannot be determined
+     */
+    public function isDomainAvailable(string $domain): ?bool
+    {
+        $domain = strtolower(trim($domain));
+        $ascii = idn_to_ascii($domain);
+        if ($ascii !== false) {
+            $domain = rtrim($ascii, '.');
+        }
+
+        if ($domain === '' || !str_contains($domain, '.') || str_starts_with($domain, '.') || str_ends_with($domain, '.')) {
+            return null;
+        }
+
+        foreach ($this->resolveServers($domain) ?? [] as $server) {
+            try {
+                $statusCode = $this->httpClient
+                    ->request('GET', rtrim($server, '/') . '/domain/' . rawurlencode($domain), [
+                        'headers' => ['Accept' => 'application/rdap+json'],
+                    ])
+                    ->getStatusCode();
+            } catch (HttpExceptionInterface $e) {
+                $this->logger?->warning('RDAP request against ' . $server . ' failed: ' . $e->getMessage());
+
+                continue;
+            }
+
+            if ($statusCode === 404) {
+                return true;
+            }
+
+            if ($statusCode < 300) {
+                return false;
+            }
+
+            $this->logger?->warning('RDAP request against ' . $server . ' returned the unexpected status code ' . $statusCode);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the RDAP base URLs serving registrations under the given domain,
+     * most specific zone first, or null when no zone of the domain is covered
+     * by the bootstrap registry.
+     *
+     * @return list<string>|null
+     */
+    private function resolveServers(string $domain): ?array
+    {
+        $bootstrap = $this->getBootstrap();
+
+        $labels = explode('.', $domain);
+        while (count($labels) > 1) {
+            array_shift($labels);
+
+            $servers = $bootstrap[implode('.', $labels)] ?? null;
+            if ($servers !== null && $servers !== []) {
+                return $servers;
+            }
+        }
+
+        if ($bootstrap !== []) {
+            $this->logger?->warning('No RDAP service is known for the ' . implode('.', $labels) . ' zone');
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function getBootstrap(): array
+    {
+        if ($this->bootstrap !== null) {
+            return $this->bootstrap;
+        }
+
+        try {
+            $body = $this->httpClient->request('GET', self::BOOTSTRAP_URL)->getContent();
+            $data = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (HttpExceptionInterface|JsonException $e) {
+            $this->logger?->warning('Unable to fetch the RDAP bootstrap registry: ' . $e->getMessage());
+
+            return [];
+        }
+
+        $map = [];
+        foreach ($data['services'] ?? [] as [$labels, $servers]) {
+            foreach ($labels ?? [] as $label) {
+                $map[strtolower($label)] = $servers;
+            }
+        }
+
+        return $this->bootstrap = $map;
+    }
+}

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -40,7 +40,11 @@ class Registrar_Rdap
         ?HttpClientInterface $httpClient = null,
         private readonly ?Psr\Log\LoggerInterface $logger = null,
     ) {
-        $this->httpClient = $httpClient ?? HttpClient::create(['bindto' => BIND_TO]);
+        $this->httpClient = $httpClient ?? HttpClient::create([
+            'bindto' => BIND_TO,
+            'timeout' => 10,
+            'max_duration' => 15,
+        ]);
     }
 
     /**
@@ -134,7 +138,7 @@ class Registrar_Rdap
         } catch (HttpExceptionInterface|JsonException $e) {
             $this->logger?->warning('Unable to fetch the RDAP bootstrap registry: ' . $e->getMessage());
 
-            return [];
+            return $this->bootstrap = [];
         }
 
         $map = [];

--- a/src/library/Registrar/Rdap.php
+++ b/src/library/Registrar/Rdap.php
@@ -183,12 +183,28 @@ class Registrar_Rdap
             return false;
         }
 
-        foreach ([...$entry[0], ...$entry[1]] as $value) {
-            if (!is_string($value) || $value === '') {
+        foreach ($entry[0] as $label) {
+            if (!is_string($label) || $label === '') {
+                return false;
+            }
+        }
+
+        foreach ($entry[1] as $server) {
+            if (!self::isValidServerUrl($server)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * @param mixed $server
+     */
+    private static function isValidServerUrl($server): bool
+    {
+        return is_string($server)
+            && filter_var($server, FILTER_VALIDATE_URL) !== false
+            && in_array(parse_url($server, PHP_URL_SCHEME), ['http', 'https'], true);
     }
 }

--- a/tests/Unit/Registrar/Adapter/CustomTest.php
+++ b/tests/Unit/Registrar/Adapter/CustomTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+function createCustomAdapter(array $options, ?callable $respond = null): Registrar_Adapter_Custom
+{
+    $httpClient = new MockHttpClient(fn (string $method, string $url): MockResponse => $respond !== null
+        ? $respond($method, $url)
+        : new MockResponse('{}'));
+
+    return new class($options, $httpClient) extends Registrar_Adapter_Custom {
+        public function __construct(array $options, private readonly MockHttpClient $httpClient)
+        {
+            parent::__construct($options);
+        }
+
+        public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
+        {
+            return $this->httpClient;
+        }
+
+        public function requestCount(): int
+        {
+            return $this->httpClient->getRequestsCount();
+        }
+    };
+}
+
+test('the Custom adapter answers positively without registry lookups unless RDAP is enabled', function (): void {
+    $adapter = createCustomAdapter([]);
+
+    expect($adapter->isDomainAvailable((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue()
+        ->and($adapter->requestCount())->toBe(0);
+});
+
+test('a legacy use_whois opt-in enables RDAP lookups on the Custom adapter', function (): void {
+    $adapter = createCustomAdapter(['use_whois' => '1'], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));
+
+    expect($adapter->isDomainAvailable((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue();
+});
+
+test('an explicit use_rdap setting takes precedence over the legacy use_whois opt-in', function (): void {
+    $adapter = createCustomAdapter(['use_whois' => '1', 'use_rdap' => '0']);
+
+    expect($adapter->isDomainAvailable((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue()
+        ->and($adapter->requestCount())->toBe(0);
+});
+
+test('the Custom adapter reports a registered domain as unavailable', function (): void {
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    $adapter = createCustomAdapter(['use_rdap' => '1'], fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? new MockResponse('{"objectClassName":"domain"}', ['http_code' => 200])
+        : new MockResponse($bootstrap));
+
+    expect($adapter->isDomainAvailable((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeFalse();
+});
+
+test('the Custom adapter falls back to a positive answer when RDAP cannot determine availability', function (): void {
+    $logger = new class extends Psr\Log\AbstractLogger {
+        /** @var list<string> */
+        public array $messages = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            $this->messages[] = (string) $message;
+        }
+    };
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    $adapter = createCustomAdapter(['use_rdap' => '1'], fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? new MockResponse('', ['http_code' => 500])
+        : new MockResponse($bootstrap));
+    $adapter->setLog($logger);
+
+    expect($adapter->isDomainAvailable((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue()
+        ->and(array_filter($logger->messages, fn (string $message): bool => str_contains($message, 'RDAP request against')))->not->toBeEmpty();
+});
+
+test('the Custom adapter configuration form offers an RDAP toggle', function (): void {
+    $form = Registrar_Adapter_Custom::getConfig();
+
+    expect(array_keys($form['form']))->toBe(['use_rdap'])
+        ->and($form['form']['use_rdap'][1]['label'])->toContain('RDAP');
+});

--- a/tests/Unit/Registrar/Adapter/EmailTest.php
+++ b/tests/Unit/Registrar/Adapter/EmailTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+function createEmailAdapter(array $options, ?callable $respond = null): Registrar_Adapter_Email
+{
+    $httpClient = new MockHttpClient(fn (string $method, string $url): MockResponse => $respond !== null
+        ? $respond($method, $url)
+        : new MockResponse('{}'));
+
+    return new class(['email' => 'registrar@example.com', ...$options], $httpClient) extends Registrar_Adapter_Email {
+        public function __construct(array $options, private readonly MockHttpClient $httpClient)
+        {
+            parent::__construct($options);
+        }
+
+        public function getHttpClient(): Symfony\Contracts\HttpClient\HttpClientInterface
+        {
+            return $this->httpClient;
+        }
+    };
+}
+
+function createEmailDomain(): Registrar_Domain
+{
+    return (new Registrar_Domain())->setSld('example')->setTld('.com');
+}
+
+test('the Email adapter refuses availability checks when RDAP lookups are disabled', function (): void {
+    $adapter = createEmailAdapter([]);
+
+    $adapter->isDomainAvailable(createEmailDomain());
+})->throws(Registrar_Exception::class);
+
+function createEmailRdapResponder(callable $domainResponse): callable
+{
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+
+    return fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? $domainResponse()
+        : new MockResponse($bootstrap);
+}
+
+test('the Email adapter reports an unregistered domain as available via RDAP', function (): void {
+    $adapter = createEmailAdapter(['use_rdap' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('', ['http_code' => 404])));
+
+    expect($adapter->isDomainAvailable(createEmailDomain()))->toBeTrue();
+});
+
+test('the Email adapter reports a registered domain as unavailable via RDAP', function (): void {
+    $adapter = createEmailAdapter(['use_whois' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('{"objectClassName":"domain"}', ['http_code' => 200])));
+
+    expect($adapter->isDomainAvailable(createEmailDomain()))->toBeFalse();
+});
+
+test('the Email adapter throws when RDAP cannot determine availability', function (): void {
+    $adapter = createEmailAdapter(['use_rdap' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('', ['http_code' => 429])));
+
+    $adapter->isDomainAvailable(createEmailDomain());
+})->throws(Registrar_Exception::class);
+
+test('the Email adapter configuration form offers an RDAP toggle', function (): void {
+    $form = Registrar_Adapter_Email::getConfig();
+
+    expect(array_keys($form['form']))->toBe(['email', 'use_rdap'])
+        ->and($form['form']['use_rdap'][1]['label'])->toContain('RDAP');
+});

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -99,7 +99,7 @@ test('a failed bootstrap fetch disables all lookups and logs a warning', functio
         ->and($logger->records[0][1])->toContain('RDAP bootstrap registry');
 });
 
-test('an unparseable bootstrap response disables all lookups for the instance', function (): void {
+test('a malformed bootstrap response disables all lookups for the instance', function (): void {
     $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('not-json'));
     $rdap = new Registrar_Rdap($httpClient);
 
@@ -138,7 +138,7 @@ test('inputs that cannot be a domain name are rejected without any HTTP traffic'
 
     expect($rdap->isDomainAvailable($input))->toBeNull()
         ->and($tracker->urls)->toBe([]);
-})->with(['', '.com', 'nodot']);
+})->with(['', '.com', 'example']);
 
 test('the bootstrap registry is only fetched once per instance', function (): void {
     [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -18,7 +18,7 @@ final class RdapRequestTracker
 function createRdapClient(array $bootstrapServices, ?callable $respond = null): array
 {
     $tracker = new RdapRequestTracker();
-    $httpClient = new MockHttpClient(function (string $method, string $url) use ($tracker, $bootstrapServices, $respond): MockResponse {
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($tracker, $bootstrapServices, $respond): MockResponse {
         if ($url === Registrar_Rdap::BOOTSTRAP_URL) {
             $tracker->urls[] = $url;
 
@@ -27,7 +27,7 @@ function createRdapClient(array $bootstrapServices, ?callable $respond = null): 
 
         $tracker->urls[] = $url;
         if ($respond !== null) {
-            return $respond($method, $url);
+            return $respond($method, $url, $options);
         }
 
         return new MockResponse('{}');
@@ -44,6 +44,27 @@ test('a domain query answered with 404 means the domain is available', function 
             Registrar_Rdap::BOOTSTRAP_URL,
             'https://rdap.example.com/com/v1/domain/example.com',
         ]);
+});
+
+test('requests are bounded with explicit time limits', function (): void {
+    $options = null;
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    [$rdap] = createRdapClient(
+        [[['com'], ['https://rdap.example.com/com/v1/']]],
+        function (string $method, string $url, array $requestOptions) use (&$options, $bootstrap): MockResponse {
+            if (!str_contains($url, '/domain/')) {
+                return new MockResponse($bootstrap);
+            }
+
+            $options = $requestOptions;
+
+            return new MockResponse('', ['http_code' => 404]);
+        },
+    );
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeTrue()
+        ->and($options['timeout'])->toBe(10.0)
+        ->and($options['max_duration'])->toBe(15.0);
 });
 
 test('a domain query answered with a success status means the domain is registered', function (int $statusCode): void {

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -78,8 +78,10 @@ test('domains under zones without an RDAP service are left undetermined without 
         ->and($tracker->urls)->toBe([Registrar_Rdap::BOOTSTRAP_URL]);
 });
 
-test('a failed bootstrap fetch disables all lookups and logs a warning', function (): void {
-    $httpClient = new MockHttpClient(function (): never {
+test('a failed bootstrap fetch disables all lookups and is not retried', function (): void {
+    $attempts = 0;
+    $httpClient = new MockHttpClient(function () use (&$attempts): never {
+        $attempts++;
         throw new TransportException('connection refused');
     });
     $logger = new class extends Psr\Log\AbstractLogger {
@@ -94,6 +96,8 @@ test('a failed bootstrap fetch disables all lookups and logs a warning', functio
     $rdap = new Registrar_Rdap($httpClient, $logger);
 
     expect($rdap->isDomainAvailable('example.com'))->toBeNull()
+        ->and($rdap->isDomainAvailable('example-two.com'))->toBeNull()
+        ->and($attempts)->toBe(1)
         ->and($logger->records)->toHaveCount(1)
         ->and($logger->records[0][0])->toBe('warning')
         ->and($logger->records[0][1])->toContain('RDAP bootstrap registry');

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -163,7 +163,7 @@ test('inputs that cannot be a domain name are rejected without any HTTP traffic'
 
     expect($rdap->isDomainAvailable($input))->toBeNull()
         ->and($tracker->urls)->toBe([]);
-})->with(['', '.com', 'example']);
+})->with(['', '.com', 'example', 'example..com']);
 
 test('the bootstrap registry is only fetched once per instance', function (): void {
     [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -15,14 +15,16 @@ final class RdapRequestTracker
 /**
  * @return array{0: Registrar_Rdap, 1: RdapRequestTracker}
  */
-function createRdapClient(array $bootstrapServices, ?callable $respond = null): array
+function createRdapClient(array|string $bootstrapServices, ?callable $respond = null): array
 {
     $tracker = new RdapRequestTracker();
     $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($tracker, $bootstrapServices, $respond): MockResponse {
         if ($url === Registrar_Rdap::BOOTSTRAP_URL) {
             $tracker->urls[] = $url;
 
-            return new MockResponse(json_encode(['version' => '1.0', 'services' => $bootstrapServices], JSON_THROW_ON_ERROR));
+            return new MockResponse(is_string($bootstrapServices)
+                ? $bootstrapServices
+                : json_encode(['version' => '1.0', 'services' => $bootstrapServices], JSON_THROW_ON_ERROR));
         }
 
         $tracker->urls[] = $url;
@@ -130,6 +132,21 @@ test('a malformed bootstrap response disables all lookups for the instance', fun
 
     expect($rdap->isDomainAvailable('example.com'))->toBeNull();
 });
+
+test('a bootstrap response violating the expected schema disables all lookups', function (string $body): void {
+    [$rdap, $tracker] = createRdapClient($body, fn (): MockResponse => new MockResponse('', ['http_code' => 404]));
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeNull()
+        ->and($tracker->urls)->toBe([Registrar_Rdap::BOOTSTRAP_URL]);
+})->with([
+    '"scalar"',
+    '{"services": "oops"}',
+    '{"services": ["oops"]}',
+    '{"services": [["com", ["https://rdap.example.com/com/v1/"]]]}',
+    '{"services": [[["com", 42], ["https://rdap.example.com/com/v1/"]]]}',
+    '{"services": [[["com"], ["https://rdap.example.com/com/v1/", null]]]}',
+    '{"services": [[["com"], [""]]]}',
+]);
 
 test('a failing domain query falls through to the next RDAP server of the zone', function (): void {
     $handlers = [

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -146,6 +146,8 @@ test('a bootstrap response violating the expected schema disables all lookups', 
     '{"services": [[["com", 42], ["https://rdap.example.com/com/v1/"]]]}',
     '{"services": [[["com"], ["https://rdap.example.com/com/v1/", null]]]}',
     '{"services": [[["com"], [""]]]}',
+    '{"services": [[["com"], ["not-a-url"]]]}',
+    '{"services": [[["com"], ["ftp://rdap.example.com"]]]}',
 ]);
 
 test('a failing domain query falls through to the next RDAP server of the zone', function (): void {

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -156,6 +156,7 @@ test('names are normalized before being queried', function (string $input, strin
 })->with([
     [' EXAMPLE.com ', 'https://rdap.example.com/com/v1/domain/example.com'],
     ['exämple.com', 'https://rdap.example.com/com/v1/domain/xn--exmple-cua.com'],
+    ['faß.com', 'https://rdap.example.com/com/v1/domain/xn--fa-hia.com'],
 ]);
 
 test('inputs that cannot be a domain name are rejected without any HTTP traffic', function (string $input): void {
@@ -163,7 +164,7 @@ test('inputs that cannot be a domain name are rejected without any HTTP traffic'
 
     expect($rdap->isDomainAvailable($input))->toBeNull()
         ->and($tracker->urls)->toBe([]);
-})->with(['', '.com', 'example', 'example..com']);
+})->with(['', '.com', 'example', 'example..com', '_foo.com']);
 
 test('the bootstrap registry is only fetched once per instance', function (): void {
     [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));

--- a/tests/Unit/Registrar/RdapTest.php
+++ b/tests/Unit/Registrar/RdapTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class RdapRequestTracker
+{
+    /** @var list<string> */
+    public array $urls = [];
+}
+
+/**
+ * @return array{0: Registrar_Rdap, 1: RdapRequestTracker}
+ */
+function createRdapClient(array $bootstrapServices, ?callable $respond = null): array
+{
+    $tracker = new RdapRequestTracker();
+    $httpClient = new MockHttpClient(function (string $method, string $url) use ($tracker, $bootstrapServices, $respond): MockResponse {
+        if ($url === Registrar_Rdap::BOOTSTRAP_URL) {
+            $tracker->urls[] = $url;
+
+            return new MockResponse(json_encode(['version' => '1.0', 'services' => $bootstrapServices], JSON_THROW_ON_ERROR));
+        }
+
+        $tracker->urls[] = $url;
+        if ($respond !== null) {
+            return $respond($method, $url);
+        }
+
+        return new MockResponse('{}');
+    });
+
+    return [new Registrar_Rdap($httpClient), $tracker];
+}
+
+test('a domain query answered with 404 means the domain is available', function (): void {
+    [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeTrue()
+        ->and($tracker->urls)->toBe([
+            Registrar_Rdap::BOOTSTRAP_URL,
+            'https://rdap.example.com/com/v1/domain/example.com',
+        ]);
+});
+
+test('a domain query answered with a success status means the domain is registered', function (int $statusCode): void {
+    [$rdap] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1']]], fn (): MockResponse => new MockResponse('{"objectClassName":"domain"}', ['http_code' => $statusCode]));
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeFalse();
+})->with([200, 204, 299]);
+
+test('an unexpected status code leaves availability undetermined', function (int $statusCode): void {
+    [$rdap] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => $statusCode]));
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeNull();
+})->with([403, 429, 500]);
+
+test('the most specific known zone of a multi-label domain is queried', function (): void {
+    [$rdap, $tracker] = createRdapClient(
+        [
+            [['uk'], ['https://rdap.nominet.uk/']],
+            [['co.uk'], ['https://registry.nominet.uk/rdap/']],
+        ],
+        fn (): MockResponse => new MockResponse('', ['http_code' => 404]),
+    );
+
+    expect($rdap->isDomainAvailable('example.co.uk'))->toBeTrue()
+        ->and($tracker->urls[1])->toBe('https://registry.nominet.uk/rdap/domain/example.co.uk');
+});
+
+test('domains under zones without an RDAP service are left undetermined without issuing a domain query', function (): void {
+    [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]]);
+
+    expect($rdap->isDomainAvailable('example.mars'))->toBeNull()
+        ->and($tracker->urls)->toBe([Registrar_Rdap::BOOTSTRAP_URL]);
+});
+
+test('a failed bootstrap fetch disables all lookups and logs a warning', function (): void {
+    $httpClient = new MockHttpClient(function (): never {
+        throw new TransportException('connection refused');
+    });
+    $logger = new class extends Psr\Log\AbstractLogger {
+        /** @var list<array{string, string}> */
+        public array $records = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            $this->records[] = [$level, (string) $message];
+        }
+    };
+    $rdap = new Registrar_Rdap($httpClient, $logger);
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeNull()
+        ->and($logger->records)->toHaveCount(1)
+        ->and($logger->records[0][0])->toBe('warning')
+        ->and($logger->records[0][1])->toContain('RDAP bootstrap registry');
+});
+
+test('an unparseable bootstrap response disables all lookups for the instance', function (): void {
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('not-json'));
+    $rdap = new Registrar_Rdap($httpClient);
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeNull();
+});
+
+test('a failing domain query falls through to the next RDAP server of the zone', function (): void {
+    $handlers = [
+        static function (): never {
+            throw new TransportException('first server unreachable');
+        },
+        static fn (): MockResponse => new MockResponse('', ['http_code' => 404]),
+    ];
+    [$rdap] = createRdapClient(
+        [[['com'], ['https://rdap-one.example.com/com/v1/', 'https://rdap-two.example.com/com/v1/']]],
+        static function () use (&$handlers): MockResponse {
+            return array_shift($handlers)();
+        },
+    );
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeTrue();
+});
+
+test('names are normalized before being queried', function (string $input, string $expectedUrl): void {
+    [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));
+
+    expect($rdap->isDomainAvailable($input))->toBeTrue()
+        ->and($tracker->urls[1])->toBe($expectedUrl);
+})->with([
+    [' EXAMPLE.com ', 'https://rdap.example.com/com/v1/domain/example.com'],
+    ['exämple.com', 'https://rdap.example.com/com/v1/domain/xn--exmple-cua.com'],
+]);
+
+test('inputs that cannot be a domain name are rejected without any HTTP traffic', function (string $input): void {
+    [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]]);
+
+    expect($rdap->isDomainAvailable($input))->toBeNull()
+        ->and($tracker->urls)->toBe([]);
+})->with(['', '.com', 'nodot']);
+
+test('the bootstrap registry is only fetched once per instance', function (): void {
+    [$rdap, $tracker] = createRdapClient([[['com'], ['https://rdap.example.com/com/v1/']]], fn (): MockResponse => new MockResponse('', ['http_code' => 404]));
+
+    expect($rdap->isDomainAvailable('example.com'))->toBeTrue()
+        ->and($rdap->isDomainAvailable('example-two.com'))->toBeTrue()
+        ->and(count(array_filter($tracker->urls, fn (string $url): bool => $url === Registrar_Rdap::BOOTSTRAP_URL)))->toBe(1);
+});


### PR DESCRIPTION
Closes #3118.

## Description

Registries and registrars are no longer obligated to offer WHOIS, while RDAP (RFC 7480-7484) is its designated successor. This replaces the `io-developer/php-whois` based domain availability checks with RDAP, per the discussion on #3118 (and #1652).

### Changes

- **New `Registrar_Rdap` client** (`src/library/Registrar/Rdap.php`):
  - Resolves the authoritative RDAP service for a TLD via the IANA DNS bootstrap registry (RFC 9224), fetched once per instance.
  - Maps the domain query HTTP status to availability: `404` = available, any other success status = registered.
  - Returns `null` when no RDAP service exists for the TLD or every query fails, letting callers decide how to handle an indeterminate result.
  - Handles IDN normalization, multi-label zones (e.g. `example.co.uk` → the `co.uk` server), and falls through to additional bootstrap servers on failure. No new Composer dependencies; uses the existing Symfony HTTP client.

- **Adapter updates**:
  - The Custom and Email registrar adapters now perform availability checks through RDAP behind a new `use_rdap` option, falling back to the legacy stored `use_whois` value so existing configurations keep working.
  - The Email adapter throws a `Registrar_Exception` when availability cannot be determined, matching its previous behavior for disabled lookups; the Custom adapter falls back to its documented always-positive answer.
  - Admin-facing form labels updated from "WHOIS" to "RDAP Registry Lookups".

- **Dependency removal**: drops `io-developer/php-whois`.