### PR TITLE
Backport CI/release tooling: Sentry release reporting + auto-cs-fix.yml auth fix

### DIFF
--- a/.github/workflows/auto-cs-fix.yml
+++ b/.github/workflows/auto-cs-fix.yml
@@ -61,6 +61,16 @@ jobs:
         id: php_cs_fixer
         run: php src/vendor/bin/php-cs-fixer fix
 
+      - name: 'Load Secrets for FOSSBilling Bot'
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
+        with:
+          export-env: true
+          version: '2.39.0'
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # FOSSBilling Bot (GitHub CI/CD) credentials stored in 1Password.
+          GH_TOKEN: op://mkqkefntgcmjlgyxzeaekzuuvq/yyxe5dc4jyw45h2pagqhl7576i/credential
+
       - name: Create Pull Request
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
@@ -70,7 +80,7 @@ jobs:
           branch: chore/cs-fix
           body: Automated run of PHP-CS-Fixer and Rector to ensure code styling, quality, and modern practices.
           delete-branch: true
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
           committer: FOSSBilling Bot <fossbilling-bot>
           author: FOSSBilling Bot <fossbilling-bot>
           labels: skip-changelog

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -1,0 +1,49 @@
+name: Report Release to Sentry
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  report-release:
+    name: 'Report Release to Sentry'
+    permissions:
+      contents: read
+    # getsentry/action-release runs as a docker:// container action on Linux, which ubuntu-slim
+    # can't support (unprivileged, no Docker daemon).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          persist-credentials: false
+
+      - name: 'Load Sentry Auth Token'
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
+        with:
+          export-env: true
+          version: '2.39.0'
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Sentry (GitHub CI/CD) credentials stored in 1Password.
+          SENTRY_AUTH_TOKEN: op://mkqkefntgcmjlgyxzeaekzuuvq/hw6jxytb2lqqjl5zzu4jjqztke/credential
+
+      - name: 'Report Release to Sentry'
+        id: sentry-release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_ORG: fossbilling
+          SENTRY_PROJECT: fossbilling
+        with:
+          # Must match SentryHelper::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION exactly.
+          release: fossbilling@${{ github.ref_name }}
+          set_commits: auto
+          finalize: true

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -29,6 +29,13 @@ class SentryHelper
      */
     final public const string last_change = '0.6.0';
 
+    /**
+     * `package@version` is required for Sentry to parse a release as semver - not composer.json's
+     * "fossbilling/fossbilling" package name, since Sentry release identifiers can't contain "/".
+     * Keep release-sentry.yml's `version:` input in sync with this.
+     */
+    private const string SENTRY_RELEASE_PACKAGE = 'fossbilling';
+
     // A full list of our own modules which we want to receive error reports for
     private const array ALLOWED_MODULES = [
         'activity',
@@ -173,7 +180,9 @@ class SentryHelper
             'ignore_exceptions' => [InformationException::class],
 
             'environment' => Environment::getCurrentEnvironment(),
-            'release' => Version::VERSION,
+
+            // Only affects releases from here on - see SENTRY_RELEASE_PACKAGE.
+            'release' => self::SENTRY_RELEASE_PACKAGE . '@' . Version::VERSION,
 
             // This option is disabled by default, but we set it to false here to be explicit & ensure it can never change unexpectedly.
             'send_default_pii' => false,

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -32,7 +32,7 @@ class SentryHelper
     /**
      * `package@version` is required for Sentry to parse a release as semver - not composer.json's
      * "fossbilling/fossbilling" package name, since Sentry release identifiers can't contain "/".
-     * Keep release-sentry.yml's `version:` input in sync with this.
+     * Keep release-sentry.yml's `release:` input in sync with this.
      */
     private const string SENTRY_RELEASE_PACKAGE = 'fossbilling';
 


### PR DESCRIPTION
Backports two CI/tooling-only changes from `main` found while confirming `0.8-next` is current post-#4244/#4245.