### PR TITLE
Fix two unhandled-exception leads from Sentry triage

### DIFF
--- a/src/library/FOSSBilling/Http/ApiResponseFactory.php
+++ b/src/library/FOSSBilling/Http/ApiResponseFactory.php
@@ -28,7 +28,7 @@ final readonly class ApiResponseFactory
             return $this->error($exception);
         }
 
-        return new JsonResponse(['result' => $data, 'error' => null], Response::HTTP_OK, self::NO_CACHE_HEADERS);
+        return $this->jsonResponse(['result' => $data, 'error' => null], Response::HTTP_OK, self::NO_CACHE_HEADERS);
     }
 
     public function error(\Exception $exception): JsonResponse
@@ -40,11 +40,30 @@ final readonly class ApiResponseFactory
             $headers['Retry-After'] = (string) $exception->getRetryAfterSeconds();
         }
 
-        return new JsonResponse(
+        return $this->jsonResponse(
             ['result' => null, 'error' => ['message' => $exception->getMessage(), 'code' => $code]],
             $this->getStatusCode($code),
             $headers,
         );
+    }
+
+    /**
+     * Data can carry invalid UTF-8 (user input, a stored third-party API response, etc.), which json_encode()
+     * otherwise rejects outright. Substitute it rather than losing the whole response to that.
+     */
+    private function jsonResponse(array $payload, int $status, array $headers): JsonResponse
+    {
+        $json = json_encode($payload, JsonResponse::DEFAULT_ENCODING_OPTIONS);
+
+        if ($json === false && json_last_error() === JSON_ERROR_UTF8) {
+            $json = json_encode($payload, JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_INVALID_UTF8_SUBSTITUTE);
+        }
+
+        if ($json === false) {
+            throw new \InvalidArgumentException(json_last_error_msg());
+        }
+
+        return JsonResponse::fromJsonString($json, $status, $headers);
     }
 
     private function getStatusCode(int|string $code): int

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -656,7 +656,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
 
         try {
             $json = $result->toArray(false);
-        } catch (DecodingExceptionInterface $error) {
+        } catch (DecodingExceptionInterface) {
             // A 2xx response with a non-JSON body (e.g. an HTML error/rate-limit/WAF page) - see #4220 for the same class of issue.
             // Symfony's exception message embeds the full request URL, which for a GET request includes
             // auth-userid/api-key in the query string - never log or surface that, log a fixed message instead.

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  * HTTP API documentation http://cp.onlyfordemo.net/kb/answer/744
  */
 
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
@@ -653,7 +654,15 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             return $trimmedContent;
         }
 
-        $json = $result->toArray(false);
+        try {
+            $json = $result->toArray(false);
+        } catch (DecodingExceptionInterface $error) {
+            // A 2xx response with a non-JSON body (e.g. an HTML error/rate-limit/WAF page) - see #4220 for the same class of issue.
+            $e = new Registrar_Exception("HttpClientException: {$error->getMessage()}.");
+            $this->getLog()->error($e->getMessage());
+
+            throw $e;
+        }
 
         if (isset($json['status']) && $json['status'] == 'ERROR') {
             $this->getLog()->error('ResellerClub error: ' . $json['message']);

--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -658,10 +658,12 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             $json = $result->toArray(false);
         } catch (DecodingExceptionInterface $error) {
             // A 2xx response with a non-JSON body (e.g. an HTML error/rate-limit/WAF page) - see #4220 for the same class of issue.
-            $e = new Registrar_Exception("HttpClientException: {$error->getMessage()}.");
-            $this->getLog()->error($e->getMessage());
+            // Symfony's exception message embeds the full request URL, which for a GET request includes
+            // auth-userid/api-key in the query string - never log or surface that, log a fixed message instead.
+            $this->getLog()->error("ResellerClub API response for {$url} could not be decoded as JSON.");
+            $placeholders = [':action:' => $url, ':type:' => 'ResellerClub'];
 
-            throw $e;
+            throw new Registrar_Exception('Failed to :action: with the :type: registrar, check the error logs for further details', $placeholders);
         }
 
         if (isset($json['status']) && $json['status'] == 'ERROR') {

--- a/tests/Unit/FOSSBilling/ApiResponseFactoryTest.php
+++ b/tests/Unit/FOSSBilling/ApiResponseFactoryTest.php
@@ -84,3 +84,14 @@ test('API response factory maps numeric string exception codes like their intege
 
     expect($response->getStatusCode())->toBe(Response::HTTP_FORBIDDEN);
 });
+
+test('API response factory substitutes invalid UTF-8 instead of failing to encode the response', function (): void {
+    // An invalid two-byte UTF-8 sequence, e.g. from a mis-encoded form field or a third-party API response.
+    $response = (new ApiResponseFactory())->create(['name' => "Caf\xE9"]);
+
+    expect($response->getStatusCode())->toBe(Response::HTTP_OK);
+
+    $decoded = json_decode((string) $response->getContent(), true);
+    expect($decoded['error'])->toBeNull()
+        ->and($decoded['result']['name'])->toContain('Caf');
+});

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -85,6 +85,36 @@ test('a non-JSON response (e.g. an HTML error/rate-limit page) throws a Registra
         ->toThrow(Registrar_Exception::class);
 });
 
