### PR TITLE
Remove inert --acl public-read from R2 uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,6 @@ jobs:
           aws s3 sync "${SOURCE_DIR}" "s3://${AWS_S3_BUCKET}/" \
             --endpoint-url "${AWS_S3_ENDPOINT}" \
             --metadata="digest=${{ env.FOSSBILLING_PREVIEW_DIGEST }},commit-sha=${{ github.sha }}" \
-            --acl public-read \
             --follow-symlinks \
             --no-progress
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -228,7 +228,6 @@ jobs:
           aws s3 cp "${asset}" "s3://${AWS_S3_BUCKET}/${key}" \
             --endpoint-url "${AWS_S3_ENDPOINT}" \
             --metadata="digest=${FOSSBILLING_RELEASE_DIGEST},version=${RELEASE_VERSION}" \
-            --acl public-read \
             --no-progress
 
           echo "url=https://download.fossbilling.org/${key}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Both R2 upload steps pass `--acl public-read` to `aws s3`. R2 doesn't implement S3 object-level ACLs - public access to objects in the `fossbilling-download` bucket is granted entirely at the bucket level via its `download.fossbilling.org` custom-domain binding, independent of any per-object ACL. Confirmed against Cloudflare's own R2 docs (object ACLs aren't part of R2's implemented S3 API surface) and empirically: objects uploaded with the flag are exactly as publicly fetchable as they'd be without it, because R2 silently accepts the flag but it has no effect.