### PR TITLE
Fix CAPTCHA double-verification breaking client signup

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -170,6 +170,7 @@
         "selectbox",
         "sitekey",
         "sitekey",
+        "siteverify",
         "autodark",
         "noopener",
         "datepicker",

--- a/src/modules/Antispam/Service.php
+++ b/src/modules/Antispam/Service.php
@@ -60,6 +60,10 @@ class Service implements InjectionAwareInterface
 
     public static function onBeforeClientSignUp(\Box_Event $event): void
     {
+        // Client\Api\Guest::create() already verifies the CAPTCHA before firing
+        // this event, so isSpam() below must not check it again: CAPTCHA
+        // tokens are single-use, and a second siteverify call would fail and
+        // reject every genuine signup.
         $di = $event->getDi();
         $antispamService = $di['mod_service']('Antispam');
         $antispamService->isBlockedIp($event);
@@ -77,6 +81,7 @@ class Service implements InjectionAwareInterface
         $di = $event->getDi();
         $antispamService = $di['mod_service']('Antispam');
         $antispamService->isBlockedIp($event);
+        $antispamService->checkCaptcha($event->getParameters());
         $antispamService->isSpam($event);
         $antispamService->isTemp($event);
     }
@@ -140,8 +145,6 @@ class Service implements InjectionAwareInterface
         ];
 
         $config = $di['mod_config']('Antispam');
-
-        $this->checkCaptcha($params);
 
         if (isset($config['sfs']) && $config['sfs']) {
             $antispamService = $di['mod_service']('Antispam');

--- a/src/modules/Antispam/tests/Unit/ServiceTest.php
+++ b/src/modules/Antispam/tests/Unit/ServiceTest.php
@@ -49,6 +49,8 @@ test('on before client open ticket checks guest submissions', function (): void 
     $spamCheckerService = Mockery::mock(Box\Mod\Antispam\Service::class);
     $spamCheckerService->shouldReceive('isBlockedIp')
         ->atLeast()->once();
+    $spamCheckerService->shouldReceive('checkCaptcha')
+        ->atLeast()->once();
     $spamCheckerService->shouldReceive('isSpam')
         ->atLeast()->once();
     $spamCheckerService->shouldReceive('isTemp')
@@ -71,6 +73,7 @@ test('on before client open ticket skips client submissions', function (): void 
     $service = new Box\Mod\Antispam\Service();
     $spamCheckerService = Mockery::mock(Box\Mod\Antispam\Service::class);
     $spamCheckerService->shouldReceive('isBlockedIp')->never();
+    $spamCheckerService->shouldReceive('checkCaptcha')->never();
     $spamCheckerService->shouldReceive('isSpam')->never();
     $spamCheckerService->shouldReceive('isTemp')->never();
 
@@ -82,6 +85,27 @@ test('on before client open ticket skips client submissions', function (): void 
         ->andReturn(['author_role' => 'client', 'client_id' => 1]);
 
     $service->onBeforeClientOpenTicket($boxEventMock);
+});
+
+test('is spam does not re-verify the captcha during signup', function (): void {
+    // The signup API already verifies the CAPTCHA before this event fires;
+    // isSpam() re-checking it would fail every signup since CAPTCHA tokens
+    // are single-use.
+    $service = Mockery::mock(Box\Mod\Antispam\Service::class)->makePartial();
+    $service->shouldReceive('checkCaptcha')->never();
+
+    $di = container();
+    $di['mod_config'] = $di->protect(fn (): array => ['sfs' => false]);
+
+    $boxEventMock = Mockery::mock('\Box_Event');
+    $boxEventMock->shouldReceive('getDi')
+        ->atLeast()->once()
+        ->andReturn($di);
+    $boxEventMock->shouldReceive('getParameters')
+        ->atLeast()->once()
+        ->andReturn(['ip' => '1.2.3.4', 'email' => 'test@example.com']);
+
+    $service->isSpam($boxEventMock);
 });
 
 test('is blocked ip ip not blocked', function (): void {

--- a/src/modules/Antispam/tests/Unit/ServiceTest.php
+++ b/src/modules/Antispam/tests/Unit/ServiceTest.php
@@ -50,7 +50,7 @@ test('on before client open ticket checks guest submissions', function (): void 
     $spamCheckerService->shouldReceive('isBlockedIp')
         ->atLeast()->once();
     $spamCheckerService->shouldReceive('checkCaptcha')
-        ->atLeast()->once();
+        ->once();
     $spamCheckerService->shouldReceive('isSpam')
         ->atLeast()->once();
     $spamCheckerService->shouldReceive('isTemp')


### PR DESCRIPTION
## Summary

Fixes #4264.

`Client\Api\Guest::create()` explicitly verifies the CAPTCHA response (via `checkCaptchaIfEnabled()`, added in #4233) so the check also covers the enumeration-safe "email already exists" branch, which never fires the `onBeforeClientSignUp` event. But for a genuine new signup, `guestCreateClient()` still fires that event, and `Antispam\Service::isSpam()` verified the *same* CAPTCHA response a second time.

CAPTCHA response tokens (reCAPTCHA, Turnstile, hCaptcha) are single-use — a repeated `siteverify` call always returns `success: false` — so the second check failed for every genuine registration, rejecting it with a "CAPTCHA verification failed" error regardless of provider.

## Fix

- Moved the CAPTCHA check out of `isSpam()`, which is shared by both the signup and guest-ticket event flows.
- Called `checkCaptcha()` explicitly from `onBeforeClientOpenTicket()` instead, since ticket submission has no other CAPTCHA check in its path.
- Signup now verifies the CAPTCHA exactly once, at the API layer.