### PR TITLE
Backport small non-breaking fixes from main since #4234

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -570,7 +570,16 @@
         "createacct",
         "setupreseller",
         "setacls",
-        "acllist"
+        "acllist",
+        "creationtime",
+        "domsecret",
+        "isprivacyprotected",
+        "admincontact",
+        "contactid",
+        "emailaddr",
+        "telno",
+        "telnocc",
+        "actionstatus"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -349,6 +349,19 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
     public function renewDomain(Registrar_Domain $domain): bool
     {
+        // ResellerClub requires the domain's current expiry date (in epoch seconds) on every
+        // renewal request, as a safeguard against renewing against stale data. FOSSBilling only
+        // learns that date via a prior successful WHOIS sync, so a domain whose sync never
+        // completed (e.g. it ran too soon after registration, before the registry had propagated
+        // the record) reaches here with no expiration time cached locally. Sending the request
+        // without exp-date fails with "Required parameter missing: exp-date", and since the
+        // renewal never succeeds, the sync that would have fixed it for next time never runs
+        // either - the domain is stuck failing every renewal attempt. Fetch it fresh instead of
+        // giving up. See https://github.com/FOSSBilling/FOSSBilling/issues/4229.
+        if (empty($domain->getExpirationTime())) {
+            $this->getDomainDetails($domain);
+        }
+
         $params = [
             'order-id' => $this->_getDomainOrderId($domain),
             'years' => $domain->getRegistrationPeriod(),

--- a/src/modules/Invoice/Service.php
+++ b/src/modules/Invoice/Service.php
@@ -2538,7 +2538,18 @@ class Service implements InjectionAwareInterface
             // products like domain registrations where multiple orders share
             // the same product — it would find an unrelated order and generate
             // a renewal invoice for the wrong service.
-            if ($originalOrder->status !== \Model_ClientOrder::STATUS_ACTIVE) {
+            //
+            // Accept the same "still renewable" statuses generateForOrder() itself
+            // recognizes below, not just active: the batch-suspend cron can suspend
+            // an order (on expiry) before a delayed gateway subscription-payment IPN
+            // for that same renewal arrives. generateForOrder() already reuses any
+            // unpaid invoice the cron generated ahead of time, so this lets that
+            // invoice be paid and the order un-suspended/renewed as normal.
+            if (!in_array($originalOrder->status, [
+                \Model_ClientOrder::STATUS_ACTIVE,
+                \Model_ClientOrder::STATUS_SUSPENDED,
+                \Model_ClientOrder::STATUS_FAILED_RENEW,
+            ], true)) {
                 return null;
             }
 

--- a/src/modules/Invoice/tests/Unit/ServiceTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceTest.php
@@ -3330,6 +3330,61 @@ test('generateRenewalInvoiceForSubscriptionPayment uses the original order and n
     expect($result->id)->toBe(99);
 });
 
+test('generateRenewalInvoiceForSubscriptionPayment still renews an order the batch-suspend cron already suspended', function (string $status): void {
+    // A gateway's subscription-payment IPN can legitimately arrive after the
+    // batch-suspend cron has already suspended the order for missing its
+    // expiry, or after a prior renewal attempt left it failed_renew.
+    $subscription = new Model_Subscription();
+    $subscription->loadBean(new Tests\Helpers\DummyBean());
+    $subscription->rel_type = 'invoice';
+    $subscription->rel_id = 82;
+
+    $invoiceItem = new Model_InvoiceItem();
+    $invoiceItem->loadBean(new Tests\Helpers\DummyBean());
+    $invoiceItem->rel_id = 82;
+
+    $originalOrder = new Model_ClientOrder();
+    $originalOrder->loadBean(new Tests\Helpers\DummyBean());
+    $originalOrder->status = $status;
+    $originalOrder->product_id = 1;
+
+    $renewalInvoice = new Model_Invoice();
+    $renewalInvoice->loadBean(new Tests\Helpers\DummyBean());
+    $renewalInvoice->id = 99;
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('findOne')
+        ->with('Subscription', 'sid = :sid', Mockery::any())
+        ->andReturn($subscription);
+    $dbMock->shouldReceive('findOne')
+        ->with('InvoiceItem', Mockery::any(), Mockery::any())
+        ->andReturn($invoiceItem);
+    $dbMock->shouldReceive('load')
+        ->with('ClientOrder', 82)
+        ->andReturn($originalOrder);
+
+    $serviceMock = Mockery::mock(Service::class)->makePartial();
+    $serviceMock->shouldReceive('generateForOrder')
+        ->with(Mockery::on(fn ($order): bool => $order === $originalOrder))
+        ->once()
+        ->andReturn($renewalInvoice);
+    $serviceMock->shouldReceive('approveInvoice')
+        ->once();
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $di['logger'] = new Tests\Helpers\TestLogger();
+    $serviceMock->setDi($di);
+
+    $result = $serviceMock->generateRenewalInvoiceForSubscriptionPayment('I-TEST123', 1);
+
+    expect($result)->toBeInstanceOf(Model_Invoice::class);
+    expect($result->id)->toBe(99);
+})->with([
+    'suspended' => Model_ClientOrder::STATUS_SUSPENDED,
+    'failed renew' => Model_ClientOrder::STATUS_FAILED_RENEW,
+]);
+
 test('markAsPaid transitions a deposit invoice to paid status', function (): void {
     $service = new Service();
 

--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -276,11 +276,11 @@ class Service implements InjectionAwareInterface
             switch ($type) {
                 case 'admin':
                     $admin = $this->di['session']->get('admin');
-                    $id = $admin['id'];
+                    $id = (int) $admin['id'];
 
                     break;
                 case 'client':
-                    $id = $this->di['session']->get('client_id');
+                    $id = (int) $this->di['session']->get('client_id');
 
                     break;
             }

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -216,6 +216,89 @@ test('modifyContact assigns per-role contact IDs for .fr, which only forces tech
     expect($body['billing-contact-id'])->toBe('-1');
 });
 
+test('renewDomain fetches fresh domain details to fill in exp-date when it is not already cached', function (): void {
+    // Regression test for #4229: FOSSBilling only learns a domain's expiration time via a prior
+    // WHOIS sync. When that sync never completed (e.g. it ran too soon after registration), the
+    // domain reaches renewDomain() with no expiration time, and ResellerClub rejects the renewal
+    // outright with "Required parameter missing: exp-date" - which then also prevents the WHOIS
+    // sync that would fix it for next time, since that only runs after a successful renewal. The
+    // adapter must fetch the expiry itself instead of sending an incomplete request.
+    $requests = [];
+    $bodies = [];
+    $responses = [
+        '112233', // domains/orderid (via getDomainDetails)
+        json_encode([ // domains/details
+            'creationtime' => 1577836800,
+            'endtime' => 1893456000,
+            'domsecret' => 'epp-code',
+            'isprivacyprotected' => 'false',
+            'admincontact' => [
+                'contactid' => '998877',
+                'name' => 'Jane Doe',
+                'emailaddr' => 'jane@example.com',
+                'company' => '',
+                'telno' => '5551234567',
+                'telnocc' => '1',
+                'address1' => '1 Example St',
+                'city' => 'Example City',
+                'country' => 'US',
+                'state' => '',
+                'zip' => '12345',
+            ],
+        ]),
+        '112233', // domains/orderid (for the renew request itself)
+        json_encode(['actionstatus' => 'Success']), // domains/renew
+    ];
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $bodies[] = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain()->setRegistrationPeriod(1);
+
+    expect($adapter->renewDomain($domain))->toBeTrue();
+    expect($requests)->toBe([
+        'GET /api/domains/orderid.json',
+        'GET /api/domains/details.json',
+        'GET /api/domains/orderid.json',
+        'POST /api/domains/renew.json',
+    ]);
+
+    parse_str((string) end($bodies), $body);
+    expect($body['exp-date'])->toBe('1893456000');
+    expect($domain->getExpirationTime())->toBe(1893456000);
+});
+
+test('renewDomain does not re-fetch domain details when an expiration time is already known', function (): void {
+    $requests = [];
+    $bodies = [];
+    $responses = [
+        '112233', // domains/orderid (for the renew request)
+        json_encode(['actionstatus' => 'Success']), // domains/renew
+    ];
+
+    $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests, &$responses, &$bodies): MockResponse {
+        $requests[] = $method . ' ' . parse_url($url, PHP_URL_PATH);
+        $bodies[] = $options['body'] ?? null;
+
+        return new MockResponse(array_shift($responses));
+    });
+    $adapter = createResellerclubAdapter($httpClient);
+    $domain = createResellerclubDomain()->setRegistrationPeriod(1)->setExpirationTime(1893456000);
+
+    expect($adapter->renewDomain($domain))->toBeTrue();
+    expect($requests)->toBe([
+        'GET /api/domains/orderid.json',
+        'POST /api/domains/renew.json',
+    ]);
+
+    parse_str((string) end($bodies), $body);
+    expect($body['exp-date'])->toBe('1893456000');
+});
+
 test('registerDomain sends the .fr registry consent attribute alongside the FrContact IDs', function (): void {
     // Regression test for #77: .fr requires accepting the registry's data-sharing terms via a tnc
     // attribute on domains/register, on top of the FrContact type/contact-id handling above. See


### PR DESCRIPTION
Curated follow-up to #4221/#4234: backports the small, self-contained fixes merged to `main` since the last backport pass (main's #4233).

## Included

- #4230 — Fix ResellerClub domain renewal failing with missing exp-date
- #4235 — Fix change password error in client area
- #4242 — Allow subscription renewal invoices for suspended/failed_renew orders

## Deliberately excluded

- **#4231** (Stripe checkout duplicate-customer/idempotency-key race)
- #4232 (security-advisory-triage skill) — `.claude/skills` 
- Docker digest bump for `docker/dockerfile`