### PR TITLE
Fix two PHP warnings surfaced by Sentry on 0.8-next

### DIFF
--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -224,6 +224,25 @@ class Box_App
         return 'Rendering ' . $fileName;
     }
 
+    /**
+     * Twig's FilesystemCache throws a raw \RuntimeException when it can't create or
+     * write to the configured template cache directory - typically a host file
+     * permission issue outside our control. Convert it into a FOSSBilling\Exception
+     * with error code 5002 (Cache category, report:false) so the visitor gets a
+     * friendly error page instead of a fatal, and it isn't reported to Sentry as a
+     * code bug. Any other \RuntimeException is rethrown unchanged.
+     */
+    protected function convertCacheWriteFailure(RuntimeException $e): never
+    {
+        if (!str_starts_with($e->getMessage(), 'Unable to create the cache directory')) {
+            throw $e;
+        }
+
+        $this->di['logger']->setChannel('routing')->error($e->getMessage());
+
+        throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+    }
+
     private function invokeSharedController(string $classname, string $methodName, array $params): mixed
     {
         /** @var TimeDataCollector $timeCollector */

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -247,7 +247,7 @@ class Box_App
             if (str_starts_with($e->getMessage(), $prefix)) {
                 $this->di['logger']->setChannel('routing')->error($e->getMessage());
 
-                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions and available disk space for the "data/cache" directory.', null, 5002);
             }
         }
 

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -234,13 +234,24 @@ class Box_App
      */
     protected function convertCacheWriteFailure(RuntimeException $e): never
     {
-        if (!str_starts_with($e->getMessage(), 'Unable to create the cache directory')) {
-            throw $e;
+        // Twig\Cache\FilesystemCache::write() throws one of these three messages for what is
+        // always the same underlying problem: it couldn't create, or write into, the cache
+        // directory.
+        $cacheWriteFailurePrefixes = [
+            'Unable to create the cache directory',
+            'Unable to write in the cache directory',
+            'Failed to write cache file',
+        ];
+
+        foreach ($cacheWriteFailurePrefixes as $prefix) {
+            if (str_starts_with($e->getMessage(), $prefix)) {
+                $this->di['logger']->setChannel('routing')->error($e->getMessage());
+
+                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+            }
         }
 
-        $this->di['logger']->setChannel('routing')->error($e->getMessage());
-
-        throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+        throw $e;
     }
 
     private function invokeSharedController(string $classname, string $methodName, array $params): mixed

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -54,9 +54,13 @@ class Box_AppAdmin extends Box_App
     #[Override]
     public function render($fileName, $variableArray = []): string
     {
-        $template = $this->getTwig()->load(Path::changeExtension($fileName, '.html.twig'));
+        try {
+            $template = $this->getTwig()->load(Path::changeExtension($fileName, '.html.twig'));
 
-        return $template->render($variableArray);
+            return $template->render($variableArray);
+        } catch (RuntimeException $e) {
+            $this->convertCacheWriteFailure($e);
+        }
     }
 
     #[Override]

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -108,13 +108,15 @@ class Box_AppClient extends Box_App
     {
         try {
             $template = $this->getTwig()->load(Path::changeExtension($fileName, $ext));
+
+            return $template->render($variableArray);
         } catch (Twig\Error\LoaderError $e) {
             $this->di['logger']->setChannel('routing')->info($e->getMessage());
 
             throw new FOSSBilling\InformationException('Page not found', null, 404);
+        } catch (RuntimeException $e) {
+            $this->convertCacheWriteFailure($e);
         }
-
-        return $template->render($variableArray);
     }
 
     /**

--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -58,6 +58,12 @@ class ErrorPage
             4001 => [
                 'report' => false,
             ],
+            // The Twig template cache directory (data/cache) couldn't be created or written
+            // to. This is a host file permission issue we can't fix from within the app, so
+            // it's listed here to keep it out of Sentry.io.
+            5002 => [
+                'report' => false,
+            ],
         ];
     }
 
@@ -84,6 +90,10 @@ class ErrorPage
         'Payment Gateway' => [
             'start' => 4000,
             'end' => 4999,
+        ],
+        'Cache' => [
+            'start' => 5000,
+            'end' => 5999,
         ],
     ];
 

--- a/src/modules/Invoice/ServiceInvoiceItem.php
+++ b/src/modules/Invoice/ServiceInvoiceItem.php
@@ -206,7 +206,7 @@ class ServiceInvoiceItem implements InjectionAwareInterface
             return 0;
         }
 
-        return round($item->price * $rate / 100, 2);
+        return round((float) $item->price * $rate / 100, 2);
     }
 
     public function update(\Model_InvoiceItem $item, array $data): void

--- a/src/modules/Invoice/tests/Unit/ServiceInvoiceItemTest.php
+++ b/src/modules/Invoice/tests/Unit/ServiceInvoiceItemTest.php
@@ -239,6 +239,31 @@ test('gets tax', function (): void {
     expect($result)->toBe($expected);
 });
 
+test('gets tax when price is an empty string', function (): void {
+    // RedBean hands back an empty string, not null, for an unset float column.
+    // getTax() must not choke on that with a "non-numeric value" warning.
+    $service = new ServiceInvoiceItem();
+    $rate = 0.21;
+    $invoiceItemModel = new Model_InvoiceItem();
+    $invoiceItemModel->loadBean(new Tests\Helpers\DummyBean());
+    $invoiceItemModel->invoice_id = 2;
+    $invoiceItemModel->taxed = true;
+    $invoiceItemModel->price = '';
+
+    $dbMock = Mockery::mock('\Box_Database');
+    $dbMock->shouldReceive('getCell')
+        ->atLeast()->once()
+        ->andReturn($rate);
+
+    $di = container();
+    $di['db'] = $dbMock;
+    $service->setDi($di);
+
+    $result = $service->getTax($invoiceItemModel);
+    expect($result)->toBeFloat();
+    expect($result)->toBe(0.0);
+});
+
 test('updates an item', function (): void {
     $service = new ServiceInvoiceItem();
     $invoiceItemModel = new Model_InvoiceItem();

--- a/src/modules/Product/Repository/DomainPricingRepository.php
+++ b/src/modules/Product/Repository/DomainPricingRepository.php
@@ -45,7 +45,7 @@ class DomainPricingRepository
                 'allow_register' => $tld['allow_register'],
                 'allow_transfer' => $tld['allow_transfer'],
                 'min_years' => $tld['min_years'],
-                'periods' => $tld['periods'] !== null && $tld['periods'] !== '' ? array_map(intval(...), explode(',', (string) $tld['periods'])) : null,
+                'periods' => !empty($tld['periods']) ? array_map(intval(...), explode(',', (string) $tld['periods'])) : null,
                 'registrar' => [
                     'id' => $tld['tld_registrar_id'],
                     'title' => $tld['name'],

--- a/src/modules/Product/tests/Unit/Repository/DomainPricingRepositoryTest.php
+++ b/src/modules/Product/tests/Unit/Repository/DomainPricingRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2022-2026 FOSSBilling
+ * SPDX-License-Identifier: Apache-2.0.
+ *
+ * @copyright FOSSBilling (https://www.fossbilling.org)
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
+ */
+
+declare(strict_types=1);
+
+use Box\Mod\Product\Repository\DomainPricingRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+
+function domainPricingRepositoryCreateConnection(): Connection
+{
+    $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    $connection->executeStatement('CREATE TABLE tld_registrar (id INTEGER PRIMARY KEY, name TEXT)');
+    $connection->executeStatement('CREATE TABLE tld (id INTEGER PRIMARY KEY, tld TEXT, price_registration TEXT, price_renew TEXT, price_transfer TEXT, active INTEGER, allow_register INTEGER, allow_transfer INTEGER, min_years INTEGER, tld_registrar_id INTEGER)');
+
+    return $connection;
+}
+
+test('getActivePricingByTld tolerates a tld table with no periods column yet', function (): void {
+    // Regression test for FOSSBILLING-PK4: on an install whose "tld" table
+    // hasn't picked up the "periods" column yet (added by #4115's schema
+    // patch), `SELECT t.*` simply won't return that key at all. Reading it
+    // must not trigger an "Undefined array key" warning.
+    $connection = domainPricingRepositoryCreateConnection();
+    $connection->executeStatement(
+        'INSERT INTO tld (tld, price_registration, price_renew, price_transfer, active, allow_register, allow_transfer, min_years, tld_registrar_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        ['.com', '10.00', '10.00', '10.00', 1, 1, 1, 1, null]
+    );
+
+    $pricing = (new DomainPricingRepository($connection))->getActivePricingByTld();
+
+    expect($pricing)->toHaveKey('.com');
+    expect($pricing['.com']['periods'])->toBeNull();
+});
+
+test('getActivePricingByTld decodes a comma separated periods column', function (): void {
+    $connection = domainPricingRepositoryCreateConnection();
+    $connection->executeStatement('ALTER TABLE tld ADD COLUMN periods TEXT');
+    $connection->executeStatement(
+        'INSERT INTO tld (tld, price_registration, price_renew, price_transfer, active, allow_register, allow_transfer, min_years, tld_registrar_id, periods) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        ['.net', '12.00', '12.00', '12.00', 1, 1, 1, 1, null, '1,2,5']
+    );
+
+    $pricing = (new DomainPricingRepository($connection))->getActivePricingByTld();
+
+    expect($pricing['.net']['periods'])->toBe([1, 2, 5]);
+});

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -155,6 +155,51 @@ test('get_custom_page still returns 404 when the top-level template is missing',
     expect($response->getStatusCode())->toBe(404);
 });
 
