### PR TITLE
Fall back to shipped theme settings template when settings_data.json is missing

### DIFF
--- a/src/modules/Theme/Model/Theme.php
+++ b/src/modules/Theme/Model/Theme.php
@@ -116,7 +116,12 @@ class Theme
     {
         $cp = $this->getPathSettingsDataFile();
         if (!self::getFilesystem()->exists($cp)) {
-            return [];
+            // Fall back to the shipped template (see install.php) rather than an empty array,
+            // which every template rendering `settings.*` would otherwise crash on.
+            $cp .= '.example';
+            if (!self::getFilesystem()->exists($cp)) {
+                return [];
+            }
         }
 
         $json = self::getFilesystem()->readFile($cp);

--- a/src/modules/Theme/tests/Unit/Model/ThemeTest.php
+++ b/src/modules/Theme/tests/Unit/Model/ThemeTest.php
@@ -66,6 +66,21 @@ test('get preset from settings data file', function () use ($existingTheme): voi
     expect($result)->toBeArray();
 });
 
+test('preset settings fall back to the shipped .example template when settings_data.json is missing', function () use ($existingTheme): void {
+    // This dev checkout has no real settings_data.json, only the tracked .example, so this
+    // exercises the fallback directly against the actual shipped file.
+    $theme = new Box\Mod\Theme\Model\Theme($existingTheme);
+
+    expect(file_exists(Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json')))->toBeFalse();
+
+    $presets = $theme->getPresetsFromSettingsDataFile();
+    expect($presets)->not->toBeEmpty()
+        ->and($presets)->toHaveKey('Default');
+
+    $default = $theme->getPresetFromSettingsDataFile('Default');
+    expect($default)->toHaveKey('side_menu_dashboard');
+});
+
 test('get url', function () use ($existingTheme): void {
     $theme = new Box\Mod\Theme\Model\Theme($existingTheme);
     $result = $theme->getUrl();

--- a/src/modules/Theme/tests/Unit/Model/ThemeTest.php
+++ b/src/modules/Theme/tests/Unit/Model/ThemeTest.php
@@ -71,7 +71,8 @@ test('preset settings fall back to the shipped .example template when settings_d
     // exercises the fallback directly against the actual shipped file.
     $theme = new Box\Mod\Theme\Model\Theme($existingTheme);
 
-    expect(file_exists(Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json')))->toBeFalse();
+    $filesystem = new Symfony\Component\Filesystem\Filesystem();
+    expect($filesystem->exists(Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json')))->toBeFalse();
 
     $presets = $theme->getPresetsFromSettingsDataFile();
     expect($presets)->not->toBeEmpty()

--- a/src/themes/huraga/html/layout_default.html.twig
+++ b/src/themes/huraga/html/layout_default.html.twig
@@ -7,10 +7,10 @@
     <meta charset="utf-8">
     <title>{{ (settings.meta_title_prefix|default('') ~ ' ' ~ block('meta_title') ~ ' ' ~ settings.meta_title_suffix|default(''))|trim }}</title>
 
-    <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
-    <meta name="keywords" content="{{ settings.meta_keywords }}">
-    <meta name="robots" content="{{ settings.meta_robots }}">
-    <meta name="author" content="{{ settings.meta_author }}">
+    <meta name="description" content="{% block meta_description %}{{ settings.meta_description|default('') }}{% endblock %}">
+    <meta name="keywords" content="{{ settings.meta_keywords|default('') }}">
+    <meta name="robots" content="{{ settings.meta_robots|default('') }}">
+    <meta name="author" content="{{ settings.meta_author|default('') }}">
     <meta name="generator" content="FOSSBilling">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark">

--- a/src/themes/huraga/html/layout_public.html.twig
+++ b/src/themes/huraga/html/layout_public.html.twig
@@ -4,18 +4,18 @@
 {% set company = guest.system_company %}
 {% set public_logo_url = company.logo_url %}
 {% set public_dark_logo_url = company.logo_url_dark %}
-{% set page_title = (settings.meta_title_prefix ~ ' ' ~ block('meta_title') ~ ' ' ~ settings.meta_title_suffix)|trim %}
-{% set meta_description = block('meta_description')|default(settings.meta_description) %}
+{% set page_title = (settings.meta_title_prefix|default('') ~ ' ' ~ block('meta_title') ~ ' ' ~ settings.meta_title_suffix|default(''))|trim %}
+{% set meta_description = block('meta_description')|default(settings.meta_description|default('')) %}
 <html lang="{{ active_locale }}" data-bs-theme="{{ settings.theme|default('light') }}">
 <head>
     <meta charset="utf-8">
     <title>{{ page_title }}</title>
     <meta name="color-scheme" content="light dark">
 
-    <meta name="description" content="{% block meta_description %}{{ settings.meta_description }}{% endblock %}">
-    <meta name="keywords" content="{{ settings.meta_keywords }}">
-    <meta name="robots" content="{{ settings.meta_robots }}">
-    <meta name="author" content="{{ settings.meta_author }}">
+    <meta name="description" content="{% block meta_description %}{{ settings.meta_description|default('') }}{% endblock %}">
+    <meta name="keywords" content="{{ settings.meta_keywords|default('') }}">
+    <meta name="robots" content="{{ settings.meta_robots|default('') }}">
+    <meta name="author" content="{{ settings.meta_author|default('') }}">
     <meta name="generator" content="FOSSBilling">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
`Theme::getSettingsData()` now falls back to reading the `.example` template when the real file doesn't exist, mirroring `install.php`'s own bootstrap logic. This closes the gap at the single point every `settings.*` access funnels through, rather than requiring `|default()` scattered across dozens of `{% if %}` checks in `mobile_menu.html.twig`, `partial_menu.html.twig`, and `layout_default.html.twig`'s own menu toggles.

Also added `|default('')` to the `meta_description`/`meta_keywords`/`meta_robots`/`meta_author` and `meta_title_prefix`/`meta_title_suffix` accesses in both layout templates, for defense in depth against a `settings_data.json` that exists but is simply missing one of these specific keys (a different, non-empty-array Twig error path).