### PR TITLE
Invalidate sessions when API tokens are rotated

### DIFF
--- a/src/modules/Profile/Service.php
+++ b/src/modules/Profile/Service.php
@@ -72,6 +72,8 @@ class Service implements InjectionAwareInterface
         $this->di['em']->persist($admin);
         $this->di['em']->flush();
 
+        $this->invalidateSessions('admin', (int) $admin->getId());
+
         $this->di['events_manager']->fire(['event' => 'onAfterAdminStaffApiKeyChange', 'params' => $event_params]);
 
         $this->di['logger']->info('Generated new API key');
@@ -231,6 +233,8 @@ class Service implements InjectionAwareInterface
 
         $this->di['em']->persist($client);
         $this->di['em']->flush();
+
+        $this->invalidateSessions('client', (int) $client->getId());
 
         $this->di['logger']->info('Generated new API key');
 

--- a/src/modules/Profile/tests/Unit/ServiceTest.php
+++ b/src/modules/Profile/tests/Unit/ServiceTest.php
@@ -67,7 +67,11 @@ test('generates new api key', function (): void {
 
     $model = createEntity(Box\Mod\Staff\Entity\Admin::class);
 
-    $service = new Service();
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('invalidateSessions')
+        ->once()
+        ->with('admin', (int) $model->getId())
+        ->andReturn(true);
     $service->setDi($di);
 
     $result = $service->generateNewApiKey($model);
@@ -259,7 +263,11 @@ test('resets api key', function (): void {
 
     $model = createEntity(Box\Mod\Client\Entity\Client::class);
 
-    $service = new Service();
+    $service = Mockery::mock(Service::class)->makePartial();
+    $service->shouldReceive('invalidateSessions')
+        ->once()
+        ->with('client', (int) $model->getId())
+        ->andReturn(true);
     $service->setDi($di);
     $result = $service->resetApiKey($model);
     expect($result)->toBeString();


### PR DESCRIPTION
Rotating an admin or client API token left existing sessions active, so a session derived from the old token survived rotation and could keep being used.

This reuses the established `invalidateSessions` pattern already used by password changes: both `generateNewApiKey` and `resetApiKey` now invalidate all sessions for the affected admin/client after persisting the new token. As with password changes, this includes the operator's current session, so re-login is required after rotating.