### PR TITLE
Report releases to Sentry in CI/CD

### DIFF
--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -14,7 +14,9 @@ jobs:
     name: 'Report Release to Sentry'
     permissions:
       contents: read
-    runs-on: ubuntu-slim
+    # getsentry/action-release runs as a docker:// container action on Linux, which ubuntu-slim
+    # can't support (unprivileged, no Docker daemon).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: 'Checkout Repository'
@@ -28,6 +30,7 @@ jobs:
         uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           export-env: true
+          version: '2.39.0'
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           # Sentry (GitHub CI/CD) credentials stored in 1Password.
@@ -41,6 +44,6 @@ jobs:
           SENTRY_PROJECT: fossbilling
         with:
           # Must match SentryHelper::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION exactly.
-          version: fossbilling@${{ github.ref_name }}
+          release: fossbilling@${{ github.ref_name }}
           set_commits: auto
           finalize: true

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -35,26 +35,13 @@ jobs:
 
       - name: 'Report Release to Sentry'
         id: sentry-release
-        # No continue-on-error here: this workflow runs after the release is already
-        # published, so a failure can't block or undo anything - but it also means a
-        # silently-swallowed failure (expired token, wrong org/project, Sentry outage) would
-        # have no other signal. Let it fail loudly so it shows up in the Actions tab instead
-        # of quietly reporting nothing again.
+        # Deliberately no continue-on-error - see PR description.
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
-          # SENTRY_AUTH_TOKEN comes from the 'Load Sentry Auth Token' step above (export-env: true).
           SENTRY_ORG: fossbilling
           SENTRY_PROJECT: fossbilling
         with:
-          # Must exactly match what SentryHelper::registerSentry() sends as the `release`
-          # option on every event (SentryHelper::SENTRY_RELEASE_PACKAGE . '@' .
-          # Version::VERSION - see that comment for why the "fossbilling@" prefix matters),
-          # or this release and the events it's meant to cover won't line up.
-          # Version::VERSION is set from this same tag via the FOSSBILLING_VERSION build arg
-          # - see create-release.yml / Dockerfile.
+          # Must match SentryHelper::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION exactly.
           version: fossbilling@${{ github.ref_name }}
-          # Associates the commit range since the previous release Sentry knows about (needs
-          # the full history from the checkout step's fetch-depth: 0) so Sentry can show
-          # suspect commits and diffs per release, not just tag issues with a version string.
           set_commits: auto
           finalize: true

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -1,0 +1,48 @@
+name: Report Release to Sentry
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  report-release:
+    name: 'Report Release to Sentry'
+    permissions:
+      contents: read
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          persist-credentials: false
+
+      - name: 'Report Release to Sentry'
+        id: sentry-release
+        # No continue-on-error here: this workflow runs after the release is already
+        # published, so a failure can't block or undo anything - but it also means a
+        # silently-swallowed failure (expired token, wrong org/project, Sentry outage) would
+        # have no other signal. Let it fail loudly so it shows up in the Actions tab instead
+        # of quietly reporting nothing again.
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: fossbilling
+          SENTRY_PROJECT: fossbilling
+        with:
+          # Matches the FOSSBILLING_VERSION build arg baked into Version::VERSION (see
+          # create-release.yml / Dockerfile), which is what SentryHelper::registerSentry()
+          # reports on every event's `release` field.
+          version: ${{ github.ref_name }}
+          # Associates the commit range since the previous release Sentry knows about (needs
+          # the full history from the checkout step's fetch-depth: 0) so Sentry can show
+          # suspect commits and diffs per release, not just tag issues with a version string.
+          set_commits: auto
+          finalize: true

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -30,12 +30,11 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          # Sentry auth token (project:releases + org:read scopes) stored in 1Password.
+          # Sentry (GitHub CI/CD) credentials stored in 1Password.
           SENTRY_AUTH_TOKEN: op://mkqkefntgcmjlgyxzeaekzuuvq/hw6jxytb2lqqjl5zzu4jjqztke/credential
 
       - name: 'Report Release to Sentry'
         id: sentry-release
-        # Deliberately no continue-on-error - see PR description.
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_ORG: fossbilling

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -37,10 +37,13 @@ jobs:
           SENTRY_ORG: fossbilling
           SENTRY_PROJECT: fossbilling
         with:
-          # Matches the FOSSBILLING_VERSION build arg baked into Version::VERSION (see
-          # create-release.yml / Dockerfile), which is what SentryHelper::registerSentry()
-          # reports on every event's `release` field.
-          version: ${{ github.ref_name }}
+          # Must exactly match what SentryHelper::registerSentry() sends as the `release`
+          # option on every event (SentryHelper::SENTRY_RELEASE_PACKAGE . '@' .
+          # Version::VERSION - see that comment for why the "fossbilling@" prefix matters),
+          # or this release and the events it's meant to cover won't line up.
+          # Version::VERSION is set from this same tag via the FOSSBILLING_VERSION build arg
+          # - see create-release.yml / Dockerfile.
+          version: fossbilling@${{ github.ref_name }}
           # Associates the commit range since the previous release Sentry knows about (needs
           # the full history from the checkout step's fetch-depth: 0) so Sentry can show
           # suspect commits and diffs per release, not just tag issues with a version string.

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -24,6 +24,15 @@ jobs:
           ref: ${{ github.ref_name }}
           persist-credentials: false
 
