### PR TITLE
Fix cache-backend prune crash and stale-cache-on-switch bugs

### DIFF
--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -136,11 +136,15 @@ class CacheFactory
     /**
      * Clears every cache pool FOSSBilling knows about. Best-effort: a misconfigured or
      * unreachable backend must not prevent the rest of the cache from being cleared.
+     *
+     * Pass an explicit $cacheConfig to clear a backend other than the currently configured
+     * one - e.g. the previous backend right after the admin settings form switches drivers,
+     * since by then the live configuration already points at the new one.
      */
-    public static function clearAll(): void
+    public static function clearAll(?array $cacheConfig = null): void
     {
         foreach (self::ALL_NAMESPACES as $namespace) {
-            self::clearNamespace($namespace);
+            self::clearNamespace($namespace, $cacheConfig);
         }
     }
 
@@ -151,11 +155,16 @@ class CacheFactory
      * but not the flush command) - callers that already did the work clear() is meant to follow up
      * (writing a new config file, wiping the filesystem cache directory) must not have that
      * reported as their own failure.
+     *
+     * Pass an explicit $cacheConfig for the same reason as {@see self::clearAll()}.
      */
-    public static function clearNamespace(string $namespace): void
+    public static function clearNamespace(string $namespace, ?array $cacheConfig = null): void
     {
         try {
-            self::create($namespace)->clear();
+            $pool = $cacheConfig !== null
+                ? self::createFromConfig($cacheConfig, $namespace, 0, fallbackOnFailure: true)
+                : self::create($namespace);
+            $pool->clear();
         } catch (\Throwable) {
             // Clearing the cache is best-effort; a failure here shouldn't halt execution.
         }

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -17,6 +17,7 @@ namespace Box\Mod\System\Api;
 
 use FOSSBilling\Cache\CacheFactory;
 use FOSSBilling\Config;
+use FOSSBilling\Doctrine\EntityManagerFactory;
 use FOSSBilling\Tools;
 use FOSSBilling\Validation\Api\RequiredParams;
 
@@ -143,9 +144,21 @@ class Admin extends \FOSSBilling\Api\AbstractApi
             CacheFactory::createFromConfig($newCacheConfig, CacheFactory::NAMESPACE_CONNECTION_TEST, 60, fallbackOnFailure: false);
         }
 
+        // Config::setConfig() below clears the pools for the new driver (it reads the live
+        // config, which by then already points at the new one). Capture the outgoing config
+        // now so its backend can be cleared too, after the switch - otherwise entries left
+        // behind there (e.g. a Redis database the admin is switching away from) could reappear
+        // if this setting is ever reverted.
+        $oldCacheConfig = Config::getProperty('cache', []);
+
         $config = Config::getConfig();
         $config['cache'] = $newCacheConfig;
         Config::setConfig($config);
+
+        if (is_array($oldCacheConfig)) {
+            CacheFactory::clearAll($oldCacheConfig);
+            CacheFactory::clearNamespace(EntityManagerFactory::metadataCacheNamespace(), $oldCacheConfig);
+        }
 
         return true;
     }

--- a/src/modules/System/Service.php
+++ b/src/modules/System/Service.php
@@ -729,9 +729,10 @@ class Service
         $geoipReader->updateDefaultDatabases();
 
         try {
-            // Prune the FS cache
+            // Prune the cache. Only filesystem-backed pools support this; Redis/Memcached
+            // expire entries on their own and don't implement PruneableInterface.
             $cache = $di['cache'];
-            if ($cache->prune()) {
+            if ($cache instanceof \Symfony\Component\Cache\PruneableInterface && $cache->prune()) {
                 $di['logger']->withChannel('cron')->info('Pruned the filesystem cache');
             }
         } catch (\Exception $e) {

--- a/src/modules/System/tests/Unit/Api/AdminTest.php
+++ b/src/modules/System/tests/Unit/Api/AdminTest.php
@@ -76,6 +76,30 @@ test('update cache settings clears the saved redis password only when explicitly
     }
 });
 
