### PR TITLE
Fix stale comment referencing release-sentry.yml's old version: input

### DIFF
--- a/src/library/FOSSBilling/SentryHelper.php
+++ b/src/library/FOSSBilling/SentryHelper.php
@@ -32,7 +32,7 @@ class SentryHelper
     /**
      * `package@version` is required for Sentry to parse a release as semver - not composer.json's
      * "fossbilling/fossbilling" package name, since Sentry release identifiers can't contain "/".
-     * Keep release-sentry.yml's `version:` input in sync with this.
+     * Keep release-sentry.yml's `release:` input in sync with this.
      */
     private const string SENTRY_RELEASE_PACKAGE = 'fossbilling';
 


### PR DESCRIPTION
Doc-comment-only fix, found while backporting #4249 to `0.8-next` (#4251).