### PR TITLE
Strip filesystem paths from Sentry stack trace filenames

### DIFF
--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -27,7 +27,7 @@ class SentryHelper
      * If you modify what's reported, update this to the version number to the release that includes your changes.
      * This is important as we rely on it to inform the user that they may want to review what's been changed.
      */
-    final public const string last_change = '0.6.0';
+    final public const string last_change = '0.8.7';
 
     /**
      * `package@version` is required for Sentry to parse a release as semver - not composer.json's
@@ -191,7 +191,8 @@ class SentryHelper
             'attach_stacktrace' => true,
 
             // Strips the install's own filesystem path from stack trace filenames - otherwise leaks per-install hosting details (usernames, domains) to Sentry.
-            'prefixes' => [PATH_ROOT],
+            // PATH_ROOT goes first so it always wins; the include_path entries are the SDK's own default and are kept as a fallback for paths reached via a symlinked docroot.
+            'prefixes' => [PATH_ROOT, ...array_filter(explode(PATH_SEPARATOR, get_include_path() ?: ''))],
         ];
 
         /*

--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -189,6 +189,9 @@ class SentryHelper
 
             // Stack traces aren't that much data to send and are valuable for us, so let's always send them.
             'attach_stacktrace' => true,
+
+            // Strips the install's own filesystem path from stack trace filenames - otherwise leaks per-install hosting details (usernames, domains) to Sentry.
+            'prefixes' => [PATH_ROOT],
         ];
 
         /*


### PR DESCRIPTION
## Why

Self-hosted FOSSBilling installs run from arbitrary absolute paths (`/home/customer123/sites/billing.example.com/`, `/home/zenicore/public_html/billing/`, etc.), and `SentryHelper` never set the Sentry PHP SDK's `prefixes` option. Without it, `prefixes` silently defaults to whatever that host's PHP `include_path` ini happens to contain (`Options::createOptionsResolver` — `array_filter(explode(PATH_SEPARATOR, get_include_path() ?: ''))`), so whether stack trace filenames looked relative or leaked the full absolute path (hosting username, domain, directory layout) to Sentry was pure accident of each server's config, not anything we controlled.

## Fix

Set `PATH_ROOT` (defined in `load.php`, the install's own root — this file already derives `PATH_MODS`/`PATH_THEMES`/`PATH_LIBRARY` from it for tagging) as the first `prefixes` entry, ahead of the SDK's own `include_path`-derived defaults, which are kept as a fallback. `PATH_ROOT` deterministically covers essentially every app-authored frame (`PATH_VENDOR` etc. are all defined relative to it), and keeping the `include_path` defaults alongside it protects the edge case of a symlinked/aliased docroot where `PATH_ROOT`'s resolved path might not exactly match what appears in the raw backtrace.

## Known remaining gaps (out of scope here)

- `frame.absPath` always carries the raw, unstripped path regardless of `prefixes` (a separate SDK field, confirmed in `FrameBuilder`/`Frame`) — `prefixes` only affects the display `filename`.
- Native PHP error messages that embed the file path in their own text (e.g. a `TypeError`'s "...called in /home/x/site/modules/Cart/Service.php on line 937") aren't touched by `prefixes` either — only stack frame filenames and closure names. Scrubbing that would need a regex pass in the existing `before_send` closure.

Verified empirically that this isn't papering over a grouping problem: Sentry already groups events with differing absolute paths from multiple real installs into a single issue today (checked via the `server_name` tag breakdown on a live multi-install issue), so this is purely a privacy/hygiene fix, not a fingerprinting fix.

Also bumped `SentryHelper::last_change` to `0.8.7` per this class's own documented contract — it tracks the last release that changed what's reported, used to nudge admins to review Sentry settings, and hadn't been bumped since the feature's original 2023 PR despite several since-then changes to reported data.

## Testing

- `php -l`
- `composer cs:fix -- --dry-run` (clean)
- `composer phpstan` (no errors)
- `composer test` (3049 passed, 2 pre-existing PostgreSQL-only skips, unrelated)