### PR TITLE
Scope schema materialization to installed modules, not every entity

### DIFF
--- a/src/library/FOSSBilling/Doctrine/ModuleEntityScope.php
+++ b/src/library/FOSSBilling/Doctrine/ModuleEntityScope.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+namespace FOSSBilling\Doctrine;
+
+use Box\Mod\Extension\Entity\Extension;
+use Doctrine\DBAL\Connection;
+use FOSSBilling\Module;
+
+/**
+ * Decides which entities' tables {@see SchemaInstaller} and the ambient
+ * {@see SchemaSynchronizer::syncEntities()} call in {@see \FOSSBilling\UpdatePatcher::
+ * applyCorePatches()} are allowed to eagerly create/maintain, versus which are left entirely to
+ * their own module's `install()` hook (also via {@see SchemaSynchronizer::syncEntities()}) - the
+ * same distinction {@see \Box\Mod\Extension\Service::isCoreModule()}/`isExtensionActive()` already
+ * draw for permissions and activation checks, applied here to schema materialization instead.
+ *
+ * Every entity lives under `Box\Mod\{Module}\Entity\...` (verified: no exception exists in this
+ * codebase), so the owning module is derivable from the class name alone - no separate manifest
+ * declaration needed.
+ */
+final class ModuleEntityScope
+{
+    /**
+     * Extensions installed by default on every fresh install - kept in sync with
+     * `install/sql/content.sql`'s seeded `extension` rows deliberately, not derived from that
+     * file at runtime, because this has to be known before any database (or that file's data)
+     * exists yet, at the exact moment {@see SchemaInstaller::createSchema()} runs.
+     */
+    private const array DEFAULT_ACTIVE_EXTENSIONS = ['news', 'branding', 'redirect'];
+
+    /**
+     * Extracts the owning module name (lowercased, matching {@see Module::CORE_MODULES}'
+     * casing) from an entity's fully-qualified class name, or null if it doesn't follow the
+     * `Box\Mod\{Module}\Entity\...` convention every entity in this codebase does today.
+     *
+     * @param class-string $entityClass
+     */
+    public static function moduleForEntityClass(string $entityClass): ?string
+    {
+        if (preg_match('/^Box\\\\Mod\\\\([^\\\\]+)\\\\Entity\\\\/', $entityClass, $matches) !== 1) {
+            return null;
+        }
+
+        return strtolower($matches[1]);
+    }
+
+    /**
+     * Whether entities owned by the given module should be eagerly materialized at fresh-install
+     * time, before the `extension` table has any rows in it (or, for a from-scratch install,
+     * before it even exists) - true for core modules and the fixed set of extensions
+     * content.sql pre-seeds as installed.
+     */
+    public static function isEagerAtInstall(string $module): bool
+    {
+        return in_array($module, Module::CORE_MODULES, true)
+            || in_array($module, self::DEFAULT_ACTIVE_EXTENSIONS, true);
+    }
+
+    /**
+     * Fetches every extension module name currently marked installed, for use with
+     * {@see self::isEagerNow()} - one query total, meant to be called once per gating pass (e.g.
+     * once per {@see \FOSSBilling\UpdatePatcher::applyCorePatches()} run) and reused for every
+     * entity being checked, rather than one query per entity. Queried directly against the
+     * connection rather than through `Box\Mod\Extension\Service` to avoid that service's DI/
+     * permission-check machinery for what is otherwise a plain column read - this mirrors
+     * `ExtensionRepository::existsActiveByTypeAndName()`'s own filter exactly.
+     *
+     * @return list<string>
+     */
+    public static function installedExtensionModules(Connection $connection): array
+    {
+        if (!$connection->createSchemaManager()->tablesExist(['extension'])) {
+            return [];
+        }
+
+        return $connection->fetchFirstColumn(
+            'SELECT name FROM extension WHERE type = :type AND status = :status',
+            ['type' => 'mod', 'status' => Extension::STATUS_INSTALLED],
+        );
+    }
+
+    /**
+     * Whether entities owned by the given module should be eagerly maintained by the *ambient*
+     * sync ({@see \FOSSBilling\UpdatePatcher::applyCorePatches()}, run while a database update is
+     * pending finalization) right now - true for core modules, and for any module present in
+     * $installedExtensionModules (see {@see self::installedExtensionModules()}).
+     *
+     * @param list<string> $installedExtensionModules
+     */
+    public static function isEagerNow(string $module, array $installedExtensionModules): bool
+    {
+        return in_array($module, Module::CORE_MODULES, true)
+            || in_array($module, $installedExtensionModules, true);
+    }
+}

--- a/src/library/FOSSBilling/Doctrine/SchemaInstaller.php
+++ b/src/library/FOSSBilling/Doctrine/SchemaInstaller.php
@@ -24,12 +24,31 @@ use Doctrine\ORM\Tools\SchemaTool;
  * This only works because the entity mapping is already portable: no `columnDefinition`, no
  * `unsigned` options, no native enum types, safe `AUTO` id generation (see the DB-portability
  * audit this followed). A schema generated this way is only as portable as that mapping stays.
