### PR TITLE
Stop Twig cache-directory write failures from flooding Sentry

### DIFF
--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -234,13 +234,24 @@ class Box_App
      */
     protected function convertCacheWriteFailure(RuntimeException $e): never
     {
-        if (!str_starts_with($e->getMessage(), 'Unable to create the cache directory')) {
-            throw $e;
+        // Twig\Cache\FilesystemCache::write() throws one of these three messages for what is
+        // always the same underlying problem: it couldn't create, or write into, the cache
+        // directory.
+        $cacheWriteFailurePrefixes = [
+            'Unable to create the cache directory',
+            'Unable to write in the cache directory',
+            'Failed to write cache file',
+        ];
+
+        foreach ($cacheWriteFailurePrefixes as $prefix) {
+            if (str_starts_with($e->getMessage(), $prefix)) {
+                $this->di['logger']->withChannel('routing')->error($e->getMessage());
+
+                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+            }
         }
 
-        $this->di['logger']->withChannel('routing')->error($e->getMessage());
-
-        throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+        throw $e;
     }
 
     private function invokeSharedController(string $classname, string $methodName, array $params): mixed

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -247,7 +247,7 @@ class Box_App
             if (str_starts_with($e->getMessage(), $prefix)) {
                 $this->di['logger']->withChannel('routing')->error($e->getMessage());
 
-                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+                throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions and available disk space for the "data/cache" directory.', null, 5002);
             }
         }
 

--- a/src/library/Box/App.php
+++ b/src/library/Box/App.php
@@ -224,6 +224,25 @@ class Box_App
         return 'Rendering ' . $fileName;
     }
 
