### PR TITLE
Don't let a failed PSL download crash checkout

### DIFF
--- a/src/library/FOSSBilling/Validate.php
+++ b/src/library/FOSSBilling/Validate.php
@@ -14,6 +14,7 @@ namespace FOSSBilling;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 
 class Validate
 {
@@ -85,11 +86,19 @@ class Validate
             $item->expiresAfter(86400);
 
             $httpClient = $this->di['http_client'];
-            $response = $httpClient->request('GET', 'https://publicsuffix.org/list/public_suffix_list.dat');
             $dbPath = Path::join(PATH_CACHE, 'tlds.txt');
 
-            if ($response->getStatusCode() === 200) {
-                $this->filesystem->dumpFile($dbPath, $response->getContent());
+            try {
+                $response = $httpClient->request('GET', 'https://publicsuffix.org/list/public_suffix_list.dat');
+                $content = $response->getStatusCode() === 200 ? $response->getContent() : null;
+            } catch (ExceptionInterface) {
+                // Network/transport failure (DNS, TLS, connection refused, unsupported address family, etc.)
+                // Fall back below instead of letting this bubble up and break the calling flow (e.g. checkout).
+                $content = null;
+            }
+
+            if ($content !== null) {
+                $this->filesystem->dumpFile($dbPath, $content);
             } else {
                 $item->expiresAfter(3600);
 

--- a/tests/Unit/FOSSBilling/ValidateTest.php
+++ b/tests/Unit/FOSSBilling/ValidateTest.php
@@ -10,6 +10,10 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
 use function Tests\Datasets\domainProvider;
 use function Tests\Datasets\emailProvider;
 
@@ -17,6 +21,29 @@ test('is sld valid', function (string $domain, bool $expected): void {
     $validate = new FOSSBilling\Validate();
     expect($validate->isSldValid($domain))->toEqual($expected);
 })->with('domainProvider');
+
+test('is tld valid falls back gracefully when the PSL download fails at the transport level', function (): void {
+    $validate = new FOSSBilling\Validate();
+
+    // Simulates e.g. "Bind failed with errno 97: Address family not supported by protocol",
+    // which surfaces as a TransportException when the response is accessed, not when the
+    // request is made.
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('', [
+        'error' => 'Address family not supported by protocol',
+    ]));
+
+    $di = new Pimple\Container();
+    $di['cache'] = fn () => new ArrayAdapter();
+    $di['http_client'] = fn () => $httpClient;
+    $validate->setDi($di);
+
+    // Must not let the transport exception bubble up and break the caller (e.g. checkout).
+    expect(fn () => $validate->isTldValid('com'))->not->toThrow(Throwable::class);
+
+    // Falls back to the simple regex-based check since the PSL couldn't be fetched.
+    expect($validate->isTldValid('com'))->toBeTrue();
+    expect($validate->isTldValid('123'))->toBeFalse();
+});
 
 dataset('domainProvider', fn (): array => domainProvider());
 


### PR DESCRIPTION
## Summary

`Validate::isTldValid()` fetches `https://publicsuffix.org/list/public_suffix_list.dat` during TLD validation, called from domain checkout (`Servicedomain\Service`) for registration/transfer/own-domain orders. The request had no exception handling. A non-200 HTTP response already had a graceful fallback (short cache TTL + simple regex-based TLD check), but a transport-level failure - DNS resolution failure, TLS error, connection refused, or an unsupported address family (as here, on a host with IPv6 fully disabled at the kernel level so curl can't even open an `AF_INET6` socket to reach the list's AAAA record) - threw an uncaught `Symfony\Contracts\HttpClient\Exception\ExceptionInterface`, which propagated out of the cache callback and out of `isTldValid()` entirely, becoming FOSSBilling's generic `9999` fatal and breaking the whole checkout flow.

## Fix

Wrap the request/response access in a `try`/`catch` for `ExceptionInterface` and fall through to the existing degraded-validation path, exactly as the non-200 branch already does.