### PR TITLE
Exclude expected cache-backend config errors from Sentry reporting

### DIFF
--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -136,7 +136,13 @@ class CacheFactory
             self::assertUsable($pool);
 
             return $pool;
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
+            // Deliberately narrower than \Throwable: the redis/memcached extensions and Symfony's
+            // cache adapters only ever raise \Exception (or a subclass) for an expected connection/
+            // configuration failure - a bad host, missing extension, wrong credentials, and so on.
+            // A \Error here (TypeError, ArgumentCountError, ...) means a genuine bug in our own
+            // adapter-construction code, not an admin misconfiguration, so it's left to propagate
+            // and be reported as usual instead of being swallowed under the ":driver" code below.
             if (!$fallbackOnFailure) {
                 throw new Exception('Could not connect to the configured ":driver" cache backend: :message', [':driver' => $driver, ':message' => $e->getMessage()], 5001);
             }

--- a/src/library/FOSSBilling/Cache/CacheFactory.php
+++ b/src/library/FOSSBilling/Cache/CacheFactory.php
@@ -110,7 +110,7 @@ class CacheFactory
         $driver = $cacheConfig['driver'] ?? 'filesystem';
 
         if (!in_array($driver, self::SUPPORTED_DRIVERS, true)) {
-            throw new Exception('Unsupported cache driver :driver. Supported drivers are: :supported.', [':driver' => $driver, ':supported' => implode(', ', self::SUPPORTED_DRIVERS)]);
+            throw new Exception('Unsupported cache driver :driver. Supported drivers are: :supported.', [':driver' => $driver, ':supported' => implode(', ', self::SUPPORTED_DRIVERS)], 5001);
         }
 
         if ($driver === 'filesystem') {
@@ -124,7 +124,7 @@ class CacheFactory
         // misconfiguration; from createFromConfig() directly (fallbackOnFailure: false), it reaches
         // the caller as this specific message instead of the generic "could not connect" one below.
         if ($instanceId === '') {
-            throw new Exception('The ":driver" cache driver requires an installation identifier ("info.instance_id" in the configuration file) so that installations sharing the same server don\'t collide. Reinstall or update FOSSBilling to have one generated automatically, or set it manually.', [':driver' => $driver]);
+            throw new Exception('The ":driver" cache driver requires an installation identifier ("info.instance_id" in the configuration file) so that installations sharing the same server don\'t collide. Reinstall or update FOSSBilling to have one generated automatically, or set it manually.', [':driver' => $driver], 5001);
         }
 
         try {
@@ -138,7 +138,7 @@ class CacheFactory
             return $pool;
         } catch (\Throwable $e) {
             if (!$fallbackOnFailure) {
-                throw new Exception('Could not connect to the configured ":driver" cache backend: :message', [':driver' => $driver, ':message' => $e->getMessage()]);
+                throw new Exception('Could not connect to the configured ":driver" cache backend: :message', [':driver' => $driver, ':message' => $e->getMessage()], 5001);
             }
 
             error_log(sprintf('FOSSBilling: failed to initialize the "%s" cache driver (%s); falling back to the filesystem cache.', $driver, $e->getMessage()));

--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -58,6 +58,12 @@ class ErrorPage
             4001 => [
                 'report' => false,
             ],
+            // Unavailable/misconfigured cache backend (e.g. a missing PHP extension, or an
+            // unreachable Redis/Memcached server). Surfaced to the admin directly when testing a
+            // cache driver before saving it, so it's listed here to keep it out of Sentry.io.
+            5001 => [
+                'report' => false,
+            ],
         ];
     }
 
@@ -84,6 +90,10 @@ class ErrorPage
         'Payment Gateway' => [
             'start' => 4000,
             'end' => 4999,
+        ],
+        'Cache' => [
+            'start' => 5000,
+            'end' => 5999,
         ],
     ];
 

--- a/src/modules/System/Api/Admin.php
+++ b/src/modules/System/Api/Admin.php
@@ -121,7 +121,7 @@ class Admin extends \FOSSBilling\Api\AbstractApi
 
         $driver = $data['driver'] ?? 'filesystem';
         if (!in_array($driver, CacheFactory::SUPPORTED_DRIVERS, true)) {
-            throw new \FOSSBilling\Exception('Unsupported cache driver: :driver', [':driver' => $driver]);
+            throw new \FOSSBilling\Exception('Unsupported cache driver: :driver', [':driver' => $driver], 5001);
         }
 
         // Keep the existing password when the admin leaves the field blank, so re-saving the


### PR DESCRIPTION
## What

Fixes FOSSBILLING-PYN

Sentry issue [FOSSBILLING-PYN](https://fossbilling.sentry.io/issues/FOSSBILLING-PYN) reported:

```
FOSSBilling\Exception: Could not connect to the configured "redis" cache backend: The "redis" cache driver requires the PHP redis (or relay) extension to be installed.
```

## Why this isn't a bug

`Admin::update_cache_settings()` eagerly connection-tests a not-yet-saved cache config (`CacheFactory::createFromConfig(..., fallbackOnFailure: false)`) before writing it, precisely so an admin gets immediate, specific feedback in the settings form if their chosen driver won't work. In this case the admin tried to switch to the `redis` driver on a server without the PHP `redis`/`relay` extension installed — the error is correct, expected, self-hosted-environment feedback, not a FOSSBilling code defect.

The problem is that these exceptions carried no error code, so `ErrorPage::getCodeInfo()` defaulted them to `report => true` and every admin who hits this (wrong extension, unreachable host, bad credentials, etc.) generates a Sentry event.

## Fix

Give this family of exceptions a dedicated `Cache` error-code range (5000–5999, code `5001`) and mark it `report => false`, mirroring the existing pattern already used for "not fully configured" server manager / domain registrar / payment gateway errors (`2001`/`3001`/`4001`) — those are excluded from Sentry for exactly the same reason: they're user-facing config validation, not bugs.

Applied to every exception reachable from `update_cache_settings()`'s connection test:
- Unsupported driver (checked both in `Admin::update_cache_settings()` and `CacheFactory::createFromConfig()`)
- Missing `info.instance_id` for a remote driver
- The wrapped "could not connect" exception (covers missing PHP extension, unreachable host, bad auth, and the Redis-password-without-TLS guard, since those are all caught and re-thrown through this one path)