### PR TITLE
Fix nginx security bugs in DDEV config

### DIFF
--- a/.ddev/nginx_full/fossbilling.dev.conf
+++ b/.ddev/nginx_full/fossbilling.dev.conf
@@ -22,7 +22,7 @@ server {
     index index.php;
 
     # Block access to sensitive files
-    location ~* .(htaccess|htpasswd|bak|conf|inc|ini|lock|log|old|sh|sql|twig|yam)$ {
+    location ~* \.(htaccess|htpasswd|bak|conf|inc|ini|lock|log|old|sh|sql|twig|ya?ml)$|(composer\.json|README\.md|CHANGELOG\.md)$ {
         return 403;
     }
 
@@ -47,7 +47,7 @@ server {
     }
 
     # PHP Handling
-    location ~ ^/(index.php|ipn.php|install/index.php|install/install.php) {
+    location ~ ^/(index\.php|ipn\.php|install/index\.php|install/install\.php)$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
 
         # On severs with multiple PHP versions the syntax the socket would likely be similar to "unix:/run/php/php8.4-fpm.sock;" 
@@ -61,7 +61,7 @@ server {
     }
 
     # Block PHP files
-    location ~* .(php)$ {
+    location ~* \.php$ {
         return 403;
     }
 }


### PR DESCRIPTION
## What

Fixes three real nginx bugs in the DDEV local-dev config (`.ddev/nginx_full/fossbilling.dev.conf`).

## Bugs fixed

- **Missing `$` anchor on the PHP entry-point allow-list.** `location ~ ^/(index.php|ipn.php|install/index.php|install/install.php)` prefix-matched instead of requiring an exact filename.
- **Unescaped leading dots** in both PHP-related regexes (`.` matches any character, not just a literal dot), including the final `.(php)$` deny-all rule.
- **`yam` typo** in the sensitive-extension list — `.yaml`/`.yml` files were never actually blocked, despite the rule's intent.
- **No protection for `composer.json`/`README.md`/`CHANGELOG.md`**, unlike `src/.htaccess`, which blocks these explicitly. Added a matching rule (merged into the existing sensitive-files `location` via regex alternation rather than a separate block, since that's how `.htaccess` treats it — one combined check).