### PR TITLE
Add .FR contact type handling to ResellerClub registrar adapter

### DIFF
--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -316,6 +316,14 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $params['ns'] = ['dns1.directi.com', 'dns2.directi.com', 'dns3.directi.com', 'dns4.directi.com'];
         }
 
+        // ResellerClub is contractually required to display a notice - and get consent via this tnc
+        // attribute - before sharing a European Registrant/Admin Organization contact's personal
+        // information with the .fr registry. See https://manage.resellerclub.com/kb/answer/752
+        if ($tld == '.fr') {
+            $params['attr-name1'] = 'tnc';
+            $params['attr-value1'] = 'Y';
+        }
+
         if ($tld == '.au' || $tld == '.net.au' || $tld == '.com.au') {
             $contact = $domain->getContactRegistrar();
 
@@ -730,6 +738,11 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $contact['type'] = 'EuContact';
         }
 
+        // @see https://manage.resellerclub.com/kb/answer/790 for the FrContact type
+        if ($tld == '.fr') {
+            $contact['type'] = 'FrContact';
+        }
+
         if ($tld == '.cn') {
             $contact['type'] = 'CnContact';
         }
@@ -860,12 +873,18 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $tech_contact_id = -1;
         }
 
-        if (in_array($tld, ['.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu', '.ca', '.nl'])) {
+        // @see https://manage.resellerclub.com/kb/answer/752 - .FR requires tech-contact-id to be -1,
+        // but (unlike .uk/.ru/.eu above) it still expects a real admin-contact-id.
+        if ($tld == '.fr') {
+            $tech_contact_id = -1;
+        }
+
+        if (in_array($tld, ['.uk', '.co.uk', '.org.uk', '.nz', '.ru', '.com.ru', '.org.ru', '.net.ru', '.eu', '.ca', '.nl', '.fr'])) {
             $billing_contact_id = -1;
         }
 
         // general contact is special contact for these TLD'S
-        if (in_array($tld, ['.de', '.nl', '.ru', '.es', '.uk', '.co.uk', '.org.uk', '.eu', '.com.ru', '.net.ru', '.org.ru', '.co'])) {
+        if (in_array($tld, ['.de', '.nl', '.ru', '.es', '.uk', '.co.uk', '.org.uk', '.eu', '.com.ru', '.net.ru', '.org.ru', '.co', '.fr'])) {
             $reg_contact_id = $special_contact_id;
         }
 

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -174,6 +174,7 @@ test('modifyContact assigns per-role contact IDs for .fr, which only forces tech
     // registry still expects a real admin-contact-id rather than -1. See
     // https://manage.resellerclub.com/kb/answer/752 and https://manage.resellerclub.com/kb/answer/790
     $requests = [];
+    $bodies = [];
     $responses = [
         json_encode(['customerid' => '555']), // customers/details
         '111111', // contacts/add (general Contact) -> id
@@ -181,11 +182,10 @@ test('modifyContact assigns per-role contact IDs for .fr, which only forces tech
         '333333', // domains/orderid
         json_encode(['status' => 'Success']), // domains/modify-contact
     ];
-    $lastBody = null;
 
-    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$lastBody): MockResponse {
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
         $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
-        $lastBody = $options['body'] ?? null;
+        $bodies[] = $options['body'] ?? null;
 
         return new MockResponse(array_shift($responses));
     });
@@ -194,7 +194,12 @@ test('modifyContact assigns per-role contact IDs for .fr, which only forces tech
 
     expect($adapter->modifyContact($domain))->toBeTrue();
 
-    parse_str((string) $lastBody, $body);
+    // the second contacts/add call must actually be creating the FrContact, not just landing on the
+    // right id by coincidence
+    parse_str((string) $bodies[2], $frContactBody);
+    expect($frContactBody['type'])->toBe('FrContact');
+
+    parse_str((string) end($bodies), $body);
     expect($body['reg-contact-id'])->toBe('222222'); // the FrContact, not the general contact
     expect($body['admin-contact-id'])->toBe('222222'); // real contact, NOT -1
     expect($body['tech-contact-id'])->toBe('-1');
@@ -206,6 +211,7 @@ test('registerDomain sends the .fr registry consent attribute alongside the FrCo
     // attribute on domains/register, on top of the FrContact type/contact-id handling above. See
     // https://manage.resellerclub.com/kb/answer/752
     $requests = [];
+    $bodies = [];
     $responses = [
         json_encode(['status' => 'ERROR', 'message' => 'Order not found']), // domains/orderid (via _hasCompletedOrder)
         json_encode(['customerid' => '555']), // customers/details
@@ -215,11 +221,10 @@ test('registerDomain sends the .fr registry consent attribute alongside the FrCo
         '222222', // contacts/add (FrContact) -> id
         json_encode(['status' => 'Success']), // domains/register
     ];
-    $lastBody = null;
 
-    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$lastBody): MockResponse {
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
         $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
-        $lastBody = $options['body'] ?? null;
+        $bodies[] = $options['body'] ?? null;
 
         return new MockResponse(array_shift($responses));
     });
@@ -233,7 +238,12 @@ test('registerDomain sends the .fr registry consent attribute alongside the FrCo
     expect($adapter->registerDomain($domain))->toBeTrue();
     expect($requests[6])->toBe('POST /api/domains/register.json');
 
-    parse_str((string) $lastBody, $body);
+    // the second contacts/add call must actually be creating the FrContact, not just landing on the
+    // right id by coincidence
+    parse_str((string) $bodies[5], $frContactBody);
+    expect($frContactBody['type'])->toBe('FrContact');
+
+    parse_str((string) end($bodies), $body);
     expect($body['reg-contact-id'])->toBe('222222');
     expect($body['admin-contact-id'])->toBe('222222');
     expect($body['tech-contact-id'])->toBe('-1');

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -168,3 +168,76 @@ test('modifyContact assigns per-role contact IDs for TLDs that require a dedicat
     expect($body['tech-contact-id'])->toBe('-1');
     expect($body['billing-contact-id'])->toBe('-1');
 });
+
+test('modifyContact assigns per-role contact IDs for .fr, which only forces tech and billing to -1', function (): void {
+    // Regression test for #77: .fr needs its own FrContact type, but - unlike .uk/.ru/.eu - the
+    // registry still expects a real admin-contact-id rather than -1. See
+    // https://manage.resellerclub.com/kb/answer/752 and https://manage.resellerclub.com/kb/answer/790
+    $requests = [];
+    $responses = [
+        json_encode(['customerid' => '555']), // customers/details
+        '111111', // contacts/add (general Contact) -> id
+        '222222', // contacts/add (FrContact) -> id
+        '333333', // domains/orderid
+        json_encode(['status' => 'Success']), // domains/modify-contact
+    ];
+    $lastBody = null;
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$lastBody): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $lastBody = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain(tld: '.fr')->setContactRegistrar(createResellerclubTestContact());
+
+    expect($adapter->modifyContact($domain))->toBeTrue();
+
+    parse_str((string) $lastBody, $body);
+    expect($body['reg-contact-id'])->toBe('222222'); // the FrContact, not the general contact
+    expect($body['admin-contact-id'])->toBe('222222'); // real contact, NOT -1
+    expect($body['tech-contact-id'])->toBe('-1');
+    expect($body['billing-contact-id'])->toBe('-1');
+});
+
+test('registerDomain sends the .fr registry consent attribute alongside the FrContact IDs', function (): void {
+    // Regression test for #77: .fr requires accepting the registry's data-sharing terms via a tnc
+    // attribute on domains/register, on top of the FrContact type/contact-id handling above. See
+    // https://manage.resellerclub.com/kb/answer/752
+    $requests = [];
+    $responses = [
+        json_encode(['status' => 'ERROR', 'message' => 'Order not found']), // domains/orderid (via _hasCompletedOrder)
+        json_encode(['customerid' => '555']), // customers/details
+        json_encode(['recsonpage' => 0]), // contacts/search (general Contact) -> none found
+        '111111', // contacts/add (general Contact) -> id
+        json_encode(['recsonpage' => 0]), // contacts/search (FrContact) -> none found
+        '222222', // contacts/add (FrContact) -> id
+        json_encode(['status' => 'Success']), // domains/register
+    ];
+    $lastBody = null;
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$lastBody): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $lastBody = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain(tld: '.fr')
+        ->setContactRegistrar(createResellerclubTestContact())
+        ->setRegistrationPeriod(1)
+        ->setNs1('ns1.example.com')
+        ->setNs2('ns2.example.com');
+
+    expect($adapter->registerDomain($domain))->toBeTrue();
+    expect($requests[6])->toBe('POST /api/domains/register.json');
+
+    parse_str((string) $lastBody, $body);
+    expect($body['reg-contact-id'])->toBe('222222');
+    expect($body['admin-contact-id'])->toBe('222222');
+    expect($body['tech-contact-id'])->toBe('-1');
+    expect($body['billing-contact-id'])->toBe('-1');
+    expect($body['attr-name1'])->toBe('tnc');
+    expect($body['attr-value1'])->toBe('Y');
+});


### PR DESCRIPTION
## Summary

Fixes #77. `.fr` domains had no special-case handling at all in the ResellerClub adapter: `registerDomain()` and `modifyContact()` (both via `_getAllContacts()`) fell through to a plain `Contact` type with all four contact roles (registrant/admin/tech/billing) pointed at the same contact id; every other special ccTLD already handled by this file (`.uk`, `.de`, `.ru`, `.nl`, `.eu`, `.es`, `.ca`, `.asia`, `.co`, `.cn`, `.us`) gets its own contact type and/or role overrides, but `.fr` was simply missing.

Per ResellerClub's API docs ([Register](https://manage.resellerclub.com/kb/answer/752), [Add Contact](https://manage.resellerclub.com/kb/answer/790)):

- registrant/admin contacts must use the `FrContact` type
- `tech-contact-id` must be `-1`
- `admin-contact-id` must **not** be `-1` (unlike `.uk`/`.ru`/`.eu`, which force both admin and tech to `-1`) — this is the one place `.fr` doesn't fit the existing combined admin+tech override group, so it needed its own single-field override
- `billing-contact-id` must be `-1`
- `domains/register` needs an `attr-name1=tnc&attr-value1=Y` consent attribute (acknowledging that a European Organization contact's personal data will be shared with the AFNIC registry)

Privacy protection isn't supported for `.fr` either, but the adapter already never opts into it (`purchase-privacy` is never set), so no change was needed there.

## Changes

- `src/library/Registrar/Adapter/Resellerclub.php`: added `.fr` handling to `_getAllContacts()` (contact type, tech/billing id overrides, reg-contact-uses-special-contact) and to `registerDomain()` (`tnc` attribute), mirroring the existing per-TLD pattern used for other ccTLDs in this file.
- `tests/Unit/Registrar/Adapter/ResellerclubTest.php`: two new regression tests, following the existing `.co.uk` test pattern — one covering `modifyContact`'s per-role contact-id assignment, one covering `registerDomain`'s `tnc` attribute.