### PR TITLE
Restore "Allow quantity selection" toggle to admin product form

### DIFF
--- a/src/modules/Product/templates/admin/mod_product_manage.html.twig
+++ b/src/modules/Product/templates/admin/mod_product_manage.html.twig
@@ -155,6 +155,15 @@
                                     <label class="form-label">{{ 'Quantity in Stock'|trans }}</label>
                                     <input class="form-control" type="text" name="quantity_in_stock" value="{{ product.quantity_in_stock }}">
                                 </div>
+                                <div class="col-lg-6">
+                                    <input type="hidden" name="allow_quantity_select" value="0">
+                                    <label class="form-label d-block">{{ 'Quantity Selection'|trans }}</label>
+                                    <label class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" id="allow-quantity-select-toggle" name="allow_quantity_select" value="1"{% if product.allow_quantity_select %} checked{% endif %}>
+                                        <span class="form-check-label">{{ 'Allow customers to choose a quantity'|trans }}</span>
+                                    </label>
+                                    <div class="form-text">{{ 'When enabled, a quantity field is shown on the order form.'|trans }}</div>
+                                </div>
                             </div>
 
                             <div class="mt-4">

--- a/src/modules/Product/templates/admin/mod_product_manage.html.twig
+++ b/src/modules/Product/templates/admin/mod_product_manage.html.twig
@@ -152,10 +152,6 @@
                                     <div class="form-text">{{ 'When enabled, ordering can be limited by the quantity available below.'|trans }}</div>
                                 </div>
                                 <div class="col-lg-6">
-                                    <label class="form-label">{{ 'Quantity in Stock'|trans }}</label>
-                                    <input class="form-control" type="text" name="quantity_in_stock" value="{{ product.quantity_in_stock }}">
-                                </div>
-                                <div class="col-lg-6">
                                     <input type="hidden" name="allow_quantity_select" value="0">
                                     <label class="form-label d-block">{{ 'Quantity Selection'|trans }}</label>
                                     <label class="form-check form-switch">
@@ -163,6 +159,10 @@
                                         <span class="form-check-label">{{ 'Allow customers to choose a quantity'|trans }}</span>
                                     </label>
                                     <div class="form-text">{{ 'When enabled, a quantity field is shown on the order form.'|trans }}</div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <label class="form-label">{{ 'Quantity in Stock'|trans }}</label>
+                                    <input class="form-control" type="text" name="quantity_in_stock" value="{{ product.quantity_in_stock }}">
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Summary

The admin UI revamp (#3596) rewrote `mod_product_manage.html.twig` and dropped the field that sets `Product::allow_quantity_select`, leaving no way to enable it from the admin UI. The backend (`Product/Service.php`) and the client-side order form (`Orderbutton`'s `mod_orderbutton_product_configuration.html.twig`) still fully support the flag end-to-end (DB column, API serialization, cart/pricing calculation, and the client quantity `<input>` gated on `product.allow_quantity_select`) — so the client-side quantity field could never appear for any product created or edited after that revamp, since there was no way to turn the flag on.

This restores the toggle in the admin product form, next to the existing "Stock Control" switch, following the same hidden-input + `form-switch` pattern already used in that section.

Fixes #2573