### PR TITLE
Fix maintenance page crash when hide_company_public is enabled

### DIFF
--- a/src/modules/Api/tests/Unit/Controller/ClientTest.php
+++ b/src/modules/Api/tests/Unit/Controller/ClientTest.php
@@ -321,7 +321,7 @@ test('non-AJAX client login returns a redirect response', function (): void {
         ->and($response->headers->get('Location'))->toBe('https://client.example.test/');
 });
 
-test('guest client login is throttled under the anti-bruteforce api_login policy', function (): void {
+test('guest client login is throttled under the anti-brute-force api_login policy', function (): void {
     [$controller, $rateLimitCalls] = createTestController();
 
     invokeApiCall($controller, 'guest', 'client', 'client_login', []);

--- a/src/modules/System/templates/client/mod_system_maintenance.html.twig
+++ b/src/modules/System/templates/client/mod_system_maintenance.html.twig
@@ -32,12 +32,12 @@
         <hr>
         <h4>{{ "While we're away, you can still reach us over other channels."|trans }}</h4>
         <ul style="list-style-type: none; padding: 0;">
-            <li>{{ company.name }}</li>
-            <li>{{ company.address_1 }}</li>
-            <li>{{ company.address_2 }}</li>
-            <li>{{ company.address_3 }}</li>
-            <li>{{ company.tel }}</li>
-            <li>{{ company.email }}</li>
+            <li>{{ company.name|default('') }}</li>
+            <li>{{ company.address_1|default('') }}</li>
+            <li>{{ company.address_2|default('') }}</li>
+            <li>{{ company.address_3|default('') }}</li>
+            <li>{{ company.tel|default('') }}</li>
+            <li>{{ company.email|default('') }}</li>
         </ul>
     </div>
 {% endblock %}

--- a/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
+++ b/tests/Unit/FOSSBilling/Twig/StrictVariablesTest.php
@@ -53,6 +53,37 @@ test('cron settings renders when module config has not been saved', function ():
         ->and($html)->not->toContain('Guest Cron URL');
 });
 
+test('maintenance page renders when hide_company_public strips company contact fields', function (): void {
+    $renderer = new StrictTemplateRenderer();
+
+    // Regression test for #4211: Guest::company() removes vat_number/email/tel/account_number/
+    // number/address_1/address_2/address_3/bank_name/bic from the company array for anonymous
+    // visitors when hide_company_public is enabled. The public layout reads `guest.system_company`
+    // into `company`, so the fixture needs to go through `guest`, not a top-level `company` override.
+    // Under strict_variables this used to throw "Key ... does not exist" instead of rendering the
+    // maintenance notice.
+    $html = $renderer->renderTemplate(PATH_MODS . '/System/templates/client/mod_system_maintenance.html.twig', [
+        'guest' => new PermissiveStub([
+            'system_company' => [
+                'www' => 'https://example.test',
+                'name' => 'Test Co',
+                'signature' => null,
+                'logo_url' => null,
+                'logo_url_dark' => null,
+                'favicon_url' => null,
+                'display_bank_info' => null,
+                'bank_info_pagebottom' => null,
+                'note' => null,
+                'privacy_policy' => null,
+                'tos' => null,
+            ],
+        ]),
+        'settings' => new PermissiveStub(['login_page_show_logo' => false]),
+    ]);
+
+    expect($html)->toContain('System Undergoing Maintenance');
+});
+
 test('order new only lists periods the product is actually priced for', function (): void {
     $renderer = new StrictTemplateRenderer();
 


### PR DESCRIPTION
## Summary

`modules/System/templates/client/mod_system_maintenance.html.twig` references `company.address_1`, `company.address_2`, `company.address_3`, `company.tel`, and `company.email` with no `|default(...)` guard.

`Box\Mod\System\Api\Guest::company()` unsets exactly those keys (plus a few others) when the visitor is anonymous and the `hide_company_public` setting is enabled. Since strict Twig rendering is used, enabling that legitimate, common privacy setting means the maintenance page itself throws a raw "Key ... does not exist" exception for the exact anonymous visitors it's meant to serve, instead of showing "System Undergoing Maintenance".

## Steps to reproduce

1. Enable "hide company info from guests" (`hide_company_public` setting).
2. Set `maintenance_mode.enabled = true` in `config.php`.
3. Visit the site as a logged-out visitor.

**Expected**: the "System Undergoing Maintenance" page renders.
**Actual**: a Twig `RuntimeError` — `Key "address_1" for sequence/mapping with keys "..." does not exist`.

## Fix

Add `|default('')` to the affected fields, matching the pattern already used elsewhere in the codebase for the same "strict Twig + optional array key" issue (e.g. `mod_cookieconsent_index.html.twig`, `mod_client_profile.html.twig`).

Fixes #4211.