### PR TITLE
Add regression coverage for Service::templateExists() path validation

### DIFF
--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -11,6 +11,8 @@
 declare(strict_types=1);
 
 use Box\Mod\System\Service;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 use function Tests\Helpers\container;
 
@@ -307,7 +309,7 @@ test('getMessages returns system messages', function (): void {
     $latestVersion = '1.0.0';
     $type = 'info';
 
-    $filesystemMock = Mockery::mock(Symfony\Component\Filesystem\Filesystem::class);
+    $filesystemMock = Mockery::mock(Filesystem::class);
     $filesystemMock->allows()->exists(Mockery::any())->andReturn(false);
     $systemServiceMock = Mockery::mock(new Service($filesystemMock))->makePartial();
     $systemServiceMock->allows()->getParamValue(Mockery::any())->andReturn(false);
@@ -349,14 +351,17 @@ test('templateExists returns false when paths are empty', function (): void {
 
 test('templateExists rejects unsafe file paths', function (): void {
     $service = new Service();
+    $filesystem = new Filesystem();
 
-    // Theme base directory containing a legitimate template, plus a sibling
-    // file that lookups should never be able to reach.
-    $baseDir = sys_get_temp_dir() . '/fb_theme_' . uniqid();
-    mkdir($baseDir, 0o755, true);
-    file_put_contents($baseDir . '/layout.html.twig', 'test');
-    $outsideFile = dirname($baseDir) . '/outside.html.twig';
-    file_put_contents($outsideFile, 'outside');
+    // Unique fixture root so parallel test runs, and this test's own
+    // cleanup, can't collide with anything else in the shared system temp
+    // directory. The base and outside directories both live under it.
+    $fixtureRoot = sys_get_temp_dir() . '/fb_template_exists_' . uniqid();
+    $baseDir = Path::join($fixtureRoot, 'theme');
+    $outsideFile = Path::join($fixtureRoot, 'outside.html.twig');
+
+    $filesystem->dumpFile(Path::join($baseDir, 'layout.html.twig'), 'test');
+    $filesystem->dumpFile($outsideFile, 'outside');
 
     $themeServiceMock = Mockery::mock(Box\Mod\Theme\Service::class)->makePartial();
     $themeServiceMock->shouldReceive('getThemeConfig')->andReturn(['paths' => [$baseDir]]);
@@ -365,22 +370,22 @@ test('templateExists rejects unsafe file paths', function (): void {
     $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $themeServiceMock);
     $service->setDi($di);
 
-    // Sanity check: a legitimate in-base template still resolves, so the
-    // assertions below aren't just exercising an always-false code path.
-    expect($service->templateExists('layout.html.twig'))->toBeTrue();
+    try {
+        // Sanity check: a legitimate in-base template still resolves, so the
+        // assertions below aren't just exercising an always-false code path.
+        expect($service->templateExists('layout.html.twig'))->toBeTrue();
 
-    // Inputs that must never resolve, even though the target file genuinely
-    // exists just outside the theme's base directory.
-    expect($service->templateExists('../outside.html.twig'))->toBeFalse();
-    expect($service->templateExists('../../../../../../outside.html.twig'))->toBeFalse();
-    expect($service->templateExists('..\\..\\outside.html.twig'))->toBeFalse();
-    expect($service->templateExists("layout.html.twig\0.png"))->toBeFalse();
-    expect($service->templateExists('/outside.html.twig'))->toBeFalse();
-    expect($service->templateExists(''))->toBeFalse();
-
-    unlink($baseDir . '/layout.html.twig');
-    unlink($outsideFile);
-    rmdir($baseDir);
+        // Inputs that must never resolve, even though the target file genuinely
+        // exists just outside the theme's base directory.
+        expect($service->templateExists('../outside.html.twig'))->toBeFalse();
+        expect($service->templateExists('../../../../../../outside.html.twig'))->toBeFalse();
+        expect($service->templateExists('..\\..\\outside.html.twig'))->toBeFalse();
+        expect($service->templateExists("layout.html.twig\0.png"))->toBeFalse();
+        expect($service->templateExists('/outside.html.twig'))->toBeFalse();
+        expect($service->templateExists(''))->toBeFalse();
+    } finally {
+        $filesystem->remove($fixtureRoot);
+    }
 });
 
 test('clearCache clears cache directory', function (): void {

--- a/src/modules/System/tests/Unit/ServiceTest.php
+++ b/src/modules/System/tests/Unit/ServiceTest.php
@@ -347,6 +347,42 @@ test('templateExists returns false when paths are empty', function (): void {
     expect($result)->toBeFalse();
 });
 
+test('templateExists rejects unsafe file paths', function (): void {
+    $service = new Service();
+
+    // Theme base directory containing a legitimate template, plus a sibling
+    // file that lookups should never be able to reach.
+    $baseDir = sys_get_temp_dir() . '/fb_theme_' . uniqid();
+    mkdir($baseDir, 0o755, true);
+    file_put_contents($baseDir . '/layout.html.twig', 'test');
+    $outsideFile = dirname($baseDir) . '/outside.html.twig';
+    file_put_contents($outsideFile, 'outside');
+
+    $themeServiceMock = Mockery::mock(Box\Mod\Theme\Service::class)->makePartial();
+    $themeServiceMock->shouldReceive('getThemeConfig')->andReturn(['paths' => [$baseDir]]);
+
+    $di = container();
+    $di['mod_service'] = $di->protect(fn (): Mockery\MockInterface => $themeServiceMock);
+    $service->setDi($di);
+
+    // Sanity check: a legitimate in-base template still resolves, so the
+    // assertions below aren't just exercising an always-false code path.
+    expect($service->templateExists('layout.html.twig'))->toBeTrue();
+
+    // Inputs that must never resolve, even though the target file genuinely
+    // exists just outside the theme's base directory.
+    expect($service->templateExists('../outside.html.twig'))->toBeFalse();
+    expect($service->templateExists('../../../../../../outside.html.twig'))->toBeFalse();
+    expect($service->templateExists('..\\..\\outside.html.twig'))->toBeFalse();
+    expect($service->templateExists("layout.html.twig\0.png"))->toBeFalse();
+    expect($service->templateExists('/outside.html.twig'))->toBeFalse();
+    expect($service->templateExists(''))->toBeFalse();
+
+    unlink($baseDir . '/layout.html.twig');
+    unlink($outsideFile);
+    rmdir($baseDir);
+});
+
 test('clearCache clears cache directory', function (): void {
     $service = new Service();
     // Use a temporary directory for testing instead of PATH_CACHE


### PR DESCRIPTION
## Summary

Adds a unit test pinning the input-validation behavior added to `Service::templateExists()` in #4219, so a future refactor can't loosen it without a test failing.

## Details

- Verifies a legitimate in-theme template still resolves `true` (sanity check, so the other assertions aren't just exercising an always-false path).
- Verifies several classes of unsafe input (relative traversal, deep traversal, backslash-style traversal, a null byte, an absolute path, and an empty string) all resolve `false`, using a real temp file placed just outside the theme base directory so the assertions can't pass by accident.
- Confirmed the new test fails if `templateExists()`'s input-validation block is removed, and passes with it in place.