+ *
+ * Deliberately does not materialize every entity's table. Only core modules ({@see
+ * \FOSSBilling\Module::CORE_MODULES}) and the fixed set of extensions `content.sql` pre-seeds as
+ * installed ({@see ModuleEntityScope}) get their tables here - everything else (custom_pages,
+ * mod_massmailer, service_apikey, and any future extension) gets its table only when actually
+ * activated, via that module's own `install()` hook calling {@see SchemaSynchronizer::syncEntities()}
+ * - the same mechanism a runtime activation already triggers through
+ * `Box\Mod\Extension\Service::activateExistingExtension()`. Eagerly creating every entity's table
+ * regardless of activation state used to be relied on as an accidental safety net for those
+ * modules' own (formerly non-portable) install() hooks; now that those hooks are portable in
+ * their own right, a fresh install's schema matches what "installed" actually means from the
+ * very first request, on every platform.
  */
 final class SchemaInstaller
 {
     public static function createSchema(EntityManagerInterface $entityManager): void
     {
-        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+        $metadata = array_values(array_filter(
+            $entityManager->getMetadataFactory()->getAllMetadata(),
+            static function ($classMetadata): bool {
+                $module = ModuleEntityScope::moduleForEntityClass($classMetadata->getName());
+
+                return $module === null || ModuleEntityScope::isEagerAtInstall($module);
+            },
+        ));
         if ($metadata === []) {
             return;
         }

--- a/src/library/FOSSBilling/Doctrine/SchemaSynchronizer.php
+++ b/src/library/FOSSBilling/Doctrine/SchemaSynchronizer.php
@@ -100,7 +100,7 @@ final class SchemaSynchronizer
     {
         $metadataFactory = $entityManager->getMetadataFactory();
         $metadata = array_map(
-            static fn (string $class) => $metadataFactory->getMetadataFor($class),
+            $metadataFactory->getMetadataFor(...),
             $entityClasses,
         );
 

--- a/src/library/FOSSBilling/Doctrine/SchemaSynchronizer.php
+++ b/src/library/FOSSBilling/Doctrine/SchemaSynchronizer.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace FOSSBilling\Doctrine;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ComparatorConfig;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\ORM\EntityManagerInterface;
@@ -57,6 +59,20 @@ final class SchemaSynchronizer
      * Applies any additive schema changes and returns what happened. Never drops or alters
      * existing tables, columns, indexes, or foreign keys - only creates what's missing.
      *
+     * Compares against the *whole* live database, so every table with no corresponding entity
+     * anywhere in current metadata is reported in `skipped` - a full audit of every structural
+     * difference at once, third-party tables included.
+     *
+     * No current call site in this codebase actually wants that: a module materializing just its
+     * own table(s) from its own `install()` hook, or the ambient per-module gating
+     * {@see \FOSSBilling\UpdatePatcher::applyCorePatches()} needs (see {@see ModuleEntityScope}),
+     * both use {@see self::syncEntities()} instead, which doesn't produce noise for every
+     * unrelated table in the database - so this method is untouched production code today,
+     * exercised only by its own tests. Kept anyway, deliberately, as the one API on this class
+     * that can answer "what, if anything, has drifted from entity metadata across the *entire*
+     * schema" - syncEntities() can't answer that by design, since it only ever looks at the
+     * tables belonging to the entities it's given.
+     *
      * @return array{applied: list<string>, skipped: list<string>}
      */
     public static function sync(EntityManagerInterface $entityManager): array
@@ -66,12 +82,57 @@ final class SchemaSynchronizer
             return ['applied' => [], 'skipped' => []];
         }
 
+        return self::apply($entityManager, $metadata, restrictComparisonToOwnTables: false);
+    }
+
+    /**
+     * Same additive-only guarantee as {@see self::sync()}, but scoped to exactly the given
+     * entity classes: only those entities' own tables are compared against the live database,
+     * so a module materializing just its own table on install never reports every *other*
+     * table in the app as "missing from metadata" - there's nothing to skip, because nothing
+     * outside the given entities was ever compared in the first place.
+     *
+     * @param non-empty-list<class-string> $entityClasses
+     *
+     * @return array{applied: list<string>, skipped: list<string>}
+     */
+    public static function syncEntities(EntityManagerInterface $entityManager, array $entityClasses): array
+    {
+        $metadataFactory = $entityManager->getMetadataFactory();
+        $metadata = array_map(
+            static fn (string $class) => $metadataFactory->getMetadataFor($class),
+            $entityClasses,
+        );
+
+        return self::apply($entityManager, $metadata, restrictComparisonToOwnTables: true);
+    }
+
+    /**
+     * @param list<\Doctrine\ORM\Mapping\ClassMetadata> $metadata
+     *
+     * @return array{applied: list<string>, skipped: list<string>}
+     */
+    private static function apply(EntityManagerInterface $entityManager, array $metadata, bool $restrictComparisonToOwnTables): array
+    {
         $connection = $entityManager->getConnection();
         $schemaManager = $connection->createSchemaManager();
         $platform = $connection->getDatabasePlatform();
 
         $toSchema = (new SchemaTool($entityManager))->getSchemaFromMetadata($metadata);
-        $fromSchema = $schemaManager->introspectSchema();
+        $fromSchema = $restrictComparisonToOwnTables
+            ? self::introspectOnly($schemaManager, array_map(
+                // Name::toString() renders a *quoted* representation for any identifier defined
+                // quoted (e.g. Transaction::class's table name is the literal string
+                // "`transaction`", to escape the reserved word) - passing that straight to
+                // tablesExist()/introspectTableByUnquotedName() below, which both want the raw
+                // unquoted name, would make an already-existing quoted-name table always look
+                // missing (never matching by its quoted string) and fail outright with "already
+                // exists" once the comparator tried to recreate it. getValue() is the raw
+                // underlying name with quoting stripped, exactly what those two want.
+                static fn ($table): string => $table->getObjectName()->getUnqualifiedName()->getValue(),
+                $toSchema->getTables(),
+            ))
+            : $schemaManager->introspectSchema();
 
         $comparator = class_exists(ComparatorConfig::class)
             ? $schemaManager->createComparator((new ComparatorConfig())->withReportModifiedIndexes(false))
@@ -87,6 +148,26 @@ final class SchemaSynchronizer
         }
 
         return ['applied' => $applied, 'skipped' => $skipped];
+    }
+
+    /**
+     * Introspects only the named tables (skipping ones that don't exist yet, so a brand-new
+     * table shows up as "created", not as some impossible diff against nothing) instead of the
+     * whole database - what {@see self::syncEntities()} compares against, so tables outside the
+     * given entity list never enter the comparison at all.
+     *
+     * @param list<string> $tableNames
+     */
+    private static function introspectOnly(AbstractSchemaManager $schemaManager, array $tableNames): Schema
+    {
+        $tables = [];
+        foreach ($tableNames as $name) {
+            if ($schemaManager->tablesExist([$name])) {
+                $tables[] = $schemaManager->introspectTableByUnquotedName($name);
+            }
+        }
+
+        return new Schema($tables);
     }
 
     /**

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -236,30 +236,36 @@ class UpdatePatcher implements InjectionAwareInterface
         }
 
         $entityManager = $this->di['em'];
-        $connection = $entityManager->getConnection();
 
-        // Fetched once and reused for every entity below, rather than one query per entity - an
-        // unbounded number of extra queries per non-core module isn't a cost worth paying just
-        // to derive a handful of booleans.
-        $installedExtensionModules = ModuleEntityScope::installedExtensionModules($connection);
-
-        $eagerEntityClasses = array_values(array_filter(
-            array_map(
-                static fn ($classMetadata): string => $classMetadata->getName(),
-                $entityManager->getMetadataFactory()->getAllMetadata(),
-            ),
-            static function (string $entityClass) use ($installedExtensionModules): bool {
-                $module = ModuleEntityScope::moduleForEntityClass($entityClass);
-
-                return $module === null || ModuleEntityScope::isEagerNow($module, $installedExtensionModules);
-            },
-        ));
-
-        if ($eagerEntityClasses === []) {
-            return;
-        }
-
+        // Scope discovery (the connection, the installed-extensions query, metadata loading) can
+        // throw for the same reasons the sync itself can - an unreachable database above all -
+        // so it has to share this method's one error boundary, not run ahead of it. Only the sync
+        // itself used to be able to throw, back when this called SchemaSynchronizer::sync() with
+        // no scope discovery beforehand at all.
         try {
+            $connection = $entityManager->getConnection();
+
+            // Fetched once and reused for every entity below, rather than one query per entity -
+            // an unbounded number of extra queries per non-core module isn't a cost worth paying
+            // just to derive a handful of booleans.
+            $installedExtensionModules = ModuleEntityScope::installedExtensionModules($connection);
+
+            $eagerEntityClasses = array_values(array_filter(
+                array_map(
+                    static fn ($classMetadata): string => $classMetadata->getName(),
+                    $entityManager->getMetadataFactory()->getAllMetadata(),
+                ),
+                static function (string $entityClass) use ($installedExtensionModules): bool {
+                    $module = ModuleEntityScope::moduleForEntityClass($entityClass);
+
+                    return $module === null || ModuleEntityScope::isEagerNow($module, $installedExtensionModules);
+                },
+            ));
+
+            if ($eagerEntityClasses === []) {
+                return;
+            }
+
             $result = SchemaSynchronizer::syncEntities($entityManager, $eagerEntityClasses);
         } catch (\Throwable $e) {
             $this->logUpdate('error', 'Schema sync against the configured database failed: ' . $e->getMessage());

--- a/src/library/FOSSBilling/UpdatePatcher.php
+++ b/src/library/FOSSBilling/UpdatePatcher.php
@@ -13,6 +13,7 @@ namespace FOSSBilling;
 
 use Box\Mod\Extension\Entity\Extension;
 use FOSSBilling\Doctrine\DriverManagerFactory;
+use FOSSBilling\Doctrine\ModuleEntityScope;
 use FOSSBilling\Doctrine\SchemaSynchronizer;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -216,6 +217,14 @@ class UpdatePatcher implements InjectionAwareInterface
      * {@see SchemaSynchronizer} for exactly what this does and does not cover (additive structural
      * changes only, never a substitute for the legacy patches' data transformations).
      *
+     * Scoped to core-module entities plus whichever extensions are currently marked installed
+     * ({@see ModuleEntityScope::isEagerNow()}) - the same gating {@see \FOSSBilling\Doctrine\
+     * SchemaInstaller} applies at fresh-install time. Running the unscoped {@see SchemaSynchronizer::
+     * sync()} here instead would undo that gating: it compares every entity's table
+     * unconditionally, so an inactive extension's table (custom_pages, mod_massmailer,
+     * service_apikey, or any future one) would get silently recreated by this method - as if it
+     * were activated - regardless of whether anyone ever installs that extension.
+     *
      * Errors are logged, not thrown: this runs on every request via UpdateFinalization, and a
      * database this can't reach (or a metadata error) should degrade to "nothing changed", the same
      * outcome as before this method existed, rather than breaking the request.
@@ -226,8 +235,32 @@ class UpdatePatcher implements InjectionAwareInterface
             return;
         }
 
+        $entityManager = $this->di['em'];
+        $connection = $entityManager->getConnection();
+
+        // Fetched once and reused for every entity below, rather than one query per entity - an
+        // unbounded number of extra queries per non-core module isn't a cost worth paying just
+        // to derive a handful of booleans.
+        $installedExtensionModules = ModuleEntityScope::installedExtensionModules($connection);
+
+        $eagerEntityClasses = array_values(array_filter(
+            array_map(
+                static fn ($classMetadata): string => $classMetadata->getName(),
+                $entityManager->getMetadataFactory()->getAllMetadata(),
+            ),
+            static function (string $entityClass) use ($installedExtensionModules): bool {
+                $module = ModuleEntityScope::moduleForEntityClass($entityClass);
+
+                return $module === null || ModuleEntityScope::isEagerNow($module, $installedExtensionModules);
+            },
+        ));
+
+        if ($eagerEntityClasses === []) {
+            return;
+        }
+
         try {
-            $result = SchemaSynchronizer::sync($this->di['em']);
+            $result = SchemaSynchronizer::syncEntities($entityManager, $eagerEntityClasses);
         } catch (\Throwable $e) {
             $this->logUpdate('error', 'Schema sync against the configured database failed: ' . $e->getMessage());
 

--- a/src/modules/Custompages/Service.php
+++ b/src/modules/Custompages/Service.php
@@ -53,10 +53,11 @@ class Service
         // Raw MySQL-only DDL here (backticks, ENGINE=InnoDB) would fail outright on
         // PostgreSQL/SQLite. custom_pages isn't in structure.sql at all - this module creates
         // its own table on activation - so unlike the core install path, this genuinely runs on
-        // every platform. SchemaSynchronizer::sync() creates (or catches up) every entity's
-        // table from current metadata, additively and safely - the same mechanism
-        // UpdatePatcher::applyCorePatches() already uses on every request.
-        \FOSSBilling\Doctrine\SchemaSynchronizer::sync($this->di['em']);
+        // every platform. SchemaSynchronizer::syncEntities() creates (or catches up) just this
+        // module's own table from current metadata, additively and safely - scoped so
+        // installing this one extension never reports every *other* table in the app as missing,
+        // unlike the whole-app SchemaSynchronizer::sync().
+        \FOSSBilling\Doctrine\SchemaSynchronizer::syncEntities($this->di['em'], [CustomPage::class]);
 
         return true;
     }

--- a/src/modules/Massmailer/Service.php
+++ b/src/modules/Massmailer/Service.php
@@ -107,10 +107,11 @@ class Service implements \FOSSBilling\InjectionAwareInterface
         // Raw MySQL-only DDL here (backticks, ENGINE=InnoDB) would fail outright on
         // PostgreSQL/SQLite. mod_massmailer already exists in structure.sql, so this hook is
         // already redundant on MySQL fresh installs - it's only load-bearing on PG/SQLite,
-        // where nothing else creates the table. SchemaSynchronizer::sync() creates (or catches
-        // up) every entity's table from current metadata, additively and safely, on every
-        // platform.
-        \FOSSBilling\Doctrine\SchemaSynchronizer::sync($this->di['em']);
+        // where nothing else creates the table. SchemaSynchronizer::syncEntities() creates (or
+        // catches up) just this module's own table from current metadata, additively and
+        // safely, scoped so installing this one extension never reports every *other* table in
+        // the app as missing.
+        \FOSSBilling\Doctrine\SchemaSynchronizer::syncEntities($this->di['em'], [MassmailerMessage::class]);
 
         // default config values
         $extensionService->setConfig(['ext' => 'mod_massmailer', 'limit' => '2', 'interval' => '10', 'test_client_id' => 1]);

--- a/src/modules/Serviceapikey/Service.php
+++ b/src/modules/Serviceapikey/Service.php
@@ -242,9 +242,10 @@ class Service implements InjectionAwareInterface
         // PostgreSQL/SQLite. On MySQL, structure.sql doesn't create service_apikey either -
         // UpdatePatcher::patch111() does, as a startup-safety-net fix - so this hook is already
         // redundant there and only load-bearing on PG/SQLite fresh installs where nothing else
-        // creates the table. SchemaSynchronizer::sync() creates (or catches up) every entity's
-        // table from current metadata, additively and safely, on every platform.
-        \FOSSBilling\Doctrine\SchemaSynchronizer::sync($this->di['em']);
+        // creates the table. SchemaSynchronizer::syncEntities() creates (or catches up) just
+        // this module's own table from current metadata, additively and safely, scoped so
+        // installing this one extension never reports every *other* table in the app as missing.
+        \FOSSBilling\Doctrine\SchemaSynchronizer::syncEntities($this->di['em'], [ServiceApiKey::class]);
 
         return true;
     }

--- a/tests/Unit/FOSSBilling/Doctrine/ModuleEntityScopeTest.php
+++ b/tests/Unit/FOSSBilling/Doctrine/ModuleEntityScopeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+use Doctrine\DBAL\DriverManager;
+use FOSSBilling\Doctrine\EntityManagerFactory;
+use FOSSBilling\Doctrine\InstallSeeder;
+use FOSSBilling\Doctrine\ModuleEntityScope;
+use FOSSBilling\Doctrine\SchemaInstaller;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+test('moduleForEntityClass extracts the lowercased module name from a Box\Mod\{Module}\Entity\... class', function (): void {
+    expect(ModuleEntityScope::moduleForEntityClass(Box\Mod\Custompages\Entity\CustomPage::class))->toBe('custompages')
+        ->and(ModuleEntityScope::moduleForEntityClass(Box\Mod\Currency\Entity\Currency::class))->toBe('currency');
+});
+
+test('moduleForEntityClass returns null for a class outside the Box\Mod\{Module}\Entity\... convention', function (): void {
+    expect(ModuleEntityScope::moduleForEntityClass(ModuleEntityScope::class))->toBeNull()
+        ->and(ModuleEntityScope::moduleForEntityClass('NotEvenNamespaced'))->toBeNull();
+});
+
+test('isEagerAtInstall is true for a core module', function (): void {
+    expect(ModuleEntityScope::isEagerAtInstall('currency'))->toBeTrue();
+});
+
+test('isEagerAtInstall is true for a default-active extension', function (): void {
+    expect(ModuleEntityScope::isEagerAtInstall('news'))->toBeTrue();
+});
+
+test('isEagerAtInstall is false for a non-core extension not installed by default', function (): void {
+    expect(ModuleEntityScope::isEagerAtInstall('custompages'))->toBeFalse();
+});
+
+test('installedExtensionModules returns an empty list when the extension table does not exist yet', function (): void {
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+    expect(ModuleEntityScope::installedExtensionModules($connection))->toBe([]);
+});
+
+test('installedExtensionModules lists only mod-type rows currently marked installed', function (): void {
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $entityManager = EntityManagerFactory::create($connection);
+    SchemaInstaller::createSchema($entityManager);
+
+    $connection->insert('extension', ['type' => 'mod', 'name' => 'custompages', 'status' => 'installed', 'version' => '1.0.0']);
+    // A deactivated mod-type row must not count, nor a non-mod (theme) type row even if installed.
+    $connection->insert('extension', ['type' => 'mod', 'name' => 'massmailer', 'status' => 'deactivated', 'version' => '1.0.0']);
+    $connection->insert('extension', ['type' => 'theme', 'name' => 'huraga', 'status' => 'installed', 'version' => '1.0.0']);
+
+    expect(ModuleEntityScope::installedExtensionModules($connection))->toBe(['custompages']);
+});
+
+test('isEagerNow is true for a core module even with an empty installed list', function (): void {
+    expect(ModuleEntityScope::isEagerNow('currency', []))->toBeTrue();
+});
+
+test('isEagerNow is true for a non-core module present in the installed list', function (): void {
+    expect(ModuleEntityScope::isEagerNow('custompages', ['custompages']))->toBeTrue();
+});
+
+test('isEagerNow is false for a non-core module absent from the installed list', function (): void {
+    expect(ModuleEntityScope::isEagerNow('custompages', ['massmailer']))->toBeFalse();
+});
+
+/*
+ * DEFAULT_ACTIVE_EXTENSIONS can't be derived from content.sql at runtime - see its own docblock:
+ * SchemaInstaller::createSchema() needs this before the `extension` table (or the database
+ * itself, on a from-scratch install) exists to query. So it's a hand-maintained copy of what
+ * content.sql actually seeds, which can silently drift out of sync with the real file. This test
+ * is what keeps that copy honest: seed the real content.sql into a real database and compare what
+ * it actually installs against the constant, so a future content.sql change that adds, removes, or
+ * renames a default-installed mod extension without updating this constant fails loudly here,
+ * rather than silently gating (or failing to gate) the wrong module at fresh-install time.
+ */
+test('DEFAULT_ACTIVE_EXTENSIONS matches exactly the mod extensions the real content.sql seeds as installed', function (): void {
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $entityManager = EntityManagerFactory::create($connection);
+    SchemaInstaller::createSchema($entityManager);
+
+    $contentSql = (new Filesystem())->readFile(Path::join(PATH_ROOT, 'install', 'sql', 'content.sql'));
+    InstallSeeder::seedContent($connection, $entityManager, $contentSql, new DateTimeImmutable());
+
+    $seededDefaultExtensions = $connection->fetchFirstColumn(
+        "SELECT name FROM extension WHERE type = 'mod' AND status = 'installed' ORDER BY name",
+    );
+
+    $declaredDefaultExtensions = (new ReflectionClass(ModuleEntityScope::class))->getConstant('DEFAULT_ACTIVE_EXTENSIONS');
+    sort($declaredDefaultExtensions);
+
+    expect($declaredDefaultExtensions)->toBe($seededDefaultExtensions);
+});