+      - name: 'Load Sentry Auth Token'
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Sentry auth token (project:releases + org:read scopes) stored in 1Password.
+          SENTRY_AUTH_TOKEN: op://mkqkefntgcmjlgyxzeaekzuuvq/hw6jxytb2lqqjl5zzu4jjqztke/credential
+
       - name: 'Report Release to Sentry'
         id: sentry-release
         # No continue-on-error here: this workflow runs after the release is already
@@ -33,7 +42,7 @@ jobs:
         # of quietly reporting nothing again.
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # SENTRY_AUTH_TOKEN comes from the 'Load Sentry Auth Token' step above (export-env: true).
           SENTRY_ORG: fossbilling
           SENTRY_PROJECT: fossbilling
         with:

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -29,6 +29,14 @@ class SentryHelper
      */
     final public const string last_change = '0.6.0';
 
+    /**
+     * The "package" identifier used as the `package@version` prefix on the release string we
+     * report to Sentry - see the `'release'` option in registerSentry() for why this exists.
+     * If this ever changes, release-sentry.yml's `version:` input must be updated to match, or
+     * events and the Sentry release Sentry-side will silently stop lining up.
+     */
+    private const string SENTRY_RELEASE_PACKAGE = 'fossbilling';
+
     // A full list of our own modules which we want to receive error reports for
     private const array ALLOWED_MODULES = [
         'activity',
@@ -173,7 +181,22 @@ class SentryHelper
             'ignore_exceptions' => [InformationException::class],
 
             'environment' => Environment::getCurrentEnvironment(),
-            'release' => Version::VERSION,
+
+            /*
+             * `package@version` is the format Sentry documents for release identifiers it can parse as
+             * semver - a bare version string like "0.8.6" isn't recognized, which silently degrades
+             * regression detection (e.g. "resolved in next release") to comparing release *creation
+             * dates* instead of version order. That's unreliable for us specifically: old releases only
+             * get a dateCreated once some install still running them sends its first event under the
+             * current Sentry project, which can happen years after the version actually shipped.
+             *
+             * We can't rewrite what already-shipped releases reported, so every release before this
+             * comment was added keeps using its bare version string; only newly-cut releases pick up
+             * the semver-parseable format. `self::SENTRY_RELEASE_PACKAGE` deliberately isn't
+             * composer.json's "fossbilling/fossbilling" package name - Sentry release identifiers can't
+             * contain a "/".
+             */
+            'release' => self::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION,
 
             // This option is disabled by default, but we set it to false here to be explicit & ensure it can never change unexpectedly.
             'send_default_pii' => false,

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -30,10 +30,9 @@ class SentryHelper
     final public const string last_change = '0.6.0';
 
     /**
-     * The "package" identifier used as the `package@version` prefix on the release string we
-     * report to Sentry - see the `'release'` option in registerSentry() for why this exists.
-     * If this ever changes, release-sentry.yml's `version:` input must be updated to match, or
-     * events and the Sentry release Sentry-side will silently stop lining up.
+     * `package@version` is required for Sentry to parse a release as semver - not composer.json's
+     * "fossbilling/fossbilling" package name, since Sentry release identifiers can't contain "/".
+     * Keep release-sentry.yml's `version:` input in sync with this.
      */
     private const string SENTRY_RELEASE_PACKAGE = 'fossbilling';
 
@@ -182,20 +181,7 @@ class SentryHelper
 
             'environment' => Environment::getCurrentEnvironment(),
 
-            /*
-             * `package@version` is the format Sentry documents for release identifiers it can parse as
-             * semver - a bare version string like "0.8.6" isn't recognized, which silently degrades
-             * regression detection (e.g. "resolved in next release") to comparing release *creation
-             * dates* instead of version order. That's unreliable for us specifically: old releases only
-             * get a dateCreated once some install still running them sends its first event under the
-             * current Sentry project, which can happen years after the version actually shipped.
-             *
-             * We can't rewrite what already-shipped releases reported, so every release before this
-             * comment was added keeps using its bare version string; only newly-cut releases pick up
-             * the semver-parseable format. `self::SENTRY_RELEASE_PACKAGE` deliberately isn't
-             * composer.json's "fossbilling/fossbilling" package name - Sentry release identifiers can't
-             * contain a "/".
-             */
+            // Only affects releases from here on - see SENTRY_RELEASE_PACKAGE.
             'release' => self::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION,
 
             // This option is disabled by default, but we set it to false here to be explicit & ensure it can never change unexpectedly.


### PR DESCRIPTION
## What

Adds a dedicated `release-sentry.yml` workflow, triggered on the GitHub **`release: published`** event, that creates/finalizes the matching Sentry release and associates the commit range since the previous release (`set_commits: auto`).

It also switches the release identifier we report to Sentry to the `package@version` format (`fossbilling@0.8.7`, `SentryHelper::SENTRY_RELEASE_PACKAGE`), instead of a bare version string. Sentry only parses `package@version` as semver; a bare `"0.8.6"` isn't recognized, which silently degrades regression detection (e.g. "resolved in next release") to comparing release *creation dates* instead of version order - unreliable for us specifically, since an old release's creation date is whenever some install still running it happens to send its first event under the current Sentry project, which can be years after the version actually shipped. This only affects releases made from here forward; already-shipped versions keep reporting their bare version string, and there's no way to retroactively fix that.