### PR TITLE
Don't throttle admin-role client_login/staff_login under the guest api_login policy

### DIFF
--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -118,7 +118,7 @@ class Client implements InjectionAwareInterface
     {
         $subject = (string) $this->_getIp();
 
-        if ($method === 'staff_login' || $method === 'client_login') {
+        if (($method === 'staff_login' || $method === 'client_login') && $role !== 'admin') {
             $policy = 'api_login';
         } elseif ($role === 'guest') {
             $policy = 'api_guest';

--- a/src/modules/Api/tests/Unit/Controller/ClientTest.php
+++ b/src/modules/Api/tests/Unit/Controller/ClientTest.php
@@ -320,3 +320,23 @@ test('non-AJAX client login returns a redirect response', function (): void {
         ->and($response->isRedirect())->toBeTrue()
         ->and($response->headers->get('Location'))->toBe('https://client.example.test/');
 });
+
+test('guest client login is throttled under the anti-bruteforce api_login policy', function (): void {
+    [$controller, $rateLimitCalls] = createTestController();
+
+    invokeApiCall($controller, 'guest', 'client', 'client_login', []);
+
+    expect($rateLimitCalls->getArrayCopy())->toBe([['api_login', '127.0.0.1', 1]]);
+});
+
+test('admin impersonation of client login is not throttled under the guest api_login policy', function (): void {
+    [$controller, $rateLimitCalls] = createTestController(['admin' => ['id' => 7]]);
+    $controller->hasValidSession = true;
+
+    invokeApiCall($controller, 'admin', 'client', 'client_login', []);
+
+    expect($rateLimitCalls->getArrayCopy())->toBe([
+        ['api_authenticated_ip', '127.0.0.1', 1],
+        ['api_authenticated_account', 'admin:7', 1],
+    ]);
+});


### PR DESCRIPTION
## Summary

`Box\Mod\Api\Controller\Client::checkRateLimit()` picked the rate-limit policy by matching `$method` (built as `$class . '_' . $method`) against the literal strings `'staff_login'`/`'client_login'`, without looking at `$role` at all. Since this string is identical regardless of role, `admin/client/login` (staff impersonation via `Client\Api\Admin::login()`) got bucketed under the same strict, low-limit `api_login` anti-brute-force policy (10/hour per IP by default) as `guest/client/login` (an anonymous visitor's real password attempt).

`admin/client/login` already requires a fully authenticated admin session (`checkPermissions('client', 'impersonate_login')` is the first line of `Client\Api\Admin::login()`), so the anonymous-brute-force protection `api_login` exists for doesn't apply to it.

## Fix

Only apply the `api_login` policy when `$role !== 'admin'`. Admin-role calls now fall through to the existing `api_authenticated_ip`/`api_authenticated_account` branches (1000/hour by default); still a reasonable general throttle for authenticated-admin API abuse, just not the anonymous-brute-force-specific one.

Fixes #4212.