### PR TITLE
Pin 1Password CLI version in auto-cs-fix.yml

### DIFF
--- a/.github/workflows/auto-cs-fix.yml
+++ b/.github/workflows/auto-cs-fix.yml
@@ -44,6 +44,7 @@ jobs:
         uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           export-env: true
+          version: '2.39.0'
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           # FOSSBilling Bot (GitHub CI/CD) credentials stored in 1Password.


### PR DESCRIPTION
## Summary

The `Load Secrets for FOSSBilling Bot` step in `auto-cs-fix.yml` omitted `with.version` for `1password/load-secrets-action`, so it installs the "latest" 1Password CLI on every scheduled run instead of a pinned, tested version.

## Changes

- Add `version: '2.39.0'` under the `with:` block, alongside the existing `export-env: true`.