+    /**
+     * Twig's FilesystemCache throws a raw \RuntimeException when it can't create or
+     * write to the configured template cache directory - typically a host file
+     * permission issue outside our control. Convert it into a FOSSBilling\Exception
+     * with error code 5002 (Cache category, report:false) so the visitor gets a
+     * friendly error page instead of a fatal, and it isn't reported to Sentry as a
+     * code bug. Any other \RuntimeException is rethrown unchanged.
+     */
+    protected function convertCacheWriteFailure(RuntimeException $e): never
+    {
+        if (!str_starts_with($e->getMessage(), 'Unable to create the cache directory')) {
+            throw $e;
+        }
+
+        $this->di['logger']->withChannel('routing')->error($e->getMessage());
+
+        throw new FOSSBilling\Exception('The template cache directory could not be written to. Please check the file permissions on the "data/cache" directory.', null, 5002);
+    }
+
     private function invokeSharedController(string $classname, string $methodName, array $params): mixed
     {
         /** @var TimeDataCollector $timeCollector */

--- a/src/library/Box/AppAdmin.php
+++ b/src/library/Box/AppAdmin.php
@@ -54,9 +54,13 @@ class Box_AppAdmin extends Box_App
     #[Override]
     public function render($fileName, $variableArray = []): string
     {
-        $template = $this->getTwig()->load(Path::changeExtension($fileName, '.html.twig'));
+        try {
+            $template = $this->getTwig()->load(Path::changeExtension($fileName, '.html.twig'));
 
-        return $template->render($variableArray);
+            return $template->render($variableArray);
+        } catch (RuntimeException $e) {
+            $this->convertCacheWriteFailure($e);
+        }
     }
 
     #[Override]

--- a/src/library/Box/AppClient.php
+++ b/src/library/Box/AppClient.php
@@ -110,13 +110,15 @@ class Box_AppClient extends Box_App
     {
         try {
             $template = $this->getTwig()->load(Path::changeExtension($fileName, $ext));
+
+            return $template->render($variableArray);
         } catch (Twig\Error\LoaderError $e) {
             $this->di['logger']->withChannel('routing')->info($e->getMessage());
 
             throw new FOSSBilling\InformationException('Page not found', null, 404);
+        } catch (RuntimeException $e) {
+            $this->convertCacheWriteFailure($e);
         }
-
-        return $template->render($variableArray);
     }
 
     /**

--- a/src/library/FOSSBilling/ErrorPage.php
+++ b/src/library/FOSSBilling/ErrorPage.php
@@ -64,6 +64,12 @@ class ErrorPage
             5001 => [
                 'report' => false,
             ],
+            // The Twig template cache directory (data/cache) couldn't be created or written
+            // to. This is a host file permission issue we can't fix from within the app, so
+            // it's listed here to keep it out of Sentry.io.
+            5002 => [
+                'report' => false,
+            ],
         ];
     }
 

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -155,6 +155,51 @@ test('get_custom_page still returns 404 when the top-level template is missing',
     expect($response->getStatusCode())->toBe(404);
 });
 
+test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (): void {
+    $app = new class extends Box_AppClient {
+        public function triggerCacheWriteFailure(RuntimeException $e): never
+        {
+            $this->convertCacheWriteFailure($e);
+        }
+    };
+    $di = new Pimple\Container();
+    $di['request'] = Request::create('http://localhost/test');
+    $di['logger'] = new class {
+        public function withChannel(string $channel): self
+        {
+            return $this;
+        }
+
+        public function error(string|Stringable $message, array $context = []): void
+        {
+        }
+    };
+    $app->setDi($di);
+
+    try {
+        $app->triggerCacheWriteFailure(new RuntimeException('Unable to create the cache directory (/var/www/data/cache/7d).'));
+        expect(false)->toBeTrue('Expected a FOSSBilling\Exception to be thrown.');
+    } catch (FOSSBilling\Exception $e) {
+        expect($e->getCode())->toBe(5002)
+            ->and(FOSSBilling\ErrorPage::getCodeInfo($e->getCode())['report'])->toBeFalse();
+    }
+});
+
+test('render() rethrows a RuntimeException unrelated to the Twig cache unchanged', function (): void {
+    $app = new class extends Box_AppClient {
+        public function triggerCacheWriteFailure(RuntimeException $e): never
+        {
+            $this->convertCacheWriteFailure($e);
+        }
+    };
+    $di = new Pimple\Container();
+    $di['request'] = Request::create('http://localhost/test');
+    $app->setDi($di);
+
+    expect(fn () => $app->triggerCacheWriteFailure(new RuntimeException('Something else entirely.')))
+        ->toThrow(RuntimeException::class, 'Something else entirely.');
+});
+
 test('numeric custom page paths return a themed 404', function (): void {
     $app = appClientWithRender(static function (string $fileName): string {
         if ($fileName === 'error') {

--- a/tests/Unit/Box/AppClientTest.php
+++ b/tests/Unit/Box/AppClientTest.php
@@ -155,7 +155,7 @@ test('get_custom_page still returns 404 when the top-level template is missing',
     expect($response->getStatusCode())->toBe(404);
 });
 
-test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (): void {
+test('render() converts a Twig cache write failure into a report:false exception (regression for FOSSBILLING-EBW)', function (string $message): void {
     $app = new class extends Box_AppClient {
         public function triggerCacheWriteFailure(RuntimeException $e): never
         {
@@ -177,13 +177,17 @@ test('render() converts a Twig cache write failure into a report:false exception
     $app->setDi($di);
 
     try {
-        $app->triggerCacheWriteFailure(new RuntimeException('Unable to create the cache directory (/var/www/data/cache/7d).'));
+        $app->triggerCacheWriteFailure(new RuntimeException($message));
         expect(false)->toBeTrue('Expected a FOSSBilling\Exception to be thrown.');
     } catch (FOSSBilling\Exception $e) {
         expect($e->getCode())->toBe(5002)
             ->and(FOSSBilling\ErrorPage::getCodeInfo($e->getCode())['report'])->toBeFalse();
     }
-});
+})->with([
+    'directory does not exist and cannot be created' => ['Unable to create the cache directory (/var/www/data/cache/7d).'],
+    'directory exists but is not writable' => ['Unable to write in the cache directory (/var/www/data/cache/7d).'],
+    'cache file itself could not be written' => ['Failed to write cache file "/var/www/data/cache/7d/abc123.php".'],
+]);
 
 test('render() rethrows a RuntimeException unrelated to the Twig cache unchanged', function (): void {
     $app = new class extends Box_AppClient {


### PR DESCRIPTION
## Summary

Found while triaging the FOSSBilling Sentry project. Twig's `FilesystemCache::write()` throws a raw `\RuntimeException('Unable to create the cache directory (...)')` when it can't create or write to the configured template cache directory (`data/cache`) - typically wrong file permissions on the host. That exception was completely uncaught in `Box_AppClient::render()` / `Box_AppAdmin::render()`, so:

- the affected visitor got a raw, unhandled 500 instead of a proper error page, and
- every occurrence was reported to Sentry as a code bug, even though it's a host misconfiguration nothing in the app can fix.

This is the same class of noise already fixed for the cache *backend* in #4275, just a different code path. Combined, four duplicate-shaped Sentry issues (FOSSBILLING-EBW/J8N/EWG/EWV) account for ~60k events.

## Changes
- `Box_App::convertCacheWriteFailure()`: a shared helper that recognizes this specific Twig message, logs it, and rethrows it as a `FOSSBilling\Exception` with a new error code (`5002`); any other `\RuntimeException` is rethrown unchanged.
- `Box_AppClient::render()` / `Box_AppAdmin::render()` now catch `\RuntimeException` and delegate to it.
- `ErrorPage::getCodes()` marks `5002` as `report => false` (same `Cache` category as the existing `5001`), so it gets a friendly error page and is excluded from Sentry, mirroring the existing `2001`/`3001`/`4001`/`5001` pattern.