### PR TITLE
Add TLS support for the Redis cache backend

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -78,7 +78,8 @@
         "unroutable",
         "namedlock",
         "entrancy",
-        "writability"
+        "writability",
+        "rediss"
     ],
 
     "ignoreWords": [

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -194,6 +194,39 @@ return [
             'port' => 6379,
             'password' => null,
             'database' => 0,
+
+            /*
+             * TLS ('rediss://') for the connection to the Redis server. Also configurable from
+             * the admin area under System > Settings > Cache.
+             *
+             * This matters most when 'host' is anything other than a loopback address
+             * (127.0.0.1, ::1, localhost) AND 'password' is set: in that case, without TLS, the
+             * password and every cached value would cross the network in plain text, so
+             * CacheFactory refuses to connect at all until either TLS is enabled here or the
+             * connection is moved to a loopback address. A loopback connection, or one with no
+             * password configured, is never blocked - TLS there is optional hardening, not a
+             * requirement. Note this deliberately does not try to recognize a "trusted private
+             * network" host (a Docker service name, a VPC-internal IP) as exempt the way loopback
+             * is: there's no reliable way to tell those apart from a genuinely remote host from
+             * the hostname/IP alone, so an admin relying on network isolation instead of TLS
+             * should leave 'password' unset rather than expect this check to special-case it.
+             */
+            'tls' => [
+                'enabled' => false,
+
+                // Verify the server's certificate, and that its certificate name matches 'host'.
+                // Leave both enabled unless you have a specific reason not to.
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+
+                // Path to a CA bundle to trust, if the Redis server's certificate isn't signed by
+                // a CA your system already trusts.
+                'cafile' => null,
+
+                // Only for a self-signed certificate in a development/testing environment - never
+                // enable this in production.
+                'allow_self_signed' => false,
+            ],
         ],
 
         /*

--- a/src/config-sample.php
+++ b/src/config-sample.php
@@ -196,20 +196,10 @@ return [
             'database' => 0,
 
             /*
-             * TLS ('rediss://') for the connection to the Redis server. Also configurable from
-             * the admin area under System > Settings > Cache.
-             *
-             * This matters most when 'host' is anything other than a loopback address
-             * (127.0.0.1, ::1, localhost) AND 'password' is set: in that case, without TLS, the
-             * password and every cached value would cross the network in plain text, so
-             * CacheFactory refuses to connect at all until either TLS is enabled here or the
-             * connection is moved to a loopback address. A loopback connection, or one with no
-             * password configured, is never blocked - TLS there is optional hardening, not a
-             * requirement. Note this deliberately does not try to recognize a "trusted private
-             * network" host (a Docker service name, a VPC-internal IP) as exempt the way loopback
-             * is: there's no reliable way to tell those apart from a genuinely remote host from
-             * the hostname/IP alone, so an admin relying on network isolation instead of TLS
-             * should leave 'password' unset rather than expect this check to special-case it.
+             * TLS ('rediss://') for the connection to the Redis server. Required whenever
+             * 'password' is set and 'host' isn't a loopback address (127.0.0.1, ::1, localhost) -
+             * see CacheFactory::assertRedisTransportIsSafe() for why. Also configurable from the
+             * admin area under System > Settings > Cache.
              */
             'tls' => [
                 'enabled' => false,

--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -217,13 +217,67 @@ class CacheFactory
 
     private static function createRedisAdapter(array $redisConfig, string $namespace, int $defaultLifetime): RedisAdapter
     {
+        // Checked ahead of the extension-availability check below: whether a configuration is
+        // internally safe to use doesn't depend on what happens to be installed on this server,
+        // and doing it first lets this be validated in environments without the redis extension.
+        self::assertRedisTransportIsSafe($redisConfig);
+
         if (!class_exists(\Redis::class) && !class_exists(\Relay\Relay::class) && !class_exists(\RedisCluster::class)) {
             throw new Exception('The "redis" cache driver requires the PHP redis (or relay) extension to be installed.');
         }
 
-        $connection = RedisAdapter::createConnection(self::buildRedisDsn($redisConfig));
+        $connection = RedisAdapter::createConnection(self::buildRedisDsn($redisConfig), self::buildRedisConnectionOptions($redisConfig));
 
         return new RedisAdapter($connection, $namespace, $defaultLifetime);
+    }
+
+    /**
+     * Rejects a password-authenticated Redis connection to a non-loopback host when TLS isn't
+     * enabled - without it, both the password and every cached value would cross the network in
+     * plaintext. A loopback host (127.0.0.1/::1/localhost) is exempt, since that traffic never
+     * leaves the machine regardless of TLS. This intentionally does NOT try to recognize "trusted
+     * private network" hosts (a Docker service name, a VPC-internal IP): there's no reliable way
+     * to tell those apart from a genuinely remote host from the hostname/IP alone, so an admin
+     * relying on that kind of network for security should leave the Redis password unset rather
+     * than expect this check to special-case their setup.
+     *
+     * @throws Exception if the connection would send a password over an unencrypted network hop
+     */
+    private static function assertRedisTransportIsSafe(array $redisConfig): void
+    {
+        if (empty($redisConfig['password'])) {
+            return;
+        }
+
+        if (Tools::normalizeBoolean($redisConfig['tls']['enabled'] ?? false, false)) {
+            return;
+        }
+
+        $host = (string) ($redisConfig['host'] ?? '127.0.0.1');
+        if (self::isLoopbackHost($host)) {
+            return;
+        }
+
+        throw new Exception('Refusing to send the Redis password to ":host" without TLS enabled. Enable "cache.redis.tls.enabled", or connect over a loopback address (127.0.0.1/::1/localhost) instead.', [':host' => $host]);
+    }
+
+    private static function isLoopbackHost(string $host): bool
+    {
+        $host = strtolower(trim($host));
+
+        if ($host === 'localhost') {
+            return true;
+        }
+
+        // Strip brackets from a literal IPv6 host, e.g. "[::1]".
+        $host = trim($host, '[]');
+
+        $ip = filter_var($host, FILTER_VALIDATE_IP);
+        if ($ip === false) {
+            return false;
+        }
+
+        return $ip === '::1' || str_starts_with($ip, '127.');
     }
 
     private static function createMemcachedAdapter(array $memcachedConfig, string $namespace, int $defaultLifetime): MemcachedAdapter
@@ -242,13 +296,42 @@ class CacheFactory
         $host = $redisConfig['host'] ?? '127.0.0.1';
         $port = Tools::normalizePort($redisConfig['port'] ?? null, 6379);
         $database = (int) ($redisConfig['database'] ?? 0);
+        $scheme = Tools::normalizeBoolean($redisConfig['tls']['enabled'] ?? false, false) ? 'rediss' : 'redis';
 
         $auth = '';
         if (!empty($redisConfig['password'])) {
             $auth = rawurlencode((string) $redisConfig['password']) . '@';
         }
 
-        return sprintf('redis://%s%s:%d%s', $auth, $host, $port, $database !== 0 ? '/' . $database : '');
+        return sprintf('%s://%s%s:%d%s', $scheme, $auth, $host, $port, $database !== 0 ? '/' . $database : '');
+    }
+
+    /**
+     * Builds the connection-options array passed as RedisAdapter::createConnection()'s second
+     * argument. The 'ssl' key maps directly onto PHP's SSL stream-context options
+     * (https://www.php.net/manual/en/context.ssl.php) - the same shape Symfony's Redis adapter
+     * documents for TLS. Only populated when TLS is enabled; a plaintext connection has nothing
+     * to configure here.
+     */
+    private static function buildRedisConnectionOptions(array $redisConfig): array
+    {
+        $tlsConfig = $redisConfig['tls'] ?? [];
+
+        if (!Tools::normalizeBoolean($tlsConfig['enabled'] ?? false, false)) {
+            return [];
+        }
+
+        $ssl = [
+            'verify_peer' => Tools::normalizeBoolean($tlsConfig['verify_peer'] ?? true, true),
+            'verify_peer_name' => Tools::normalizeBoolean($tlsConfig['verify_peer_name'] ?? true, true),
+            'allow_self_signed' => Tools::normalizeBoolean($tlsConfig['allow_self_signed'] ?? false, false),
+        ];
+
+        if (!empty($tlsConfig['cafile'])) {
+            $ssl['cafile'] = (string) $tlsConfig['cafile'];
+        }
+
+        return ['ssl' => $ssl];
     }
 
     private static function buildMemcachedDsn(array $memcachedConfig): string

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -94,6 +94,11 @@ class Admin extends \FOSSBilling\Api\AbstractApi
             'redis_port' => (int) Config::getProperty('cache.redis.port', 6379),
             'redis_password_set' => Config::getProperty('cache.redis.password') !== null,
             'redis_database' => (int) Config::getProperty('cache.redis.database', 0),
+            'redis_tls_enabled' => Tools::normalizeBoolean(Config::getProperty('cache.redis.tls.enabled', false), false),
+            'redis_tls_verify_peer' => Tools::normalizeBoolean(Config::getProperty('cache.redis.tls.verify_peer', true), true),
+            'redis_tls_verify_peer_name' => Tools::normalizeBoolean(Config::getProperty('cache.redis.tls.verify_peer_name', true), true),
+            'redis_tls_allow_self_signed' => Tools::normalizeBoolean(Config::getProperty('cache.redis.tls.allow_self_signed', false), false),
+            'redis_tls_cafile' => (string) Config::getProperty('cache.redis.tls.cafile', ''),
             'memcached_host' => (string) Config::getProperty('cache.memcached.host', '127.0.0.1'),
             'memcached_port' => (int) Config::getProperty('cache.memcached.port', 11211),
         ];
