### PR TITLE
Stop reporting native PHP deprecation notices to Sentry

### DIFF
--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -127,6 +127,19 @@ class SentryHelper
             // We explicitly set the HTTP client to use the Symfony HTTP client to provide wider support VS their default cURL client.
             'http_client' => $httpClient,
 
+            /*
+             * Every PHP version bump deprecates a fresh batch of constants/casts/signatures, and instances
+             * running ahead of our tested PHP baseline (or simply on an older FOSSBilling release) throw these
+             * on effectively every request. Since we don't control when self-hosted instances upgrade PHP,
+             * these deprecation notices are unbounded and drown out real errors instead of being one-time noise.
+             * `error_reporting(E_ALL)` (see load.php) means the SDK's ErrorListenerIntegration would otherwise
+             * capture E_DEPRECATED same as any other error. We deliberately keep E_USER_DEPRECATED enabled:
+             * that's our own trigger_error() calls flagging things we should investigate (see
+             * Currency\Service::getExchangeRateAPIRates()), not interpreter noise.
+             * E_STRICT has been a no-op since PHP 8.4 but is excluded for clarity/future-proofing.
+             */
+            'error_types' => E_ALL & ~E_DEPRECATED & ~E_STRICT,
+
             'before_send' => function (Event $event, ?EventHint $hint) use ($serverSoftware): ?Event {
                 $module = null;
                 $theme = null;

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -136,9 +136,13 @@ class SentryHelper
              * capture E_DEPRECATED same as any other error. We deliberately keep E_USER_DEPRECATED enabled:
              * that's our own trigger_error() calls flagging things we should investigate (see
              * Currency\Service::getExchangeRateAPIRates()), not interpreter noise.
-             * E_STRICT has been a no-op since PHP 8.4 but is excluded for clarity/future-proofing.
+             *
+             * Deliberately not also excluding E_STRICT: referencing that constant at all triggers its own
+             * "Constant E_STRICT is deprecated" notice as of PHP 8.4, and E_STRICT hasn't been a real error
+             * level PHP ever raises since 8.0 anyway (its cases were folded into E_DEPRECATED/E_WARNING), so
+             * excluding it buys nothing.
              */
-            'error_types' => E_ALL & ~E_DEPRECATED & ~E_STRICT,
+            'error_types' => E_ALL & ~E_DEPRECATED,
 
             'before_send' => function (Event $event, ?EventHint $hint) use ($serverSoftware): ?Event {
                 $module = null;

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -128,14 +128,13 @@ class SentryHelper
             'http_client' => $httpClient,
 
             /*
-             * Every PHP version bump deprecates a fresh batch of constants/casts/signatures, and instances
-             * running ahead of our tested PHP baseline (or simply on an older FOSSBilling release) throw these
-             * on effectively every request. Since we don't control when self-hosted instances upgrade PHP,
-             * these deprecation notices are unbounded and drown out real errors instead of being one-time noise.
-             * `error_reporting(E_ALL)` (see load.php) means the SDK's ErrorListenerIntegration would otherwise
-             * capture E_DEPRECATED same as any other error. We deliberately keep E_USER_DEPRECATED enabled:
-             * that's our own trigger_error() calls flagging things we should investigate (see
-             * Currency\Service::getExchangeRateAPIRates()), not interpreter noise.
+             * Every PHP version bump deprecates a fresh batch of constants/casts/signatures, and we don't
+             * control when self-hosted instances upgrade PHP - so on an instance running ahead of our tested
+             * baseline, these fire on effectively every request, forever. `error_reporting(E_ALL)` (see
+             * load.php) means the SDK's ErrorListenerIntegration would otherwise capture E_DEPRECATED same as
+             * any other error. We deliberately keep E_USER_DEPRECATED enabled: that's our own trigger_error()
+             * calls flagging things we should investigate (see Currency\Service::getExchangeRateAPIRates()),
+             * not interpreter noise.
              *
              * Deliberately not also excluding E_STRICT: referencing that constant at all triggers its own
              * "Constant E_STRICT is deprecated" notice as of PHP 8.4, and E_STRICT hasn't been a real error


### PR DESCRIPTION
## Problem

Our Sentry project's unresolved-issues list is dominated by noise: the top issues by event volume (millions of events each) are all PHP `E_DEPRECATED` notices (deprecated PDO constants, `SplObjectStorage::attach()`, non-canonical casts, implicitly-nullable params, etc.) thrown by self-hosted instances running newer PHP than the release they're on was built/tested against.

`SentryHelper::registerSentry()` never set `error_types`, so the SDK's `ErrorListenerIntegration` captures every error level allowed by `error_reporting()` — which `load.php` sets to `E_ALL`. Since we don't control when instances upgrade PHP, this is an unbounded, ever-growing source of noise (a new deprecation batch every PHP release, on every request), and it's currently burning quota and drowning out real errors.

## Fix

Set `error_types => E_ALL & ~E_DEPRECATED & ~E_STRICT` when initializing Sentry. `E_USER_DEPRECATED` is deliberately left enabled — that covers our own intentional `trigger_error()` calls (e.g. the ExchangeRate-API EOL warning in `Currency\Service`), which is real signal, not interpreter noise.