--- a/tests/Unit/FOSSBilling/Doctrine/SchemaSynchronizerTest.php
+++ b/tests/Unit/FOSSBilling/Doctrine/SchemaSynchronizerTest.php
@@ -26,6 +26,17 @@ function schemaSynchronizerFixture(): array
 
     SchemaInstaller::createSchema($entityManager);
 
+    // SchemaInstaller deliberately leaves non-core, non-default-active extensions' tables
+    // uncreated (see ModuleEntityScope) - these tests exercise sync()/syncEntities() against a
+    // database current with *all* entity metadata, the same state a real install reaches once
+    // every extension it has is activated, so materialize those tables the same way each
+    // module's own install() hook would.
+    SchemaSynchronizer::syncEntities($entityManager, [
+        Box\Mod\Custompages\Entity\CustomPage::class,
+        Box\Mod\Massmailer\Entity\MassmailerMessage::class,
+        Box\Mod\Serviceapikey\Entity\ServiceApiKey::class,
+    ]);
+
     return [$connection, $entityManager];
 }
 
@@ -188,4 +199,71 @@ test('sync never adds a foreign key constraint to an existing table', function (
     ));
     expect($foreignKeys)->toBe([])
         ->and($skippedForeignKeyMessages)->toHaveCount(1);
+});
+
+test('syncEntities creates only the given entity\'s table, reporting no unrelated tables as missing', function (): void {
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $entityManager = EntityManagerFactory::create($connection);
+
+    expect($connection->createSchemaManager()->tablesExist(['custom_pages']))->toBeFalse();
+
+    $result = SchemaSynchronizer::syncEntities($entityManager, [Box\Mod\Custompages\Entity\CustomPage::class]);
+
+    expect($connection->createSchemaManager()->tablesExist(['custom_pages']))->toBeTrue()
+        // Every other entity's table is absent from this brand-new database too, but none of
+        // them were ever compared - scoping to just CustomPage means nothing outside it is
+        // reported as "missing from metadata", unlike a full sync() against an empty database.
+        ->and($result['skipped'])->toBe([]);
+});
+
+test('syncEntities is a no-op when the entity\'s table is already current', function (): void {
+    [, $entityManager] = schemaSynchronizerFixture();
+
+    $result = SchemaSynchronizer::syncEntities($entityManager, [Box\Mod\Custompages\Entity\CustomPage::class]);
+
+    expect($result['applied'])->toBe([])
+        ->and($result['skipped'])->toBe([]);
+});
+
+test('syncEntities never drops a column the target entity no longer maps, but leaves unrelated tables untouched', function (): void {
+    [$connection, $entityManager] = schemaSynchronizerFixture();
+
+    $connection->executeStatement('ALTER TABLE custom_pages ADD COLUMN legacy_unmapped_column TEXT');
+    // A completely unrelated table is missing a column too - syncEntities() must never see it,
+    // let alone report or fix it, since only CustomPage was asked for.
+    $connection->executeStatement('ALTER TABLE post DROP COLUMN description');
+
+    $result = SchemaSynchronizer::syncEntities($entityManager, [Box\Mod\Custompages\Entity\CustomPage::class]);
+
+    $columnNames = array_map(
+        static fn ($column) => $column->getName(),
+        $connection->createSchemaManager()->listTableColumns('custom_pages'),
+    );
+    // introspectTableByUnquotedName() (what introspectOnly() uses) quotes the column name
+    // differently than a full introspectSchema() would in the resulting skip message - cosmetic
+    // only, the column itself is identical and just as untouched either way - so this asserts
+    // on substrings rather than the exact string sync()'s equivalent test asserts on.
+    expect($columnNames)->toContain('legacy_unmapped_column')
+        ->and($result['skipped'])->toHaveCount(1)
+        ->and($result['skipped'][0])->toContain('custom_pages')
+        ->and($result['skipped'][0])->toContain('legacy_unmapped_column')
+        ->and($result['skipped'][0])->toContain('exists in the database but not in entity metadata');
+});
+
+/*
+ * Regression test for a real bug found wiring syncEntities() into UpdatePatcher::
+ * applyCorePatches() against a live MariaDB database: Transaction::class maps to the literal
+ * table name "`transaction`" (backtick-quoted in the name string itself, to escape the SQL
+ * keyword) - Name::toString() renders that back out *quoted*, and passing that quoted string to
+ * tablesExist()/introspectTableByUnquotedName() (which both want the raw unquoted name) made an
+ * already-existing `transaction` table always look missing from introspection, so the comparator
+ * tried to CREATE TABLE `transaction` again and failed outright with "table already exists".
+ */
+test('syncEntities is a no-op for an entity whose table name is itself quoted (a reserved SQL word)', function (): void {
+    [, $entityManager] = schemaSynchronizerFixture();
+
+    $result = SchemaSynchronizer::syncEntities($entityManager, [Box\Mod\Invoice\Entity\Transaction::class]);
+
+    expect($result['applied'])->toBe([])
+        ->and($result['skipped'])->toBe([]);
 });

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -1265,8 +1265,10 @@ test('applyCorePatches runs a portable schema sync instead of legacy patches on 
         FOSSBilling\Doctrine\SchemaInstaller::createSchema($entityManager);
 
         // Simulate a PostgreSQL/SQLite install that predates a table current entity metadata
-        // knows about - the same situation a real upgrade would hit.
-        $connection->executeStatement('DROP TABLE custom_pages');
+        // knows about - the same situation a real upgrade would hit. `currency` is a core-module
+        // table (see ModuleEntityScope), so it's always in scope for the ambient sync below,
+        // unlike an extension's own table - see the gating tests further down.
+        $connection->executeStatement('DROP TABLE currency');
 
         $pdo = Mockery::mock(PDO::class);
         $pdo->shouldNotReceive('prepare');
@@ -1282,7 +1284,7 @@ test('applyCorePatches runs a portable schema sync instead of legacy patches on 
 
         $patcher->applyCorePatches(force: true);
 
-        expect($connection->createSchemaManager()->tablesExist(['custom_pages']))->toBeTrue();
+        expect($connection->createSchemaManager()->tablesExist(['currency']))->toBeTrue();
     });
 });
 
