### PR TITLE
Fix Server_Manager::getPasswordLength() TypeError on non-int config

### DIFF
--- a/src/library/Server/Manager.php
+++ b/src/library/Server/Manager.php
@@ -138,11 +138,16 @@ abstract class Server_Manager
      * Get the password length from the configuration.
      * If the password length is not set in the configuration, it defaults to 10.
      *
+     * The value is cast to int because `_config['passwordLength']` is untyped and
+     * has been observed containing a numeric string (e.g. from a stored server
+     * configuration predating strict int typing), which would otherwise violate
+     * this method's return type.
+     *
      * @return int the password length
      */
     public function getPasswordLength(): int
     {
-        return $this->_config['passwordLength'] ?? 10;
+        return (int) ($this->_config['passwordLength'] ?? 10);
     }
 
     /**

--- a/tests/Unit/Server/ManagerTest.php
+++ b/tests/Unit/Server/ManagerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+test('getPasswordLength returns the default when not configured', function (): void {
+    $manager = new Server_Manager_Custom([]);
+
+    expect($manager->getPasswordLength())->toBe(10);
+});
+
+test('getPasswordLength returns an int when configured with an int', function (): void {
+    $manager = new Server_Manager_Custom(['passwordLength' => 16]);
+
+    expect($manager->getPasswordLength())->toBe(16);
+});
+
+test('getPasswordLength coerces a numeric string to int', function (): void {
+    // Guards against FOSSBILLING-MZA: a numeric string stored in the server
+    // configuration must not violate the `int` return type.
+    $manager = new Server_Manager_Custom(['passwordLength' => '12']);
+
+    expect($manager->getPasswordLength())->toBe(12);
+});


### PR DESCRIPTION
## Summary

`Server_Manager::getPasswordLength()` declares an `int` return type but returned `$this->_config['passwordLength']` unmodified, which is an untyped array value. When a server's stored config carries a numeric string instead of an int, PHP throws a fatal `TypeError`.

Found via Sentry triage of issues since the 0.8.7 release (issue [FOSSBILLING-MZA](https://fossbilling.sentry.io/issues/FOSSBILLING-MZA)): ~7,800 occurrences since June 2026, still recurring today. It's not a fresh 0.8.7 regression, but it's a real, current, unfixed bug — the crash happens inside `Order::activateOrder()` during `invoice_batch_activate_paid`, and since `Cron\Service` doesn't catch it, it takes down the *entire* cron run, not just the one hosting order.

## Fix

Cast defensively at the return boundary:

```php
return (int) ($this->_config['passwordLength'] ?? 10);
```