### PR TITLE
Fix broken Style Guides link in contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ The process described here has several goals:
 
 Please follow these steps to have your contribution considered by the maintainers:
 
-1. Follow the [style guides](#styleguides)
+1. Follow the [style guides](#style-guides)
 2. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 
 Before a PR can be merged it must pass all of the automated tests and also be reviewed by two maintainers. All of the above requirements must be met before your pull request will be reviewed. Please be aware that the reviewers may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.


### PR DESCRIPTION
## Summary
- fix the broken internal link to the contributor guide's Style Guides section
- keep the change limited to documentation

## Validation
- checked every internal Markdown fragment in `CONTRIBUTING.md`
- ran `git diff --check`


<!-- repo-agent-case:3e3e2365-b35a-4218-b184-ad1baf33fcb2 -->