### PR TITLE
API always returns the 200 status code

### DIFF
--- a/src/library/FOSSBilling/Http/ApiResponseFactory.php
+++ b/src/library/FOSSBilling/Http/ApiResponseFactory.php
@@ -79,11 +79,9 @@ final readonly class ApiResponseFactory
 
         return match (true) {
             in_array($code, [201, 202, 203, 204, 205, 206, 1002, 1004], true) => Response::HTTP_UNAUTHORIZED,
-            $code === 403 => Response::HTTP_FORBIDDEN,
-            $code === 740 => Response::HTTP_NOT_FOUND,
-            $code === 429 => Response::HTTP_TOO_MANY_REQUESTS,
-            $code === 503 => Response::HTTP_SERVICE_UNAVAILABLE,
             in_array($code, [701, 879], true) => Response::HTTP_BAD_REQUEST,
+            $code === 740 => Response::HTTP_NOT_FOUND,
+            $code >= 400 && $code <= 599 => $code,
             default => Response::HTTP_OK,
         };
     }

--- a/tests/Unit/FOSSBilling/ApiResponseFactoryTest.php
+++ b/tests/Unit/FOSSBilling/ApiResponseFactoryTest.php
@@ -95,3 +95,23 @@ test('API response factory substitutes invalid UTF-8 instead of failing to encod
     expect($decoded['error'])->toBeNull()
         ->and($decoded['result']['name'])->toContain('Caf');
 });
+
+test('API response factory maps standard HTTP status codes and custom application codes', function (int $code, int $expectedStatus): void {
+    $response = (new ApiResponseFactory())->create(null, new FOSSBilling\Exception('Error occurred', null, $code));
+
+    expect($response->getStatusCode())->toBe($expectedStatus);
+})->with([
+    [400, Response::HTTP_BAD_REQUEST],
+    [401, Response::HTTP_UNAUTHORIZED],
+    [403, Response::HTTP_FORBIDDEN],
+    [404, Response::HTTP_NOT_FOUND],
+    [405, Response::HTTP_METHOD_NOT_ALLOWED],
+    [422, Response::HTTP_UNPROCESSABLE_ENTITY],
+    [429, Response::HTTP_TOO_MANY_REQUESTS],
+    [500, Response::HTTP_INTERNAL_SERVER_ERROR],
+    [503, Response::HTTP_SERVICE_UNAVAILABLE],
+    [701, Response::HTTP_BAD_REQUEST],
+    [740, Response::HTTP_NOT_FOUND],
+    [879, Response::HTTP_BAD_REQUEST],
+]);
+


### PR DESCRIPTION
Fixes #589

Updated ApiResponseFactory::getStatusCode to map standard HTTP error status codes (400-599) to their corresponding HTTP status codes while preserving mappings for internal application codes and legacy OK status for unmapped internal error codes.

**Testing:** Added unit test in ApiResponseFactoryTest covering standard HTTP status codes (400, 401, 403, 404, 405, 422, 429, 500, 503) and custom internal codes (701, 740, 879).