### PR TITLE
Require an installation identifier for remote cache drivers

### DIFF
--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -95,13 +95,17 @@ class CacheFactory
      * $fallbackOnFailure is false, connection/extension problems are thrown as a FOSSBilling
      * Exception with a specific reason instead of silently degrading to filesystem.
      *
-     * @throws Exception if the driver is unsupported, or (when $fallbackOnFailure is false) unreachable
+     * @throws Exception if the driver is unsupported, if a remote driver is selected without an
+     *                   installation identifier configured, or (when $fallbackOnFailure is false)
+     *                   the backend is unreachable
      */
     public static function createFromConfig(array $cacheConfig, string $namespace, int $defaultLifetime, bool $fallbackOnFailure): CacheItemPoolInterface
     {
+        $instanceId = (string) Config::getProperty('info.instance_id', '');
+
         // Scope every pool to this installation, so installs that happen to share a Redis
         // database or Memcached server don't collide on the same cache keys.
-        $namespace = self::scopeNamespaceToInstallation($namespace);
+        $namespace = self::scopeNamespaceToInstallation($namespace, $instanceId);
 
         $driver = $cacheConfig['driver'] ?? 'filesystem';
 
@@ -111,6 +115,23 @@ class CacheFactory
 
         if ($driver === 'filesystem') {
             return new FilesystemAdapter($namespace, $defaultLifetime, PATH_CACHE);
+        }
+
+        // A remote cache backend namespaces its keys by info.instance_id (see
+        // scopeNamespaceToInstallation() above) precisely so that multiple FOSSBilling installs
+        // pointed at the same Redis/Memcached server don't read or overwrite each other's cache
+        // entries. Every supported install/upgrade path generates this id (see install.php and
+        // UpdatePatcher::applyCorePatches()), but a manually edited or hand-crafted config.php
+        // could still leave it blank - in which case the namespace silently falls back to the
+        // unscoped one and that isolation is lost. Refuse to build the pool at all rather than
+        // let that happen quietly. This intentionally sits outside the try/catch below: thrown
+        // from create() (fallbackOnFailure: true), it's caught by create()'s own outer catch and
+        // degrades to the filesystem cache like any other misconfiguration; thrown from
+        // createFromConfig() directly (fallbackOnFailure: false, e.g. the admin settings form),
+        // it surfaces to the caller as this specific, actionable message instead of being
+        // reworded by the generic "could not connect" handling below.
+        if ($instanceId === '') {
+            throw new Exception('The ":driver" cache driver requires an installation identifier ("info.instance_id" in the configuration file) so that installations sharing the same server don\'t collide. Reinstall or update FOSSBilling to have one generated automatically, or set it manually.', [':driver' => $driver]);
         }
 
         try {
@@ -183,10 +204,8 @@ class CacheFactory
      * installs pointed at the same Redis/Memcached server don't read or overwrite each other's
      * cache entries.
      */
-    private static function scopeNamespaceToInstallation(string $namespace): string
+    private static function scopeNamespaceToInstallation(string $namespace, string $instanceId): string
     {
-        $instanceId = (string) Config::getProperty('info.instance_id', '');
-
         if ($instanceId === '') {
             return $namespace;
         }

--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -117,19 +117,12 @@ class CacheFactory
             return new FilesystemAdapter($namespace, $defaultLifetime, PATH_CACHE);
         }
 
-        // A remote cache backend namespaces its keys by info.instance_id (see
-        // scopeNamespaceToInstallation() above) precisely so that multiple FOSSBilling installs
-        // pointed at the same Redis/Memcached server don't read or overwrite each other's cache
-        // entries. Every supported install/upgrade path generates this id (see install.php and
-        // UpdatePatcher::applyCorePatches()), but a manually edited or hand-crafted config.php
-        // could still leave it blank - in which case the namespace silently falls back to the
-        // unscoped one and that isolation is lost. Refuse to build the pool at all rather than
-        // let that happen quietly. This intentionally sits outside the try/catch below: thrown
-        // from create() (fallbackOnFailure: true), it's caught by create()'s own outer catch and
-        // degrades to the filesystem cache like any other misconfiguration; thrown from
-        // createFromConfig() directly (fallbackOnFailure: false, e.g. the admin settings form),
-        // it surfaces to the caller as this specific, actionable message instead of being
-        // reworded by the generic "could not connect" handling below.
+        // Every install/upgrade path generates info.instance_id, but a manually edited config.php
+        // could leave it blank - silently sharing the unscoped namespace with another install. This
+        // sits outside the try/catch below on purpose: from create() (fallbackOnFailure: true) it's
+        // caught by create()'s own outer catch and degrades to filesystem like any other
+        // misconfiguration; from createFromConfig() directly (fallbackOnFailure: false), it reaches
+        // the caller as this specific message instead of the generic "could not connect" one below.
         if ($instanceId === '') {
             throw new Exception('The ":driver" cache driver requires an installation identifier ("info.instance_id" in the configuration file) so that installations sharing the same server don\'t collide. Reinstall or update FOSSBilling to have one generated automatically, or set it manually.', [':driver' => $driver]);
         }

--- a/src/modules/System/tests/Unit/Api/AdminTest.php
+++ b/src/modules/System/tests/Unit/Api/AdminTest.php
@@ -76,6 +76,22 @@ test('update cache settings clears the saved redis password only when explicitly
     }
 });
 