@@ -104,7 +109,9 @@ class Admin extends \FOSSBilling\Api\AbstractApi
      *
      * The new settings are validated by attempting to connect to the configured backend before
      * anything is saved, so a mistyped host/port/password is rejected with a clear reason rather
-     * than being written and silently falling back to the filesystem cache later.
+     * than being written and silently falling back to the filesystem cache later. That same
+     * validation also rejects a Redis password on a non-loopback host with TLS disabled, since
+     * that combination would send the password in plain text (see CacheFactory).
      *
      * @throws \FOSSBilling\Exception
      */
@@ -132,6 +139,13 @@ class Admin extends \FOSSBilling\Api\AbstractApi
                 'port' => Tools::normalizePort($data['redis_port'] ?? null, 6379),
                 'password' => $redisPassword ?: null,
                 'database' => (int) ($data['redis_database'] ?? 0),
+                'tls' => [
+                    'enabled' => Tools::normalizeBoolean($data['redis_tls_enabled'] ?? false, false),
+                    'verify_peer' => Tools::normalizeBoolean($data['redis_tls_verify_peer'] ?? true, true),
+                    'verify_peer_name' => Tools::normalizeBoolean($data['redis_tls_verify_peer_name'] ?? true, true),
+                    'allow_self_signed' => Tools::normalizeBoolean($data['redis_tls_allow_self_signed'] ?? false, false),
+                    'cafile' => ($data['redis_tls_cafile'] ?? '') !== '' ? $data['redis_tls_cafile'] : null,
+                ],
             ],
             'memcached' => [
                 'host' => $data['memcached_host'] ?? '127.0.0.1',

--- a/src/modules/System/templates/admin/mod_system_settings.html.twig
+++ b/src/modules/System/templates/admin/mod_system_settings.html.twig
@@ -307,6 +307,45 @@
                                     </div>
                                 </div>
                                 <div class="form-hint mt-2">{{ 'Requires the PHP redis (or relay) extension.'|trans }}</div>
+
+                                <hr>
+
+                                <div class="form-check form-switch mb-2">
+                                    <input type="hidden" name="redis_tls_enabled" value="0">
+                                    <input class="form-check-input" id="redis_tls_enabled" type="checkbox" name="redis_tls_enabled" value="1"{% if cache_settings.redis_tls_enabled %} checked{% endif %}>
+                                    <label class="form-check-label" for="redis_tls_enabled">{{ 'Use TLS'|trans }}</label>
+                                </div>
+                                <p class="text-secondary">{{ 'Required whenever a password is set above and the host isn\'t a loopback address (127.0.0.1, ::1, localhost) - otherwise the password and cached data would be sent in plain text.'|trans }}</p>
+
+                                <div class="row g-3" id="redis-tls-options"{% if not cache_settings.redis_tls_enabled %} style="display:none;"{% endif %}>
+                                    <div class="col-lg-6">
+                                        <label class="form-check form-switch">
+                                            <input type="hidden" name="redis_tls_verify_peer" value="0">
+                                            <input class="form-check-input" type="checkbox" name="redis_tls_verify_peer" value="1"{% if cache_settings.redis_tls_verify_peer %} checked{% endif %}>
+                                            <span class="form-check-label">{{ 'Verify server certificate'|trans }}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-check form-switch">
+                                            <input type="hidden" name="redis_tls_verify_peer_name" value="0">
+                                            <input class="form-check-input" type="checkbox" name="redis_tls_verify_peer_name" value="1"{% if cache_settings.redis_tls_verify_peer_name %} checked{% endif %}>
+                                            <span class="form-check-label">{{ 'Verify certificate hostname'|trans }}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-label" for="redis_tls_cafile">{{ 'CA Bundle Path'|trans }}</label>
+                                        <input class="form-control" id="redis_tls_cafile" type="text" name="redis_tls_cafile" value="{{ cache_settings.redis_tls_cafile }}" placeholder="{{ '(system default)'|trans }}">
+                                        <div class="form-hint">{{ 'Only needed if the Redis server\'s certificate isn\'t signed by a CA your system already trusts.'|trans }}</div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <label class="form-check form-switch mt-4 mt-lg-0">
+                                            <input type="hidden" name="redis_tls_allow_self_signed" value="0">
+                                            <input class="form-check-input" type="checkbox" name="redis_tls_allow_self_signed" value="1"{% if cache_settings.redis_tls_allow_self_signed %} checked{% endif %}>
+                                            <span class="form-check-label">{{ 'Allow self-signed certificate'|trans }}</span>
+                                        </label>
+                                        <div class="form-hint">{{ 'Development/testing only - never enable this in production.'|trans }}</div>
+                                    </div>
+                                </div>
                             </fieldset>
 
                             <fieldset class="cache-memcached"{% if cache_settings.driver != 'memcached' %} style="display:none;"{% endif %}>
@@ -585,6 +624,13 @@
             memcachedFieldset.style.display = this.value === 'memcached' ? 'block' : 'none';
         });
     });
