### PR TITLE
Exclude Email registrar RDAP-not-enabled error from Sentry

### DIFF
--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -49,7 +49,7 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
         $this->getLog()->debug('Checking domain availability: ' . $domain->getName());
 
         if (!$this->config['use_rdap']) {
-            throw new Registrar_Exception(':type: registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain availability']);
+            throw new Registrar_Exception(':type: registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain availability'], 3001);
         }
 
         $result = $this->getRdap()->isDomainAvailable($domain->getName());


### PR DESCRIPTION
## Summary

Fixes [FOSSBILLING-PZ4](https://fossbilling.sentry.io/issues/FOSSBILLING-PZ4), associated with #4204.

The Email registrar adapter's `isDomainAvailable()` throws when RDAP lookups aren't enabled for it. That's an expected, admin-actionable configuration state (the site owner hasn't ticked "Use RDAP Registry Lookups"), not an application bug. Unlike the sibling "not fully configured" exception two lines above it in the constructor, this throw used the default error code (`0`), so it fell outside `ErrorPage`'s `3001` "incomplete registrar configuration" exclusion and got reported to Sentry as if it were a real error.

## Fix

Reuse the existing `3001` error code so it's suppressed by the same mechanism, consistent with every other registrar adapter's "not fully configured" exceptions (Namecheap, Internetbs, Resellbiz, Resellerclub, Resellerid, Netearthone all use `3001` for this).

Fixes FOSSBILLING-PZ4