+test('update cache settings rejects a remote driver when no installation identifier is configured', function (): void {
+    $api = apiEndpoint(new Box\Mod\System\Api\Admin());
+    $originalConfig = Config::getConfig();
+
+    try {
+        $config = Config::getConfig();
+        $config['info']['instance_id'] = '';
+        Config::setConfig($config, false);
+
+        expect(fn () => $api->update_cache_settings(['driver' => 'redis']))
+            ->toThrow(FOSSBilling\Exception::class, 'installation identifier');
+    } finally {
+        Config::setConfig($originalConfig, false);
+    }
+});
+
 test('messages', function (): void {
     $api = apiEndpoint(new Box\Mod\System\Api\Admin());
     $data = [];

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -190,6 +190,48 @@ test('cache pools are isolated per installation instance id', function (): void 
     $poolA2->deleteItem('shared-key');
 });
 
+test('rejects saving a remote cache driver when no installation identifier is configured', function (): void {
+    setInstanceId('');
+
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, 'installation identifier');
+
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'memcached', 'memcached' => ['host' => '127.0.0.1', 'port' => 11211]],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, 'installation identifier');
+});
+
+test('falls back to the filesystem cache at runtime when a remote driver is configured but no installation identifier is set', function (): void {
+    setInstanceId('');
+    setCacheConfig(['driver' => 'redis', 'redis' => ['host' => '127.0.0.1', 'port' => 6379]]);
+
+    $pool = CacheFactory::create('cache_factory_test');
+
+    $item = $pool->getItem('probe');
+    $item->set('value');
+    $pool->save($item);
+
+    expect($pool->getItem('probe')->get())->toBe('value');
+
+    $pool->deleteItem('probe');
+});
+
+test('a blank installation identifier does not affect the filesystem driver', function (): void {
+    setInstanceId('');
+    setCacheConfig(['driver' => 'filesystem']);
+
+    $pool = CacheFactory::create('cache_factory_test');
+
+    expect($pool)->toBeInstanceOf(CacheItemPoolInterface::class);
+});
+
 test('clearAll never throws even with a misconfigured driver', function (): void {
     if (hasRedisExtension()) {
         $this->markTestSkipped('This test requires an environment without the redis/relay extension.');


### PR DESCRIPTION
`CacheFactory::scopeNamespaceToInstallation()` namespaces every cache pool by `info.instance_id`, but silently fell back to the **unscoped** namespace when that value is empty. Two installations pointed at the same Redis/Memcached server with no instance ID configured would read and overwrite each other's cache entries.

Every supported install/upgrade path generates this id automatically (`install.php`, `UpdatePatcher::applyCorePatches()`), so the gap only manifests when `config.php` is manually edited/hand-crafted with a blank `info.instance_id` and a remote driver already selected — but the cache-settings admin endpoint didn't reject that combination either.

## What changed

Enforced the invariant in `CacheFactory::createFromConfig()` itself, rather than only at the admin settings endpoint, so it holds for every caller:

- Added a check right after the filesystem-driver short-circuit (redis/memcached only) and before the connection attempt: if `info.instance_id` is empty, throw a `FOSSBilling\Exception` with a specific, actionable message.
- This check intentionally sits **outside** the existing connection try/catch, so it's handled consistently by both callers without needing to special-case `$fallbackOnFailure`:
  - `CacheFactory::create()` (`fallbackOnFailure: true`) already wraps the whole `createFromConfig()` call in a catch-all that degrades to the filesystem cache for any misconfiguration — a blank instance ID now takes that same soft-fail path at runtime instead of silently sharing an unscoped namespace.
  - `System\Api\Admin::update_cache_settings()` calls `createFromConfig()` directly with `fallbackOnFailure: false` (its existing eager-validation pattern) — the new check surfaces straight to the admin as this specific message, rather than being generically reworded as a connection failure by the code below it.
- Refactored `scopeNamespaceToInstallation()` to take the already-fetched `$instanceId` as a parameter instead of re-reading config, since `createFromConfig()` now needs that value for the new check too.