### PR TITLE
Fix ResellerClub domain renewal failing with missing exp-date

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -588,7 +588,16 @@
         "createacct",
         "setupreseller",
         "setacls",
-        "acllist"
+        "acllist",
+        "creationtime",
+        "domsecret",
+        "isprivacyprotected",
+        "admincontact",
+        "contactid",
+        "emailaddr",
+        "telno",
+        "telnocc",
+        "actionstatus"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -347,6 +347,19 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     public function renewDomain(Registrar_Domain $domain): bool
     {
+        // ResellerClub requires the domain's current expiry date (in epoch seconds) on every
+        // renewal request, as a safeguard against renewing against stale data. FOSSBilling only
+        // learns that date via a prior successful WHOIS sync, so a domain whose sync never
+        // completed (e.g. it ran too soon after registration, before the registry had propagated
+        // the record) reaches here with no expiration time cached locally. Sending the request
+        // without exp-date fails with "Required parameter missing: exp-date", and since the
+        // renewal never succeeds, the sync that would have fixed it for next time never runs
+        // either - the domain is stuck failing every renewal attempt. Fetch it fresh instead of
+        // giving up. See https://github.com/FOSSBilling/FOSSBilling/issues/4229.
+        if (empty($domain->getExpirationTime())) {
+            $this->getDomainDetails($domain);
+        }
+
         $params = [
             'order-id' => $this->_getDomainOrderId($domain),
             'years' => $domain->getRegistrationPeriod(),

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -206,6 +206,89 @@ test('modifyContact assigns per-role contact IDs for .fr, which only forces tech
     expect($body['billing-contact-id'])->toBe('-1');
 });
 
+test('renewDomain fetches fresh domain details to fill in exp-date when it is not already cached', function (): void {
+    // Regression test for #4229: FOSSBilling only learns a domain's expiration time via a prior
+    // WHOIS sync. When that sync never completed (e.g. it ran too soon after registration), the
+    // domain reaches renewDomain() with no expiration time, and ResellerClub rejects the renewal
+    // outright with "Required parameter missing: exp-date" - which then also prevents the WHOIS
+    // sync that would fix it for next time, since that only runs after a successful renewal. The
+    // adapter must fetch the expiry itself instead of sending an incomplete request.
+    $requests = [];
+    $bodies = [];
+    $responses = [
+        '112233', // domains/orderid (via getDomainDetails)
+        json_encode([ // domains/details
+            'creationtime' => 1577836800,
+            'endtime' => 1893456000,
+            'domsecret' => 'epp-code',
+            'isprivacyprotected' => 'false',
+            'admincontact' => [
+                'contactid' => '998877',
+                'name' => 'Jane Doe',
+                'emailaddr' => 'jane@example.com',
+                'company' => '',
+                'telno' => '5551234567',
+                'telnocc' => '1',
+                'address1' => '1 Example St',
+                'city' => 'Example City',
+                'country' => 'US',
+                'state' => '',
+                'zip' => '12345',
+            ],
+        ]),
+        '112233', // domains/orderid (for the renew request itself)
+        json_encode(['actionstatus' => 'Success']), // domains/renew
+    ];
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $bodies[] = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain()->setRegistrationPeriod(1);
+
+    expect($adapter->renewDomain($domain))->toBeTrue();
+    expect($requests)->toBe([
+        'GET /api/domains/orderid.json',
+        'GET /api/domains/details.json',
+        'GET /api/domains/orderid.json',
+        'POST /api/domains/renew.json',
+    ]);
+
+    parse_str((string) end($bodies), $body);
+    expect($body['exp-date'])->toBe('1893456000');
+    expect($domain->getExpirationTime())->toBe(1893456000);
+});
+
+test('renewDomain does not re-fetch domain details when an expiration time is already known', function (): void {
+    $requests = [];
+    $bodies = [];
+    $responses = [
+        '112233', // domains/orderid (for the renew request)
+        json_encode(['actionstatus' => 'Success']), // domains/renew
+    ];
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $bodies[] = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain()->setRegistrationPeriod(1)->setExpirationTime(1893456000);
+
+    expect($adapter->renewDomain($domain))->toBeTrue();
+    expect($requests)->toBe([
+        'GET /api/domains/orderid.json',
+        'POST /api/domains/renew.json',
+    ]);
+
+    parse_str((string) end($bodies), $body);
+    expect($body['exp-date'])->toBe('1893456000');
+});
+
 test('registerDomain sends the .fr registry consent attribute alongside the FrContact IDs', function (): void {
     // Regression test for #77: .fr requires accepting the registry's data-sharing terms via a tnc
     // attribute on domains/register, on top of the FrContact type/contact-id handling above. See


### PR DESCRIPTION
## Summary

Fixes #4229.

ResellerClub's `domains/renew` API requires an `exp-date` param (the domain's current registry expiration, in epoch seconds), used as a safeguard against renewing against stale data. FOSSBilling only learns that value via a prior successful WHOIS sync, which for the renewal flow only runs **after** a successful renewal, and for the activation flow is wrapped in a try/catch that silently swallows failures.

If that first sync never completes — e.g. it runs too soon after registration, before the registry has propagated the record — the domain's cached expiration stays `null` forever. `renewDomain()` then sent `exp-date` as `null`, which `http_build_query()` silently drops from the request entirely, producing exactly the reported error: `Required parameter missing: exp-date`. Because the renewal fails, the sync that would have backfilled the expiration never runs either, so the domain is stuck failing **every** subsequent renewal attempt (auto-renewal and manual alike).

## Fix

`renewDomain()` now fetches fresh domain details from ResellerClub to populate the expiration time when it isn't already cached locally, instead of sending an incomplete renewal request and giving up.