### PR TITLE
Fix multi-byte UTF-8 corruption in Guest::countries()

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -83,7 +83,8 @@
         "dedup",
         "GHSA",
         "macrovector",
-        "rubygems"
+        "rubygems",
+        "Åland"
     ],
 
     "ignoreWords": [

--- a/src/modules/System/Api/Guest.php
+++ b/src/modules/System/Api/Guest.php
@@ -78,7 +78,7 @@ class Guest extends \FOSSBilling\Api\AbstractApi
         }
 
         $countries = [];
-        foreach (preg_split('/\R/', $configuredCountries) as $line) {
+        foreach (preg_split('/\R/u', $configuredCountries) as $line) {
             $parts = explode('=', trim($line), 2);
             if (count($parts) !== 2) {
                 continue;

--- a/src/modules/System/tests/Unit/Api/GuestTest.php
+++ b/src/modules/System/tests/Unit/Api/GuestTest.php
@@ -179,3 +179,45 @@ test('locale returns the active locale string', function (): void {
 
     expect($result)->toBeString()->not->toBeEmpty();
 });
+
+test('countries returns full list when none are configured', function (): void {
+    $api = apiEndpoint(new Box\Mod\System\Api\Guest());
+
+    $modMock = Mockery::mock(FOSSBilling\Module::class);
+    $modMock->shouldReceive('getConfig')->atLeast()->once()->andReturn([]);
+
+    $di = container();
+    $di['mod'] = $di->protect(fn (): Mockery\MockInterface => $modMock);
+    $api->setDi($di);
+
+    $result = $api->countries();
+
+    expect($result)->toBeArray()->not->toBeEmpty();
+    expect($result)->toHaveKey('US');
+});
+
+test('countries correctly splits multi-byte UTF-8 country names', function (): void {
+    // Regression test for a bug where preg_split('/\R/', ...) (without the
+    // 'u' modifier) matched \R against raw bytes, splitting mid-character on
+    // the 0x85 continuation byte present in multi-byte UTF-8 sequences (e.g.
+    // "Å" = 0xC3 0x85), corrupting the entry and breaking json_encode() for
+    // the entire returned array.
+    $api = apiEndpoint(new Box\Mod\System\Api\Guest());
+
+    $configuredCountries = "AX=Åland Islands\nUS=United States";
+
+    $modMock = Mockery::mock(FOSSBilling\Module::class);
+    $modMock->shouldReceive('getConfig')->atLeast()->once()->andReturn(['countries' => $configuredCountries]);
+
+    $di = container();
+    $di['mod'] = $di->protect(fn (): Mockery\MockInterface => $modMock);
+    $api->setDi($di);
+
+    $result = $api->countries();
+
+    expect($result)->toBe([
+        'AX' => 'Åland Islands',
+        'US' => 'United States',
+    ]);
+    expect(json_encode($result))->not->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Fixes #4239.

`System::Guest::countries()` split the admin-configured custom country list with `preg_split('/\R/', $configuredCountries)`. Without the `u` (PCRE_UTF8) modifier, `\R` matches raw *bytes*, including `0x85` (NEL), which is also the continuation byte in many multi-byte UTF-8 sequences (e.g. "Å" = `0xC3 0x85`).

A configured line such as `AX=Åland Islands` therefore got split mid-character, leaving an invalid dangling UTF-8 byte in the resulting country name. That single corrupted entry then broke `json_encode()` for the *entire* `guest/system/countries` API response (`Malformed UTF-8 characters, possibly incorrectly encoded`), not just the one bad entry.

## Fix

Add the `u` modifier so `\R` is interpreted in Unicode mode and never splits mid-character:

```diff
-foreach (preg_split('/\R/', $configuredCountries) as $line) {
+foreach (preg_split('/\R/u', $configuredCountries) as $line) {
```