### PR TITLE
Mask payment gateway and domain registrar secrets in API and admin UI

### DIFF
--- a/src/library/Payment/Adapter/Stripe.php
+++ b/src/library/Payment/Adapter/Stripe.php
@@ -103,15 +103,17 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                     ],
                 ],
                 'api_key' => [
-                    'text', [
+                    'password', [
                         'label' => 'Live Secret Key:',
                         'required_when' => ['enabled' => true, 'test_mode' => false],
+                        'secret' => true,
                     ],
                 ],
                 'webhook_secret' => [
-                    'text', [
+                    'password', [
                         'label' => 'Live Webhook signing secret:',
                         'required_when' => ['enabled' => true, 'test_mode' => false],
+                        'secret' => true,
                     ],
                 ],
                 'test_pub_key' => [
@@ -121,15 +123,17 @@ class Payment_Adapter_Stripe implements FOSSBilling\InjectionAwareInterface
                     ],
                 ],
                 'test_api_key' => [
-                    'text', [
+                    'password', [
                         'label' => 'Test Secret Key:',
                         'required_when' => ['enabled' => true, 'test_mode' => true],
+                        'secret' => true,
                     ],
                 ],
                 'test_webhook_secret' => [
-                    'text', [
+                    'password', [
                         'label' => 'Test Webhook signing secret:',
                         'required_when' => ['enabled' => true, 'test_mode' => true],
+                        'secret' => true,
                     ],
                 ],
             ],

--- a/src/library/Payment/AdapterAbstract.php
+++ b/src/library/Payment/AdapterAbstract.php
@@ -87,6 +87,19 @@ abstract class Payment_AdapterAbstract
     abstract public static function getConfig();
 
     /**
+     * Config field names whose stored values must be hidden in the API and admin UI.
+     * Adapters should mark the relevant fields in their {@see self::getConfig()} form
+     * with `'secret' => true` instead of overriding this; it exists as an escape hatch
+     * for fields that need masking but are not declared through the form schema.
+     *
+     * @return string[]
+     */
+    public static function getSecretFields(): array
+    {
+        return [];
+    }
+
+    /**
      * Return payment gateway type (TYPE_HTML, TYPE_FORM, TYPE_API).
      */
     public function getType(): string

--- a/src/library/Registrar/Adapter/Internetbs.php
+++ b/src/library/Registrar/Adapter/Internetbs.php
@@ -32,15 +32,16 @@ class Registrar_Adapter_Internetbs extends Registrar_AdapterAbstract
         return [
             'label' => 'Manages domains on Internetbs via API',
             'form' => [
-                'apikey' => ['text', [
+                'apikey' => ['password', [
                     'label' => 'Internetbs API Key',
                     'description' => 'Internetbs API Key',
+                    'secret' => true,
                 ],
                 ],
                 'password' => ['password', [
                     'label' => 'Internetbs API Password',
                     'description' => 'Internetbs API Password',
-                    'renderPassword' => true,
+                    'secret' => true,
                 ],
                 ],
             ],

--- a/src/library/Registrar/Adapter/Namecheap.php
+++ b/src/library/Registrar/Adapter/Namecheap.php
@@ -66,6 +66,7 @@ class Registrar_Adapter_Namecheap extends Registrar_AdapterAbstract
                         'label' => 'API Key',
                         'description' => 'You can get this at Namecheap control panel.',
                         'required' => true,
+                        'secret' => true,
                     ],
                 ],
                 'username' => [

--- a/src/library/Registrar/Adapter/Netearthone.php
+++ b/src/library/Registrar/Adapter/Netearthone.php
@@ -35,6 +35,7 @@ class Registrar_Adapter_Netearthone extends Registrar_Adapter_Resellerclub
                     'label' => 'NetEarthOne API Key',
                     'description' => 'You can get this at NetEarthOne control panel, go to Settings -> API',
                     'required' => false,
+                    'secret' => true,
                 ],
                 ],
             ],

--- a/src/library/Registrar/Adapter/Resellbiz.php
+++ b/src/library/Registrar/Adapter/Resellbiz.php
@@ -35,6 +35,7 @@ class Registrar_Adapter_Resellbiz extends Registrar_Adapter_Resellerclub
                     'label' => 'Resell.biz API Key',
                     'description' => 'You can get this at Resell.biz control panel, go to Settings -> API',
                     'required' => false,
+                    'secret' => true,
                 ],
                 ],
             ],

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -68,6 +68,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
                         'label' => 'ResellerClub API Key',
                         'description' => 'You can get this at ResellerClub control panel, go to Settings -> API',
                         'required' => false,
