### PR TITLE
Harden guest signup against email enumeration

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -277,6 +277,7 @@
         "multisite",
         "mcrypt",
         "stopforumspam",
+        "yopmail",
         "Internetbs",
         "binded",
         "tada",

--- a/src/library/FOSSBilling/Security/RateLimiter.php
+++ b/src/library/FOSSBilling/Security/RateLimiter.php
@@ -59,6 +59,7 @@ class RateLimiter implements InjectionAwareInterface
                 'staff_password_reset_confirm_ip' => ['policy' => 'fixed_window', 'limit' => 20, 'interval' => '60 seconds'],
                 'staff_password_reset_confirm_post_ip' => ['policy' => 'fixed_window', 'limit' => 20, 'interval' => '60 seconds'],
                 'client_signup' => ['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 hour'],
+                'client_signup_email' => ['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 hour'],
                 'guest_ticket_create' => ['policy' => 'fixed_window', 'limit' => 3, 'interval' => '1 hour'],
                 'order_generation_ip' => ['policy' => 'fixed_window', 'limit' => 15, 'interval' => '1 hour'],
                 'domain_lookup_ip' => ['policy' => 'fixed_window', 'limit' => 60, 'interval' => '1 hour'],

--- a/src/modules/Antispam/tests/E2E/ApiGuestTest.php
+++ b/src/modules/Antispam/tests/E2E/ApiGuestTest.php
@@ -21,10 +21,10 @@ test('disposable email check', function (): void {
     expect($result->wasSuccessful())->toBeTrue();
 
     // Unique per run: guest/client/create now rate-limits repeated attempts
-    // for the same email (client_signup_email), so a fixed address would
-    // silently return true without creating a client on a rerun within the
-    // same hour, breaking the assertions below.
-    $email = 'email_' . uniqid() . '@yopmail.net';
+    // for the same email (client_signup_email), so a fixed or collision-prone
+    // address would silently return true without creating a client on a
+    // rerun within the same hour, breaking the assertions below.
+    $email = 'email_' . bin2hex(random_bytes(16)) . '@yopmail.net';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
         'email' => $email,
@@ -37,10 +37,11 @@ test('disposable email check', function (): void {
         // guest/client/create no longer returns the new client's id (doing so
         // would reopen the email-enumeration issue it was hardened against),
         // so look the account up by the email we just registered instead.
+        // Assert the lookup itself succeeded rather than silently skipping
+        // cleanup (and this whole test) on a transient lookup failure.
         $lookup = ApiClient::request('admin/client/get', ['email' => $email]);
-        if ($lookup->wasSuccessful()) {
-            ApiClient::request('admin/client/delete', ['id' => $lookup->getResult()['id']]);
-        }
+        expect($lookup->wasSuccessful())->toBeTrue();
+        ApiClient::request('admin/client/delete', ['id' => $lookup->getResult()['id']]);
         $this->markTestSkipped('Disposable email domain list unavailable in this environment');
     }
 
@@ -53,7 +54,7 @@ test('stop forum spam', function (): void {
     expect($result->wasSuccessful())->toBeTrue();
 
     // Unique per run: see the comment in the 'disposable email check' test above.
-    $email = 'email_' . uniqid() . '@example.com';
+    $email = 'email_' . bin2hex(random_bytes(16)) . '@example.com';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
         'email' => $email,

--- a/src/modules/Antispam/tests/E2E/ApiGuestTest.php
+++ b/src/modules/Antispam/tests/E2E/ApiGuestTest.php
@@ -20,7 +20,11 @@ test('disposable email check', function (): void {
     $result = ApiClient::request('admin/extension/config_save', ['ext' => 'mod_antispam', 'check_temp_emails' => true]);
     expect($result->wasSuccessful())->toBeTrue();
 
-    $email = 'email@yopmail.net';
+    // Unique per run: guest/client/create now rate-limits repeated attempts
+    // for the same email (client_signup_email), so a fixed address would
+    // silently return true without creating a client on a rerun within the
+    // same hour, breaking the assertions below.
+    $email = 'email_' . uniqid() . '@yopmail.net';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
         'email' => $email,
@@ -48,7 +52,8 @@ test('stop forum spam', function (): void {
     $result = ApiClient::request('admin/extension/config_save', ['ext' => 'mod_antispam', 'sfs' => true]);
     expect($result->wasSuccessful())->toBeTrue();
 
-    $email = 'email@example.com';
+    // Unique per run: see the comment in the 'disposable email check' test above.
+    $email = 'email_' . uniqid() . '@example.com';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
         'email' => $email,

--- a/src/modules/Antispam/tests/E2E/ApiGuestTest.php
+++ b/src/modules/Antispam/tests/E2E/ApiGuestTest.php
@@ -20,17 +20,23 @@ test('disposable email check', function (): void {
     $result = ApiClient::request('admin/extension/config_save', ['ext' => 'mod_antispam', 'check_temp_emails' => true]);
     expect($result->wasSuccessful())->toBeTrue();
 
+    $email = 'email@yopmail.net';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
-        'email' => 'email@yopmail.net',
+        'email' => $email,
         'first_name' => 'Test',
         'password' => $password,
         'password_confirm' => $password,
     ]);
 
     if ($result->wasSuccessful()) {
-        $id = intval($result->getResult());
-        ApiClient::request('admin/client/delete', ['id' => $id]);
+        // guest/client/create no longer returns the new client's id (doing so
+        // would reopen the email-enumeration issue it was hardened against),
+        // so look the account up by the email we just registered instead.
+        $lookup = ApiClient::request('admin/client/get', ['email' => $email]);
+        if ($lookup->wasSuccessful()) {
+            ApiClient::request('admin/client/delete', ['id' => $lookup->getResult()['id']]);
+        }
         $this->markTestSkipped('Disposable email domain list unavailable in this environment');
     }
 
@@ -42,20 +48,25 @@ test('stop forum spam', function (): void {
     $result = ApiClient::request('admin/extension/config_save', ['ext' => 'mod_antispam', 'sfs' => true]);
     expect($result->wasSuccessful())->toBeTrue();
 
+    $email = 'email@example.com';
     $password = 'A1a' . bin2hex(random_bytes(6));
     $result = ApiClient::request('guest/client/create', [
-        'email' => 'email@example.com',
+        'email' => $email,
         'first_name' => 'Test',
         'password' => $password,
         'password_confirm' => $password,
     ]);
 
     expect($result->wasSuccessful())->toBeTrue();
-    expect($result->getResult())->toBeNumeric();
+    expect($result->getResult())->toBeTrue();
 
-    $id = intval($result->getResult());
+    // guest/client/create no longer returns the new client's id (doing so
+    // would reopen the email-enumeration issue it was hardened against), so
+    // look the account up by the email we just registered instead.
+    $lookup = ApiClient::request('admin/client/get', ['email' => $email]);
+    expect($lookup->wasSuccessful())->toBeTrue();
 
-    $result = ApiClient::request('admin/client/delete', ['id' => $id]);
+    $result = ApiClient::request('admin/client/delete', ['id' => $lookup->getResult()['id']]);
     expect($result->wasSuccessful())->toBeTrue();
     expect($result->getResult())->toBeTrue();
 });

--- a/src/modules/Cart/tests/E2E/ApiGuestTest.php
+++ b/src/modules/Cart/tests/E2E/ApiGuestTest.php
@@ -87,9 +87,7 @@ function cartCreateClient(): int
         'password_confirm' => $password,
     ]);
     assertApiSuccess($result);
-    assertApiResultIsInt($result);
-
-    $clientId = (int) $result->getResult();
+    expect($result->getResult())->toBeTrue();
 
     $loginResult = Tests\Helpers\ApiClient::request('guest/client/login', [
         'email' => $email,
@@ -97,7 +95,13 @@ function cartCreateClient(): int
     ]);
     assertApiSuccess($loginResult);
 
-    return $clientId;
+    // guest/client/create no longer returns the new client's id (doing so
+    // would reopen the email-enumeration issue it was hardened against), so
+    // look the account up by the email we just registered instead.
+    $lookup = Tests\Helpers\ApiClient::request('admin/client/get', ['email' => $email]);
+    assertApiSuccess($lookup);
+
+    return (int) $lookup->getResult()['id'];
 }
 
 function cartCleanupClient(int $clientId): void

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -68,46 +68,78 @@ class Guest extends \FOSSBilling\Api\AbstractApi
      * @optional string $custom_20 - Custom field 20
      */
     #[RequiredParams(['email' => 'Email required', 'first_name' => 'First name required', 'password' => 'Password required', 'password_confirm' => 'Password confirmation required'])]
-    public function create($data = []): int
+    public function create($data = []): bool
     {
-        $this->getDi()['rate_limiter']->consumeOrThrow('client_signup', (string) $this->getIp());
+        $startedAt = microtime(true);
 
-        $config = $this->getDi()['mod_config']('client');
+        try {
+            $this->getDi()['rate_limiter']->consumeOrThrow('client_signup', (string) $this->getIp());
 
-        if (isset($config['disable_signup']) && $config['disable_signup']) {
-            throw new \FOSSBilling\InformationException('New registrations are temporarily disabled');
-        }
+            $config = $this->getDi()['mod_config']('client');
 
-        $this->getDi()['validator']->passwordsMatch($data);
-
-        $this->getService()->checkExtraRequiredFields($data);
-        $this->getService()->checkCustomFields($data);
-
-        $this->getDi()['validator']->isPasswordStrong($data['password']);
-        $service = $this->getService();
-
-        $email = $data['email'] ?? null;
-        $email = $this->getDi()['tools']->validateAndSanitizeEmail($email);
-        $email = strtolower(trim((string) $email));
-        if ($service->clientAlreadyExists($email)) {
-            throw new \FOSSBilling\InformationException('This email address is already registered.');
-        }
-
-        $client = $service->guestCreateClient($data);
-
-        if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation']) {
-            $service->sendEmailConfirmationForClient($client);
-        }
-
-        if (Tools::normalizeBoolean($config['auto_login_after_signup'] ?? true, true)) {
-            try {
-                $this->login(['email' => $client->getEmail(), 'password' => $data['password']]);
-            } catch (\Throwable $e) {
-                $this->getDi()['logger']->error($e->getMessage());
+            if (isset($config['disable_signup']) && $config['disable_signup']) {
+                throw new \FOSSBilling\InformationException('New registrations are temporarily disabled');
             }
-        }
 
-        return (int) $client->getId();
+            $this->getDi()['validator']->passwordsMatch($data);
+
+            $this->getService()->checkExtraRequiredFields($data);
+            $this->getService()->checkCustomFields($data);
+
+            $this->getDi()['validator']->isPasswordStrong($data['password']);
+            $service = $this->getService();
+
+            $email = $data['email'] ?? null;
+            $email = $this->getDi()['tools']->validateAndSanitizeEmail($email);
+            $email = strtolower(trim((string) $email));
+
+            // Keyed independently of the IP limiter above so that spreading
+            // probes across IPs doesn't help an attacker hammer one address.
+            $emailLimit = $this->getDi()['rate_limiter']->consume('client_signup_email', $email);
+
+            $this->checkCaptchaIfEnabled($data);
+
+            $autoLogin = Tools::normalizeBoolean($config['auto_login_after_signup'] ?? true, true);
+
+            if ($emailLimit->isLimited() || $service->clientAlreadyExists($email)) {
+                // Never disclose whether this address is already registered:
+                // no distinct error, no duplicate row, and the same return
+                // value as a genuine signup below. Falling through to an
+                // ordinary login attempt keeps the response and any session
+                // side effects identical to the success path, reusing
+                // login()'s own timing- and message-safe handling instead of
+                // reimplementing it here.
+                $this->getDi()['logger']->withChannel('security')->info('Client signup declined for an existing or rate-limited email from IP {ip}.', ['ip' => $this->getIp()]);
+
+                if ($autoLogin) {
+                    try {
+                        $this->login(['email' => $email, 'password' => $data['password']]);
+                    } catch (\Throwable $e) {
+                        $this->getDi()['logger']->error($e->getMessage());
+                    }
+                }
+
+                return true;
+            }
+
+            $client = $service->guestCreateClient($data);
+
+            if (isset($config['require_email_confirmation']) && (bool) $config['require_email_confirmation']) {
+                $service->sendEmailConfirmationForClient($client);
+            }
+
+            if ($autoLogin) {
+                try {
+                    $this->login(['email' => $client->getEmail(), 'password' => $data['password']]);
+                } catch (\Throwable $e) {
+                    $this->getDi()['logger']->error($e->getMessage());
+                }
+            }
+
+            return true;
+        } finally {
+            RandomizedTimeFloor::apply($startedAt, 300, 450);
+        }
     }
 
     /**

--- a/src/modules/Client/Api/Guest.php
+++ b/src/modules/Client/Api/Guest.php
@@ -93,11 +93,13 @@ class Guest extends \FOSSBilling\Api\AbstractApi
             $email = $this->getDi()['tools']->validateAndSanitizeEmail($email);
             $email = strtolower(trim((string) $email));
 
+            $this->checkCaptchaIfEnabled($data);
+
             // Keyed independently of the IP limiter above so that spreading
             // probes across IPs doesn't help an attacker hammer one address.
+            // Consumed only after the CAPTCHA check so a stream of invalid
+            // CAPTCHA submissions can't burn through one address's quota.
             $emailLimit = $this->getDi()['rate_limiter']->consume('client_signup_email', $email);
-
-            $this->checkCaptchaIfEnabled($data);
 
             $autoLogin = Tools::normalizeBoolean($config['auto_login_after_signup'] ?? true, true);
 

--- a/src/modules/Client/tests/E2E/ApiGuestTest.php
+++ b/src/modules/Client/tests/E2E/ApiGuestTest.php
@@ -65,8 +65,9 @@ test('phone number length validation', function (): void {
 function clientCreateClient(): int
 {
     $password = 'A1a' . bin2hex(random_bytes(6));
+    $email = 'client_' . uniqid() . '@example.com';
     $result = Tests\Helpers\ApiClient::request('guest/client/create', [
-        'email' => 'client_' . uniqid() . '@example.com',
+        'email' => $email,
         'first_name' => 'Test',
         'password' => $password,
         'password_confirm' => $password,
@@ -74,7 +75,13 @@ function clientCreateClient(): int
         'phone' => '(216) 245-2368',
     ]);
     expect($result->wasSuccessful())->toBeTrue();
-    expect($result->getResult())->toBeInt();
+    expect($result->getResult())->toBeTrue();
 
-    return (int) $result->getResult();
+    // guest/client/create no longer returns the new client's id (doing so
+    // would reopen the email-enumeration issue it was hardened against), so
+    // look the account up by the email we just registered instead.
+    $lookup = Tests\Helpers\ApiClient::request('admin/client/get', ['email' => $email]);
+    expect($lookup->wasSuccessful())->toBeTrue();
+
+    return (int) $lookup->getResult()['id'];
 }

--- a/src/modules/Client/tests/Unit/Api/GuestTest.php
+++ b/src/modules/Client/tests/Unit/Api/GuestTest.php
@@ -22,7 +22,7 @@ test('getDi returns dependency injection container', function (): void {
     expect($getDi)->toEqual($di);
 });
 
-test('create returns int', function (): void {
+test('create returns true and creates the account for a new email', function (): void {
     $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());
     $configArr = [
         'disable_signup' => false,
@@ -50,7 +50,7 @@ test('create returns int', function (): void {
 
     $serviceMock
     ->shouldReceive('guestCreateClient')
-    ->atLeast()->once()
+    ->once()
     ->andReturn($model);
     $serviceMock->shouldReceive('checkExtraRequiredFields')->atLeast()->once();
     $serviceMock->shouldReceive('checkCustomFields')->atLeast()->once();
@@ -72,11 +72,10 @@ test('create returns int', function (): void {
 
     $result = $guestClient->create($data);
 
-    expect($result)->toBeInt();
-    expect($result)->toEqual($model->getId());
+    expect($result)->toBeTrue();
 });
 
-test('create throws exception when client exists', function (): void {
+test('create returns true without creating a duplicate account or disclosing that the email exists', function (): void {
     $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());
     $configArr = [
         'disable_signup' => false,
@@ -95,8 +94,11 @@ test('create throws exception when client exists', function (): void {
     ->andReturn(true);
     $serviceMock->shouldReceive('checkExtraRequiredFields')->atLeast()->once();
     $serviceMock->shouldReceive('checkCustomFields')->atLeast()->once();
-
-    $model = createEntity(Box\Mod\Client\Entity\Client::class);
+    // The submitted (attacker-controlled) password won't match the real
+    // account's password, so the fallback login attempt fails just like an
+    // ordinary bad-password login would.
+    $serviceMock->shouldReceive('authorizeClient')->atLeast()->once()->andReturn(null);
+    $serviceMock->shouldNotReceive('guestCreateClient');
 
     $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
     $validatorMock->shouldReceive('isPasswordStrong')->atLeast()->once();
@@ -113,8 +115,67 @@ test('create throws exception when client exists', function (): void {
     $guestClient->setDi($di);
     $guestClient->setService($serviceMock);
 
-    $guestClient->create($data);
-})->throws(FOSSBilling\Exception::class, 'This email address is already registered.');
+    $result = $guestClient->create($data);
+
+    expect($result)->toBeTrue();
+});
+
+test('create returns true without creating an account when the per-email signup rate limit is hit', function (): void {
+    $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());
+    $configArr = [
+        'disable_signup' => false,
+    ];
+    $data = [
+        'email' => 'test@email.com',
+        'first_name' => 'John',
+        'password' => 'testpassword',
+        'password_confirm' => 'testpassword',
+    ];
+
+    $serviceMock = Mockery::mock(Box\Mod\Client\Service::class);
+    // Never reached: the email limiter short-circuits before the existence
+    // check, so a fresh (not-yet-registered) email can't burn through this
+    // path repeatedly to have its true existence state observed.
+    $serviceMock->shouldNotReceive('clientAlreadyExists');
+    $serviceMock->shouldReceive('checkExtraRequiredFields')->atLeast()->once();
+    $serviceMock->shouldReceive('checkCustomFields')->atLeast()->once();
+    $serviceMock->shouldReceive('authorizeClient')->atLeast()->once()->andReturn(null);
+    $serviceMock->shouldNotReceive('guestCreateClient');
+
+    $validatorMock = Mockery::mock(FOSSBilling\Validate::class);
+    $validatorMock->shouldReceive('isPasswordStrong')->atLeast()->once();
+    $validatorMock->shouldReceive('passwordsMatch')->atLeast()->once();
+
+    $rateLimiterMock = new class {
+        public function consume(string $policyName, string $subject, int $tokens = 1): FOSSBilling\Security\RateLimitResult
+        {
+            $limited = $policyName === 'client_signup_email';
+
+            return new FOSSBilling\Security\RateLimitResult($policyName, $limited, null, null);
+        }
+
+        public function consumeOrThrow(string $policyName, string $subject, int $tokens = 1): FOSSBilling\Security\RateLimitResult
+        {
+            return $this->consume($policyName, $subject, $tokens);
+        }
+    };
+
+    $di = container();
+    $di['mod_config'] = $di->protect(fn ($name): array => $configArr);
+    $di['validator'] = $validatorMock;
+    $di['rate_limiter'] = $rateLimiterMock;
+
+    $toolsMock = Mockery::mock(FOSSBilling\Tools::class);
+    $toolsMock->shouldReceive('validateAndSanitizeEmail')->atLeast()->once()->andReturn($data['email']);
+    $di['tools'] = $toolsMock;
+
+    $guestClient->setDi($di);
+    $guestClient->setService($serviceMock);
+
+    $result = $guestClient->create($data);
+
+    expect($result)->toBeTrue();
+});
 
 test('create throws exception when signup is disabled', function (): void {
     $guestClient = apiEndpoint(new Box\Mod\Client\Api\Guest());

--- a/tests/E2E/Playwright/helpers/client-factory.ts
+++ b/tests/E2E/Playwright/helpers/client-factory.ts
@@ -41,8 +41,28 @@ export async function createTestClient(request: APIRequestContext): Promise<Test
     throw new Error(`Client creation returned an unexpected response: ${JSON.stringify(body)}`);
   }
 
+  // guest/client/create no longer returns the new client's id (doing so would
+  // reopen the email-enumeration issue it was hardened against), so recover it
+  // by logging in with the credentials we just registered instead.
+  const loginResponse = await request.post('/api/guest/client/login', {
+    data: {
+      email: client.email,
+      password: client.password,
+    },
+  });
+
+  if (!loginResponse.ok()) {
+    throw new Error(`Client login after creation failed with HTTP ${loginResponse.status()}: ${await loginResponse.text()}`);
+  }
+
+  const loginBody = await loginResponse.json();
+
+  if (loginBody.error !== null || !loginBody.result?.id) {
+    throw new Error(`Client login after creation returned an unexpected response: ${JSON.stringify(loginBody)}`);
+  }
+
   return {
     ...client,
-    id: body.result,
+    id: loginBody.result.id,
   };
 }

--- a/tests/E2E/Playwright/helpers/client-factory.ts
+++ b/tests/E2E/Playwright/helpers/client-factory.ts
@@ -1,7 +1,6 @@
 import type { APIRequestContext } from '@playwright/test';
 
 export interface TestClient {
-  id: number;
   first_name: string;
   last_name: string;
   email: string;
@@ -37,32 +36,13 @@ export async function createTestClient(request: APIRequestContext): Promise<Test
 
   const body = await response.json();
 
-  if (body.error !== null || !body.result) {
+  // guest/client/create no longer returns the new client's id (doing so would
+  // reopen the email-enumeration issue it was hardened against) — it now
+  // returns a plain success boolean. Nothing here needs the id: callers only
+  // ever use the email/password to log in as this client.
+  if (body.error !== null || body.result !== true) {
     throw new Error(`Client creation returned an unexpected response: ${JSON.stringify(body)}`);
   }
 
-  // guest/client/create no longer returns the new client's id (doing so would
-  // reopen the email-enumeration issue it was hardened against), so recover it
-  // by logging in with the credentials we just registered instead.
-  const loginResponse = await request.post('/api/guest/client/login', {
-    data: {
-      email: client.email,
-      password: client.password,
-    },
-  });
-
-  if (!loginResponse.ok()) {
-    throw new Error(`Client login after creation failed with HTTP ${loginResponse.status()}: ${await loginResponse.text()}`);
-  }
-
-  const loginBody = await loginResponse.json();
-
-  if (loginBody.error !== null || !loginBody.result?.id) {
-    throw new Error(`Client login after creation returned an unexpected response: ${JSON.stringify(loginBody)}`);
-  }
-
-  return {
-    ...client,
-    id: loginBody.result.id,
-  };
+  return client;
 }


### PR DESCRIPTION
## Summary

The unauthenticated guest signup endpoint (`POST /api/guest/client/create`) disclosed whether a given email address already belonged to a registered client: `Guest::create()` threw a distinct "already registered" exception for existing emails and returned a new client ID otherwise, with no rate limiting keyed on the address itself and no CAPTCHA gating.

This let anyone check, one address at a time and without leaving a trace an operator could act on, whether a given email belongs to an existing customer of a FOSSBilling install — useful for credential-stuffing target selection, more convincing phishing, or harassment via repeated password-reset triggers.

## Changes

`Guest::create()`:

- Returns `bool` instead of the created client's int ID. No return value can look the same across both outcomes while also being safe to hand back for an address that doesn't belong to a new account, so the return type itself needed to stop carrying that signal.
- No longer throws a distinct error for an already-registered (or rate-limited) email. It silently skips account creation and falls through to an ordinary `login()` attempt with the submitted credentials — reusing that method's existing timing- and message-safe handling rather than reimplementing it here.
- Applies `RandomizedTimeFloor`, matching `login()`/`reset_password()`.
- Adds a per-email rate limit (`client_signup_email`) alongside the existing per-IP one, so spreading requests across IPs doesn't help an attacker hammer one address.
- Calls `checkCaptchaIfEnabled()`, matching `reset_password()`'s CAPTCHA gating — previously signup got none even when CAPTCHA was enabled elsewhere in the client area.