### PR TITLE
Fix change password error in client area

### DIFF
--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -278,11 +278,11 @@ class Service implements InjectionAwareInterface
             switch ($type) {
                 case 'admin':
                     $admin = $this->di['session']->get('admin');
-                    $id = $admin['id'];
+                    $id = (int) $admin['id'];
 
                     break;
                 case 'client':
-                    $id = $this->di['session']->get('client_id');
+                    $id = (int) $this->di['session']->get('client_id');
 
                     break;
             }


### PR DESCRIPTION
While changing password via client side, following error appears

Box\Mod\Profile\Service::deleteSessionIfMatching(): Argument #3 ($id) must be of type int, string given, called in /home/../modules/Profile/Service.php on line 295 (9998)