+                        'secret' => true,
                     ],
                 ],
             ],

--- a/src/library/Registrar/Adapter/Resellerid.php
+++ b/src/library/Registrar/Adapter/Resellerid.php
@@ -35,6 +35,7 @@ class Registrar_Adapter_Resellerid extends Registrar_Adapter_Resellerclub
                     'label' => 'ResellerID API Key',
                     'description' => 'You can get this at ResellerID control panel, go to Settings -> API',
                     'required' => false,
+                    'secret' => true,
                 ],
                 ],
             ],

--- a/src/library/Registrar/AdapterAbstract.php
+++ b/src/library/Registrar/AdapterAbstract.php
@@ -34,6 +34,19 @@ abstract class Registrar_AdapterAbstract
     abstract public static function getConfig();
 
     /**
+     * Config field names whose stored values must be hidden in the API and admin UI.
+     * Adapters should mark the relevant fields in their {@see self::getConfig()} form
+     * with `'secret' => true` instead of overriding this; it exists as an escape hatch
+     * for fields that need masking but are not declared through the form schema.
+     *
+     * @return string[]
+     */
+    public static function getSecretFields(): array
+    {
+        return [];
+    }
+
+    /**
      * Checks if a domain is available for registration.
      *
      * @param Registrar_Domain $domain domain object containing the details of the domain to check

--- a/src/modules/Invoice/ServicePayGateway.php
+++ b/src/modules/Invoice/ServicePayGateway.php
@@ -23,6 +23,13 @@ use Symfony\Component\Finder\Finder;
 
 class ServicePayGateway implements InjectionAwareInterface
 {
+    /**
+     * Sent by the admin UI in place of a secret config field's value to mean
+     * "keep the currently stored value". Blank input means the same thing;
+     * this sentinel exists only for clients that can't send an empty string.
+     */
+    public const string CREDENTIAL_KEEP_SENTINEL = '__KEEP__';
+
     protected ?\Pimple\Container $di = null;
 
     protected PayGatewayRepository $payGatewayRepository;