+
+    const redisTlsToggle = document.getElementById('redis_tls_enabled');
+    if (redisTlsToggle) {
+        redisTlsToggle.addEventListener('change', function() {
+            document.getElementById('redis-tls-options').style.display = this.checked ? 'flex' : 'none';
+        });
+    }
 </script>
 {% endblock %}
 

--- a/src/modules/System/templates/admin/mod_system_settings.html.twig
+++ b/src/modules/System/templates/admin/mod_system_settings.html.twig
@@ -625,12 +625,9 @@
         });
     });
 
-    const redisTlsToggle = document.getElementById('redis_tls_enabled');
-    if (redisTlsToggle) {
-        redisTlsToggle.addEventListener('change', function() {
-            document.getElementById('redis-tls-options').style.display = this.checked ? 'flex' : 'none';
-        });
-    }
+    document.getElementById('redis_tls_enabled').addEventListener('change', function() {
+        document.getElementById('redis-tls-options').style.display = this.checked ? 'flex' : 'none';
+    });
 </script>
 {% endblock %}
 

--- a/src/modules/System/tests/Unit/Api/AdminTest.php
+++ b/src/modules/System/tests/Unit/Api/AdminTest.php
@@ -116,6 +116,65 @@ test('update cache settings clears the previously configured backend, not just t
     }
 });
 