@@ -1291,7 +1293,7 @@ test('applyCorePatches also runs a portable schema sync after legacy patches on 
         $connection = Doctrine\DBAL\DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
         $entityManager = FOSSBilling\Doctrine\EntityManagerFactory::create($connection);
         FOSSBilling\Doctrine\SchemaInstaller::createSchema($entityManager);
-        $connection->executeStatement('DROP TABLE custom_pages');
+        $connection->executeStatement('DROP TABLE currency');
 
         // The legacy patch loop still needs a patch level to compare against - report the latest
         // one so getPatches() finds nothing pending and the loop body never runs. That isolates
@@ -1303,6 +1305,70 @@ test('applyCorePatches also runs a portable schema sync after legacy patches on 
 
         $pdo = Mockery::mock(PDO::class);
         $pdo->shouldReceive('prepare')->once()->andReturn($statement);
+
+        $di = new Pimple\Container();
+        $di['pdo'] = $pdo;
+        $di['em'] = $entityManager;
+        $di['logger'] = new Tests\Helpers\TestLogger();
+
+        $patcher = new UpdatePatcher();
+        $patcher->setDi($di);
+
+        $patcher->applyCorePatches(force: true);
+
+        expect($connection->createSchemaManager()->tablesExist(['currency']))->toBeTrue();
+    });
+});
+
+/*
+ * Regression coverage for the gating ModuleEntityScope adds: the ambient sync above must not undo
+ * SchemaInstaller's fresh-install gating by unconditionally recreating an inactive extension's
+ * table on every request, as if it had been activated.
+ */
+test('applyCorePatches never recreates an inactive extension\'s table via the ambient schema sync', function (): void {
+    withNonMysqlDbDriver(function (): void {
+        $connection = Doctrine\DBAL\DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $entityManager = FOSSBilling\Doctrine\EntityManagerFactory::create($connection);
+        FOSSBilling\Doctrine\SchemaInstaller::createSchema($entityManager);
+
+        // custompages is neither a core module nor one of content.sql's default-active
+        // extensions, so a fresh install never creates its table - nothing here to "predate".
+        expect($connection->createSchemaManager()->tablesExist(['custom_pages']))->toBeFalse();
+
+        $pdo = Mockery::mock(PDO::class);
+        $pdo->shouldNotReceive('prepare');
+        $pdo->shouldNotReceive('query');
+
+        $di = new Pimple\Container();
+        $di['pdo'] = $pdo;
+        $di['em'] = $entityManager;
+        $di['logger'] = new Tests\Helpers\TestLogger();
+
+        $patcher = new UpdatePatcher();
+        $patcher->setDi($di);
+
+        $patcher->applyCorePatches(force: true);
+
+        expect($connection->createSchemaManager()->tablesExist(['custom_pages']))->toBeFalse();
+    });
+});
+
+test('applyCorePatches does resync an extension\'s table once it is marked installed', function (): void {
+    withNonMysqlDbDriver(function (): void {
+        $connection = Doctrine\DBAL\DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $entityManager = FOSSBilling\Doctrine\EntityManagerFactory::create($connection);
+        FOSSBilling\Doctrine\SchemaInstaller::createSchema($entityManager);
+
+        // Simulate the module having been activated (its own install() hook already ran once,
+        // creating its table) and then predating a later metadata change - the same situation
+        // a currently-installed extension's table missing a new column would hit.
+        FOSSBilling\Doctrine\SchemaSynchronizer::syncEntities($entityManager, [Box\Mod\Custompages\Entity\CustomPage::class]);
+        $connection->executeStatement("INSERT INTO extension (type, name, status, version) VALUES ('mod', 'custompages', 'installed', '1.0.0')");
+        $connection->executeStatement('DROP TABLE custom_pages');
+
+        $pdo = Mockery::mock(PDO::class);
+        $pdo->shouldNotReceive('prepare');
+        $pdo->shouldNotReceive('query');
 
         $di = new Pimple\Container();
         $di['pdo'] = $pdo;

--- a/tests/Unit/FOSSBilling/UpdatePatcherTest.php
+++ b/tests/Unit/FOSSBilling/UpdatePatcherTest.php
@@ -1384,6 +1384,46 @@ test('applyCorePatches does resync an extension\'s table once it is marked insta
     });
 });
 
+/*
+ * Regression test: scope discovery (installedExtensionModules()'s schema introspection and
+ * query, plus metadata loading) has to fail inside the same try/catch as the sync call itself -
+ * it can throw for the same reasons the sync can (an unreachable database above all), and this
+ * method's whole contract is "errors are logged, not thrown". A connection that fails outright
+ * (rather than one that's merely missing a table) reproduces exactly that: the failure happens
+ * during installedExtensionModules()'s own tablesExist() call, before SchemaSynchronizer::
+ * syncEntities() is ever reached.
+ */
+test('applyCorePatches logs, rather than throws, when scope discovery itself fails to reach the database', function (): void {
+    withNonMysqlDbDriver(function (): void {
+        $brokenConnection = Doctrine\DBAL\DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => '/definitely-not-a-real-directory-987654321/db.sqlite',
+        ]);
+        $entityManager = FOSSBilling\Doctrine\EntityManagerFactory::create($brokenConnection);
+
+        $pdo = Mockery::mock(PDO::class);
+        $pdo->shouldNotReceive('prepare');
+        $pdo->shouldNotReceive('query');
+
+        $logger = new Tests\Helpers\TestLogger();
+        $di = new Pimple\Container();
+        $di['pdo'] = $pdo;
+        $di['em'] = $entityManager;
+        $di['logger'] = $logger;
+
+        $patcher = new UpdatePatcher();
+        $patcher->setDi($di);
+
+        // Must not throw - the whole point of the try/catch this scope discovery has to live
+        // inside.
+        $patcher->applyCorePatches(force: true);
+
+        $errorCalls = array_values(array_filter($logger->calls, static fn (array $call): bool => $call['method'] === 'error'));
+        expect($errorCalls)->not->toBe([])
+            ->and($errorCalls[0]['params'][0])->toContain('Schema sync against the configured database failed');
+    });
+});
+
 test('availablePatches reports 0 on a non-MySQL driver regardless of the last_patch value', function (): void {
     withNonMysqlDbDriver(function (): void {
         $pdo = Mockery::mock(PDO::class);


### PR DESCRIPTION
## Why

Following up on #4207 (which unified MySQL fresh installs onto `SchemaInstaller`, generated from Doctrine entity metadata): `SchemaInstaller::createSchema()` materialized *every* entity's table unconditionally, regardless of whether the owning module/extension was ever activated. That was relied on as an accidental safety net for three extension modules (`Custompages`, `Massmailer`, `Serviceapikey`) whose own `install()` hooks used to run raw, MySQL-only DDL - the table already existed by the time `install()` ran, so the broken SQL was a silent no-op everywhere it was ever exercised.

This closes that gap and works toward modules/extensions being able to define and own their own tables on install, materialized only when actually activated - matching what "installed" is supposed to mean, on every platform.

## What changed

1. **`SchemaSynchronizer::syncEntities()`** - a scoped sibling of the existing `sync()` that compares only the given entity classes' own tables against the live database, instead of the whole schema. A module's `install()` hook can now materialize exactly its own table without `sync()`'s "every other table in the app is missing from metadata" noise. `Custompages`/`Massmailer`/`Serviceapikey`'s `install()` hooks now use this instead of whole-app `sync()`.

2. **`ModuleEntityScope`** (new) - derives an entity's owning module from its namespace (every entity lives under `Box\Mod\{Module}\Entity\...`) and classifies it as eager-at-install (core modules, plus content.sql's fixed default-active extensions: `news`, `branding`, `redirect`) or eager-now (core modules, plus whatever the `extension` table currently marks installed).

3. **`SchemaInstaller::createSchema()`** now filters entity metadata through `isEagerAtInstall()`. A fresh install (MySQL/MariaDB included) no longer eagerly creates `custom_pages`/`mod_massmailer`/`service_apikey` - those extensions get their table only when actually activated, via that module's own `install()` hook, the same as any future extension would.

4. **`UpdatePatcher::syncPortableSchema()`** (the ambient per-request schema catch-up) now scopes to core-module entities plus currently-installed extensions via `ModuleEntityScope::isEagerNow()`, using `syncEntities()` instead of the whole-app `sync()`. Without this, the ambient sync would silently undo (3)'s gating the next time it runs, recreating an inactive extension's table as if it had been activated. The installed-extensions list is fetched once per run and reused across every entity checked, rather than one query per non-core module.

## Bug found and fixed along the way

`syncEntities()`'s table-name lookup used `Name::toString()`, which renders a *quoted* representation for any identifier defined quoted. `Transaction::class` maps to the literal table name `` `transaction` `` (backtick-escaping the reserved SQL word) - so an already-existing `transaction` table always looked missing from introspection, and the comparator tried to recreate it, failing outright with "table already exists" the moment `UpdatePatcher`'s core-entity list included it (reproduced live against MariaDB before fixing). Fixed by using the raw unquoted name (`getUnqualifiedName()->getValue()`), with a regression test covering a quoted-name entity.