@@ -150,9 +157,18 @@ class ServicePayGateway implements InjectionAwareInterface
         ];
 
         if ($identity instanceof \Box\Mod\Staff\Entity\Admin) {
+            $config = json_decode($model->getConfig() ?? '', true) ?? [];
+            $secretFields = $this->getSecretFields($model);
+            foreach ($secretFields as $field) {
+                $value = $config[$field] ?? null;
+                $config[$field] = null;
+                $config[$field . '_set'] = $value !== null && $value !== '';
+            }
+
             $result['supports_one_time_payments'] = $single;
             $result['supports_subscriptions'] = $recurrent;
-            $result['config'] = json_decode($model->getConfig() ?? '', true) ?? [];
+            $result['config'] = $config;
+            $result['secret_fields'] = $secretFields;
             $result['form'] = $this->getFormElements($model);
             $result['description'] = $this->getDescription($model);
             $result['enabled'] = $model->isEnabled();
@@ -161,6 +177,40 @@ class ServicePayGateway implements InjectionAwareInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Config field names for this gateway's adapter whose stored values must
+     * be hidden in the API and admin UI: the adapter's own declared secrets
+     * plus any form field marked `'secret' => true`.
+     *
+     * @return string[]
+     */
+    public function getSecretFields(PayGateway $model): array
+    {
+        $secrets = [];
+
+        try {
+            $class = $this->getAdapterClassName($model);
+            if (is_callable($class . '::getSecretFields')) {
+                $declared = $class::getSecretFields();
+                $secrets = array_merge($secrets, $declared);
+            }
+        } catch (\Throwable) {
+            // Gateway adapter could not be resolved; fall back to the form's own 'secret' flags below.
+        }
+
+        $form = $this->getAdapterConfig($model)['form'] ?? [];
+        if (is_array($form)) {
+            foreach ($form as $name => $element) {
+                $options = $element[1] ?? [];
+                if (!empty($options['secret'])) {
+                    $secrets[] = (string) $name;
+                }
+            }
+        }
+
+        return array_values(array_unique($secrets));
     }
 
     public function copy(PayGateway $model): int
@@ -186,9 +236,15 @@ class ServicePayGateway implements InjectionAwareInterface
 
         $newEnabled = isset($data['enabled']) ? (bool) $data['enabled'] : $model->isEnabled();
         $newTestMode = isset($data['test_mode']) ? (bool) $data['test_mode'] : $model->isTestMode();
-        $mergedConfig = json_decode($model->getConfig() ?? '', true) ?? [];
+        $existingConfig = json_decode($model->getConfig() ?? '', true) ?? [];
+        $mergedConfig = $existingConfig;
         if (isset($data['config']) && is_array($data['config'])) {
-            $mergedConfig = array_merge($mergedConfig, $data['config']);
+            $secretFields = $this->getSecretFields($model);
+            foreach ($data['config'] as $key => $value) {
+                $mergedConfig[$key] = in_array($key, $secretFields, true)
+                    ? $this->normalizeSecretValue((string) $key, $value, $existingConfig[$key] ?? null, $model)
+                    : $value;
+            }
         }
 
         if ($newEnabled) {
@@ -235,6 +291,32 @@ class ServicePayGateway implements InjectionAwareInterface
         } catch (\Throwable $e) {
             throw new \FOSSBilling\Exception('Payment gateway configuration error: ' . $e->getMessage(), null, 819);
         }
+    }
+
+    /**
+     * Returns the value to store for a secret config field. Blank, whitespace-only
+     * or {@see CREDENTIAL_KEEP_SENTINEL} inputs preserve the existing value;
+     * everything else replaces it. A successful rotation is logged (the value
+     * itself is never logged).
+     */
+    private function normalizeSecretValue(string $field, mixed $incoming, mixed $existing, PayGateway $model): mixed
+    {
+        if ($incoming === null || !is_scalar($incoming)) {
+            return $existing;
+        }
+
+        $incoming = (string) $incoming;
+
+        if (trim($incoming) === '' || $incoming === self::CREDENTIAL_KEEP_SENTINEL) {
+            return $existing;
+        }
+
+        if ($incoming !== $existing) {
+            $adminId = $this->di['loggedin_admin']->getId() ?? 'unknown';
+            $this->di['logger']->info('Rotated {field} for payment gateway {gateway_id} by admin {admin_id}', ['field' => $field, 'gateway_id' => (string) $model->getId(), 'admin_id' => (string) $adminId]);
+        }
+
+        return $incoming;
     }
 
     public function delete(PayGateway $model): bool

--- a/src/modules/Invoice/templates/admin/mod_invoice_gateway.html.twig
+++ b/src/modules/Invoice/templates/admin/mod_invoice_gateway.html.twig
@@ -75,6 +75,8 @@
                     <div class="d-flex flex-column gap-4">
                         {% for name, element in gateway.form %}
                             {% set field_required = mf.compute_field_required(element, gateway) == 'true' %}
+                            {% set is_secret = name in (gateway.secret_fields|default([])) %}
+                            {% set is_set = is_secret and gateway.config[name ~ '_set']|default(false) %}
                             <div>
                                 {% if element[0] == 'select' %}
                                     <label class="form-label" for="gateway-config-{{ name }}">{{ element[1].label }}</label>
@@ -104,19 +106,24 @@
                                         {% endfor %}
                                     </div>
                                 {% elseif element[0] == 'textarea' %}
-                                    <label class="form-label" for="gateway-config-{{ name }}">{{ element[1].label }}</label>
+                                    <label class="form-label" for="gateway-config-{{ name }}">{{ element[1].label }}{% if is_set %} <span class="badge text-bg-success">{{ 'Configured'|trans }}</span>{% endif %}</label>
                                     {% if element[1].description is defined and element[1].description %}<div class="form-text mb-2">{{ element[1].description|markdown_to_html }}</div>{% endif %}
                                     <textarea class="form-control" id="gateway-config-{{ name }}" name="config[{{ name }}]" rows="8"