+test('a non-JSON response never logs the request URL, since it carries auth-userid and api-key in the query string', function (): void {
+    // CodeRabbit finding on #4254: Symfony's DecodingExceptionInterface message embeds the full
+    // request URL, which for a GET request (as used here) includes ResellerClub credentials in the
+    // query string - the error handler must log a fixed message instead of the raw exception message.
+    // Scoped to error-level messages: the pre-existing debug-level "API REQUEST" log already includes
+    // the full URL for every call, which is a separate, pre-existing issue outside this fix's scope.
+    $logger = new class extends Psr\Log\AbstractLogger {
+        /** @var list<string> */
+        public array $errorMessages = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            if ($level === Psr\Log\LogLevel::ERROR) {
+                $this->errorMessages[] = (string) $message;
+            }
+        }
+    };
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('<html>Rate limit exceeded</html>'));
+    $adapter = createResellerclubAdapter($httpClient);
+    $adapter->setLog($logger);
+
+    expect(fn (): bool => $adapter->isDomaincanBeTransferred(createResellerclubDomain()))
+        ->toThrow(Registrar_Exception::class);
+
+    $logged = implode("\n", $logger->errorMessages);
+    expect($logged)->not->toContain('secret') // the api-key configured in createResellerclubAdapter()
+        ->and($logged)->not->toContain('auth-userid')
+        ->and($logged)->not->toContain('api-key');
+});
+
 test('an error-object response still throws a Registrar_Exception', function (): void {
     $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse(json_encode([
         'status' => 'ERROR',

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -64,12 +64,25 @@ test('a bare numeric response (e.g. domains/orderid) is still returned as-is', f
 test('a bare "null" response is not silently treated as a scalar', function (): void {
     // Regression guard for the scalar short-circuit above: json_decode('null') also returns
     // null with no decode error, but null isn't a usable scalar result (e.g. getDomainDetails()
-    // would go on to index it like an array), so it must fall through to toArray() instead.
+    // would go on to index it like an array), so it must fall through to toArray() instead,
+    // which now surfaces as a clean Registrar_Exception rather than a leaked Symfony one.
     $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('null'));
     $adapter = createResellerclubAdapter($httpClient);
 
     expect(fn (): bool => $adapter->isDomaincanBeTransferred(createResellerclubDomain()))
-        ->toThrow(Symfony\Component\HttpClient\Exception\JsonException::class);
+        ->toThrow(Registrar_Exception::class);
+});
+
+test('a non-JSON response (e.g. an HTML error/rate-limit page) throws a Registrar_Exception instead of leaking a JsonException', function (): void {
+    // Regression test for FOSSBILLING-N7M: a 2xx response whose body isn't valid JSON at all (an
+    // HTML error page, a WAF block page, a truncated response) made toArray() throw Symfony's raw
+    // JsonException uncaught - only the 4xx/5xx and bare-scalar cases were handled. See #4220 for
+    // the same class of issue fixed elsewhere (PSL download).
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('<html>Rate limit exceeded</html>'));
+    $adapter = createResellerclubAdapter($httpClient);
+
+    expect(fn (): bool => $adapter->isDomaincanBeTransferred(createResellerclubDomain()))
+        ->toThrow(Registrar_Exception::class);
 });
 
 test('an error-object response still throws a Registrar_Exception', function (): void {


### PR DESCRIPTION
## FOSSBILLING-NVR — malformed UTF-8 crashes API responses

`ApiResponseFactory::create()`/`error()` built `JsonResponse` directly, and `json_encode()` rejects invalid UTF-8 outright with no fallback anywhere upstream. That data can come from ordinary user input (a mis-encoded form field) or a stored third-party API response, not just malicious input. It's caught generically in `Api\Controller\Client::tryCall()` and reported to Sentry, so it doesn't crash the whole request - but the caller silently gets an opaque error instead of their actual API response.

Fixed by substituting invalid UTF-8 (`JSON_INVALID_UTF8_SUBSTITUTE`) only for the specific `JSON_ERROR_UTF8` case, going through `JsonResponse::fromJsonString()` instead of the constructor so the encoding can be retried before the exception reaches the caller. Any other `json_encode()` failure still throws exactly as before.

## FOSSBILLING-N7M — non-JSON ResellerClub response leaks a raw JsonException

`Registrar_Adapter_Resellerclub::_makeRequest()` only guarded the 4xx/5xx transport-exception path and a narrower bare-scalar case (#4194). A 2xx response with a non-JSON body (an HTML error/rate-limit/WAF page) still crashed `$result->toArray(false)` uncaught - the exact same class of issue as the PSL-download crash fixed in #4220, just never applied to this adapter.

Fixed by wrapping that call in a `DecodingExceptionInterface` catch and raising the adapter's normal `Registrar_Exception`, matching the existing `HttpExceptionInterface` catch immediately above it.

This also changes the existing "bare null response" test: `toArray()` throws the exact same `JsonException` for that case (valid JSON, but not array-shaped), so it's now caught by the same guard too - which is arguably the right fix for that path as well, since `_makeRequest()`'s own docblock only ever documented `@throws Registrar_Exception`.