### PR TITLE
Harden template existence checks

### DIFF
--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -186,18 +186,21 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
     /**
      * Check if passed file name template exists for admin area.
-     *
-     * @return bool
      */
-    public function template_exists($data)
+    public function template_exists($data): bool
     {
         $this->checkPermissions('system', 'manage_settings');
 
-        if (!isset($data['file'])) {
+        if (!isset($data['file']) || !is_string($data['file'])) {
             return false;
         }
 
-        return $this->getService()->templateExists($data['file'], $this->getIdentity());
+        $file = trim($data['file']);
+        if ($file === '' || str_contains($file, "\0")) {
+            return false;
+        }
+
+        return $this->getService()->templateExists($file, $this->getIdentity());
     }
 
     /**

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -176,16 +176,19 @@ class Guest extends \FOSSBilling\Api\AbstractApi
 
     /**
      * Check if passed file name template exists for client area.
-     *
-     * @return bool
      */
-    public function template_exists($data)
+    public function template_exists($data): bool
     {
-        if (!isset($data['file'])) {
+        if (!isset($data['file']) || !is_string($data['file'])) {
             return false;
         }
 
-        return $this->getService()->templateExists($data['file']);
+        $file = trim($data['file']);
+        if ($file === '' || str_contains($file, "\0")) {
+            return false;
+        }
+
+        return $this->getService()->templateExists($file);
     }
 
     /**

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -500,8 +500,16 @@ class Service
         }
     }
 
-    public function templateExists($file, $identity = null): bool
+    public function templateExists(string $file, ?\Box\Mod\Staff\Entity\Admin $identity = null): bool
     {
+        $file = trim($file);
+        if ($file === '' || str_contains($file, "\0") || Path::isAbsolute($file) || str_contains($file, '..') || str_contains($file, '\\')) {
+            return false;
+        }
+        if (!preg_match('/\A[a-zA-Z0-9_\-\/]+\.html\.twig\z/', $file)) {
+            return false;
+        }
+
         if ($identity instanceof \Box\Mod\Staff\Entity\Admin) {
             $client = false;
         } else {
@@ -510,7 +518,13 @@ class Service
         $themeService = $this->di['mod_service']('theme');
         $theme = $themeService->getThemeConfig($client);
         foreach ($theme['paths'] as $path) {
-            if ($this->filesystem->exists(Path::join($path, $file))) {
+            $candidate = Path::join($path, $file);
+            $canonicalBase = Path::canonicalize($path);
+            $canonicalCandidate = Path::canonicalize($candidate);
+            if (!Path::isBasePath($canonicalBase, $canonicalCandidate)) {
+                continue;
+            }
+            if ($this->filesystem->exists($canonicalCandidate)) {
                 return true;
             }
         }

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -342,7 +342,7 @@ test('templateExists returns false when paths are empty', function (): void {
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $themeServiceMock);
     $service->setDi($di);
 
-    $result = $service->templateExists('defaultFile.cp');
+    $result = $service->templateExists('layout.html.twig');
     expect($result)->toBeBool();
     expect($result)->toBeFalse();
 });


### PR DESCRIPTION
Improves the security and robustness of the template existence checks in both the admin and client areas by adding stricter validation and sanitisation of template file names. It also enhances the `templateExists` service method to prevent path traversal and invalid file access.