### PR TITLE
Allow domain transfers through the Email and Custom registrars

### DIFF
--- a/src/library/Registrar/Adapter/Custom.php
+++ b/src/library/Registrar/Adapter/Custom.php
@@ -37,6 +37,14 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
     {
         $this->getLog()->debug('Checking if domain can be transferred: ' . $domain->getName());
 
+        if (!$this->config['use_rdap']) {
+            return true;
+        }
+
+        if ($this->getRdap()->isDomainAvailable($domain->getName()) ?? false) {
+            throw new Registrar_Exception('Domain :domain is not registered, so it cannot be transferred. You may be able to register it instead.', [':domain' => $domain->getName()]);
+        }
+
         return true;
     }
 

--- a/src/library/Registrar/Adapter/Email.php
+++ b/src/library/Registrar/Adapter/Email.php
@@ -60,9 +60,19 @@ class Registrar_Adapter_Email extends Registrar_AdapterAbstract
         throw new Registrar_Exception('Unable to determine the availability of :domain via RDAP', [':domain' => $domain->getName()]);
     }
 
-    public function isDomaincanBeTransferred(Registrar_Domain $domain): never
+    public function isDomaincanBeTransferred(Registrar_Domain $domain): bool
     {
-        throw new Registrar_Exception(':type: registrar is unable to :action:', [':type:' => 'Email', ':action:' => 'determine domain transferability']);
+        $this->getLog()->debug('Checking if domain can be transferred: ' . $domain->getName());
+
+        if (!$this->config['use_rdap']) {
+            return true;
+        }
+
+        if ($this->getRdap()->isDomainAvailable($domain->getName()) ?? false) {
+            throw new Registrar_Exception('Domain :domain is not registered, so it cannot be transferred. You may be able to register it instead.', [':domain' => $domain->getName()]);
+        }
+
+        return true;
     }
 
     public function modifyNs(Registrar_Domain $domain)

--- a/tests/Unit/Registrar/Adapter/CustomTest.php
+++ b/tests/Unit/Registrar/Adapter/CustomTest.php
@@ -78,6 +78,40 @@ test('the Custom adapter falls back to a positive answer when RDAP cannot determ
         ->and(array_filter($logger->messages, fn (string $message): bool => str_contains($message, 'RDAP request against')))->not->toBeEmpty();
 });
 
+test('the Custom adapter allows transfers without registry lookups unless RDAP is enabled', function (): void {
+    $adapter = createCustomAdapter([]);
+
+    expect($adapter->isDomaincanBeTransferred((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue()
+        ->and($adapter->requestCount())->toBe(0);
+});
+
+test('the Custom adapter allows transferring a registered domain', function (): void {
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    $adapter = createCustomAdapter(['use_rdap' => '1'], fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? new MockResponse('{"objectClassName":"domain"}', ['http_code' => 200])
+        : new MockResponse($bootstrap));
+
+    expect($adapter->isDomaincanBeTransferred((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue();
+});
+
+test('the Custom adapter refuses transferring an unregistered domain', function (): void {
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    $adapter = createCustomAdapter(['use_rdap' => '1'], fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? new MockResponse('', ['http_code' => 404])
+        : new MockResponse($bootstrap));
+
+    $adapter->isDomaincanBeTransferred((new Registrar_Domain())->setSld('example')->setTld('.com'));
+})->throws(Registrar_Exception::class, 'not registered');
+
+test('the Custom adapter falls back to allowing a transfer when RDAP cannot determine availability', function (): void {
+    $bootstrap = json_encode(['version' => '1.0', 'services' => [[['com'], ['https://rdap.example.com/com/v1/']]]], JSON_THROW_ON_ERROR);
+    $adapter = createCustomAdapter(['use_rdap' => '1'], fn (string $method, string $url): MockResponse => str_contains($url, '/domain/')
+        ? new MockResponse('', ['http_code' => 500])
+        : new MockResponse($bootstrap));
+
+    expect($adapter->isDomaincanBeTransferred((new Registrar_Domain())->setSld('example')->setTld('.com')))->toBeTrue();
+});
+
 test('the Custom adapter configuration form offers an RDAP toggle', function (): void {
     $form = Registrar_Adapter_Custom::getConfig();
 

--- a/tests/Unit/Registrar/Adapter/EmailTest.php
+++ b/tests/Unit/Registrar/Adapter/EmailTest.php
@@ -62,6 +62,30 @@ test('the Email adapter throws when RDAP cannot determine availability', functio
     $adapter->isDomainAvailable(createEmailDomain());
 })->throws(Registrar_Exception::class);
 
+test('the Email adapter allows transfers when RDAP lookups are disabled', function (): void {
+    $adapter = createEmailAdapter([]);
+
+    expect($adapter->isDomaincanBeTransferred(createEmailDomain()))->toBeTrue();
+});
+
+test('the Email adapter allows transferring a registered domain via RDAP', function (): void {
+    $adapter = createEmailAdapter(['use_rdap' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('{"objectClassName":"domain"}', ['http_code' => 200])));
+
+    expect($adapter->isDomaincanBeTransferred(createEmailDomain()))->toBeTrue();
+});
+
+test('the Email adapter refuses transferring an unregistered domain via RDAP', function (): void {
+    $adapter = createEmailAdapter(['use_rdap' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('', ['http_code' => 404])));
+
+    $adapter->isDomaincanBeTransferred(createEmailDomain());
+})->throws(Registrar_Exception::class, 'not registered');
+
+test('the Email adapter falls back to allowing a transfer when RDAP cannot determine availability', function (): void {
+    $adapter = createEmailAdapter(['use_rdap' => '1'], createEmailRdapResponder(fn (): MockResponse => new MockResponse('', ['http_code' => 429])));
+
+    expect($adapter->isDomaincanBeTransferred(createEmailDomain()))->toBeTrue();
+});
+
 test('the Email adapter configuration form offers an RDAP toggle', function (): void {
     $form = Registrar_Adapter_Email::getConfig();
 


### PR DESCRIPTION
Fixes #4303

The Email registrar's `isDomaincanBeTransferred()` has thrown unconditionally since the 2014 initial release, so any TLD assigned to it could not take transfer orders even though `transferDomain()` is implemented. The Custom registrar returned `true` without consulting RDAP, so with lookups enabled it accepted transfers for domains that do not exist.

Both adapters now mirror their own `isDomainAvailable()`:

- RDAP off: the transfer is allowed, as Custom always did.
- RDAP on, domain registered: allowed.
- RDAP on, domain not registered: rejected with a message telling the client the domain isn't registered and may be registerable instead. Same bar the Internet.bs adapter set in #2241.
- RDAP cannot answer: allowed, and the operator verifies manually, matching Custom's existing availability fallback.

The Custom change is included because it is the same six lines and leaving it out would make Custom the odd one out after the Email fix.

Tested with `composer test`, `composer phpstan`, PHP-CS-Fixer and Rector on PHP 8.5. Eight new unit tests cover the four cases above for each adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)