+test('update cache settings clears the previously configured backend, not just the new one', function (): void {
+    if (hasRedisExtension()) {
+        $this->markTestSkipped('This test requires an environment without the redis/relay extension.');
+    }
+
+    $api = apiEndpoint(new Box\Mod\System\Api\Admin());
+    $originalConfig = Config::getConfig();
+
+    try {
+        // Seed a redis config directly (bypassing the API's own eager-connect check on save,
+        // since no redis server is reachable in this test environment).
+        $config = Config::getConfig();
+        $config['cache'] = ['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]];
+        Config::setConfig($config, false);
+
+        // Switching back to filesystem must not throw even though clearing the previous
+        // (unreachable) redis backend is attempted as part of the switch.
+        expect(fn () => $api->update_cache_settings(['driver' => 'filesystem']))->not->toThrow(Throwable::class);
+        expect(Config::getProperty('cache.driver'))->toBe('filesystem');
+    } finally {
+        Config::setConfig($originalConfig, false);
+    }
+});
+
 test('messages', function (): void {
     $api = apiEndpoint(new Box\Mod\System\Api\Admin());
     $data = [];

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -70,6 +70,16 @@ require_once __DIR__ . '/Datasets/ValidationData.php';
 require_once __DIR__ . '/Datasets/GeographicData.php';
 
 /**
+ * Whether a Redis client extension is available. Cache-backend tests that need an
+ * environment without it (to exercise the connection-failure/fallback paths) skip
+ * themselves when this is true.
+ */
+function hasRedisExtension(): bool
+{
+    return class_exists(Redis::class) || class_exists(Relay\Relay::class) || class_exists(RedisCluster::class);
+}
+
+/**
  * Construct an API endpoint with the default test container.
  *
  * @template T of FOSSBilling\Api\AbstractApi

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -26,11 +26,6 @@ afterEach(function (): void {
     Config::setConfig($this->cacheFactoryOriginalConfig, false);
 });
 
-function hasRedisExtension(): bool
-{
-    return class_exists(Redis::class) || class_exists(Relay\Relay::class) || class_exists(RedisCluster::class);
-}
-
 function setCacheConfig(?array $cacheConfig): void
 {
     $config = Config::getConfig();

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -199,3 +199,30 @@ test('clearAll never throws even with a misconfigured driver', function (): void
 
     CacheFactory::clearAll();
 })->expectNotToPerformAssertions();
+
+test('clearAll clears the pools for an explicitly given configuration, not just the live one', function (): void {
+    // The live configuration stays on filesystem throughout; only the explicit config passed
+    // to clearAll() below points at redis. This is the shape of a driver switch: by the time
+    // the previous backend needs clearing, the live configuration already points at the new one.
+    setCacheConfig(['driver' => 'filesystem']);
+
+    if (hasRedisExtension()) {
+        $this->markTestSkipped('This test requires an environment without the redis/relay extension.');
+    }
+
+    CacheFactory::clearAll(['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]]);
+})->expectNotToPerformAssertions();
+
+test('clearNamespace clears the pool for an explicitly given configuration, not just the live one', function (): void {
+    setCacheConfig(['driver' => 'filesystem']);
+    $pool = CacheFactory::create('cache_factory_test');
+    $item = $pool->getItem('regression_probe');
+    $item->set('value');
+    $pool->save($item);
+
+    // Passing the live filesystem config explicitly must reach the same pool as the live config
+    // does implicitly.
+    CacheFactory::clearNamespace('cache_factory_test', ['driver' => 'filesystem']);
+
+    expect(CacheFactory::create('cache_factory_test')->getItem('regression_probe')->isHit())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

### Bug 1 (P1): admin cron crashes on Redis/Memcached

`System\Service::onBeforeAdminCronRun()` unconditionally called `$cache->prune()`. `$di['cache']` can now be a `RedisAdapter` or `MemcachedAdapter` (via `CacheFactory`), and neither implements `PruneableInterface` (only `FilesystemAdapter` and a few others do). Calling `prune()` on them threw a PHP `Error` ("Call to undefined method"), which is **not** caught by `catch (\Exception $e)` since `Error` doesn't extend `Exception` — aborting the whole admin cron job before other scheduled tasks (billing, maintenance, etc.) ran, for anyone who has switched to Redis or Memcached.

Fixed by guarding the `prune()` call with `$cache instanceof \Symfony\Component\Cache\PruneableInterface`.

### Bug 2 (P2): switching cache drivers leaves the old backend's data stale

`Config::setConfig()` writes the new config to disk *before* it flushes the cache via `CacheFactory::clearAll()`/`clearNamespace()`. Both of those read the *live* config when called with no arguments — which by then already points at the *new* driver/host/database. So `System\Api\Admin::update_cache_settings()` switching an admin from e.g. Redis database 0 to Redis database 1 (or Redis to filesystem) only ever cleared the newly configured backend; entries left in the previous backend were never touched and could reappear if the admin switched back.

Fixed by:
1. Giving `CacheFactory::clearAll()` and `clearNamespace()` an optional explicit `$cacheConfig` parameter (default `null` = use the live config, as today), so a caller can target a specific (e.g. outgoing) config instead of whatever's currently saved.
2. `update_cache_settings()` now captures the outgoing `cache` config before calling `Config::setConfig()`, then explicitly clears that captured (old) config afterwards — both the general namespaces and the Doctrine metadata cache namespace, mirroring what `Config::setConfig()` already does for the new config.