### PR TITLE
fix popups error display 

### DIFF
--- a/src/modules/Api/Controller/Client.php
+++ b/src/modules/Api/Controller/Client.php
@@ -96,7 +96,11 @@ class Client implements InjectionAwareInterface
             // Sentry by default only captures unhandled exceptions, so we need to manually capture these.
             \Sentry\captureException($exc);
 
-            return $this->renderJson(null, $exc);
+            $displayException = \FOSSBilling\Environment::isProduction() && !($exc instanceof \FOSSBilling\Exception)
+                ? new \FOSSBilling\Exception('An unexpected error occurred.', [], 9998, $exc)
+                : ($exc instanceof \Exception ? $exc : new \FOSSBilling\Exception($exc->getMessage(), [], $exc->getCode(), $exc));
+
+            return $this->renderJson(null, $displayException);
         }
     }
 


### PR DESCRIPTION
when something goes wrong there is a little box in which real error shows.  I want to show generic error on client side but sentry/logs should have real error when fossbilling is in production