+test('update cache settings saves and reads back the redis TLS options', function (): void {
+    $api = apiEndpoint(new Box\Mod\System\Api\Admin());
+    $originalConfig = Config::getConfig();
+
+    try {
+        $api->update_cache_settings([
+            'driver' => 'filesystem',
+            'redis_tls_enabled' => '1',
+            'redis_tls_verify_peer' => '0',
+            'redis_tls_verify_peer_name' => '0',
+            'redis_tls_allow_self_signed' => '1',
+            'redis_tls_cafile' => '/etc/ssl/certs/redis-ca.pem',
+        ]);
+
+        $settings = $api->cache_settings();
+        expect($settings['redis_tls_enabled'])->toBeTrue();
+        expect($settings['redis_tls_verify_peer'])->toBeFalse();
+        expect($settings['redis_tls_verify_peer_name'])->toBeFalse();
+        expect($settings['redis_tls_allow_self_signed'])->toBeTrue();
+        expect($settings['redis_tls_cafile'])->toBe('/etc/ssl/certs/redis-ca.pem');
+
+        // The template pairs every TLS checkbox with a hidden "0" input (same trick already used
+        // for redis_password_clear), so an unchecked box still submits explicit "0" rather than
+        // being left out of the request entirely - this is what that resulting request looks like.
+        $api->update_cache_settings([
+            'driver' => 'filesystem',
+            'redis_tls_enabled' => '0',
+            'redis_tls_verify_peer' => '0',
+            'redis_tls_verify_peer_name' => '0',
+            'redis_tls_allow_self_signed' => '0',
+            'redis_tls_cafile' => '',
+        ]);
+
+        $settings = $api->cache_settings();
+        expect($settings['redis_tls_enabled'])->toBeFalse();
+        expect($settings['redis_tls_verify_peer'])->toBeFalse();
+        expect($settings['redis_tls_verify_peer_name'])->toBeFalse();
+        expect($settings['redis_tls_allow_self_signed'])->toBeFalse();
+        expect($settings['redis_tls_cafile'])->toBe('');
+    } finally {
+        Config::setConfig($originalConfig, false);
+    }
+});
+
+test('update cache settings rejects a redis password on a non-loopback host with TLS disabled', function (): void {
+    $api = apiEndpoint(new Box\Mod\System\Api\Admin());
+    $originalConfig = Config::getConfig();
+
+    try {
+        expect(fn (): bool => $api->update_cache_settings([
+            'driver' => 'redis',
+            'redis_host' => 'redis.example.com',
+            'redis_password' => 'secret',
+        ]))->toThrow(FOSSBilling\Exception::class, 'without TLS enabled');
+    } finally {
+        Config::setConfig($originalConfig, false);
+    }
+});
+
 test('messages', function (): void {
     $api = apiEndpoint(new Box\Mod\System\Api\Admin());
     $data = [];

--- a/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
+++ b/tests/Unit/FOSSBilling/Cache/CacheFactoryTest.php
@@ -167,6 +167,49 @@ test('rejects saving a memcached configuration when the memcached extension is u
     ))->toThrow(Exception::class, 'requires the PHP memcached');
 });
 