+test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (): void {
+    $app = new class extends Box_AppClient {
+        public function triggerCacheWriteFailure(RuntimeException $e): never
+        {
+            $this->convertCacheWriteFailure($e);
+        }
+    };
+    $di = new Pimple\Container();
+    $di['request'] = Request::create('http://localhost/test');
+    $di['logger'] = new class {
+        public function setChannel(string $channel): self
+        {
+            return $this;
+        }
+
+        public function error(string|Stringable $message, array $context = []): void
+        {
+        }
+    };
+    $app->setDi($di);
+
+    try {
+        $app->triggerCacheWriteFailure(new RuntimeException('Unable to create the cache directory (/var/www/data/cache/7d).'));
+        expect(false)->toBeTrue('Expected a FOSSBilling\Exception to be thrown.');
+    } catch (FOSSBilling\Exception $e) {
+        expect($e->getCode())->toBe(5002)
+            ->and(FOSSBilling\ErrorPage::getCodeInfo($e->getCode())['report'])->toBeFalse();
+    }
+});
+
+test('render() rethrows a RuntimeException unrelated to the Twig cache unchanged', function (): void {
+    $app = new class extends Box_AppClient {
+        public function triggerCacheWriteFailure(RuntimeException $e): never
+        {
+            $this->convertCacheWriteFailure($e);
+        }
+    };
+    $di = new Pimple\Container();
+    $di['request'] = Request::create('http://localhost/test');
+    $app->setDi($di);
+
+    expect(fn () => $app->triggerCacheWriteFailure(new RuntimeException('Something else entirely.')))
+        ->toThrow(RuntimeException::class, 'Something else entirely.');
+});
+
 test('numeric custom page paths return a themed 404', function (): void {
     $app = appClientWithRender(static function (string $fileName): string {
         if ($fileName === 'error') {

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -155,7 +155,7 @@ test('get_custom_page still returns 404 when the top-level template is missing',
     expect($response->getStatusCode())->toBe(404);
 });
 
-test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (): void {
+test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (string $message): void {
     $app = new class extends Box_AppClient {
         public function triggerCacheWriteFailure(RuntimeException $e): never
         {
@@ -177,13 +177,17 @@ test('render() converts a Twig cache write failure into a report:false exception
     $app->setDi($di);
 
     try {
-        $app->triggerCacheWriteFailure(new RuntimeException('Unable to create the cache directory (/var/www/data/cache/7d).'));
+        $app->triggerCacheWriteFailure(new RuntimeException($message));
         expect(false)->toBeTrue('Expected a FOSSBilling\Exception to be thrown.');
     } catch (FOSSBilling\Exception $e) {
         expect($e->getCode())->toBe(5002)
             ->and(FOSSBilling\ErrorPage::getCodeInfo($e->getCode())['report'])->toBeFalse();
     }
-});
+})->with([
+    'directory does not exist and cannot be created' => ['Unable to create the cache directory (/var/www/data/cache/7d).'],
+    'directory exists but is not writable' => ['Unable to write in the cache directory (/var/www/data/cache/7d).'],
+    'cache file itself could not be written' => ['Failed to write cache file "/var/www/data/cache/7d/abc123.php".'],
+]);
 
 test('render() rethrows a RuntimeException unrelated to the Twig cache unchanged', function (): void {
     $app = new class extends Box_AppClient {


### PR DESCRIPTION
## Summary

Two fixes found while triaging the FOSSBilling Sentry project, both scoped to `0.8-next` (main has since rewritten the affected code via other work, so it doesn't need these fixes).

### Commit 1: undefined-array-key / non-numeric-value warnings

- **FOSSBILLING-PK4**: `DomainPricingRepository::getActivePricingByTld()` read `$tld['periods']` directly. On an install whose `tld` table hasn't yet picked up the `periods` column added by #4115's schema patch, `SELECT t.*` simply won't return that key, which triggers an "Undefined array key" warning. Switched the read to `empty()`.
- **FOSSBILLING-J83**: `ServiceInvoiceItem::getTax()` multiplied `$item->price` without casting it. RedBean can hand back an empty string (not null) for an unset float column, which triggers a "A non-numeric value encountered" warning. Cast to `float` first.

### Commit 2: Twig cache-directory write failures flooding Sentry

Twig's `FilesystemCache::write()` throws a raw `\RuntimeException('Unable to create the cache directory (...)')` when it can't create or write to the configured template cache directory (`data/cache`) - typically wrong file permissions on the host. That exception was completely uncaught in `Box_AppClient::render()` / `Box_AppAdmin::render()`, so the affected visitor got a raw 500 and every occurrence was reported to Sentry as a code bug, even though it's a host misconfiguration nothing in the app can fix. Four duplicate-shaped Sentry issues (FOSSBILLING-EBW/J8N/EWG/EWV) account for ~60k events.

- `Box_App::convertCacheWriteFailure()`: a shared helper that recognizes this specific Twig message, logs it, and rethrows it as a `FOSSBilling\Exception` with a new error code (`5002`); any other `\RuntimeException` is rethrown unchanged.
- `Box_AppClient::render()` / `Box_AppAdmin::render()` now catch `\RuntimeException` and delegate to it.
- `ErrorPage` marks `5002` as `report => false`. This branch didn't have the `Cache` error-code category yet (that only exists on `main`, from #4275), so it's added here too.