### PR TITLE
Fix subscription renewal invoice failing on suspended/failed_renew orders

### DIFF
--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -89,18 +89,14 @@ class Service implements InjectionAwareInterface
 
     public function getInvoiceItemRepository(): InvoiceItemRepository
     {
-        if ($this->invoiceItemRepository === null) {
-            $this->invoiceItemRepository = $this->di['em']->getRepository(InvoiceItem::class);
-        }
+        $this->invoiceItemRepository ??= $this->di['em']->getRepository(InvoiceItem::class);
 
         return $this->invoiceItemRepository;
     }
 
     public function getInvoiceRepository(): InvoiceRepository
     {
-        if ($this->invoiceRepository === null) {
-            $this->invoiceRepository = $this->di['em']->getRepository(Invoice::class);
-        }
+        $this->invoiceRepository ??= $this->di['em']->getRepository(Invoice::class);
 
         return $this->invoiceRepository;
     }

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -2617,7 +2617,18 @@ class Service implements InjectionAwareInterface
             // products like domain registrations where multiple orders share
             // the same product — it would find an unrelated order and generate
             // a renewal invoice for the wrong service.
-            if ($originalOrder->getStatus() !== Order::STATUS_ACTIVE) {
+            //
+            // Accept the same "still renewable" statuses generateForOrder() itself
+            // recognizes below, not just active: the batch-suspend cron can suspend
+            // an order (on expiry) before a delayed gateway subscription-payment IPN
+            // for that same renewal arrives. generateForOrder() already reuses any
+            // unpaid invoice the cron generated ahead of time, so this lets that
+            // invoice be paid and the order un-suspended/renewed as normal.
+            if (!in_array($originalOrder->getStatus(), [
+                Order::STATUS_ACTIVE,
+                Order::STATUS_SUSPENDED,
+                Order::STATUS_FAILED_RENEW,
+            ], true)) {
                 return null;
             }
 

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -3089,6 +3089,59 @@ test('generateRenewalInvoiceForSubscriptionPayment uses the original order and n
     expect($result->id)->toBe(99);
 });
 
+test('generateRenewalInvoiceForSubscriptionPayment still renews an order the batch-suspend cron already suspended', function (string $status): void {
+    // A gateway's subscription-payment IPN can legitimately arrive after the
+    // batch-suspend cron has already suspended the order for missing its
+    // expiry, or after a prior renewal attempt left it failed_renew.
+    $subscription = createEntity(Subscription::class, ['id' => 7, 'relType' => 'invoice', 'relId' => 82]);
+
+    $invoiceItem = createEntity(InvoiceItem::class, ['rel_id' => 82]);
+
+    $originalOrder = createEntity(Order::class, [
+        'status' => $status,
+        'productId' => 1,
+    ]);
+
+    $renewalInvoice = createEntity(Invoice::class);
+
+    $renewalInvoice->id = 99;
+
+    $orderRepoMock = Mockery::mock(OrderRepository::class);
+    $orderRepoMock->shouldReceive('find')
+        ->with(82)
+        ->andReturn($originalOrder);
+
+    [$em, $invoiceItemRepo] = invoiceItemEmAndRepo();
+    $invoiceItemRepo->shouldReceive('findOneByInvoiceIdAndType')
+        ->with(82, InvoiceItem::TYPE_ORDER)
+        ->andReturn($invoiceItem);
+    $subscriptionRepo = Mockery::mock(SubscriptionRepository::class);
+    $subscriptionRepo->shouldReceive('findOneBy')->once()->andReturn($subscription);
+    $em->shouldReceive('getRepository')->with(Subscription::class)->andReturn($subscriptionRepo);
+    $em->shouldReceive('getRepository')->with(Order::class)->andReturn($orderRepoMock);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('generateForOrder')
+        ->with(Mockery::on(fn ($order): bool => $order === $originalOrder))
+        ->once()
+        ->andReturn($renewalInvoice);
+    $serviceMock->shouldReceive('approveInvoice')
+        ->once();
+
+    $di = container();
+    $di['em'] = $em;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->generateRenewalInvoiceForSubscriptionPayment('I-TEST123', 1);
+
+    expect($result)->toBeInstanceOf(Invoice::class);
+    expect($result->id)->toBe(99);
+})->with([
+    'suspended' => Order::STATUS_SUSPENDED,
+    'failed renew' => Order::STATUS_FAILED_RENEW,
+]);
+
 test('markAsPaid transitions a deposit invoice to paid status', function (): void {
     $service = new Service();
 


### PR DESCRIPTION
## Summary

Fixes #4241 — most PayPal (and Stripe) subscription renewal payments were failing with `"Unable to generate a renewal invoice for subscription payment"`, forcing the admin to mark the invoice as paid manually every time.

## Root cause

`Invoice\Service::generateRenewalInvoiceForSubscriptionPayment()` only generated a renewal invoice when the original order's status was exactly `active`. FOSSBilling's own `Order::batchSuspendExpired()` cron auto-suspends an order as soon as its `expires_at` (plus grace period) passes — independent of whether the payment gateway has actually processed the recurring charge yet. The gateway's real billing cycle routinely lands slightly after that cron tick, so by the time the legitimate `subscr_payment`/subscription IPN arrives, the order is already `suspended` (or `failed_renew`, if a prior renewal attempt errored) rather than `active`. The status check rejected these every time, which is why the failure recurred for most renewals rather than being a one-off edge case.

`generateForOrder()` itself already treats `active`, `suspended`, and `failed_renew` as valid renewal states, and `ServiceInvoiceItem::executeTask()` already knows how to un-suspend an order as part of processing a renewal invoice item — the status gate in `generateRenewalInvoiceForSubscriptionPayment()` was simply narrower than the rest of the renewal pipeline it feeds into.

## Fix

Widen the accepted order statuses to match `generateForOrder()`'s own set (`active`, `suspended`, `failed_renew`). This lets the normal payment pipeline (approve → pay → renew task → un-suspend/renew) run to completion, reusing any unpaid invoice the cron already generated instead of duplicating it. Orders in `pending_setup`, `failed_setup`, or `canceled` are still rejected, since those indicate a genuinely broken order rather than a timing race.