### PR TITLE
Stop assuming settings_data.json is absent in the theme settings fallback test

### DIFF
--- a/src/modules/Theme/tests/Unit/Model/ThemeTest.php
+++ b/src/modules/Theme/tests/Unit/Model/ThemeTest.php
@@ -67,19 +67,31 @@ test('get preset from settings data file', function () use ($existingTheme): voi
 });
 
 test('preset settings fall back to the shipped .example template when settings_data.json is missing', function () use ($existingTheme): void {
-    // This dev checkout has no real settings_data.json, only the tracked .example, so this
-    // exercises the fallback directly against the actual shipped file.
+    // A dev checkout can have a real settings_data.json (e.g. from previously saving theme
+    // settings locally), so move it out of the way for the duration of this test rather than
+    // assuming it's absent.
     $theme = new Box\Mod\Theme\Model\Theme($existingTheme);
-
     $filesystem = new Symfony\Component\Filesystem\Filesystem();
-    expect($filesystem->exists(Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json')))->toBeFalse();
+    $realFile = Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json');
+    $backupFile = $realFile . '.bak';
+    $hadRealFile = $filesystem->exists($realFile);
 
-    $presets = $theme->getPresetsFromSettingsDataFile();
-    expect($presets)->not->toBeEmpty()
-        ->and($presets)->toHaveKey('Default');
+    if ($hadRealFile) {
+        $filesystem->rename($realFile, $backupFile);
+    }
 
-    $default = $theme->getPresetFromSettingsDataFile('Default');
-    expect($default)->toHaveKey('side_menu_dashboard');
+    try {
+        $presets = $theme->getPresetsFromSettingsDataFile();
+        expect($presets)->not->toBeEmpty()
+            ->and($presets)->toHaveKey('Default');
+
+        $default = $theme->getPresetFromSettingsDataFile('Default');
+        expect($default)->toHaveKey('side_menu_dashboard');
+    } finally {
+        if ($hadRealFile) {
+            $filesystem->rename($backupFile, $realFile);
+        }
+    }
 });
 
 test('get url', function () use ($existingTheme): void {

--- a/src/modules/Theme/tests/Unit/Model/ThemeTest.php
+++ b/src/modules/Theme/tests/Unit/Model/ThemeTest.php
@@ -73,7 +73,7 @@ test('preset settings fall back to the shipped .example template when settings_d
     $theme = new Box\Mod\Theme\Model\Theme($existingTheme);
     $filesystem = new Symfony\Component\Filesystem\Filesystem();
     $realFile = Symfony\Component\Filesystem\Path::join($theme->getPathConfig(), 'settings_data.json');
-    $backupFile = $realFile . '.bak';
+    $backupFile = $realFile . '.bak-' . bin2hex(random_bytes(4));
     $hadRealFile = $filesystem->exists($realFile);
 
     if ($hadRealFile) {


### PR DESCRIPTION
Found while re-running the local suite in a dev checkout with a real `settings_data.json` (from previously saving theme settings there locally). The regression test from #4258 asserted the file didn't exist rather than controlling for it, so it fails for any contributor in that situation - even though the fix under test is fine.

Move the real file out of the way for the duration of the test (if present) and restore it afterward in a `finally`, rather than assuming a particular ambient filesystem state.

Verified the restore path leaves the file byte-identical (checksum before/after) and doesn't leak on test failure (`finally`).