-                                        {% if field_required %} required{% endif %}
-                                        {% if element[1].required_when is defined and element[1].required_when.enabled is defined %} data-required-when-enabled="{{ element[1].required_when.enabled ? 'true' : 'false' }}"{% endif %}
-                                        {% if element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>{{ gateway.config[name]|default('') }}</textarea>
+                                        {% if field_required and not is_set %} required{% endif %}
+                                        {% if is_set %} placeholder="{{ 'Leave blank to keep the saved credential.'|trans }}"{% endif %}
+                                        {% if not is_set and element[1].required_when is defined and element[1].required_when.enabled is defined %} data-required-when-enabled="{{ element[1].required_when.enabled ? 'true' : 'false' }}"{% endif %}
+                                        {% if not is_set and element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>{{ gateway.config[name]|default('') }}</textarea>
+                                    {% if is_set %}<div class="form-text">{{ 'Leave blank to keep the saved credential.'|trans }}</div>{% endif %}
                                 {% else %}
-                                    <label class="form-label" for="gateway-config-{{ name }}">{{ element[1].label }}</label>
+                                    <label class="form-label" for="gateway-config-{{ name }}">{{ element[1].label }}{% if is_set %} <span class="badge text-bg-success">{{ 'Configured'|trans }}</span>{% endif %}</label>
                                     {% if element[1].description is defined and element[1].description %}<div class="form-text mb-2">{{ element[1].description|markdown_to_html }}</div>{% endif %}
                                     <input class="form-control" id="gateway-config-{{ name }}" type="{{ element[0] }}" name="config[{{ name }}]" value="{{ gateway.config[name]|default('') }}"
-                                        {% if field_required %} required{% endif %}
-                                        {% if element[1].required_when is defined and element[1].required_when.enabled is defined %} data-required-when-enabled="{{ element[1].required_when.enabled ? 'true' : 'false' }}"{% endif %}
-                                        {% if element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>
+                                        {% if is_secret %} autocomplete="new-password"{% endif %}
+                                        {% if field_required and not is_set %} required{% endif %}
+                                        {% if is_set %} placeholder="{{ 'Leave blank to keep the saved credential.'|trans }}"{% endif %}
+                                        {% if not is_set and element[1].required_when is defined and element[1].required_when.enabled is defined %} data-required-when-enabled="{{ element[1].required_when.enabled ? 'true' : 'false' }}"{% endif %}
+                                        {% if not is_set and element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>
+                                    {% if is_set %}<div class="form-text">{{ 'Leave blank to keep the saved credential.'|trans }}</div>{% endif %}
                                 {% endif %}
                             </div>
                         {% endfor %}

--- a/src/modules/Invoice/tests/Unit/ServicePayGatewayTest.php
+++ b/src/modules/Invoice/tests/Unit/ServicePayGatewayTest.php
@@ -213,6 +213,100 @@ test('updates a gateway', function (): void {
     expect($payGateway->isEnabled())->toBeTrue();
 });
 
+test('converts to api array masks secrets for an admin', function (): void {
+    $payGateway = createEntity(PayGateway::class, [
+        'id' => 1,
+        'name' => 'Stripe',
+        'gateway' => 'Stripe',
+        'acceptedCurrencies' => json_encode(['USD']),
+        'enabled' => true,
+        'allowSingle' => true,
+        'allowRecurrent' => true,
+        'testMode' => false,
+        'config' => json_encode([
+            'pub_key' => 'pk_live_visible',
+            'api_key' => 'sk_live_secret',
+            'webhook_secret' => 'whsec_secret',
+        ]),
+    ]);
+
+    $service = payGatewayService();
+
+    $result = $service->toApiArray($payGateway, false, \Tests\Helpers\admin());
+
+    expect($result['secret_fields'])->toContain('api_key');
+    expect($result['secret_fields'])->toContain('webhook_secret');
+    expect($result['secret_fields'])->toContain('test_api_key');
+    expect($result['secret_fields'])->toContain('test_webhook_secret');
+    expect($result['secret_fields'])->not->toContain('pub_key');
+    expect($result['config']['pub_key'])->toBe('pk_live_visible');
+    expect($result['config']['api_key'])->toBeNull();
+    expect($result['config']['api_key_set'])->toBeTrue();
+    expect($result['config']['webhook_secret'])->toBeNull();
+    expect($result['config']['webhook_secret_set'])->toBeTrue();
+    expect($result['config']['test_api_key_set'])->toBeFalse();
+});
+
+test('update keeps the existing secret gateway value when the incoming value is blank', function (): void {
+    $payGateway = createEntity(PayGateway::class, [
+        'id' => 1,
+        'name' => 'Stripe',
+        'gateway' => 'Stripe',
+        'enabled' => false,
+        'config' => json_encode(['api_key' => 'sk_live_existing', 'pub_key' => 'pk_live_existing']),
+    ]);
+
+    $em = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $repo = Mockery::mock(PayGatewayRepository::class);
+    $em->shouldReceive('getRepository')->with(PayGateway::class)->andReturn($repo);
+
+    $service = new ServicePayGateway();
+    $di = container();
+    $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['loggedin_admin'] = \Tests\Helpers\admin(['id' => 7]);
+    $service->setDi($di);
+
+    $result = $service->update($payGateway, [
+        'config' => [
+            'api_key' => ServicePayGateway::CREDENTIAL_KEEP_SENTINEL,
+            'pub_key' => 'pk_live_new',
+        ],
+    ]);
+
+    expect($result)->toBeTrue();
+    $config = json_decode((string) $payGateway->getConfig(), true);
+    expect($config['api_key'])->toBe('sk_live_existing');
+    expect($config['pub_key'])->toBe('pk_live_new');
+});
+
+test('update rotates a secret gateway value when a new value is submitted', function (): void {
+    $payGateway = createEntity(PayGateway::class, [
+        'id' => 1,
+        'name' => 'Stripe',
+        'gateway' => 'Stripe',
+        'enabled' => false,
+        'config' => json_encode(['api_key' => 'sk_live_old']),
+    ]);
+
+    $em = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $repo = Mockery::mock(PayGatewayRepository::class);
+    $em->shouldReceive('getRepository')->with(PayGateway::class)->andReturn($repo);
+
+    $service = new ServicePayGateway();
+    $di = container();
+    $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['loggedin_admin'] = \Tests\Helpers\admin(['id' => 7]);
+    $service->setDi($di);
+
+    $result = $service->update($payGateway, ['config' => ['api_key' => 'sk_live_new']]);
+
+    expect($result)->toBeTrue();
+    $config = json_decode((string) $payGateway->getConfig(), true);
+    expect($config['api_key'])->toBe('sk_live_new');
+});
+
 test('deletes a gateway', function (): void {
     $payGateway = createEntity(PayGateway::class, ['id' => 7]);
 

--- a/src/modules/Servicedomain/Service.php
+++ b/src/modules/Servicedomain/Service.php
@@ -27,6 +27,13 @@ use Symfony\Component\Finder\Finder;
 
 class Service implements \FOSSBilling\InjectionAwareInterface
 {
+    /**
+     * Sent by the admin UI in place of a secret registrar config field's value
+     * to mean "keep the currently stored value". Blank input means the same
+     * thing; this sentinel exists only for clients that can't send an empty string.
+     */
+    public const string REGISTRAR_CREDENTIAL_KEEP_SENTINEL = '__KEEP__';
+
     protected ?\Pimple\Container $di = null;
     private Filesystem $filesystem;
 
@@ -1230,8 +1237,15 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $model->setName($data['title'] ?? $model->getName());
         $model->setTestMode(array_key_exists('test_mode', $data) ? (bool) $data['test_mode'] : $model->isTestMode());
         if (isset($data['config']) && is_array($data['config'])) {
-            $configuration = array_replace($this->registrarGetConfiguration($model), $data['config']);
+            $existingConfiguration = $this->registrarGetConfiguration($model);
+            $configuration = $existingConfiguration;
             $adapterConfiguration = $this->registrarGetRegistrarAdapterConfig($model);
+            $secretFields = $this->resolveRegistrarSecretFields($model, $adapterConfiguration);
+            foreach ($data['config'] as $key => $value) {
+                $configuration[$key] = in_array($key, $secretFields, true)
+                    ? $this->normalizeRegistrarSecretValue((string) $key, $value, $existingConfiguration[$key] ?? null, $model)
+                    : $value;
+            }
 
             foreach ($adapterConfiguration['form'] ?? [] as $field => $element) {
                 $options = $element[1] ?? [];
@@ -1249,6 +1263,32 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         $this->di['logger']->info('Updated domain registrar {model_registrar} configuration', ['model_registrar' => $model->getRegistrar()]);
 
         return true;
+    }
+
+    /**
+     * Returns the value to store for a secret registrar config field. Blank,
+     * whitespace-only or {@see REGISTRAR_CREDENTIAL_KEEP_SENTINEL} inputs preserve
+     * the existing value; everything else replaces it. A successful rotation is
+     * logged (the value itself is never logged).
+     */
+    private function normalizeRegistrarSecretValue(string $field, mixed $incoming, mixed $existing, TldRegistrar $model): mixed
+    {
+        if ($incoming === null || !is_scalar($incoming)) {
+            return $existing;
+        }
+
+        $incoming = (string) $incoming;
+
+        if (trim($incoming) === '' || $incoming === self::REGISTRAR_CREDENTIAL_KEEP_SENTINEL) {
+            return $existing;
+        }
+
+        if ($incoming !== $existing) {
+            $adminId = $this->di['loggedin_admin']->getId() ?? 'unknown';
+            $this->di['logger']->info('Rotated {field} for domain registrar {registrar_id} by admin {admin_id}', ['field' => $field, 'registrar_id' => (string) $model->getId(), 'admin_id' => (string) $adminId]);
+        }
+
+        return $incoming;
     }
 
     public function registrarRm(TldRegistrar $model): bool
@@ -1281,14 +1321,59 @@ class Service implements \FOSSBilling\InjectionAwareInterface
     {
         $c = $this->registrarGetRegistrarAdapterConfig($model);
 
+        $config = $this->registrarGetConfiguration($model);
+        $secretFields = $this->resolveRegistrarSecretFields($model, $c);
+        foreach ($secretFields as $field) {
+            $value = $config[$field] ?? null;
+            $config[$field] = null;
+            $config[$field . '_set'] = $value !== null && $value !== '';
+        }
+
         return [
             'id' => $model->getId(),
             'title' => $model->getName(),
             'label' => $c['label'],
-            'config' => $this->registrarGetConfiguration($model),
+            'config' => $config,
+            'secret_fields' => $secretFields,
             'form' => $c['form'],
             'test_mode' => $model->isTestMode(),
         ];
+    }
+
+    /**
+     * Config field names for this registrar's adapter whose stored values must
+     * be hidden in the API and admin UI: the adapter's own declared secrets
+     * plus any form field marked `'secret' => true`. Takes the already-resolved
+     * {@see registrarGetRegistrarAdapterConfig()} output so callers that need
+     * it anyway don't fetch it twice.
+     *
+     * @return string[]
+     */
+    private function resolveRegistrarSecretFields(TldRegistrar $model, array $adapterConfiguration): array
+    {
+        $secrets = [];
+
+        try {
+            $class = $this->registrarGetRegistrarAdapterClassName($model);
+            if (is_callable($class . '::getSecretFields')) {
+                $declared = $class::getSecretFields();
+                $secrets = array_merge($secrets, $declared);
+            }
+        } catch (\Throwable) {
+            // Registrar adapter could not be resolved; fall back to the form's own 'secret' flags below.
+        }
+
+        $form = $adapterConfiguration['form'] ?? [];
+        if (is_array($form)) {
+            foreach ($form as $name => $element) {
+                $options = $element[1] ?? [];
+                if (!empty($options['secret'])) {
+                    $secrets[] = (string) $name;
+                }
+            }
+        }
+
+        return array_values(array_unique($secrets));
     }
 
     public function updateDomain(ServiceDomain $s, $data): bool

--- a/src/modules/Servicedomain/templates/admin/mod_servicedomain_registrar.html.twig
+++ b/src/modules/Servicedomain/templates/admin/mod_servicedomain_registrar.html.twig
@@ -60,7 +60,7 @@
                         <h6 class="card-title mb-0">{{ 'Adapter Settings'|trans }}</h6>
                         <p class="text-secondary mb-0">{{ 'Provide the credentials and connection details required by this registrar adapter.'|trans }}</p>
                     </div>
-                    {{ mf.build_form(registrar.form, registrar.config, {'test_mode': registrar.test_mode}) }}
+                    {{ mf.build_form(registrar.form, registrar.config, {'test_mode': registrar.test_mode}, registrar.secret_fields) }}
                 </div>
 
                 <input type="hidden" name="id" value="{{ registrar.id }}">

--- a/src/modules/Servicedomain/tests/Unit/ServiceTest.php
+++ b/src/modules/Servicedomain/tests/Unit/ServiceTest.php
@@ -1943,6 +1943,92 @@ test('converts registrar to api array', function (): void {
     $serviceMock->registrarToApiArray($model);
 });
 
+test('converts registrar to api array masks secrets for an admin', function (): void {
+    $service = new Service();
+    $di = container();
+    $service->setDi($di);
+
+    $model = new TldRegistrar();
+    setEntityId($model, 1);
+    $model->setName('Namecheap');
+    $model->setRegistrar('Namecheap');
+    $model->setTestMode(false);
+    $model->setConfig(json_encode([
+        'api-user-id' => 'reseller-id',
+        'api-key' => 'super-secret-key',
+        'username' => 'my-username',
+    ]));
+
+    $result = $service->registrarToApiArray($model);
+
+    expect($result['secret_fields'])->toContain('api-key');
+    expect($result['secret_fields'])->not->toContain('api-user-id');
+    expect($result['secret_fields'])->not->toContain('username');
+    expect($result['config']['api-user-id'])->toBe('reseller-id');
+    expect($result['config']['api-key'])->toBeNull();
+    expect($result['config']['api-key_set'])->toBeTrue();
+});
+
+test('registrarUpdate keeps the existing secret when the incoming value is blank', function (): void {
+    $service = new Service();
+
+    $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $di = container();
+    $di['em'] = $emMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['loggedin_admin'] = \Tests\Helpers\admin(['id' => 7]);
+    $service->setDi($di);
+
+    $model = new TldRegistrar();
+    setEntityId($model, 1);
+    $model->setRegistrar('Namecheap');
+    $model->setConfig(json_encode([
+        'api-user-id' => 'reseller-id',
+        'api-key' => 'existing-secret',
+        'username' => 'existing-username',
+        'ip' => '127.0.0.1',
+    ]));
+
+    $result = $service->registrarUpdate($model, [
+        'config' => [
+            'api-key' => Service::REGISTRAR_CREDENTIAL_KEEP_SENTINEL,
+            'api-user-id' => 'new-reseller-id',
+        ],
+    ]);
+
+    expect($result)->toBeTrue();
+    $config = json_decode((string) $model->getConfig(), true);
+    expect($config['api-key'])->toBe('existing-secret');
+    expect($config['api-user-id'])->toBe('new-reseller-id');
+});
+
+test('registrarUpdate rotates a secret when a new value is submitted', function (): void {
+    $service = new Service();
+
+    $emMock = Mockery::mock(EntityManagerInterface::class)->shouldIgnoreMissing();
+    $di = container();
+    $di['em'] = $emMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $di['loggedin_admin'] = \Tests\Helpers\admin(['id' => 7]);
+    $service->setDi($di);
+
+    $model = new TldRegistrar();
+    setEntityId($model, 1);
+    $model->setRegistrar('Namecheap');
+    $model->setConfig(json_encode([
+        'api-user-id' => 'reseller-id',
+        'api-key' => 'old-secret',
+        'username' => 'existing-username',
+        'ip' => '127.0.0.1',
+    ]));
+
+    $result = $service->registrarUpdate($model, ['config' => ['api-key' => 'new-secret']]);
+
+    expect($result)->toBeTrue();
+    $config = json_decode((string) $model->getConfig(), true);
+    expect($config['api-key'])->toBe('new-secret');
+});
+
 test('creates tld', function (): void {
     $service = Mockery::mock(Service::class)->makePartial();
     $service->shouldReceive('registrarValidateConfiguration')->once();

--- a/src/themes/admin_default/html/macro_functions.html.twig
+++ b/src/themes/admin_default/html/macro_functions.html.twig
@@ -15,12 +15,15 @@
     {{ result ? 'true' : 'false' }}
 {% endmacro %}
 
-{% macro build_form(elements, values, context) %}
+{% macro build_form(elements, values, context, secretFields) %}
     {% set ctx = context|default({}) %}
+    {% set secrets = secretFields|default([]) %}
     <div class="row g-3">
     {% for name, element in elements %}
     {% set field_class = element[0] == 'textarea' ? 'col-12' : 'col-lg-6' %}
     {% set field_required = _self.compute_field_required(element, ctx) == 'true' %}
+    {% set is_secret = name in secrets %}
+    {% set is_set = is_secret and values[name ~ '_set']|default(false) %}
     <div class="{{ field_class }}">
         {% if element[0] == 'select' %}
             <label class="form-label">{{ element[1].label }}</label>
@@ -50,17 +53,22 @@
             {% endfor %}
             </div>
         {% elseif element[0] == 'textarea' %}
-            <label class="form-label" for="el-{{ name }}">{{ element[1].label }}</label>
+            <label class="form-label" for="el-{{ name }}">{{ element[1].label }}{% if is_set %} <span class="badge text-bg-success">{{ 'Configured'|trans }}</span>{% endif %}</label>
             {% if element[1].description is defined and element[1].description %}<div class="form-text mt-0 mb-2">{{ element[1].description|markdown_to_html }}</div>{% endif %}
             <textarea class="form-control" id="el-{{ name }}" name="config[{{ name }}]" rows="20"
-                {% if field_required %} required{% endif %}
-                {% if element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>{{ values[name]|default('') }}</textarea>
+                {% if field_required and not is_set %} required{% endif %}
+                {% if is_set %} placeholder="{{ 'Leave blank to keep the saved credential.'|trans }}"{% endif %}
+                {% if not is_set and element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>{{ values[name]|default('') }}</textarea>
+            {% if is_set %}<div class="form-text">{{ 'Leave blank to keep the saved credential.'|trans }}</div>{% endif %}
         {% else %}
-            <label class="form-label" for="el-{{ name }}">{{ element[1].label }}</label>
+            <label class="form-label" for="el-{{ name }}">{{ element[1].label }}{% if is_set %} <span class="badge text-bg-success">{{ 'Configured'|trans }}</span>{% endif %}</label>
             {% if element[1].description is defined and element[1].description %}<div class="form-text mt-0 mb-2">{{ element[1].description|markdown_to_html }}</div>{% endif %}
             <input class="form-control" id="el-{{ name }}" type="{{ element[0] }}" name="config[{{ name }}]" value="{{ values[name]|default('') }}"
-                {% if field_required %} required{% endif %}
-                {% if element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>
+                {% if is_secret %} autocomplete="new-password"{% endif %}
+                {% if field_required and not is_set %} required{% endif %}
+                {% if is_set %} placeholder="{{ 'Leave blank to keep the saved credential.'|trans }}"{% endif %}
+                {% if not is_set and element[1].required_when is defined and element[1].required_when.test_mode is defined %} data-required-when-test-mode="{{ element[1].required_when.test_mode ? 'true' : 'false' }}"{% endif %}>
+            {% if is_set %}<div class="form-text">{{ 'Leave blank to keep the saved credential.'|trans }}</div>{% endif %}
         {% endif %}
     </div>
     {% endfor %}


### PR DESCRIPTION
## Summary

`PayGateway::toApiArray()` and `Servicedomain`'s `registrarToApiArray()` returned the raw, decoded adapter config (Stripe secret keys, registrar API passwords, etc.) to any admin with `manage_gateways`/`manage_registrars`, in both the single-get and list-get responses. Edit-page templates then embedded those raw secrets directly into the rendered HTML to prefill the form.

## Changes

- Adapters now declare which of their config fields are secret via a `'secret' => true` form flag (mirroring `Server_Manager`'s existing `getSecretFields()` convention), or by overriding a new `getSecretFields()` on `Payment_AdapterAbstract` / `Registrar_AdapterAbstract`:
  - **Stripe**: `api_key`, `webhook_secret`, `test_api_key`, `test_webhook_secret` (not the publishable keys, which Stripe's own docs treat as public)
  - **Internetbs, Namecheap, Netearthone, Resellbiz, Resellerclub, Resellerid**: their existing API key/password fields
- `ServicePayGateway` and `Servicedomain\Service` now null out secret fields in the API response and add a `{field}_set` flag plus a `secret_fields` list — same shape as the existing hosting-server response.
- `update()`/`registrarUpdate()` preserve the existing value when a secret field arrives blank or as a `CREDENTIAL_KEEP_SENTINEL`, and log (without the value) when one actually rotates.
- The gateway and registrar edit templates now show a "Configured" badge and leave the field blank with a "leave blank to keep the saved credential" hint, only requiring input on first-time setup.