+test('rejects a redis password on a non-loopback host with TLS disabled', function (): void {
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => 'redis.example.com', 'password' => 'secret']],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, 'without TLS enabled');
+});
+
+test('allows a redis password on a non-loopback host once TLS is enabled', function (): void {
+    // Neither the redis/relay extension nor a reachable TLS Redis server is guaranteed here, so
+    // this still throws either way - just never the transport-safety exception, proving TLS
+    // being enabled was what let it past that specific check.
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => 'redis.example.com', 'password' => 'secret', 'tls' => ['enabled' => true]]],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, hasRedisExtension() ? 'Could not connect' : 'requires the PHP redis');
+});
+
+dataset('loopback hosts', ['127.0.0.1', '127.0.0.53', '::1', '[::1]', 'localhost', 'LOCALHOST']);
+
+test('allows a redis password on a loopback host without TLS', function (string $host): void {
+    // Same reasoning as above: this still throws either way, just never the transport-safety
+    // exception, proving the loopback host was what let it past that specific check.
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => $host, 'password' => 'secret']],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, hasRedisExtension() ? 'Could not connect' : 'requires the PHP redis');
+})->with('loopback hosts');
+
+test('allows a redis connection on a non-loopback host with no password regardless of TLS', function (): void {
+    expect(fn () => CacheFactory::createFromConfig(
+        ['driver' => 'redis', 'redis' => ['host' => 'redis.example.com']],
+        'cache_factory_test',
+        0,
+        false,
+    ))->toThrow(Exception::class, hasRedisExtension() ? 'Could not connect' : 'requires the PHP redis');
+});
+
 test('cache pools are isolated per installation instance id', function (): void {
     setInstanceId('install-a');
     $poolA = CacheFactory::create('cache_factory_test');


### PR DESCRIPTION
## What changed

- **`cache.redis.tls` config block** (`src/config-sample.php`): `enabled`, `verify_peer`, `verify_peer_name`, `cafile`, `allow_self_signed` — mirrors the SSL stream-context options Symfony's `RedisAdapter::createConnection()` accepts under its `ssl` option (verified against Symfony's docs, not guessed).
- **`CacheFactory`** (`src/library/FOSSBilling/Cache/CacheFactory.php`): builds a `rediss://` DSN and the matching SSL context array when TLS is enabled.
- **Admin settings** (`src/modules/System/Api/Admin.php`, `mod_system_settings.html.twig`): TLS toggle + verify-peer/verify-peer-name/CA-bundle/allow-self-signed fields added to `cache_settings()`/`update_cache_settings()` and the form.