### PR TITLE
Fix reCAPTCHA v3 bypass on fast form submit in Antispam module

### DIFF
--- a/src/modules/Antispam/templates/client/mod_antispam_recaptcha.html.twig
+++ b/src/modules/Antispam/templates/client/mod_antispam_recaptcha.html.twig
@@ -34,24 +34,44 @@
         event.preventDefault();
         event.stopImmediatePropagation();
 
-        if (!window.grecaptcha) {
-            form.dataset.recaptchaV3Verified = 'true';
-            form.requestSubmit();
+        const tokenField = form.querySelector('input[name="g-recaptcha-response"]');
+        const actionField = form.querySelector('input[name="g-recaptcha-action"]');
+        const generateToken = function () {
+            window.grecaptcha.ready(function () {
+                window.grecaptcha.execute('{{ rc.publickey|default('')|e('js') }}', { action: actionField.value }).then(function (token) {
+                    tokenField.value = token;
+                    form.dataset.recaptchaV3Verified = 'true';
+                    form.requestSubmit();
+                }).catch(function () {
+                    form.dataset.recaptchaV3Verified = 'true';
+                    form.requestSubmit();
+                });
+            });
+        };
+
+        if (window.grecaptcha) {
+            generateToken();
             return;
         }
 
-        const tokenField = form.querySelector('input[name="g-recaptcha-response"]');
-        const actionField = form.querySelector('input[name="g-recaptcha-action"]');
-        window.grecaptcha.ready(function () {
-            window.grecaptcha.execute('{{ rc.publickey|default('')|e('js') }}', { action: actionField.value }).then(function (token) {
-                tokenField.value = token;
+        // api.js loads with async/defer, so on a fast submit window.grecaptcha may not
+        // exist yet even though the script tag is present. Poll briefly for it before
+        // falling back to a submit without a token (e.g. if it's actually blocked).
+        let waited = 0;
+        const poll = setInterval(function () {
+            if (window.grecaptcha) {
+                clearInterval(poll);
+                generateToken();
+                return;
+            }
+
+            waited += 100;
+            if (waited >= 5000) {
+                clearInterval(poll);
                 form.dataset.recaptchaV3Verified = 'true';
                 form.requestSubmit();
-            }).catch(function () {
-                form.dataset.recaptchaV3Verified = 'true';
-                form.requestSubmit();
-            });
-        });
+            }
+        }, 100);
     }, true);
 }());
 </script>

--- a/src/modules/Antispam/templates/client/mod_antispam_recaptcha.html.twig
+++ b/src/modules/Antispam/templates/client/mod_antispam_recaptcha.html.twig
@@ -25,6 +25,8 @@
         return;
     }
 
+    let pending = false;
+
     form.addEventListener('submit', function (event) {
         if (form.dataset.recaptchaV3Verified === 'true') {
             form.dataset.recaptchaV3Verified = '';
@@ -34,17 +36,33 @@
         event.preventDefault();
         event.stopImmediatePropagation();
 
+        if (pending) {
+            return;
+        }
+        pending = true;
+
         const tokenField = form.querySelector('input[name="g-recaptcha-response"]');
         const actionField = form.querySelector('input[name="g-recaptcha-action"]');
+        // Resets recaptchaV3Verified right after requestSubmit() rather than relying on
+        // the submit handler above to do it: requestSubmit() runs constraint validation
+        // first and never dispatches submit at all if that fails, which would otherwise
+        // leave the marker stuck true for the next, unrelated submission attempt.
+        const resubmit = function () {
+            form.dataset.recaptchaV3Verified = 'true';
+            form.requestSubmit();
+            form.dataset.recaptchaV3Verified = '';
+            pending = false;
+        };
         const generateToken = function () {
             window.grecaptcha.ready(function () {
                 window.grecaptcha.execute('{{ rc.publickey|default('')|e('js') }}', { action: actionField.value }).then(function (token) {
                     tokenField.value = token;
-                    form.dataset.recaptchaV3Verified = 'true';
-                    form.requestSubmit();
+                    resubmit();
                 }).catch(function () {
-                    form.dataset.recaptchaV3Verified = 'true';
-                    form.requestSubmit();
+                    // grecaptcha is loaded but token generation itself failed; this isn't
+                    // the "blocked" case the timeout fallback below exists for, so don't
+                    // submit without a token here. Let the user retry the submission.
+                    pending = false;
                 });
             });
         };
@@ -68,8 +86,7 @@
             waited += 100;
             if (waited >= 5000) {
                 clearInterval(poll);
-                form.dataset.recaptchaV3Verified = 'true';
-                form.requestSubmit();
+                resubmit();
             }
         }, 100);
     }, true);


### PR DESCRIPTION
## Summary

`mod_antispam_recaptcha.html.twig`'s inline reCAPTCHA v3 submit-interception script has its own copy of the token-generation logic, independent of `partial_recaptcha_shared.html.twig`. It had the same bug once present in that shared partial: the reCAPTCHA `api.js` script tag loads `async defer`, so on a fast form submission `window.grecaptcha` may not exist yet even though the script tag is present. The old code treated `!window.grecaptcha` as "reCAPTCHA is unavailable" and immediately resubmitted the form without ever generating a token — silently defeating the CAPTCHA whenever a user submits before the async script finishes loading, not just when it's genuinely blocked.

## Fix

- Replaced the immediate-resubmit branch with a short poll (~5s at 100ms intervals) for `window.grecaptcha` to appear before generating the token.
- Falls back to submitting without a token only if `window.grecaptcha` never shows up within that window (e.g. actually blocked by the browser or an extension).
- Change is scoped to this one inline script block in the Antispam module; existing `rc.publickey` variable name and this file's own indentation/markup conventions are preserved.