### PR TITLE
Redact ResellerClub credentials from the per-request debug log

### DIFF
--- a/src/library/Registrar/Adapter/Resellerclub.php
+++ b/src/library/Registrar/Adapter/Resellerclub.php
@@ -626,7 +626,7 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
                 ]);
             } else {
                 $result = $client->request('GET', $callUrl . '?' . $this->_formatParams($params));
-                $this->getLog()->debug('API REQUEST: ' . $callUrl . '?' . $this->_formatParams($params));
+                $this->getLog()->debug('API REQUEST: ' . $callUrl . '?' . $this->_formatParams($this->_redactAuthParams($params)));
             }
             $this->getLog()->info('API RESULT: ' . $result->getContent(false));
         } catch (HttpExceptionInterface $error) {
@@ -677,6 +677,23 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
         }
 
         return $json;
+    }
+
+    /**
+     * Redact auth-userid/api-key from params before they're logged. includeAuthorizationParams()
+     * adds these to every request, so the debug-level "API REQUEST" log would otherwise leak
+     * ResellerClub credentials on every single call - see the credential leak fixed in #4254 for
+     * the same category of issue on the error path.
+     */
+    private function _redactAuthParams(array $params): array
+    {
+        foreach (['auth-userid', 'api-key'] as $key) {
+            if (isset($params[$key])) {
+                $params[$key] = '***REDACTED***';
+            }
+        }
+
+        return $params;
     }
 
     /**

--- a/tests/Unit/Registrar/Adapter/ResellerclubTest.php
+++ b/tests/Unit/Registrar/Adapter/ResellerclubTest.php
@@ -83,6 +83,36 @@ test('an error-object response still throws a Registrar_Exception', function ():
         ->toThrow(Registrar_Exception::class);
 });
 
+test('a GET request never logs its auth-userid/api-key in the debug-level "API REQUEST" log', function (): void {
+    // includeAuthorizationParams() appends auth-userid/api-key to every request, and GET requests
+    // put them straight into the query string. _makeRequest() logs that query string at debug
+    // level on every single call (unlike the narrower error-path leak fixed for #4254, which only
+    // covered the JSON-decoding-failure log line), so the debug log must redact both params too.
+    $logger = new class extends Psr\Log\AbstractLogger {
+        /** @var list<string> */
+        public array $debugMessages = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            if ($level === Psr\Log\LogLevel::DEBUG) {
+                $this->debugMessages[] = (string) $message;
+            }
+        }
+    };
+    $httpClient = new MockHttpClient(fn (): MockResponse => new MockResponse('true'));
+    $adapter = createResellerclubAdapter($httpClient);
+    $adapter->setLog($logger);
+
+    $adapter->isDomaincanBeTransferred(createResellerclubDomain());
+
+    $logged = implode("\n", $logger->debugMessages);
+    expect($logger->debugMessages)->not->toBeEmpty()
+        ->and($logged)->toContain('API REQUEST')
+        ->and($logged)->not->toContain('secret') // the api-key configured in createResellerclubAdapter()
+        ->and($logged)->not->toContain('auth-userid=12345')
+        ->and($logged)->toContain('api-key=');
+});
+
 function createResellerclubTestContact(): Registrar_Domain_Contact
 {
     return (new Registrar_Domain_Contact())


### PR DESCRIPTION
## What changed

`_makeRequest()` in the ResellerClub registrar adapter logged the full GET request URL — including the `auth-userid`/`api-key` query params added by `includeAuthorizationParams()` — at debug level on **every single API call**, not just on error. This is a wider leak than the one fixed in #4254, which only addressed the narrower JSON-decoding-failure log line on the error path.

## Fix

- Added a private `_redactAuthParams()` helper that returns a redacted copy of `$params` (replacing `auth-userid` and `api-key` values) for logging purposes only — the actual outgoing request still uses the real, unredacted params.
- Applied it to the debug-level `API REQUEST` log line. There was no separate POST-path debug log to fix; the shared `info()` call after the request only logs the response body.
- Added a regression test in `ResellerclubTest.php` following the same logger-spy pattern used for the #4254 fix, asserting the debug log never contains the configured api-key or the raw auth-userid value.